### PR TITLE
Remove srcOffset parameter from zerEnqueueMemBufferCopyRect

### DIFF
--- a/include/zer_api.h
+++ b/include/zer_api.h
@@ -907,7 +907,6 @@ ZER_APIEXPORT zer_result_t ZER_APICALL
 zerEnqueueMemBufferCopyRect(
     zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
     zer_mem_handle_t hBufferSrc,                    ///< [in] handle of the source buffer object
-    size_t srcOffset,                               ///< [in] offset in bytes in the source buffer object
     zer_mem_handle_t hBufferDst,                    ///< [in] handle of the dest buffer object
     zer_rect_offset_t srcOrigin,                    ///< [in] 3D offset in the source buffer
     zer_rect_offset_t dstOrigin,                    ///< [in] 3D offset in the destination buffer
@@ -5947,7 +5946,6 @@ typedef struct _zer_enqueue_mem_buffer_copy_rect_params_t
 {
     zer_queue_handle_t* phQueue;
     zer_mem_handle_t* phBufferSrc;
-    size_t* psrcOffset;
     zer_mem_handle_t* phBufferDst;
     zer_rect_offset_t* psrcOrigin;
     zer_rect_offset_t* pdstOrigin;

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -420,9 +420,6 @@ params:
     - type: $x_mem_handle_t
       name: hBufferSrc
       desc: "[in] handle of the source buffer object"
-    - type: size_t
-      name: srcOffset
-      desc: "[in] offset in bytes in the source buffer object"
     - type: $x_mem_handle_t
       name: hBufferDst
       desc: "[in] handle of the dest buffer object"


### PR DESCRIPTION
* `zerEnqueueMemBufferCopyRect` currently accepts a `srcOffset` argument that is of type `size_t`, but also takes a `srcOrigin` which is a struct of three `size_t`s representing a 3D offset and making the `srcOffset` argument redundant. The API also doesn't have a `dstOffset` argument, making it inconsistent with itself. Since `srcOffset` is redundant it is better to remove that than add a `dstOffset`. This also makes it more consistent with the `clEnqueueCopyBufferRect` OpenCL analogue, which doesn't have a `srcOffset` parameter.