### PR TITLE
Remove UR_DEVICE_INFO_OPENCL_C_VERSION query

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -621,37 +621,36 @@ class ur_device_info_v(IntEnum):
     DRIVER_VERSION = 65                             ## char[]: Driver version
     PROFILE = 66                                    ## char[]: Device profile
     VERSION = 67                                    ## char[]: Device version
-    OPENCL_C_VERSION = 68                           ## char[]: OpenCL C version
-    EXTENSIONS = 69                                 ## char[]: Return a space separated list of extension names
-    PRINTF_BUFFER_SIZE = 70                         ## size_t: Maximum size in bytes of internal printf buffer
-    PREFERRED_INTEROP_USER_SYNC = 71                ## bool: prefer user synchronization when sharing object with other API
-    PARENT_DEVICE = 72                              ## ::ur_device_handle_t: return parent device handle
-    PARTITION_PROPERTIES = 73                       ## uint32_t: return a bit-field of partition properties
+    EXTENSIONS = 68                                 ## char[]: Return a space separated list of extension names
+    PRINTF_BUFFER_SIZE = 69                         ## size_t: Maximum size in bytes of internal printf buffer
+    PREFERRED_INTEROP_USER_SYNC = 70                ## bool: prefer user synchronization when sharing object with other API
+    PARENT_DEVICE = 71                              ## ::ur_device_handle_t: return parent device handle
+    PARTITION_PROPERTIES = 72                       ## uint32_t: return a bit-field of partition properties
                                                     ## ::ur_device_partition_property_flags_t
-    PARTITION_MAX_SUB_DEVICES = 74                  ## uint32_t: maximum number of sub-devices when the device is partitioned
-    PARTITION_AFFINITY_DOMAIN = 75                  ## uint32_t: return a bit-field of affinity domain
+    PARTITION_MAX_SUB_DEVICES = 73                  ## uint32_t: maximum number of sub-devices when the device is partitioned
+    PARTITION_AFFINITY_DOMAIN = 74                  ## uint32_t: return a bit-field of affinity domain
                                                     ## ::ur_device_affinity_domain_flags_t
-    PARTITION_TYPE = 76                             ## uint32_t: return a bit-field of ::ur_device_partition_property_flags_t
+    PARTITION_TYPE = 75                             ## uint32_t: return a bit-field of ::ur_device_partition_property_flags_t
                                                     ## for properties specified in ::urDevicePartition
-    MAX_NUM_SUB_GROUPS = 77                         ## uint32_t: max number of sub groups
-    SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 78     ## bool: support sub group independent forward progress
-    SUB_GROUP_SIZES_INTEL = 79                      ## uint32_t[]: return an array of sub group sizes supported on Intel
+    MAX_NUM_SUB_GROUPS = 76                         ## uint32_t: max number of sub groups
+    SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 77     ## bool: support sub group independent forward progress
+    SUB_GROUP_SIZES_INTEL = 78                      ## uint32_t[]: return an array of sub group sizes supported on Intel
                                                     ## device
-    USM_HOST_SUPPORT = 80                           ## bool: support USM host memory access
-    USM_DEVICE_SUPPORT = 81                         ## bool: support USM device memory access
-    USM_SINGLE_SHARED_SUPPORT = 82                  ## bool: support USM single device shared memory access
-    USM_CROSS_SHARED_SUPPORT = 83                   ## bool: support USM cross device shared memory access
-    USM_SYSTEM_SHARED_SUPPORT = 84                  ## bool: support USM system wide shared memory access
-    UUID = 85                                       ## char[]: return device UUID
-    PCI_ADDRESS = 86                                ## char[]: return device PCI address
-    GPU_EU_COUNT = 87                               ## uint32_t: return Intel GPU EU count
-    GPU_EU_SIMD_WIDTH = 88                          ## uint32_t: return Intel GPU EU SIMD width
-    GPU_EU_SLICES = 89                              ## uint32_t: return Intel GPU number of slices
-    GPU_SUBSLICES_PER_SLICE = 90                    ## uint32_t: return Intel GPU number of subslices per slice
-    MAX_MEMORY_BANDWIDTH = 91                       ## uint32_t: return max memory bandwidth in Mb/s
-    IMAGE_SRGB = 92                                 ## bool: image is SRGB
-    ATOMIC_64 = 93                                  ## bool: support 64 bit atomics
-    ATOMIC_MEMORY_ORDER_CAPABILITIES = 94           ## uint32_t: atomics memory order capabilities
+    USM_HOST_SUPPORT = 79                           ## bool: support USM host memory access
+    USM_DEVICE_SUPPORT = 80                         ## bool: support USM device memory access
+    USM_SINGLE_SHARED_SUPPORT = 81                  ## bool: support USM single device shared memory access
+    USM_CROSS_SHARED_SUPPORT = 82                   ## bool: support USM cross device shared memory access
+    USM_SYSTEM_SHARED_SUPPORT = 83                  ## bool: support USM system wide shared memory access
+    UUID = 84                                       ## char[]: return device UUID
+    PCI_ADDRESS = 85                                ## char[]: return device PCI address
+    GPU_EU_COUNT = 86                               ## uint32_t: return Intel GPU EU count
+    GPU_EU_SIMD_WIDTH = 87                          ## uint32_t: return Intel GPU EU SIMD width
+    GPU_EU_SLICES = 88                              ## uint32_t: return Intel GPU number of slices
+    GPU_SUBSLICES_PER_SLICE = 89                    ## uint32_t: return Intel GPU number of subslices per slice
+    MAX_MEMORY_BANDWIDTH = 90                       ## uint32_t: return max memory bandwidth in Mb/s
+    IMAGE_SRGB = 91                                 ## bool: image is SRGB
+    ATOMIC_64 = 92                                  ## bool: support 64 bit atomics
+    ATOMIC_MEMORY_ORDER_CAPABILITIES = 93           ## uint32_t: atomics memory order capabilities
 
 class ur_device_info_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2674,37 +2674,36 @@ typedef enum _ur_device_info_t
     UR_DEVICE_INFO_DRIVER_VERSION = 65,             ///< char[]: Driver version
     UR_DEVICE_INFO_PROFILE = 66,                    ///< char[]: Device profile
     UR_DEVICE_INFO_VERSION = 67,                    ///< char[]: Device version
-    UR_DEVICE_INFO_OPENCL_C_VERSION = 68,           ///< char[]: OpenCL C version
-    UR_DEVICE_INFO_EXTENSIONS = 69,                 ///< char[]: Return a space separated list of extension names
-    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 70,         ///< size_t: Maximum size in bytes of internal printf buffer
-    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 71,///< bool: prefer user synchronization when sharing object with other API
-    UR_DEVICE_INFO_PARENT_DEVICE = 72,              ///< ::ur_device_handle_t: return parent device handle
-    UR_DEVICE_INFO_PARTITION_PROPERTIES = 73,       ///< uint32_t: return a bit-field of partition properties
+    UR_DEVICE_INFO_EXTENSIONS = 68,                 ///< char[]: Return a space separated list of extension names
+    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 69,         ///< size_t: Maximum size in bytes of internal printf buffer
+    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 70,///< bool: prefer user synchronization when sharing object with other API
+    UR_DEVICE_INFO_PARENT_DEVICE = 71,              ///< ::ur_device_handle_t: return parent device handle
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 72,       ///< uint32_t: return a bit-field of partition properties
                                                     ///< ::ur_device_partition_property_flags_t
-    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 74,  ///< uint32_t: maximum number of sub-devices when the device is partitioned
-    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 75,  ///< uint32_t: return a bit-field of affinity domain
+    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 73,  ///< uint32_t: maximum number of sub-devices when the device is partitioned
+    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 74,  ///< uint32_t: return a bit-field of affinity domain
                                                     ///< ::ur_device_affinity_domain_flags_t
-    UR_DEVICE_INFO_PARTITION_TYPE = 76,             ///< uint32_t: return a bit-field of ::ur_device_partition_property_flags_t
+    UR_DEVICE_INFO_PARTITION_TYPE = 75,             ///< uint32_t: return a bit-field of ::ur_device_partition_property_flags_t
                                                     ///< for properties specified in ::urDevicePartition
-    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 77,         ///< uint32_t: max number of sub groups
-    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 78, ///< bool: support sub group independent forward progress
-    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 79,      ///< uint32_t[]: return an array of sub group sizes supported on Intel
+    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 76,         ///< uint32_t: max number of sub groups
+    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 77, ///< bool: support sub group independent forward progress
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 78,      ///< uint32_t[]: return an array of sub group sizes supported on Intel
                                                     ///< device
-    UR_DEVICE_INFO_USM_HOST_SUPPORT = 80,           ///< bool: support USM host memory access
-    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 81,         ///< bool: support USM device memory access
-    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 82,  ///< bool: support USM single device shared memory access
-    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 83,   ///< bool: support USM cross device shared memory access
-    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 84,  ///< bool: support USM system wide shared memory access
-    UR_DEVICE_INFO_UUID = 85,                       ///< char[]: return device UUID
-    UR_DEVICE_INFO_PCI_ADDRESS = 86,                ///< char[]: return device PCI address
-    UR_DEVICE_INFO_GPU_EU_COUNT = 87,               ///< uint32_t: return Intel GPU EU count
-    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 88,          ///< uint32_t: return Intel GPU EU SIMD width
-    UR_DEVICE_INFO_GPU_EU_SLICES = 89,              ///< uint32_t: return Intel GPU number of slices
-    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 90,    ///< uint32_t: return Intel GPU number of subslices per slice
-    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 91,       ///< uint32_t: return max memory bandwidth in Mb/s
-    UR_DEVICE_INFO_IMAGE_SRGB = 92,                 ///< bool: image is SRGB
-    UR_DEVICE_INFO_ATOMIC_64 = 93,                  ///< bool: support 64 bit atomics
-    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 94,   ///< uint32_t: atomics memory order capabilities
+    UR_DEVICE_INFO_USM_HOST_SUPPORT = 79,           ///< bool: support USM host memory access
+    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 80,         ///< bool: support USM device memory access
+    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 81,  ///< bool: support USM single device shared memory access
+    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 82,   ///< bool: support USM cross device shared memory access
+    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 83,  ///< bool: support USM system wide shared memory access
+    UR_DEVICE_INFO_UUID = 84,                       ///< char[]: return device UUID
+    UR_DEVICE_INFO_PCI_ADDRESS = 85,                ///< char[]: return device PCI address
+    UR_DEVICE_INFO_GPU_EU_COUNT = 86,               ///< uint32_t: return Intel GPU EU count
+    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 87,          ///< uint32_t: return Intel GPU EU SIMD width
+    UR_DEVICE_INFO_GPU_EU_SLICES = 88,              ///< uint32_t: return Intel GPU number of slices
+    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 89,    ///< uint32_t: return Intel GPU number of subslices per slice
+    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 90,       ///< uint32_t: return max memory bandwidth in Mb/s
+    UR_DEVICE_INFO_IMAGE_SRGB = 91,                 ///< bool: image is SRGB
+    UR_DEVICE_INFO_ATOMIC_64 = 92,                  ///< bool: support 64 bit atomics
+    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 93,   ///< uint32_t: atomics memory order capabilities
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_info_t;

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -206,8 +206,6 @@ etors:
       desc: "char[]: Device profile"
     - name: VERSION
       desc: "char[]: Device version"
-    - name: OPENCL_C_VERSION
-      desc: "char[]: OpenCL C version"
     - name: EXTENSIONS
       desc: "char[]: Return a space separated list of extension names"
     - name: PRINTF_BUFFER_SIZE


### PR DESCRIPTION
* `UR_DEVICE_INFO_OPENCL_C_VERSION` is an OpenCL specific query. Unified Runtime devices will not consume OpenCL C, so this should be removed.