### PR TITLE
Add pointer to urSelectBinary out param

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1796,9 +1796,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urDeviceSelectBinary
 if __use_win_types:
-    _urDeviceSelectBinary_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte*), c_ulong )
+    _urDeviceSelectBinary_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(c_ubyte*), c_ulong, POINTER(c_ulong) )
 else:
-    _urDeviceSelectBinary_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte*), c_ulong )
+    _urDeviceSelectBinary_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(c_ubyte*), c_ulong, POINTER(c_ulong) )
 
 ###############################################################################
 ## @brief Function-pointer for urDeviceGetNativeHandle

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2908,13 +2908,14 @@ urDevicePartition(
 ///         + `nullptr == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == Binaries`
+///         + `nullptr == SelectedBinary`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceSelectBinary(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
+    const uint8_t** Binaries,                       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries,                           ///< [in] the number of binaries passed in Binaries. Must greater or equal
                                                     ///< than zero.
-    const uint8_t** Binaries,                       ///< [in] the array of binaries to select from.
-    uint32_t SelectedBinary                         ///< [out] the index of the selected binary in the input array of binaries.
+    uint32_t* SelectedBinary                        ///< [out] the index of the selected binary in the input array of binaries.
                                                     ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
     );
 
@@ -6772,9 +6773,9 @@ typedef void (UR_APICALL *ur_pfnDevicePartitionCb_t)(
 typedef struct _ur_device_select_binary_params_t
 {
     ur_device_handle_t* phDevice;
-    uint32_t* pNumBinaries;
     const uint8_t*** pBinaries;
-    uint32_t* pSelectedBinary;
+    uint32_t* pNumBinaries;
+    uint32_t** pSelectedBinary;
 } ur_device_select_binary_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1345,9 +1345,9 @@ typedef ur_result_t (UR_APICALL *ur_pfnDevicePartition_t)(
 /// @brief Function-pointer for urDeviceSelectBinary 
 typedef ur_result_t (UR_APICALL *ur_pfnDeviceSelectBinary_t)(
     ur_device_handle_t,
-    uint32_t,
     const uint8_t**,
-    uint32_t
+    uint32_t,
+    uint32_t*
     );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -403,15 +403,15 @@ params:
       name: hDevice
       desc: |
             [in] handle of the device to select binary for.
-    - type: "uint32_t"
-      name: NumBinaries
-      desc: |
-            [in] the number of binaries passed in Binaries. Must greater or equal than zero.
     - type: "const uint8_t**"
       name: Binaries
       desc: |
             [in] the array of binaries to select from.
     - type: "uint32_t"
+      name: NumBinaries
+      desc: |
+            [in] the number of binaries passed in Binaries. Must greater or equal than zero.
+    - type: "uint32_t*"
       name: SelectedBinary
       desc: |
             [out] the index of the selected binary in the input array of binaries.


### PR DESCRIPTION
* The `SelectedBinary` out parameter of the `urSelectBinary` was missing a pointer in its type.