### PR TITLE
Include stdbool.h in API headers

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -17,6 +17,7 @@
 // standard headers
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #if defined(__cplusplus)
 extern "C" {

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -30,6 +30,7 @@ from templates import helper as th
 // standard headers
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 %endif
 
 #if defined(__cplusplus)


### PR DESCRIPTION
* `ur_api.h` makes use of `bool`. `ur_api.h` is a C header and in C the `bool` type is defined in `stdbool.h`, hence we should include `ur_api.h` in the API header.