### PR TITLE
Remove incorrect documentation from zerEnqueueMemBufferCopy

### DIFF
--- a/include/zer_api.h
+++ b/include/zer_api.h
@@ -840,10 +840,6 @@ zerEnqueueMemBufferWriteRect(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to copy from a buffer object to another
 /// 
-/// @details
-///     - The source and destination 2D or 3D rectangular regions can have
-///       different shapes.
-/// 
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueCopyBuffer**

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -368,8 +368,6 @@ desc: "Enqueue a command to copy from a buffer object to another"
 class: $xEnqueue
 name: MemBufferCopy
 ordinal: "0"
-details:
-    - "The source and destination 2D or 3D rectangular regions can have different shapes."
 analogue:
     - "**clEnqueueCopyBuffer**"
 params:


### PR DESCRIPTION
* `zerEnqueueMemBufferCopy` does a linear copy between two buffers viewed as 1D contiguous memory, the description: *The source and destination 2D or 3D rectangular regions can have different shapes.* makes no sense in this context.