### PR TITLE
Rename API namespace to ur/UR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
-project(level_zero)
+project(unified_runtime)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/include/ur.py
+++ b/include/ur.py
@@ -1,0 +1,2057 @@
+"""
+ Copyright (C) 2022 Intel Corporation
+
+ SPDX-License-Identifier: MIT
+
+ @file ur.py
+ @version v0.5-r0.5
+
+ """
+import platform
+from ctypes import *
+from enum import *
+
+###############################################################################
+__version__ = "1.0"
+
+###############################################################################
+## @brief Generates generic 'oneAPI' API versions
+def UR_MAKE_VERSION( _major, _minor ):
+    return (( _major << 16 )|( _minor & 0x0000ffff))
+
+###############################################################################
+## @brief Extracts 'oneAPI' API major version
+def UR_MAJOR_VERSION( _ver ):
+    return ( _ver >> 16 )
+
+###############################################################################
+## @brief Extracts 'oneAPI' API minor version
+def UR_MINOR_VERSION( _ver ):
+    return ( _ver & 0x0000ffff )
+
+###############################################################################
+## @brief Calling convention for all API functions
+# UR_APICALL not required for python
+
+###############################################################################
+## @brief Microsoft-specific dllexport storage-class attribute
+# UR_APIEXPORT not required for python
+
+###############################################################################
+## @brief Microsoft-specific dllexport storage-class attribute
+# UR_DLLEXPORT not required for python
+
+###############################################################################
+## @brief GCC-specific dllexport storage-class attribute
+# UR_DLLEXPORT not required for python
+
+###############################################################################
+## @brief compiler-independent type
+class ur_bool_t(c_ubyte):
+    pass
+
+###############################################################################
+## @brief Handle of a platform instance
+class ur_platform_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of platform's device object
+class ur_device_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of context object
+class ur_context_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of event object
+class ur_event_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of Program object
+class ur_program_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of Module object
+class ur_module_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of module's Kernel object
+class ur_kernel_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of a queue object
+class ur_queue_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of a native object
+class ur_native_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of a Sampler object
+class ur_sampler_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of memory object which can either be buffer or image
+class ur_mem_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Generic macro for enumerator bit masks
+def UR_BIT( _i ):
+    return ( 1 << _i )
+
+###############################################################################
+## @brief Defines Return/Error codes
+class ur_result_v(IntEnum):
+    SUCCESS = 0                                     ## Success
+    INVALID_KERNEL_NAME = 1                         ## Invalid kernel name
+    INVALID_OPERATION = 2                           ## Invalid operation
+    INVALID_KERNEL = 3                              ## Invalid kernel
+    INVALID_QUEUE_PROPERTIES = 4                    ## Invalid queue properties
+    INVALID_VALUE = 5                               ## Invalid Value
+    INVALID_CONTEXT = 6                             ## Invalid context
+    INVALID_PLATFORM = 7                            ## Invalid platform
+    INVALID_DEVICE = 8                              ## Invalid device
+    INVALID_BINARY = 9                              ## Invalid binary
+    INVALID_QUEUE = 10                              ## Invalid queue
+    OUT_OF_HOST_MEMORY = 11                         ## Out of host memory
+    INVALID_PROGRAM = 12                            ## Invalid program
+    INVALID_PROGRAM_EXECUTABLE = 13                 ## Invalid program executable
+    INVALID_SAMPLER = 14                            ## Invalid sampler
+    INVALID_BUFFER_SIZE = 15                        ## Invalid buffer size
+    INVALID_MEM_OBJECT = 16                         ## Invalid memory object
+    OUT_OF_RESOURCES = 17                           ## Out of resources
+    INVALID_EVENT = 18                              ## Invalid event
+    INVALID_EVENT_WAIT_LIST = 19                    ## Invalid event wait list
+    MISALIGNED_SUB_BUFFER_OFFSET = 20               ## Misaligned sub buffer offset
+    BUILD_PROGRAM_FAILURE = 21                      ## Build program failure
+    INVALID_WORK_GROUP_SIZE = 22                    ## Invalid work group size
+    COMPILER_NOT_AVAILABLE = 23                     ## Compiler not available
+    PROFILING_INFO_NOT_AVAILABLE = 24               ## Profiling info not available
+    DEVICE_NOT_FOUND = 25                           ## Device not found
+    INVALID_WORK_ITEM_SIZE = 26                     ## Invalid work item size
+    INVALID_WORK_DIMENSION = 27                     ## Invalid work dimension
+    INVALID_KERNEL_ARGS = 28                        ## Invalid kernel args
+    INVALID_IMAGE_SIZE = 29                         ## Invalid image size
+    INVALID_IMAGE_FORMAT_DESCRIPTOR = 30            ## Invalid image format descriptor
+    IMAGE_FORMAT_NOT_SUPPORTED = 31                 ## Image format not supported
+    MEM_OBJECT_ALLOCATION_FAILURE = 32              ## Memory object allocation failure
+    ERROR_INVALID_PROGRAM_EXECUTABLE = 33           ## Program object parameter is invalid.
+    ERROR_UNINITIALIZED = 0x78000001                ## [Validation] driver is not initialized
+    ERROR_DEVICE_LOST = 0x78000002                  ## Device hung, reset, was removed, or driver update occurred
+    ERROR_OUT_OF_HOST_MEMORY = 0x78000003           ## Insufficient host memory to satisfy call
+    ERROR_OUT_OF_DEVICE_MEMORY = 0x78000004         ## Insufficient device memory to satisfy call
+    ERROR_MODULE_BUILD_FAILURE = 0x78000005         ## Error occurred when building module, see build log for details
+    ERROR_MODULE_LINK_FAILURE = 0x78000006          ## Error occurred when linking modules, see build log for details
+    ERROR_DEVICE_REQUIRES_RESET = 0x78000007        ## Device requires a reset
+    ERROR_DEVICE_IN_LOW_POWER_STATE = 0x78000008    ## Device currently in low power state
+    ERROR_UNSUPPORTED_VERSION = 0x78000009          ## [Validation] generic error code for unsupported versions
+    ERROR_UNSUPPORTED_FEATURE = 0x7800000a          ## [Validation] generic error code for unsupported features
+    ERROR_INVALID_ARGUMENT = 0x7800000b             ## [Validation] generic error code for invalid arguments
+    ERROR_INVALID_NULL_HANDLE = 0x7800000c          ## [Validation] handle argument is not valid
+    ERROR_HANDLE_OBJECT_IN_USE = 0x7800000d         ## [Validation] object pointed to by handle still in-use by device
+    ERROR_INVALID_NULL_POINTER = 0x7800000e         ## [Validation] pointer argument may not be nullptr
+    ERROR_INVALID_SIZE = 0x7800000f                 ## [Validation] size argument is invalid (e.g., must not be zero)
+    ERROR_UNSUPPORTED_SIZE = 0x78000010             ## [Validation] size argument is not supported by the device (e.g., too
+                                                    ## large)
+    ERROR_UNSUPPORTED_ALIGNMENT = 0x78000011        ## [Validation] alignment argument is not supported by the device (e.g.,
+                                                    ## too small)
+    ERROR_INVALID_SYNCHRONIZATION_OBJECT = 0x78000012   ## [Validation] synchronization object in invalid state
+    ERROR_INVALID_ENUMERATION = 0x78000013          ## [Validation] enumerator argument is not valid
+    ERROR_UNSUPPORTED_ENUMERATION = 0x78000014      ## [Validation] enumerator argument is not supported by the device
+    ERROR_UNSUPPORTED_IMAGE_FORMAT = 0x78000015     ## [Validation] image format is not supported by the device
+    ERROR_INVALID_NATIVE_BINARY = 0x78000016        ## [Validation] native binary is not supported by the device
+    ERROR_INVALID_GLOBAL_NAME = 0x78000017          ## [Validation] global variable is not found in the module
+    ERROR_INVALID_KERNEL_NAME = 0x78000018          ## [Validation] kernel name is not found in the module
+    ERROR_INVALID_FUNCTION_NAME = 0x78000019        ## [Validation] function name is not found in the module
+    ERROR_INVALID_GROUP_SIZE_DIMENSION = 0x7800001a ## [Validation] group size dimension is not valid for the kernel or
+                                                    ## device
+    ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 0x7800001b   ## [Validation] global width dimension is not valid for the kernel or
+                                                    ## device
+    ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 0x7800001c## [Validation] kernel argument index is not valid for kernel
+    ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 0x7800001d ## [Validation] kernel argument size does not match kernel
+    ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 0x7800001e   ## [Validation] value of kernel attribute is not valid for the kernel or
+                                                    ## device
+    ERROR_INVALID_MODULE_UNLINKED = 0x7800001f      ## [Validation] module with imports needs to be linked before kernels can
+                                                    ## be created from it.
+    ERROR_INVALID_COMMAND_LIST_TYPE = 0x78000020    ## [Validation] command list type does not match command queue type
+    ERROR_OVERLAPPING_REGIONS = 0x78000021          ## [Validation] copy operations do not support overlapping regions of
+                                                    ## memory
+    INVALID_HOST_PTR = 0x78000022                   ## Invalid host pointer
+    INVALID_USM_SIZE = 0x78000023                   ## Invalid USM size
+    OBJECT_ALLOCATION_FAILURE = 0x78000024          ## Objection allocation failure
+    ERROR_UNKNOWN = 0x7ffffffe                      ## Unknown or internal error
+
+class ur_result_t(c_int):
+    def __str__(self):
+        return str(ur_result_v(self.value))
+
+
+###############################################################################
+## @brief Defines structure types
+class ur_structure_type_v(IntEnum):
+    IMAGE_DESC = 0                                  ## ::ur_image_desc_t
+
+class ur_structure_type_t(c_int):
+    def __str__(self):
+        return str(ur_structure_type_v(self.value))
+
+
+###############################################################################
+## @brief Base for all properties types
+class ur_base_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in,out][optional] pointer to extension-specific structure
+    ]
+
+###############################################################################
+## @brief Base for all descriptor types
+class ur_base_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
+    ]
+
+###############################################################################
+## @brief 3D offset argument passed to buffer rect operations
+class ur_rect_offset_t(Structure):
+    _fields_ = [
+        ("x", c_ulonglong),                                             ## [in] x offset (bytes)
+        ("y", c_ulonglong),                                             ## [in] y offset (scalar)
+        ("z", c_ulonglong)                                              ## [in] z offset (scalar)
+    ]
+
+###############################################################################
+## @brief 3D region argument passed to buffer rect operations
+class ur_rect_region_t(Structure):
+    _fields_ = [
+        ("width", c_ulonglong),                                         ## [in] width (bytes)
+        ("height", c_ulonglong),                                        ## [in] height (scalar)
+        ("depth", c_ulonglong)                                          ## [in] scalar (scalar)
+    ]
+
+###############################################################################
+## @brief Supported context info
+class ur_context_info_v(IntEnum):
+    NUM_DEVICES = 1                                 ## [uint32_t] The number of the devices in the context
+    DEVICES = 2                                     ## [::ur_context_handle_t...] The array of the device handles in the
+                                                    ## context
+
+class ur_context_info_t(c_int):
+    def __str__(self):
+        return str(ur_context_info_v(self.value))
+
+
+###############################################################################
+## @brief Map flags
+class ur_map_flags_v(IntEnum):
+    READ = UR_BIT(0)                                ## Map for read access
+    WRITE = UR_BIT(1)                               ## Map for write access
+
+class ur_map_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Map flags
+class ur_usm_migration_flags_v(IntEnum):
+    DEFAULT = UR_BIT(0)                             ## Default migration TODO: Add more enums! 
+
+class ur_usm_migration_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief USM memory advice
+class ur_mem_advice_v(IntEnum):
+    MEM_ADVICE_DEFAULT = 0                          ## The USM memory advice is default
+
+class ur_mem_advice_t(c_int):
+    def __str__(self):
+        return str(ur_mem_advice_v(self.value))
+
+
+###############################################################################
+## @brief Event query information type
+class ur_event_info_v(IntEnum):
+    EVENT_INFO_COMMAND_QUEUE = 0                    ## Command queue information of an event object
+    EVENT_INFO_CONTEXT = 1                          ## Context information of an event object
+    EVENT_INFO_COMMAND_TYPE = 2                     ## Command type information of an event object
+    EVENT_INFO_COMMAND_EXECUTION_STATUS = 3         ## Command execution status of an event object
+    EVENT_INFO_REFERENCE_COUNT = 4                  ## Reference count of an event object
+
+class ur_event_info_t(c_int):
+    def __str__(self):
+        return str(ur_event_info_v(self.value))
+
+
+###############################################################################
+## @brief Profiling query information type
+class ur_profiling_info_v(IntEnum):
+    PROFILING_INFO_COMMAND_QUEUED = 0               ## A 64-bit value of current device counter in nanoseconds when the event
+                                                    ## is enqueued
+    PROFILING_INFO_COMMAND_SUBMIT = 1               ## A 64-bit value of current device counter in nanoseconds when the event
+                                                    ## is submitted
+    PROFILING_INFO_COMMAND_START = 2                ## A 64-bit value of current device counter in nanoseconds when the event
+                                                    ## starts execution
+    PROFILING_INFO_COMMAND_END = 3                  ## A 64-bit value of current device counter in nanoseconds when the event
+                                                    ## has finished execution
+
+class ur_profiling_info_t(c_int):
+    def __str__(self):
+        return str(ur_profiling_info_v(self.value))
+
+
+###############################################################################
+## @brief Memory flags
+class ur_mem_flags_v(IntEnum):
+    MEM_READ_WRITE = UR_BIT(0)                      ## The memory object will be read and written by a kernel. This is the
+                                                    ## default
+    MEM_WRITE_ONLY = UR_BIT(1)                      ## The memory object will be written but not read by a kernel
+    MEM_READ_ONLY = UR_BIT(2)                       ## The memory object is a read-only inside a kernel
+    MEM_USE_HOST_POINTER = UR_BIT(3)                ## Use memory pointed by a host pointer parameter as the storage bits for
+                                                    ## the memory object
+    MEM_ALLOC_HOST_POINTER = UR_BIT(4)              ## Allocate memory object from host accessible memory
+    MEM_ALLOC_COPY_HOST_POINTER = UR_BIT(5)         ## Allocate memory and copy the data from host pointer pointed memory
+
+class ur_mem_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Memory types
+class ur_mem_type_v(IntEnum):
+    MEM_TYPE_BUFFER = 0                             ## Buffer object
+    MEM_TYPE_IMAGE2D = 1                            ## 2D image object
+    MEM_TYPE_IMAGE3D = 2                            ## 3D image object
+    MEM_TYPE_IMAGE2D_ARRAY = 3                      ## 2D image array object
+    MEM_TYPE_IMAGE1D = 4                            ## 1D image object
+    MEM_TYPE_IMAGE1D_ARRAY = 5                      ## 1D image array object
+    MEM_TYPE_IMAGE1D_BUFFER = 6                     ## 1D image buffer object
+
+class ur_mem_type_t(c_int):
+    def __str__(self):
+        return str(ur_mem_type_v(self.value))
+
+
+###############################################################################
+## @brief Image channel order info: number of channels and the channel layout
+class ur_image_channel_order_v(IntEnum):
+    CHANNEL_ORDER_A = 0                             ## channel order A
+    CHANNEL_ORDER_R = 1                             ## channel order R
+    CHANNEL_ORDER_RG = 2                            ## channel order RG
+    CHANNEL_ORDER_RA = 3                            ## channel order RA
+    CHANNEL_ORDER_RGB = 4                           ## channel order RGB
+    CHANNEL_ORDER_RGBA = 5                          ## channel order RGBA
+    CHANNEL_ORDER_BGRA = 6                          ## channel order BGRA
+    CHANNEL_ORDER_ARGB = 7                          ## channel order ARGB
+    CHANNEL_ORDER_INTENSITY = 8                     ## channel order intensity
+    CHANNEL_ORDER_LUMINANCE = 9                     ## channel order luminance
+    CHANNEL_ORDER_RX = 10                           ## channel order Rx
+    CHANNEL_ORDER_RGX = 11                          ## channel order RGx
+    CHANNEL_ORDER_RGBX = 12                         ## channel order RGBx
+    CHANNEL_ORDER_SRGBA = 13                        ## channel order sRGBA
+
+class ur_image_channel_order_t(c_int):
+    def __str__(self):
+        return str(ur_image_channel_order_v(self.value))
+
+
+###############################################################################
+## @brief Image channel type info: describe the size of the channel data type
+class ur_image_channel_type_v(IntEnum):
+    CHANNEL_TYPE_SNORM_INT8 = 0                     ## channel type snorm int8
+    CHANNEL_TYPE_SNORM_INT16 = 1                    ## channel type snorm int16
+    CHANNEL_TYPE_UNORM_INT8 = 2                     ## channel type unorm int8
+    CHANNEL_TYPE_UNORM_INT16 = 3                    ## channel type unorm int16
+    CHANNEL_TYPE_UNORM_SHORT_565 = 4                ## channel type unorm short 565
+    CHANNEL_TYPE_UNORM_SHORT_555 = 5                ## channel type unorm short 555
+    CHANNEL_TYPE_INT_101010 = 6                     ## channel type int 101010
+    CHANNEL_TYPE_SIGNED_INT8 = 7                    ## channel type signed int8
+    CHANNEL_TYPE_SIGNED_INT16 = 8                   ## channel type signed int16
+    CHANNEL_TYPE_SIGNED_INT32 = 9                   ## channel type signed int32
+    CHANNEL_TYPE_UNSIGNED_INT8 = 10                 ## channel type unsigned int8
+    CHANNEL_TYPE_UNSIGNED_INT16 = 11                ## channel type unsigned int16
+    CHANNEL_TYPE_UNSIGNED_INT32 = 12                ## channel type unsigned int32
+    CHANNEL_TYPE_HALF_FLOAT = 13                    ## channel type half float
+    CHANNEL_TYPE_FLOAT = 14                         ## channel type float
+
+class ur_image_channel_type_t(c_int):
+    def __str__(self):
+        return str(ur_image_channel_type_v(self.value))
+
+
+###############################################################################
+## @brief Image format including channel layout and data type
+class ur_image_format_t(Structure):
+    _fields_ = [
+        ("channelOrder", ur_image_channel_order_t),                     ## [in] image channel order
+        ("channelType", ur_image_channel_type_t)                        ## [in] image channel type
+    ]
+
+###############################################################################
+## @brief Image descriptor type.
+class ur_image_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("type", ur_mem_type_t),                                        ## [in] memory object type
+        ("width", c_size_t),                                            ## [in] image width
+        ("height", c_size_t),                                           ## [in] image height
+        ("depth", c_size_t),                                            ## [in] image depth
+        ("arraySize", c_size_t),                                        ## [in] image array size
+        ("rowPitch", c_size_t),                                         ## [in] image row pitch
+        ("slicePitch", c_size_t),                                       ## [in] image slice pitch
+        ("numMipLevel", c_ulong),                                       ## [in] number of MIP levels
+        ("numSamples", c_ulong)                                         ## [in] number of samples
+    ]
+
+###############################################################################
+## @brief Buffer region type, used to describe a sub buffer
+class ur_buffer_region_t(Structure):
+    _fields_ = [
+        ("origin", c_size_t),                                           ## [in] buffer origin offset
+        ("size", c_size_t)                                              ## [in] size of the buffer region
+    ]
+
+###############################################################################
+## @brief Buffer creation type
+class ur_buffer_create_type_v(IntEnum):
+    BUFFER_CREATE_TYPE_REGION = 0                   ## buffer create type is region
+
+class ur_buffer_create_type_t(c_int):
+    def __str__(self):
+        return str(ur_buffer_create_type_v(self.value))
+
+
+###############################################################################
+## @brief Query queue info
+class ur_queue_info_v(IntEnum):
+    CONTEXT = 0                                     ## Queue context info
+    DEVICE = 1                                      ## Queue device info
+    DEVICE_DEFAULT = 2                              ## Queue device default info
+    PROPERTIES = 3                                  ## Queue properties info
+    REFERENCE_COUNT = 4                             ## Queue reference count
+    SIZE = 5                                        ## Queue size info
+
+class ur_queue_info_t(c_int):
+    def __str__(self):
+        return str(ur_queue_info_v(self.value))
+
+
+###############################################################################
+## @brief Queue properties
+class ur_queue_flags_v(IntEnum):
+    OUT_OF_ORDER_EXEC_MODE_ENABLE = UR_BIT(0)       ## Enable/disable out of order execution
+    PROFILING_ENABLE = UR_BIT(1)                    ## Enable/disable profiling
+    ON_DEVICE = UR_BIT(2)                           ## Is a device queue
+    ON_DEVICE_DEFAULT = UR_BIT(3)                   ## Is the default queue for a device
+
+class ur_queue_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Get sample object information
+class ur_sampler_info_v(IntEnum):
+    SAMPLER_INFO_REFERENCE_COUNT = 0                ## Sampler reference count info
+    SAMPLER_INFO_CONTEXT = 1                        ## Sampler context info
+    SAMPLER_INFO_NORMALIZED_COORDS = 2              ## Sampler normalized coordindate setting
+    SAMPLER_INFO_ADDRESSING_MODE = 3                ## Sampler addressing mode setting
+    SAMPLER_INFO_FILTER_MODE = 4                    ## Sampler filter mode setting
+    SAMPLER_INFO_MIP_FILTER_MODE = 5                ## Sampler MIP filter mode setting
+    SAMPLER_INFO_LOD_MIN = 6                        ## Sampler LOD Min value
+    SAMPLER_INFO_LOD_MAX = 7                        ## Sampler LOD Max value
+
+class ur_sampler_info_t(c_int):
+    def __str__(self):
+        return str(ur_sampler_info_v(self.value))
+
+
+###############################################################################
+## @brief Sampler properties
+class ur_sampler_properties_v(IntEnum):
+    SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0        ## Sampler normalized coordinates
+    SAMPLER_PROPERTIES_ADDRESSING_MODE = 1          ## Sampler addressing mode
+    SAMPLER_PROPERTIES_FILTER_MODE = 2              ## Sampler filter mode
+
+class ur_sampler_properties_t(c_int):
+    def __str__(self):
+        return str(ur_sampler_properties_v(self.value))
+
+
+###############################################################################
+## @brief Sampler properties <name, value> pair
+class ur_sampler_property_value_t(Structure):
+    _fields_ = [
+        ("propName", ur_sampler_properties_t),                          ## [in] Sampler property
+        ("propValue", c_ulong)                                          ## [in] Sampler property value
+    ]
+
+###############################################################################
+## @brief USM memory property flags
+class ur_usm_mem_flags_v(IntEnum):
+    MEM_ALLOC_FLAGS_INTEL = UR_BIT(0)               ## The USM memory allocation is from Intel USM
+
+class ur_usm_mem_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief USM memory allocation information type
+class ur_mem_info_v(IntEnum):
+    MEM_ALLOC_TYPE = 0                              ## Memory allocation type info
+    MEM_ALLOC_BASE_PTR = 1                          ## Memory allocation base pointer info
+    MEM_ALLOC_SIZE = 2                              ## Memory allocation size info
+    MEM_ALLOC_DEVICE = 3                            ## Memory allocation device info
+
+class ur_mem_info_t(c_int):
+    def __str__(self):
+        return str(ur_mem_info_v(self.value))
+
+
+###############################################################################
+## @brief Supported device types
+class ur_device_type_v(IntEnum):
+    DEFAULT = 1                                     ## The default device type as preferred by the runtime
+    ALL = 2                                         ## Devices of all types
+    GPU = 3                                         ## Graphics Processing Unit
+    CPU = 4                                         ## Central Processing Unit
+    FPGA = 5                                        ## Field Programmable Gate Array
+    MCA = 6                                         ## Memory Copy Accelerator
+    VPU = 7                                         ## Vision Processing Unit
+
+class ur_device_type_t(c_int):
+    def __str__(self):
+        return str(ur_device_type_v(self.value))
+
+
+###############################################################################
+## @brief Supported device info
+class ur_device_info_v(IntEnum):
+    TYPE = 0                                        ## ::ur_device_type_t: type of the device
+    VENDOR_ID = 1                                   ## uint32_t: vendor Id of the device
+    MAX_COMPUTE_UNITS = 2                           ## uint32_t: the number of compute units
+    MAX_WORK_ITEM_DIMENSIONS = 3                    ## uint32_t: max work item dimensions
+    MAX_WORK_ITEM_SIZES = 4                         ## size_t[]: return an array of max work item sizes
+    MAX_WORK_GROUP_SIZE = 5                         ## size_t: max work group size
+    SINGLE_FP_CONFIG = 6                            ## Return a bit field of ::ur_fp_capability_flags_t: single precision
+                                                    ## floating point capability
+    HALF_FP_CONFIG = 7                              ## Return a bit field of ::ur_fp_capability_flags_t: half precsion
+                                                    ## floating point capability
+    DOUBLE_FP_CONFIG = 8                            ## Return a bit field of ::ur_fp_capability_flags_t: double precision
+                                                    ## floating point capability
+    QUEUE_PROPERTIES = 9                            ## Return a bit field of ::ur_queue_flags_t: command queue properties
+                                                    ## supported by the device
+    PREFERRED_VECTOR_WIDTH_CHAR = 10                ## uint32_t: preferred vector width for char
+    PREFERRED_VECTOR_WIDTH_SHORT = 11               ## uint32_t: preferred vector width for short
+    PREFERRED_VECTOR_WIDTH_INT = 12                 ## uint32_t: preferred vector width for int
+    PREFERRED_VECTOR_WIDTH_LONG = 13                ## uint32_t: preferred vector width for long
+    PREFERRED_VECTOR_WIDTH_FLOAT = 14               ## uint32_t: preferred vector width for float
+    PREFERRED_VECTOR_WIDTH_DOUBLE = 15              ## uint32_t: preferred vector width for double
+    PREFERRED_VECTOR_WIDTH_HALF = 16                ## uint32_t: preferred vector width for half float
+    NATIVE_VECTOR_WIDTH_CHAR = 17                   ## uint32_t: native vector width for char
+    NATIVE_VECTOR_WIDTH_SHORT = 18                  ## uint32_t: native vector width for short
+    NATIVE_VECTOR_WIDTH_INT = 19                    ## uint32_t: native vector width for int
+    NATIVE_VECTOR_WIDTH_LONG = 20                   ## uint32_t: native vector width for long
+    NATIVE_VECTOR_WIDTH_FLOAT = 21                  ## uint32_t: native vector width for float
+    NATIVE_VECTOR_WIDTH_DOUBLE = 22                 ## uint32_t: native vector width for double
+    NATIVE_VECTOR_WIDTH_HALF = 23                   ## uint32_t: native vector width for half float
+    MAX_CLOCK_FREQUENCY = 24                        ## uint32_t: max clock frequency in MHz
+    ADDRESS_BITS = 25                               ## uint32_t: address bits
+    MAX_MEM_ALLOC_SIZE = 26                         ## uint64_t: max memory allocation size
+    IMAGE_SUPPORTED = 27                            ## bool: images are supported
+    MAX_READ_IMAGE_ARGS = 28                        ## uint32_t: max number of image objects arguments of a kernel declared
+                                                    ## with the read_only qualifier
+    MAX_WRITE_IMAGE_ARGS = 29                       ## uint32_t: max number of image objects arguments of a kernel declared
+                                                    ## with the write_only qualifier
+    MAX_READ_WRITE_IMAGE_ARGS = 30                  ## uint32_t: max number of image objects arguments of a kernel declared
+                                                    ## with the read_write qualifier
+    IMAGE2D_MAX_WIDTH = 31                          ## size_t: max width of Image2D object
+    IMAGE2D_MAX_HEIGHT = 32                         ## size_t: max heigh of Image2D object
+    IMAGE3D_MAX_WIDTH = 33                          ## size_t: max width of Image3D object
+    IMAGE3D_MAX_HEIGHT = 34                         ## size_t: max height of Image3D object
+    IMAGE3D_MAX_DEPTH = 35                          ## size_t: max depth of Image3D object
+    IMAGE_MAX_BUFFER_SIZE = 36                      ## size_t: max image buffer size
+    IMAGE_MAX_ARRAR_SIZE = 37                       ## size_t: max image array size
+    MAX_SAMPLERS = 38                               ## uint32_t: max number of samplers that can be used in a kernel
+    MAX_PARAMETER_SIZE = 39                         ## size_t: max size in bytes of all arguments passed to a kernel
+    MEM_BASE_ADDR_ALIGN = 40                        ## uint32_t: memory base address alignment
+    GLOBAL_MEM_CACHE_TYPE = 41                      ## ::ur_device_mem_cache_type_t: global memory cache type
+    GLOBAL_MEM_CACHELINE_SIZE = 42                  ## uint32_t: global memory cache line size in bytes
+    GLOBAL_MEM_CACHE_SIZE = 43                      ## uint64_t: size of global memory cache in bytes
+    GLOBAL_MEM_SIZE = 44                            ## uint64_t: size of global memory in bytes
+    MAX_CONSTANT_BUFFER_SIZE = 45                   ## uint64_t: max constant buffer size in bytes
+    MAX_CONSTANT_ARGS = 46                          ## uint32_t: max number of __const declared arguments in a kernel
+    LOCAL_MEM_TYPE = 47                             ## ::ur_device_local_mem_type_t: local memory type
+    LOCAL_MEM_SIZE = 48                             ## uint64_t: local memory size in bytes
+    ERROR_CORRECTION_SUPPORT = 49                   ## bool: support error correction to gloal and local memory
+    HOST_UNIFIED_MEMORY = 50                        ## bool: unifed host device memory
+    PROFILING_TIMER_RESOLUTION = 51                 ## size_t: profiling timer resolution in nanoseconds
+    ENDIAN_LITTLE = 52                              ## bool: little endian byte order
+    AVAILABLE = 53                                  ## bool: device is available
+    COMPILER_AVAILABLE = 54                         ## bool: device compiler is available
+    LINKER_AVAILABLE = 55                           ## bool: device linker is available
+    EXECUTION_CAPABILITIES = 56                     ## ::ur_device_exec_capability_flags_t: device kernel execution
+                                                    ## capability bit-field
+    QUEUE_ON_DEVICE_PROPERTIES = 57                 ## ::ur_queue_flags_t: device command queue property bit-field
+    QUEUE_ON_HOST_PROPERTIES = 58                   ## ::ur_queue_flags_t: host queue property bit-field
+    BUILT_IN_KERNELS = 59                           ## char[]: a semi-colon separated list of built-in kernels
+    PLATFORM = 60                                   ## ::ur_platform_handle_t: the platform associated with the device
+    REFERENCE_COUNT = 61                            ## uint32_t: reference count
+    IL_VERSION = 62                                 ## char[]: IL version
+    NAME = 63                                       ## char[]: Device name
+    VENDOR = 64                                     ## char[]: Device vendor
+    DRIVER_VERSION = 65                             ## char[]: Driver version
+    PROFILE = 66                                    ## char[]: Device profile
+    VERSION = 67                                    ## char[]: Device version
+    OPENCL_C_VERSION = 68                           ## char[]: OpenCL C version
+    EXTENSIONS = 69                                 ## char[]: Return a space separated list of extension names
+    PRINTF_BUFFER_SIZE = 70                         ## size_t: Maximum size in bytes of internal printf buffer
+    PREFERRED_INTEROP_USER_SYNC = 71                ## bool: prefer user synchronization when sharing object with other API
+    PARENT_DEVICE = 72                              ## ::ur_device_handle_t: return parent device handle
+    PARTITION_PROPERTIES = 73                       ## uint32_t: return a bit-field of partition properties
+                                                    ## ::ur_device_partition_property_flags_t
+    PARTITION_MAX_SUB_DEVICES = 74                  ## uint32_t: maximum number of sub-devices when the device is partitioned
+    PARTITION_AFFINITY_DOMAIN = 75                  ## uint32_t: return a bit-field of affinity domain
+                                                    ## ::ur_device_affinity_domain_flags_t
+    PARTITION_TYPE = 76                             ## uint32_t: return a bit-field of ::ur_device_partition_property_flags_t
+                                                    ## for properties specified in ::urDevicePartition
+    MAX_NUM_SUB_GROUPS = 77                         ## uint32_t: max number of sub groups
+    SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 78     ## bool: support sub group independent forward progress
+    SUB_GROUP_SIZES_INTEL = 79                      ## uint32_t[]: return an array of sub group sizes supported on Intel
+                                                    ## device
+    USM_HOST_SUPPORT = 80                           ## bool: support USM host memory access
+    USM_DEVICE_SUPPORT = 81                         ## bool: support USM device memory access
+    USM_SINGLE_SHARED_SUPPORT = 82                  ## bool: support USM single device shared memory access
+    USM_CROSS_SHARED_SUPPORT = 83                   ## bool: support USM cross device shared memory access
+    USM_SYSTEM_SHARED_SUPPORT = 84                  ## bool: support USM system wide shared memory access
+    UUID = 85                                       ## char[]: return device UUID
+    PCI_ADDRESS = 86                                ## char[]: return device PCI address
+    GPU_EU_COUNT = 87                               ## uint32_t: return Intel GPU EU count
+    GPU_EU_SIMD_WIDTH = 88                          ## uint32_t: return Intel GPU EU SIMD width
+    GPU_EU_SLICES = 89                              ## uint32_t: return Intel GPU number of slices
+    GPU_SUBSLICES_PER_SLICE = 90                    ## uint32_t: return Intel GPU number of subslices per slice
+    MAX_MEMORY_BANDWIDTH = 91                       ## uint32_t: return max memory bandwidth in Mb/s
+    IMAGE_SRGB = 92                                 ## bool: image is SRGB
+    ATOMIC_64 = 93                                  ## bool: support 64 bit atomics
+    ATOMIC_MEMORY_ORDER_CAPABILITIES = 94           ## uint32_t: atomics memory order capabilities
+
+class ur_device_info_t(c_int):
+    def __str__(self):
+        return str(ur_device_info_v(self.value))
+
+
+###############################################################################
+## @brief Device partition property
+class ur_device_partition_property_flags_v(IntEnum):
+    EQUALLY = UR_BIT(0)                             ## Support equal partition
+    BY_COUNTS = UR_BIT(1)                           ## Support partition by count
+    BY_AFFINITY_DOMAIN = UR_BIT(2)                  ## Support partition by affinity domain
+
+class ur_device_partition_property_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Partition property value
+class ur_device_partition_property_value_t(Structure):
+    _fields_ = [
+        ("property", ur_device_partition_property_flags_t),             ## [in] device partition property flags
+        ("value", c_ulong)                                              ## [in] partition value
+    ]
+
+###############################################################################
+## @brief FP capabilities
+class ur_fp_capability_flags_v(IntEnum):
+    CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0)       ## Support correctly rounded divide and sqrt
+    ROUND_TO_NEAREST = UR_BIT(1)                    ## Support round to nearest
+    ROUND_TO_ZERO = UR_BIT(2)                       ## Support round to zero
+    ROUND_TO_INF = UR_BIT(3)                        ## Support round to infinity
+    INF_NAN = UR_BIT(4)                             ## Support INF to NAN
+    DENORM = UR_BIT(5)                              ## Support denorm
+    FMA = UR_BIT(6)                                 ## Support FMA
+
+class ur_fp_capability_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device memory cache type
+class ur_device_mem_cache_type_v(IntEnum):
+    NONE = 0                                        ## Has none cache
+    READ_ONLY_CACHE = 1                             ## Has read only cache
+    READ_WRITE_CACHE = 2                            ## Has read write cache
+
+class ur_device_mem_cache_type_t(c_int):
+    def __str__(self):
+        return str(ur_device_mem_cache_type_v(self.value))
+
+
+###############################################################################
+## @brief Device local memory type
+class ur_device_local_mem_type_v(IntEnum):
+    LOCAL = 0                                       ## Dedicated local memory
+    GLOBAL = 1                                      ## Global memory
+
+class ur_device_local_mem_type_t(c_int):
+    def __str__(self):
+        return str(ur_device_local_mem_type_v(self.value))
+
+
+###############################################################################
+## @brief Device kernel execution capability
+class ur_device_exec_capability_flags_v(IntEnum):
+    KERNEL = UR_BIT(0)                              ## Support kernel execution
+    NATIVE_KERNEL = UR_BIT(1)                       ## Support native kernel execution
+
+class ur_device_exec_capability_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Device affinity domain
+class ur_device_affinity_domain_flags_v(IntEnum):
+    NUMA = UR_BIT(0)                                ## By NUMA
+    NEXT_PARTITIONABLE = UR_BIT(1)                  ## BY next partitionable
+
+class ur_device_affinity_domain_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Get Kernel object information
+class ur_kernel_info_v(IntEnum):
+    FUNCTION_NAME = 0                               ## Return Kernel function name, return type char[]
+    NUM_ARGS = 1                                    ## Return Kernel number of arguments
+    REFERENCE_COUNT = 2                             ## Return Kernel reference count
+    CONTEXT = 3                                     ## Return Context object associated with Kernel
+    PROGRAM = 4                                     ## Return Program object associated with Kernel
+    ATTRIBUTES = 5                                  ## Return Kernel attributes, return type char[]
+
+class ur_kernel_info_t(c_int):
+    def __str__(self):
+        return str(ur_kernel_info_v(self.value))
+
+
+###############################################################################
+## @brief Get Kernel Work Group information
+class ur_kernel_group_info_v(IntEnum):
+    GLOBAL_WORK_SIZE = 0                            ## Return Work Group maximum global size, return type size_t[3]
+    WORK_GROUP_SIZE = 1                             ## Return maximum Work Group size, return type size_t
+    COMPILE_WORK_GROUP_SIZE = 2                     ## Return Work Group size required by the source code, such as
+                                                    ## __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]
+    LOCAL_MEM_SIZE = 3                              ## Return local memory required by the Kernel, return type size_t
+    PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4          ## Return preferred multiple of Work Group size for launch, return type
+                                                    ## size_t
+    PRIVATE_MEM_SIZE = 5                            ## Return minimum amount of private memory in bytes used by each work
+                                                    ## item in the Kernel, return type size_t
+
+class ur_kernel_group_info_t(c_int):
+    def __str__(self):
+        return str(ur_kernel_group_info_v(self.value))
+
+
+###############################################################################
+## @brief Get Kernel SubGroup information
+class ur_kernel_sub_group_info_v(IntEnum):
+    MAX_SUB_GROUP_SIZE = 0                          ## Return maximum SubGroup size, return type uint32_t
+    MAX_NUM_SUB_GROUPS = 1                          ## Return maximum number of SubGroup, return type uint32_t
+    COMPILE_NUM_SUB_GROUPS = 2                      ## Return number of SubGroup required by the source code, return type
+                                                    ## uint32_t
+    SUB_GROUP_SIZE_INTEL = 3                        ## Return SubGroup size required by Intel, return type uint32_t
+
+class ur_kernel_sub_group_info_t(c_int):
+    def __str__(self):
+        return str(ur_kernel_sub_group_info_v(self.value))
+
+
+###############################################################################
+## @brief Set additional Kernel execution information
+class ur_kernel_exec_info_v(IntEnum):
+    USM_INDIRECT_ACCESS = 0                         ## Kernel might access data through USM pointer, type bool_t*
+    USM_PTRS = 1                                    ## Provide an explicit list of USM pointers that the kernel will access,
+                                                    ## type void*[].
+
+class ur_kernel_exec_info_t(c_int):
+    def __str__(self):
+        return str(ur_kernel_exec_info_v(self.value))
+
+
+###############################################################################
+## @brief Supported platform info
+class ur_platform_info_v(IntEnum):
+    NAME = 1                                        ## [char*] The string denoting name of the platform. The size of the info
+                                                    ## needs to be dynamically queried.
+    VENDOR_NAME = 2                                 ## [char*] The string denoting name of the vendor of the platform. The
+                                                    ## size of the info needs to be dynamically queried.
+    VERSION = 3                                     ## [char*] The string denoting the version of the platform. The size of
+                                                    ## the info needs to be dynamically queried.
+    EXTENSIONS = 4                                  ## [char*] The string denoting extensions supported by the platform. The
+                                                    ## size of the info needs to be dynamically queried.
+    PROFILE = 5                                     ## [char*] The string denoting profile of the platform. The size of the
+                                                    ## info needs to be dynamically queried.
+
+class ur_platform_info_t(c_int):
+    def __str__(self):
+        return str(ur_platform_info_v(self.value))
+
+
+###############################################################################
+## @brief Supported API versions
+## 
+## @details
+##     - API versions contain major and minor attributes, use
+##       ::UR_MAJOR_VERSION and ::UR_MINOR_VERSION
+class ur_api_version_v(IntEnum):
+    _0_9 = UR_MAKE_VERSION( 0, 9 )                  ## version 0.9
+    CURRENT = UR_MAKE_VERSION( 0, 9 )               ## latest known version
+
+class ur_api_version_t(c_int):
+    def __str__(self):
+        return str(ur_api_version_v(self.value))
+
+
+###############################################################################
+## @brief Get Program object information
+class ur_program_info_v(IntEnum):
+    REFERENCE_COUNT = 0                             ## Program reference count info
+    CONTEXT = 1                                     ## Program context info
+    NUM_DEVICES = 2                                 ## Return number of devices associated with Program
+    DEVICES = 3                                     ## Return list of devices associated with Program, return type
+                                                    ## uint32_t[].
+    SOURCE = 4                                      ## Return program source associated with Program, return type char[].
+    BINARY_SIZES = 5                                ## Return program binary sizes for each device, return type size_t[].
+    BINARIES = 6                                    ## Return program binaries for all devices for this Program, return type
+                                                    ## uchar[].
+    NUM_KERNELS = 7                                 ## Number of kernels in Program, return type size_t
+    KERNEL_NAMES = 8                                ## Return a semi-colon separated list of kernel names in Program, return
+                                                    ## type char[]
+
+class ur_program_info_t(c_int):
+    def __str__(self):
+        return str(ur_program_info_v(self.value))
+
+
+###############################################################################
+## @brief Program object build status
+class ur_program_build_status_v(IntEnum):
+    NONE = 0                                        ## Program build status none
+    ERROR = 1                                       ## Program build error
+    SUCCESS = 2                                     ## Program build success
+    IN_PROGRESS = 3                                 ## Program build in progress
+
+class ur_program_build_status_t(c_int):
+    def __str__(self):
+        return str(ur_program_build_status_v(self.value))
+
+
+###############################################################################
+## @brief Program object binary type
+class ur_program_binary_type_v(IntEnum):
+    NONE = 0                                        ## No program binary is associated with device
+    COMPILED_OBJECT = 1                             ## Program binary is compiled object
+    LIBRARY = 2                                     ## Program binary is library object
+    EXECUTABLE = 3                                  ## Program binary is executable
+
+class ur_program_binary_type_t(c_int):
+    def __str__(self):
+        return str(ur_program_binary_type_v(self.value))
+
+
+###############################################################################
+## @brief Get Program object build information
+class ur_program_build_info_v(IntEnum):
+    STATUS = 0                                      ## Program build status, return type ::ur_program_build_status_t
+    OPTIONS = 1                                     ## Program build options, return type char[]
+    LOG = 2                                         ## Program build log, return type char[]
+    BINARY_TYPE = 3                                 ## Program binary type, return type ::ur_program_binary_type_t
+
+class ur_program_build_info_t(c_int):
+    def __str__(self):
+        return str(ur_program_build_info_v(self.value))
+
+
+###############################################################################
+## @brief Supported platform initialization flags
+class ur_platform_init_flags_v(IntEnum):
+    LEVEL_ZERO = UR_BIT(0)                          ## initialize Unified Runtime platform drivers
+
+class ur_platform_init_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported device initialization flags
+class ur_device_init_flags_v(IntEnum):
+    GPU = UR_BIT(0)                                 ## initialize GPU device drivers
+
+class ur_device_init_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+__use_win_types = "Windows" == platform.uname()[0]
+
+###############################################################################
+## @brief Function-pointer for urPlatformGet
+if __use_win_types:
+    _urPlatformGet_t = WINFUNCTYPE( ur_result_t, POINTER(c_ulong), POINTER(ur_platform_handle_t) )
+else:
+    _urPlatformGet_t = CFUNCTYPE( ur_result_t, POINTER(c_ulong), POINTER(ur_platform_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urPlatformGetInfo
+if __use_win_types:
+    _urPlatformGetInfo_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_platform_info_t, POINTER(c_size_t), c_void_p )
+else:
+    _urPlatformGetInfo_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_platform_info_t, POINTER(c_size_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urPlatformGetNativeHandle
+if __use_win_types:
+    _urPlatformGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urPlatformGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urPlatformCreateWithNativeHandle
+if __use_win_types:
+    _urPlatformCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_platform_handle_t) )
+else:
+    _urPlatformCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_platform_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urPlatformGetApiVersion
+if __use_win_types:
+    _urPlatformGetApiVersion_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(ur_api_version_t) )
+else:
+    _urPlatformGetApiVersion_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(ur_api_version_t) )
+
+
+###############################################################################
+## @brief Table of Platform functions pointers
+class _ur_platform_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGet", c_void_p),                                           ## _urPlatformGet_t
+        ("pfnGetInfo", c_void_p),                                       ## _urPlatformGetInfo_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urPlatformGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p),                        ## _urPlatformCreateWithNativeHandle_t
+        ("pfnGetApiVersion", c_void_p)                                  ## _urPlatformGetApiVersion_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urContextCreate
+if __use_win_types:
+    _urContextCreate_t = WINFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_handle_t) )
+else:
+    _urContextCreate_t = CFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urContextGetReference
+if __use_win_types:
+    _urContextGetReference_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t )
+else:
+    _urContextGetReference_t = CFUNCTYPE( ur_result_t, ur_context_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urContextRelease
+if __use_win_types:
+    _urContextRelease_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t )
+else:
+    _urContextRelease_t = CFUNCTYPE( ur_result_t, ur_context_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urContextGetInfo
+if __use_win_types:
+    _urContextGetInfo_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_context_info_t, POINTER(c_size_t), c_void_p )
+else:
+    _urContextGetInfo_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_context_info_t, POINTER(c_size_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urContextGetNativeHandle
+if __use_win_types:
+    _urContextGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urContextGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urContextCreateWithNativeHandle
+if __use_win_types:
+    _urContextCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_context_handle_t) )
+else:
+    _urContextCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_context_handle_t) )
+
+
+###############################################################################
+## @brief Table of Context functions pointers
+class _ur_context_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _urContextCreate_t
+        ("pfnGetReference", c_void_p),                                  ## _urContextGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urContextRelease_t
+        ("pfnGetInfo", c_void_p),                                       ## _urContextGetInfo_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urContextGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urContextCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urEventCreate
+if __use_win_types:
+    _urEventCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_event_handle_t) )
+else:
+    _urEventCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEventGetInfo
+if __use_win_types:
+    _urEventGetInfo_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t, ur_event_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urEventGetInfo_t = CFUNCTYPE( ur_result_t, ur_event_handle_t, ur_event_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for urEventGetProfilingInfo
+if __use_win_types:
+    _urEventGetProfilingInfo_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t, ur_profiling_info_t, c_size_t, c_void_p, c_size_t )
+else:
+    _urEventGetProfilingInfo_t = CFUNCTYPE( ur_result_t, ur_event_handle_t, ur_profiling_info_t, c_size_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for urEventWait
+if __use_win_types:
+    _urEventWait_t = WINFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_event_handle_t) )
+else:
+    _urEventWait_t = CFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEventGetReference
+if __use_win_types:
+    _urEventGetReference_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t )
+else:
+    _urEventGetReference_t = CFUNCTYPE( ur_result_t, ur_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urEventRelease
+if __use_win_types:
+    _urEventRelease_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t )
+else:
+    _urEventRelease_t = CFUNCTYPE( ur_result_t, ur_event_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urEventGetNativeHandle
+if __use_win_types:
+    _urEventGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urEventGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_event_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEventCreateWithNativeHandle
+if __use_win_types:
+    _urEventCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_event_handle_t) )
+else:
+    _urEventCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_event_handle_t) )
+
+
+###############################################################################
+## @brief Table of Event functions pointers
+class _ur_event_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _urEventCreate_t
+        ("pfnGetInfo", c_void_p),                                       ## _urEventGetInfo_t
+        ("pfnGetProfilingInfo", c_void_p),                              ## _urEventGetProfilingInfo_t
+        ("pfnWait", c_void_p),                                          ## _urEventWait_t
+        ("pfnGetReference", c_void_p),                                  ## _urEventGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urEventRelease_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urEventGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urEventCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urProgramCreate
+if __use_win_types:
+    _urProgramCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_module_handle_t), c_char_p, POINTER(ur_program_handle_t) )
+else:
+    _urProgramCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_module_handle_t), c_char_p, POINTER(ur_program_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urProgramCreateWithBinary
+if __use_win_types:
+    _urProgramCreateWithBinary_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte), POINTER(ur_program_handle_t) )
+else:
+    _urProgramCreateWithBinary_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte), POINTER(ur_program_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urProgramGetReference
+if __use_win_types:
+    _urProgramGetReference_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t )
+else:
+    _urProgramGetReference_t = CFUNCTYPE( ur_result_t, ur_program_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urProgramRelease
+if __use_win_types:
+    _urProgramRelease_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t )
+else:
+    _urProgramRelease_t = CFUNCTYPE( ur_result_t, ur_program_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urProgramGetFunctionPointer
+if __use_win_types:
+    _urProgramGetFunctionPointer_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, ur_program_handle_t, c_char_p, POINTER(c_void_p) )
+else:
+    _urProgramGetFunctionPointer_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, ur_program_handle_t, c_char_p, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urProgramGetInfo
+if __use_win_types:
+    _urProgramGetInfo_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t, ur_program_info_t, POINTER(c_size_t), c_void_p )
+else:
+    _urProgramGetInfo_t = CFUNCTYPE( ur_result_t, ur_program_handle_t, ur_program_info_t, POINTER(c_size_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urProgramGetBuildInfo
+if __use_win_types:
+    _urProgramGetBuildInfo_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t, ur_device_handle_t, ur_program_build_info_t, POINTER(c_size_t), c_void_p )
+else:
+    _urProgramGetBuildInfo_t = CFUNCTYPE( ur_result_t, ur_program_handle_t, ur_device_handle_t, ur_program_build_info_t, POINTER(c_size_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urProgramSetSpecializationConstant
+if __use_win_types:
+    _urProgramSetSpecializationConstant_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t, c_ulong, c_size_t, c_void_p )
+else:
+    _urProgramSetSpecializationConstant_t = CFUNCTYPE( ur_result_t, ur_program_handle_t, c_ulong, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urProgramGetNativeHandle
+if __use_win_types:
+    _urProgramGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urProgramGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_program_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urProgramCreateWithNativeHandle
+if __use_win_types:
+    _urProgramCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t, ur_native_handle_t, POINTER(ur_program_handle_t) )
+else:
+    _urProgramCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_program_handle_t, ur_native_handle_t, POINTER(ur_program_handle_t) )
+
+
+###############################################################################
+## @brief Table of Program functions pointers
+class _ur_program_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _urProgramCreate_t
+        ("pfnCreateWithBinary", c_void_p),                              ## _urProgramCreateWithBinary_t
+        ("pfnGetReference", c_void_p),                                  ## _urProgramGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urProgramRelease_t
+        ("pfnGetFunctionPointer", c_void_p),                            ## _urProgramGetFunctionPointer_t
+        ("pfnGetInfo", c_void_p),                                       ## _urProgramGetInfo_t
+        ("pfnGetBuildInfo", c_void_p),                                  ## _urProgramGetBuildInfo_t
+        ("pfnSetSpecializationConstant", c_void_p),                     ## _urProgramSetSpecializationConstant_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urProgramGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urProgramCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urModuleCreate
+if __use_win_types:
+    _urModuleCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_ulong, c_char_p, POINTER(c_void_p), c_void_p, POINTER(ur_module_handle_t) )
+else:
+    _urModuleCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_ulong, c_char_p, POINTER(c_void_p), c_void_p, POINTER(ur_module_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urModuleGetReference
+if __use_win_types:
+    _urModuleGetReference_t = WINFUNCTYPE( ur_result_t, ur_module_handle_t )
+else:
+    _urModuleGetReference_t = CFUNCTYPE( ur_result_t, ur_module_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urModuleRelease
+if __use_win_types:
+    _urModuleRelease_t = WINFUNCTYPE( ur_result_t, ur_module_handle_t )
+else:
+    _urModuleRelease_t = CFUNCTYPE( ur_result_t, ur_module_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urModuleGetNativeHandle
+if __use_win_types:
+    _urModuleGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_module_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urModuleGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_module_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urModuleCreateWithNativeHandle
+if __use_win_types:
+    _urModuleCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_module_handle_t) )
+else:
+    _urModuleCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_module_handle_t) )
+
+
+###############################################################################
+## @brief Table of Module functions pointers
+class _ur_module_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _urModuleCreate_t
+        ("pfnGetReference", c_void_p),                                  ## _urModuleGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urModuleRelease_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urModuleGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urModuleCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urKernelCreate
+if __use_win_types:
+    _urKernelCreate_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t, c_char_p, POINTER(ur_kernel_handle_t) )
+else:
+    _urKernelCreate_t = CFUNCTYPE( ur_result_t, ur_program_handle_t, c_char_p, POINTER(ur_kernel_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urKernelGetInfo
+if __use_win_types:
+    _urKernelGetInfo_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_kernel_info_t, POINTER(c_size_t), c_void_p )
+else:
+    _urKernelGetInfo_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_kernel_info_t, POINTER(c_size_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urKernelGetGroupInfo
+if __use_win_types:
+    _urKernelGetGroupInfo_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_device_handle_t, ur_kernel_group_info_t, c_size_t, c_void_p )
+else:
+    _urKernelGetGroupInfo_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_device_handle_t, ur_kernel_group_info_t, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urKernelGetSubGroupInfo
+if __use_win_types:
+    _urKernelGetSubGroupInfo_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_device_handle_t, ur_kernel_sub_group_info_t, c_size_t, c_void_p )
+else:
+    _urKernelGetSubGroupInfo_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_device_handle_t, ur_kernel_sub_group_info_t, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urKernelGetReference
+if __use_win_types:
+    _urKernelGetReference_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t )
+else:
+    _urKernelGetReference_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urKernelRelease
+if __use_win_types:
+    _urKernelRelease_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t )
+else:
+    _urKernelRelease_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urKernelGetNativeHandle
+if __use_win_types:
+    _urKernelGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urKernelGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urKernelCreateWithNativeHandle
+if __use_win_types:
+    _urKernelCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_kernel_handle_t) )
+else:
+    _urKernelCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_kernel_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urKernelSetArg
+if __use_win_types:
+    _urKernelSetArg_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, c_size_t, c_void_p )
+else:
+    _urKernelSetArg_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urKernelSetArgPointer
+if __use_win_types:
+    _urKernelSetArgPointer_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, c_size_t, c_void_p )
+else:
+    _urKernelSetArgPointer_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urKernelSetExecInfo
+if __use_win_types:
+    _urKernelSetExecInfo_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_kernel_exec_info_t, c_size_t, c_void_p )
+else:
+    _urKernelSetExecInfo_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_kernel_exec_info_t, c_size_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urKernelSetArgSampler
+if __use_win_types:
+    _urKernelSetArgSampler_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, ur_sampler_handle_t )
+else:
+    _urKernelSetArgSampler_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, ur_sampler_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urKernelSetArgMemObj
+if __use_win_types:
+    _urKernelSetArgMemObj_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, ur_mem_handle_t )
+else:
+    _urKernelSetArgMemObj_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, c_ulong, ur_mem_handle_t )
+
+
+###############################################################################
+## @brief Table of Kernel functions pointers
+class _ur_kernel_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _urKernelCreate_t
+        ("pfnGetInfo", c_void_p),                                       ## _urKernelGetInfo_t
+        ("pfnGetGroupInfo", c_void_p),                                  ## _urKernelGetGroupInfo_t
+        ("pfnGetSubGroupInfo", c_void_p),                               ## _urKernelGetSubGroupInfo_t
+        ("pfnGetReference", c_void_p),                                  ## _urKernelGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urKernelRelease_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urKernelGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p),                        ## _urKernelCreateWithNativeHandle_t
+        ("pfnSetArg", c_void_p),                                        ## _urKernelSetArg_t
+        ("pfnSetArgPointer", c_void_p),                                 ## _urKernelSetArgPointer_t
+        ("pfnSetExecInfo", c_void_p),                                   ## _urKernelSetExecInfo_t
+        ("pfnSetArgSampler", c_void_p),                                 ## _urKernelSetArgSampler_t
+        ("pfnSetArgMemObj", c_void_p)                                   ## _urKernelSetArgMemObj_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urSamplerCreate
+if __use_win_types:
+    _urSamplerCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_value_t), POINTER(ur_sampler_handle_t) )
+else:
+    _urSamplerCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_value_t), POINTER(ur_sampler_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urSamplerGetReference
+if __use_win_types:
+    _urSamplerGetReference_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t )
+else:
+    _urSamplerGetReference_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urSamplerRelease
+if __use_win_types:
+    _urSamplerRelease_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t )
+else:
+    _urSamplerRelease_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urSamplerGetInfo
+if __use_win_types:
+    _urSamplerGetInfo_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t, ur_sampler_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urSamplerGetInfo_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t, ur_sampler_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for urSamplerGetNativeHandle
+if __use_win_types:
+    _urSamplerGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urSamplerGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urSamplerCreateWithNativeHandle
+if __use_win_types:
+    _urSamplerCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t, ur_native_handle_t, POINTER(ur_sampler_handle_t) )
+else:
+    _urSamplerCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t, ur_native_handle_t, POINTER(ur_sampler_handle_t) )
+
+
+###############################################################################
+## @brief Table of Sampler functions pointers
+class _ur_sampler_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreate", c_void_p),                                        ## _urSamplerCreate_t
+        ("pfnGetReference", c_void_p),                                  ## _urSamplerGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urSamplerRelease_t
+        ("pfnGetInfo", c_void_p),                                       ## _urSamplerGetInfo_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urSamplerGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urSamplerCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urMemImageCreate
+if __use_win_types:
+    _urMemImageCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), c_void_p, POINTER(ur_mem_handle_t) )
+else:
+    _urMemImageCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), c_void_p, POINTER(ur_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urMemBufferCreate
+if __use_win_types:
+    _urMemBufferCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, c_void_p, POINTER(ur_mem_handle_t) )
+else:
+    _urMemBufferCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, c_void_p, POINTER(ur_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urMemGetReference
+if __use_win_types:
+    _urMemGetReference_t = WINFUNCTYPE( ur_result_t, ur_mem_handle_t )
+else:
+    _urMemGetReference_t = CFUNCTYPE( ur_result_t, ur_mem_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urMemRelease
+if __use_win_types:
+    _urMemRelease_t = WINFUNCTYPE( ur_result_t, ur_mem_handle_t )
+else:
+    _urMemRelease_t = CFUNCTYPE( ur_result_t, ur_mem_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urMemBufferPartition
+if __use_win_types:
+    _urMemBufferPartition_t = WINFUNCTYPE( ur_result_t, ur_mem_handle_t, ur_mem_flags_t, ur_buffer_create_type_t, POINTER(ur_buffer_region_t), POINTER(ur_mem_handle_t) )
+else:
+    _urMemBufferPartition_t = CFUNCTYPE( ur_result_t, ur_mem_handle_t, ur_mem_flags_t, ur_buffer_create_type_t, POINTER(ur_buffer_region_t), POINTER(ur_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urMemGetNativeHandle
+if __use_win_types:
+    _urMemGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_mem_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urMemGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_mem_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urMemCreateWithNativeHandle
+if __use_win_types:
+    _urMemCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_mem_handle_t) )
+else:
+    _urMemCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urMemFree
+if __use_win_types:
+    _urMemFree_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+else:
+    _urMemFree_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urMemGetMemAllocInfo
+if __use_win_types:
+    _urMemGetMemAllocInfo_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_mem_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urMemGetMemAllocInfo_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_mem_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+
+
+###############################################################################
+## @brief Table of Mem functions pointers
+class _ur_mem_dditable_t(Structure):
+    _fields_ = [
+        ("pfnImageCreate", c_void_p),                                   ## _urMemImageCreate_t
+        ("pfnBufferCreate", c_void_p),                                  ## _urMemBufferCreate_t
+        ("pfnGetReference", c_void_p),                                  ## _urMemGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urMemRelease_t
+        ("pfnBufferPartition", c_void_p),                               ## _urMemBufferPartition_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urMemGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p),                        ## _urMemCreateWithNativeHandle_t
+        ("pfnFree", c_void_p),                                          ## _urMemFree_t
+        ("pfnGetMemAllocInfo", c_void_p)                                ## _urMemGetMemAllocInfo_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urEnqueueKernelLaunch
+if __use_win_types:
+    _urEnqueueKernelLaunch_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueKernelLaunch_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueEventsWait
+if __use_win_types:
+    _urEnqueueEventsWait_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueEventsWait_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueEventsWaitWithBarrier
+if __use_win_types:
+    _urEnqueueEventsWaitWithBarrier_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueEventsWaitWithBarrier_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferRead
+if __use_win_types:
+    _urEnqueueMemBufferRead_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferRead_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferWrite
+if __use_win_types:
+    _urEnqueueMemBufferWrite_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferWrite_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferReadRect
+if __use_win_types:
+    _urEnqueueMemBufferReadRect_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferReadRect_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferWriteRect
+if __use_win_types:
+    _urEnqueueMemBufferWriteRect_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferWriteRect_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferCopy
+if __use_win_types:
+    _urEnqueueMemBufferCopy_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferCopy_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferCopyRect
+if __use_win_types:
+    _urEnqueueMemBufferCopyRect_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferCopyRect_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferFill
+if __use_win_types:
+    _urEnqueueMemBufferFill_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, c_void_p, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemBufferFill_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, c_void_p, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemImageRead
+if __use_win_types:
+    _urEnqueueMemImageRead_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemImageRead_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemImageWrite
+if __use_win_types:
+    _urEnqueueMemImageWrite_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemImageWrite_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemImageCopy
+if __use_win_types:
+    _urEnqueueMemImageCopy_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemImageCopy_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemBufferMap
+if __use_win_types:
+    _urEnqueueMemBufferMap_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_map_flags_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t), POINTER(c_void_p) )
+else:
+    _urEnqueueMemBufferMap_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, bool, ur_map_flags_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t), POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueMemUnmap
+if __use_win_types:
+    _urEnqueueMemUnmap_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueMemUnmap_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueUSMMemset
+if __use_win_types:
+    _urEnqueueUSMMemset_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_int8_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueUSMMemset_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_int8_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueUSMMemcpy
+if __use_win_types:
+    _urEnqueueUSMMemcpy_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, bool, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueUSMMemcpy_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, bool, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueUSMPrefetch
+if __use_win_types:
+    _urEnqueueUSMPrefetch_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_migration_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueUSMPrefetch_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_migration_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueUSMMemAdvice
+if __use_win_types:
+    _urEnqueueUSMMemAdvice_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_mem_advice_t, POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueUSMMemAdvice_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_mem_advice_t, POINTER(ur_event_handle_t) )
+
+
+###############################################################################
+## @brief Table of Enqueue functions pointers
+class _ur_enqueue_dditable_t(Structure):
+    _fields_ = [
+        ("pfnKernelLaunch", c_void_p),                                  ## _urEnqueueKernelLaunch_t
+        ("pfnEventsWait", c_void_p),                                    ## _urEnqueueEventsWait_t
+        ("pfnEventsWaitWithBarrier", c_void_p),                         ## _urEnqueueEventsWaitWithBarrier_t
+        ("pfnMemBufferRead", c_void_p),                                 ## _urEnqueueMemBufferRead_t
+        ("pfnMemBufferWrite", c_void_p),                                ## _urEnqueueMemBufferWrite_t
+        ("pfnMemBufferReadRect", c_void_p),                             ## _urEnqueueMemBufferReadRect_t
+        ("pfnMemBufferWriteRect", c_void_p),                            ## _urEnqueueMemBufferWriteRect_t
+        ("pfnMemBufferCopy", c_void_p),                                 ## _urEnqueueMemBufferCopy_t
+        ("pfnMemBufferCopyRect", c_void_p),                             ## _urEnqueueMemBufferCopyRect_t
+        ("pfnMemBufferFill", c_void_p),                                 ## _urEnqueueMemBufferFill_t
+        ("pfnMemImageRead", c_void_p),                                  ## _urEnqueueMemImageRead_t
+        ("pfnMemImageWrite", c_void_p),                                 ## _urEnqueueMemImageWrite_t
+        ("pfnMemImageCopy", c_void_p),                                  ## _urEnqueueMemImageCopy_t
+        ("pfnMemBufferMap", c_void_p),                                  ## _urEnqueueMemBufferMap_t
+        ("pfnMemUnmap", c_void_p),                                      ## _urEnqueueMemUnmap_t
+        ("pfnUSMMemset", c_void_p),                                     ## _urEnqueueUSMMemset_t
+        ("pfnUSMMemcpy", c_void_p),                                     ## _urEnqueueUSMMemcpy_t
+        ("pfnUSMPrefetch", c_void_p),                                   ## _urEnqueueUSMPrefetch_t
+        ("pfnUSMMemAdvice", c_void_p)                                   ## _urEnqueueUSMMemAdvice_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urUSMHostAlloc
+if __use_win_types:
+    _urUSMHostAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_mem_flags_t), c_size_t, c_ulong, POINTER(c_void_p) )
+else:
+    _urUSMHostAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_mem_flags_t), c_size_t, c_ulong, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urUSMDeviceAlloc
+if __use_win_types:
+    _urUSMDeviceAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_mem_flags_t), c_size_t, c_ulong, POINTER(c_void_p) )
+else:
+    _urUSMDeviceAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_mem_flags_t), c_size_t, c_ulong, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urUSMSharedAlloc
+if __use_win_types:
+    _urUSMSharedAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_mem_flags_t), c_size_t, c_ulong, POINTER(c_void_p) )
+else:
+    _urUSMSharedAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_mem_flags_t), c_size_t, c_ulong, POINTER(c_void_p) )
+
+
+###############################################################################
+## @brief Table of USM functions pointers
+class _ur_usm_dditable_t(Structure):
+    _fields_ = [
+        ("pfnHostAlloc", c_void_p),                                     ## _urUSMHostAlloc_t
+        ("pfnDeviceAlloc", c_void_p),                                   ## _urUSMDeviceAlloc_t
+        ("pfnSharedAlloc", c_void_p)                                    ## _urUSMSharedAlloc_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urTearDown
+if __use_win_types:
+    _urTearDown_t = WINFUNCTYPE( ur_result_t, c_void_p )
+else:
+    _urTearDown_t = CFUNCTYPE( ur_result_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urInit
+if __use_win_types:
+    _urInit_t = WINFUNCTYPE( ur_result_t, ur_platform_init_flags_t, ur_device_init_flags_t )
+else:
+    _urInit_t = CFUNCTYPE( ur_result_t, ur_platform_init_flags_t, ur_device_init_flags_t )
+
+
+###############################################################################
+## @brief Table of Global functions pointers
+class _ur_global_dditable_t(Structure):
+    _fields_ = [
+        ("pfnTearDown", c_void_p),                                      ## _urTearDown_t
+        ("pfnInit", c_void_p)                                           ## _urInit_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urQueueGetInfo
+if __use_win_types:
+    _urQueueGetInfo_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_queue_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urQueueGetInfo_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_queue_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for urQueueCreate
+if __use_win_types:
+    _urQueueCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, ur_queue_flags_t, POINTER(ur_queue_handle_t) )
+else:
+    _urQueueCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, ur_queue_flags_t, POINTER(ur_queue_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urQueueGetReference
+if __use_win_types:
+    _urQueueGetReference_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t )
+else:
+    _urQueueGetReference_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urQueueRelease
+if __use_win_types:
+    _urQueueRelease_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t )
+else:
+    _urQueueRelease_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urQueueGetNativeHandle
+if __use_win_types:
+    _urQueueGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urQueueGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urQueueCreateWithNativeHandle
+if __use_win_types:
+    _urQueueCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_native_handle_t, POINTER(ur_queue_handle_t) )
+else:
+    _urQueueCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_native_handle_t, POINTER(ur_queue_handle_t) )
+
+
+###############################################################################
+## @brief Table of Queue functions pointers
+class _ur_queue_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGetInfo", c_void_p),                                       ## _urQueueGetInfo_t
+        ("pfnCreate", c_void_p),                                        ## _urQueueCreate_t
+        ("pfnGetReference", c_void_p),                                  ## _urQueueGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urQueueRelease_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urQueueGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urQueueCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urDeviceGet
+if __use_win_types:
+    _urDeviceGet_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_device_type_t, POINTER(c_ulong), POINTER(ur_device_handle_t) )
+else:
+    _urDeviceGet_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_device_type_t, POINTER(c_ulong), POINTER(ur_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urDeviceGetInfo
+if __use_win_types:
+    _urDeviceGetInfo_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, ur_device_info_t, POINTER(c_size_t), c_void_p )
+else:
+    _urDeviceGetInfo_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, ur_device_info_t, POINTER(c_size_t), c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urDeviceGetReference
+if __use_win_types:
+    _urDeviceGetReference_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t )
+else:
+    _urDeviceGetReference_t = CFUNCTYPE( ur_result_t, ur_device_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urDeviceRelease
+if __use_win_types:
+    _urDeviceRelease_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t )
+else:
+    _urDeviceRelease_t = CFUNCTYPE( ur_result_t, ur_device_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urDevicePartition
+if __use_win_types:
+    _urDevicePartition_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_partition_property_value_t), POINTER(c_ulong), POINTER(ur_device_handle_t) )
+else:
+    _urDevicePartition_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_partition_property_value_t), POINTER(c_ulong), POINTER(ur_device_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urDeviceSelectBinary
+if __use_win_types:
+    _urDeviceSelectBinary_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte*), c_ulong )
+else:
+    _urDeviceSelectBinary_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte*), c_ulong )
+
+###############################################################################
+## @brief Function-pointer for urDeviceGetNativeHandle
+if __use_win_types:
+    _urDeviceGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_native_handle_t) )
+else:
+    _urDeviceGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_native_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urDeviceCreateWithNativeHandle
+if __use_win_types:
+    _urDeviceCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_device_handle_t) )
+else:
+    _urDeviceCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_native_handle_t, POINTER(ur_device_handle_t) )
+
+
+###############################################################################
+## @brief Table of Device functions pointers
+class _ur_device_dditable_t(Structure):
+    _fields_ = [
+        ("pfnGet", c_void_p),                                           ## _urDeviceGet_t
+        ("pfnGetInfo", c_void_p),                                       ## _urDeviceGetInfo_t
+        ("pfnGetReference", c_void_p),                                  ## _urDeviceGetReference_t
+        ("pfnRelease", c_void_p),                                       ## _urDeviceRelease_t
+        ("pfnPartition", c_void_p),                                     ## _urDevicePartition_t
+        ("pfnSelectBinary", c_void_p),                                  ## _urDeviceSelectBinary_t
+        ("pfnGetNativeHandle", c_void_p),                               ## _urDeviceGetNativeHandle_t
+        ("pfnCreateWithNativeHandle", c_void_p)                         ## _urDeviceCreateWithNativeHandle_t
+    ]
+
+###############################################################################
+class _ur_dditable_t(Structure):
+    _fields_ = [
+        ("Platform", _ur_platform_dditable_t),
+        ("Context", _ur_context_dditable_t),
+        ("Event", _ur_event_dditable_t),
+        ("Program", _ur_program_dditable_t),
+        ("Module", _ur_module_dditable_t),
+        ("Kernel", _ur_kernel_dditable_t),
+        ("Sampler", _ur_sampler_dditable_t),
+        ("Mem", _ur_mem_dditable_t),
+        ("Enqueue", _ur_enqueue_dditable_t),
+        ("USM", _ur_usm_dditable_t),
+        ("Global", _ur_global_dditable_t),
+        ("Queue", _ur_queue_dditable_t),
+        ("Device", _ur_device_dditable_t)
+    ]
+
+###############################################################################
+## @brief ur device-driver interfaces
+class UR_DDI:
+    def __init__(self, version : ur_api_version_t):
+        # load the ur_loader library
+        if "Windows" == platform.uname()[0]:
+            self.__dll = WinDLL("ur_loader.dll")
+        else:
+            self.__dll = CDLL("ur_loader.so")
+
+        # fill the ddi tables
+        self.__dditable = _ur_dditable_t()
+
+        # call driver to get function pointers
+        _Platform = _ur_platform_dditable_t()
+        r = ur_result_v(self.__dll.urGetPlatformProcAddrTable(version, byref(_Platform)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Platform = _Platform
+
+        # attach function interface to function address
+        self.urPlatformGet = _urPlatformGet_t(self.__dditable.Platform.pfnGet)
+        self.urPlatformGetInfo = _urPlatformGetInfo_t(self.__dditable.Platform.pfnGetInfo)
+        self.urPlatformGetNativeHandle = _urPlatformGetNativeHandle_t(self.__dditable.Platform.pfnGetNativeHandle)
+        self.urPlatformCreateWithNativeHandle = _urPlatformCreateWithNativeHandle_t(self.__dditable.Platform.pfnCreateWithNativeHandle)
+        self.urPlatformGetApiVersion = _urPlatformGetApiVersion_t(self.__dditable.Platform.pfnGetApiVersion)
+
+        # call driver to get function pointers
+        _Context = _ur_context_dditable_t()
+        r = ur_result_v(self.__dll.urGetContextProcAddrTable(version, byref(_Context)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Context = _Context
+
+        # attach function interface to function address
+        self.urContextCreate = _urContextCreate_t(self.__dditable.Context.pfnCreate)
+        self.urContextGetReference = _urContextGetReference_t(self.__dditable.Context.pfnGetReference)
+        self.urContextRelease = _urContextRelease_t(self.__dditable.Context.pfnRelease)
+        self.urContextGetInfo = _urContextGetInfo_t(self.__dditable.Context.pfnGetInfo)
+        self.urContextGetNativeHandle = _urContextGetNativeHandle_t(self.__dditable.Context.pfnGetNativeHandle)
+        self.urContextCreateWithNativeHandle = _urContextCreateWithNativeHandle_t(self.__dditable.Context.pfnCreateWithNativeHandle)
+
+        # call driver to get function pointers
+        _Event = _ur_event_dditable_t()
+        r = ur_result_v(self.__dll.urGetEventProcAddrTable(version, byref(_Event)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Event = _Event
+
+        # attach function interface to function address
+        self.urEventCreate = _urEventCreate_t(self.__dditable.Event.pfnCreate)
+        self.urEventGetInfo = _urEventGetInfo_t(self.__dditable.Event.pfnGetInfo)
+        self.urEventGetProfilingInfo = _urEventGetProfilingInfo_t(self.__dditable.Event.pfnGetProfilingInfo)
+        self.urEventWait = _urEventWait_t(self.__dditable.Event.pfnWait)
+        self.urEventGetReference = _urEventGetReference_t(self.__dditable.Event.pfnGetReference)
+        self.urEventRelease = _urEventRelease_t(self.__dditable.Event.pfnRelease)
+        self.urEventGetNativeHandle = _urEventGetNativeHandle_t(self.__dditable.Event.pfnGetNativeHandle)
+        self.urEventCreateWithNativeHandle = _urEventCreateWithNativeHandle_t(self.__dditable.Event.pfnCreateWithNativeHandle)
+
+        # call driver to get function pointers
+        _Program = _ur_program_dditable_t()
+        r = ur_result_v(self.__dll.urGetProgramProcAddrTable(version, byref(_Program)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Program = _Program
+
+        # attach function interface to function address
+        self.urProgramCreate = _urProgramCreate_t(self.__dditable.Program.pfnCreate)
+        self.urProgramCreateWithBinary = _urProgramCreateWithBinary_t(self.__dditable.Program.pfnCreateWithBinary)
+        self.urProgramGetReference = _urProgramGetReference_t(self.__dditable.Program.pfnGetReference)
+        self.urProgramRelease = _urProgramRelease_t(self.__dditable.Program.pfnRelease)
+        self.urProgramGetFunctionPointer = _urProgramGetFunctionPointer_t(self.__dditable.Program.pfnGetFunctionPointer)
+        self.urProgramGetInfo = _urProgramGetInfo_t(self.__dditable.Program.pfnGetInfo)
+        self.urProgramGetBuildInfo = _urProgramGetBuildInfo_t(self.__dditable.Program.pfnGetBuildInfo)
+        self.urProgramSetSpecializationConstant = _urProgramSetSpecializationConstant_t(self.__dditable.Program.pfnSetSpecializationConstant)
+        self.urProgramGetNativeHandle = _urProgramGetNativeHandle_t(self.__dditable.Program.pfnGetNativeHandle)
+        self.urProgramCreateWithNativeHandle = _urProgramCreateWithNativeHandle_t(self.__dditable.Program.pfnCreateWithNativeHandle)
+
+        # call driver to get function pointers
+        _Module = _ur_module_dditable_t()
+        r = ur_result_v(self.__dll.urGetModuleProcAddrTable(version, byref(_Module)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Module = _Module
+
+        # attach function interface to function address
+        self.urModuleCreate = _urModuleCreate_t(self.__dditable.Module.pfnCreate)
+        self.urModuleGetReference = _urModuleGetReference_t(self.__dditable.Module.pfnGetReference)
+        self.urModuleRelease = _urModuleRelease_t(self.__dditable.Module.pfnRelease)
+        self.urModuleGetNativeHandle = _urModuleGetNativeHandle_t(self.__dditable.Module.pfnGetNativeHandle)
+        self.urModuleCreateWithNativeHandle = _urModuleCreateWithNativeHandle_t(self.__dditable.Module.pfnCreateWithNativeHandle)
+
+        # call driver to get function pointers
+        _Kernel = _ur_kernel_dditable_t()
+        r = ur_result_v(self.__dll.urGetKernelProcAddrTable(version, byref(_Kernel)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Kernel = _Kernel
+
+        # attach function interface to function address
+        self.urKernelCreate = _urKernelCreate_t(self.__dditable.Kernel.pfnCreate)
+        self.urKernelGetInfo = _urKernelGetInfo_t(self.__dditable.Kernel.pfnGetInfo)
+        self.urKernelGetGroupInfo = _urKernelGetGroupInfo_t(self.__dditable.Kernel.pfnGetGroupInfo)
+        self.urKernelGetSubGroupInfo = _urKernelGetSubGroupInfo_t(self.__dditable.Kernel.pfnGetSubGroupInfo)
+        self.urKernelGetReference = _urKernelGetReference_t(self.__dditable.Kernel.pfnGetReference)
+        self.urKernelRelease = _urKernelRelease_t(self.__dditable.Kernel.pfnRelease)
+        self.urKernelGetNativeHandle = _urKernelGetNativeHandle_t(self.__dditable.Kernel.pfnGetNativeHandle)
+        self.urKernelCreateWithNativeHandle = _urKernelCreateWithNativeHandle_t(self.__dditable.Kernel.pfnCreateWithNativeHandle)
+        self.urKernelSetArg = _urKernelSetArg_t(self.__dditable.Kernel.pfnSetArg)
+        self.urKernelSetArgPointer = _urKernelSetArgPointer_t(self.__dditable.Kernel.pfnSetArgPointer)
+        self.urKernelSetExecInfo = _urKernelSetExecInfo_t(self.__dditable.Kernel.pfnSetExecInfo)
+        self.urKernelSetArgSampler = _urKernelSetArgSampler_t(self.__dditable.Kernel.pfnSetArgSampler)
+        self.urKernelSetArgMemObj = _urKernelSetArgMemObj_t(self.__dditable.Kernel.pfnSetArgMemObj)
+
+        # call driver to get function pointers
+        _Sampler = _ur_sampler_dditable_t()
+        r = ur_result_v(self.__dll.urGetSamplerProcAddrTable(version, byref(_Sampler)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Sampler = _Sampler
+
+        # attach function interface to function address
+        self.urSamplerCreate = _urSamplerCreate_t(self.__dditable.Sampler.pfnCreate)
+        self.urSamplerGetReference = _urSamplerGetReference_t(self.__dditable.Sampler.pfnGetReference)
+        self.urSamplerRelease = _urSamplerRelease_t(self.__dditable.Sampler.pfnRelease)
+        self.urSamplerGetInfo = _urSamplerGetInfo_t(self.__dditable.Sampler.pfnGetInfo)
+        self.urSamplerGetNativeHandle = _urSamplerGetNativeHandle_t(self.__dditable.Sampler.pfnGetNativeHandle)
+        self.urSamplerCreateWithNativeHandle = _urSamplerCreateWithNativeHandle_t(self.__dditable.Sampler.pfnCreateWithNativeHandle)
+
+        # call driver to get function pointers
+        _Mem = _ur_mem_dditable_t()
+        r = ur_result_v(self.__dll.urGetMemProcAddrTable(version, byref(_Mem)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Mem = _Mem
+
+        # attach function interface to function address
+        self.urMemImageCreate = _urMemImageCreate_t(self.__dditable.Mem.pfnImageCreate)
+        self.urMemBufferCreate = _urMemBufferCreate_t(self.__dditable.Mem.pfnBufferCreate)
+        self.urMemGetReference = _urMemGetReference_t(self.__dditable.Mem.pfnGetReference)
+        self.urMemRelease = _urMemRelease_t(self.__dditable.Mem.pfnRelease)
+        self.urMemBufferPartition = _urMemBufferPartition_t(self.__dditable.Mem.pfnBufferPartition)
+        self.urMemGetNativeHandle = _urMemGetNativeHandle_t(self.__dditable.Mem.pfnGetNativeHandle)
+        self.urMemCreateWithNativeHandle = _urMemCreateWithNativeHandle_t(self.__dditable.Mem.pfnCreateWithNativeHandle)
+        self.urMemFree = _urMemFree_t(self.__dditable.Mem.pfnFree)
+        self.urMemGetMemAllocInfo = _urMemGetMemAllocInfo_t(self.__dditable.Mem.pfnGetMemAllocInfo)
+
+        # call driver to get function pointers
+        _Enqueue = _ur_enqueue_dditable_t()
+        r = ur_result_v(self.__dll.urGetEnqueueProcAddrTable(version, byref(_Enqueue)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Enqueue = _Enqueue
+
+        # attach function interface to function address
+        self.urEnqueueKernelLaunch = _urEnqueueKernelLaunch_t(self.__dditable.Enqueue.pfnKernelLaunch)
+        self.urEnqueueEventsWait = _urEnqueueEventsWait_t(self.__dditable.Enqueue.pfnEventsWait)
+        self.urEnqueueEventsWaitWithBarrier = _urEnqueueEventsWaitWithBarrier_t(self.__dditable.Enqueue.pfnEventsWaitWithBarrier)
+        self.urEnqueueMemBufferRead = _urEnqueueMemBufferRead_t(self.__dditable.Enqueue.pfnMemBufferRead)
+        self.urEnqueueMemBufferWrite = _urEnqueueMemBufferWrite_t(self.__dditable.Enqueue.pfnMemBufferWrite)
+        self.urEnqueueMemBufferReadRect = _urEnqueueMemBufferReadRect_t(self.__dditable.Enqueue.pfnMemBufferReadRect)
+        self.urEnqueueMemBufferWriteRect = _urEnqueueMemBufferWriteRect_t(self.__dditable.Enqueue.pfnMemBufferWriteRect)
+        self.urEnqueueMemBufferCopy = _urEnqueueMemBufferCopy_t(self.__dditable.Enqueue.pfnMemBufferCopy)
+        self.urEnqueueMemBufferCopyRect = _urEnqueueMemBufferCopyRect_t(self.__dditable.Enqueue.pfnMemBufferCopyRect)
+        self.urEnqueueMemBufferFill = _urEnqueueMemBufferFill_t(self.__dditable.Enqueue.pfnMemBufferFill)
+        self.urEnqueueMemImageRead = _urEnqueueMemImageRead_t(self.__dditable.Enqueue.pfnMemImageRead)
+        self.urEnqueueMemImageWrite = _urEnqueueMemImageWrite_t(self.__dditable.Enqueue.pfnMemImageWrite)
+        self.urEnqueueMemImageCopy = _urEnqueueMemImageCopy_t(self.__dditable.Enqueue.pfnMemImageCopy)
+        self.urEnqueueMemBufferMap = _urEnqueueMemBufferMap_t(self.__dditable.Enqueue.pfnMemBufferMap)
+        self.urEnqueueMemUnmap = _urEnqueueMemUnmap_t(self.__dditable.Enqueue.pfnMemUnmap)
+        self.urEnqueueUSMMemset = _urEnqueueUSMMemset_t(self.__dditable.Enqueue.pfnUSMMemset)
+        self.urEnqueueUSMMemcpy = _urEnqueueUSMMemcpy_t(self.__dditable.Enqueue.pfnUSMMemcpy)
+        self.urEnqueueUSMPrefetch = _urEnqueueUSMPrefetch_t(self.__dditable.Enqueue.pfnUSMPrefetch)
+        self.urEnqueueUSMMemAdvice = _urEnqueueUSMMemAdvice_t(self.__dditable.Enqueue.pfnUSMMemAdvice)
+
+        # call driver to get function pointers
+        _USM = _ur_usm_dditable_t()
+        r = ur_result_v(self.__dll.urGetUSMProcAddrTable(version, byref(_USM)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.USM = _USM
+
+        # attach function interface to function address
+        self.urUSMHostAlloc = _urUSMHostAlloc_t(self.__dditable.USM.pfnHostAlloc)
+        self.urUSMDeviceAlloc = _urUSMDeviceAlloc_t(self.__dditable.USM.pfnDeviceAlloc)
+        self.urUSMSharedAlloc = _urUSMSharedAlloc_t(self.__dditable.USM.pfnSharedAlloc)
+
+        # call driver to get function pointers
+        _Global = _ur_global_dditable_t()
+        r = ur_result_v(self.__dll.urGetGlobalProcAddrTable(version, byref(_Global)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Global = _Global
+
+        # attach function interface to function address
+        self.urTearDown = _urTearDown_t(self.__dditable.Global.pfnTearDown)
+        self.urInit = _urInit_t(self.__dditable.Global.pfnInit)
+
+        # call driver to get function pointers
+        _Queue = _ur_queue_dditable_t()
+        r = ur_result_v(self.__dll.urGetQueueProcAddrTable(version, byref(_Queue)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Queue = _Queue
+
+        # attach function interface to function address
+        self.urQueueGetInfo = _urQueueGetInfo_t(self.__dditable.Queue.pfnGetInfo)
+        self.urQueueCreate = _urQueueCreate_t(self.__dditable.Queue.pfnCreate)
+        self.urQueueGetReference = _urQueueGetReference_t(self.__dditable.Queue.pfnGetReference)
+        self.urQueueRelease = _urQueueRelease_t(self.__dditable.Queue.pfnRelease)
+        self.urQueueGetNativeHandle = _urQueueGetNativeHandle_t(self.__dditable.Queue.pfnGetNativeHandle)
+        self.urQueueCreateWithNativeHandle = _urQueueCreateWithNativeHandle_t(self.__dditable.Queue.pfnCreateWithNativeHandle)
+
+        # call driver to get function pointers
+        _Device = _ur_device_dditable_t()
+        r = ur_result_v(self.__dll.urGetDeviceProcAddrTable(version, byref(_Device)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Device = _Device
+
+        # attach function interface to function address
+        self.urDeviceGet = _urDeviceGet_t(self.__dditable.Device.pfnGet)
+        self.urDeviceGetInfo = _urDeviceGetInfo_t(self.__dditable.Device.pfnGetInfo)
+        self.urDeviceGetReference = _urDeviceGetReference_t(self.__dditable.Device.pfnGetReference)
+        self.urDeviceRelease = _urDeviceRelease_t(self.__dditable.Device.pfnRelease)
+        self.urDevicePartition = _urDevicePartition_t(self.__dditable.Device.pfnPartition)
+        self.urDeviceSelectBinary = _urDeviceSelectBinary_t(self.__dditable.Device.pfnSelectBinary)
+        self.urDeviceGetNativeHandle = _urDeviceGetNativeHandle_t(self.__dditable.Device.pfnGetNativeHandle)
+        self.urDeviceCreateWithNativeHandle = _urDeviceCreateWithNativeHandle_t(self.__dditable.Device.pfnCreateWithNativeHandle)
+
+        # success!

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4,12 +4,12 @@
  *
  * SPDX-License-Identifier: MIT
  *
- * @file zer_api.h
+ * @file ur_api.h
  * @version v0.5-r0.5
  *
  */
-#ifndef _ZER_API_H
-#define _ZER_API_H
+#ifndef _UR_API_H
+#define _UR_API_H
 #if defined(__cplusplus)
 #pragma once
 #endif
@@ -27,283 +27,283 @@ extern "C" {
 #pragma region common
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_MAKE_VERSION
+#ifndef UR_MAKE_VERSION
 /// @brief Generates generic 'oneAPI' API versions
-#define ZER_MAKE_VERSION( _major, _minor )  (( _major << 16 )|( _minor & 0x0000ffff))
-#endif // ZER_MAKE_VERSION
+#define UR_MAKE_VERSION( _major, _minor )  (( _major << 16 )|( _minor & 0x0000ffff))
+#endif // UR_MAKE_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_MAJOR_VERSION
+#ifndef UR_MAJOR_VERSION
 /// @brief Extracts 'oneAPI' API major version
-#define ZER_MAJOR_VERSION( _ver )  ( _ver >> 16 )
-#endif // ZER_MAJOR_VERSION
+#define UR_MAJOR_VERSION( _ver )  ( _ver >> 16 )
+#endif // UR_MAJOR_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_MINOR_VERSION
+#ifndef UR_MINOR_VERSION
 /// @brief Extracts 'oneAPI' API minor version
-#define ZER_MINOR_VERSION( _ver )  ( _ver & 0x0000ffff )
-#endif // ZER_MINOR_VERSION
+#define UR_MINOR_VERSION( _ver )  ( _ver & 0x0000ffff )
+#endif // UR_MINOR_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_APICALL
+#ifndef UR_APICALL
 #if defined(_WIN32)
 /// @brief Calling convention for all API functions
-#define ZER_APICALL  __cdecl
+#define UR_APICALL  __cdecl
 #else
-#define ZER_APICALL  
+#define UR_APICALL  
 #endif // defined(_WIN32)
-#endif // ZER_APICALL
+#endif // UR_APICALL
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_APIEXPORT
+#ifndef UR_APIEXPORT
 #if defined(_WIN32)
 /// @brief Microsoft-specific dllexport storage-class attribute
-#define ZER_APIEXPORT  __declspec(dllexport)
+#define UR_APIEXPORT  __declspec(dllexport)
 #else
-#define ZER_APIEXPORT  
+#define UR_APIEXPORT  
 #endif // defined(_WIN32)
-#endif // ZER_APIEXPORT
+#endif // UR_APIEXPORT
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_DLLEXPORT
+#ifndef UR_DLLEXPORT
 #if defined(_WIN32)
 /// @brief Microsoft-specific dllexport storage-class attribute
-#define ZER_DLLEXPORT  __declspec(dllexport)
+#define UR_DLLEXPORT  __declspec(dllexport)
 #endif // defined(_WIN32)
-#endif // ZER_DLLEXPORT
+#endif // UR_DLLEXPORT
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_DLLEXPORT
+#ifndef UR_DLLEXPORT
 #if __GNUC__ >= 4
 /// @brief GCC-specific dllexport storage-class attribute
-#define ZER_DLLEXPORT  __attribute__ ((visibility ("default")))
+#define UR_DLLEXPORT  __attribute__ ((visibility ("default")))
 #else
-#define ZER_DLLEXPORT  
+#define UR_DLLEXPORT  
 #endif // __GNUC__ >= 4
-#endif // ZER_DLLEXPORT
+#endif // UR_DLLEXPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief compiler-independent type
-typedef uint8_t zer_bool_t;
+typedef uint8_t ur_bool_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of a platform instance
-typedef struct _zer_platform_handle_t *zer_platform_handle_t;
+typedef struct _ur_platform_handle_t *ur_platform_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of platform's device object
-typedef struct _zer_device_handle_t *zer_device_handle_t;
+typedef struct _ur_device_handle_t *ur_device_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of context object
-typedef struct _zer_context_handle_t *zer_context_handle_t;
+typedef struct _ur_context_handle_t *ur_context_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of event object
-typedef struct _zer_event_handle_t *zer_event_handle_t;
+typedef struct _ur_event_handle_t *ur_event_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of Program object
-typedef struct _zer_program_handle_t *zer_program_handle_t;
+typedef struct _ur_program_handle_t *ur_program_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of Module object
-typedef struct _zer_module_handle_t *zer_module_handle_t;
+typedef struct _ur_module_handle_t *ur_module_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of module's Kernel object
-typedef struct _zer_kernel_handle_t *zer_kernel_handle_t;
+typedef struct _ur_kernel_handle_t *ur_kernel_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of a queue object
-typedef struct _zer_queue_handle_t *zer_queue_handle_t;
+typedef struct _ur_queue_handle_t *ur_queue_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of a native object
-typedef struct _zer_native_handle_t *zer_native_handle_t;
+typedef struct _ur_native_handle_t *ur_native_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of a Sampler object
-typedef struct _zer_sampler_handle_t *zer_sampler_handle_t;
+typedef struct _ur_sampler_handle_t *ur_sampler_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of memory object which can either be buffer or image
-typedef struct _zer_mem_handle_t *zer_mem_handle_t;
+typedef struct _ur_mem_handle_t *ur_mem_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifndef ZER_BIT
+#ifndef UR_BIT
 /// @brief Generic macro for enumerator bit masks
-#define ZER_BIT( _i )  ( 1 << _i )
-#endif // ZER_BIT
+#define UR_BIT( _i )  ( 1 << _i )
+#endif // UR_BIT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines Return/Error codes
-typedef enum _zer_result_t
+typedef enum _ur_result_t
 {
-    ZER_RESULT_SUCCESS = 0,                         ///< Success
-    ZER_RESULT_INVALID_KERNEL_NAME = 1,             ///< Invalid kernel name
-    ZER_RESULT_INVALID_OPERATION = 2,               ///< Invalid operation
-    ZER_RESULT_INVALID_KERNEL = 3,                  ///< Invalid kernel
-    ZER_RESULT_INVALID_QUEUE_PROPERTIES = 4,        ///< Invalid queue properties
-    ZER_RESULT_INVALID_VALUE = 5,                   ///< Invalid Value
-    ZER_RESULT_INVALID_CONTEXT = 6,                 ///< Invalid context
-    ZER_RESULT_INVALID_PLATFORM = 7,                ///< Invalid platform
-    ZER_RESULT_INVALID_DEVICE = 8,                  ///< Invalid device
-    ZER_RESULT_INVALID_BINARY = 9,                  ///< Invalid binary
-    ZER_RESULT_INVALID_QUEUE = 10,                  ///< Invalid queue
-    ZER_RESULT_OUT_OF_HOST_MEMORY = 11,             ///< Out of host memory
-    ZER_RESULT_INVALID_PROGRAM = 12,                ///< Invalid program
-    ZER_RESULT_INVALID_PROGRAM_EXECUTABLE = 13,     ///< Invalid program executable
-    ZER_RESULT_INVALID_SAMPLER = 14,                ///< Invalid sampler
-    ZER_RESULT_INVALID_BUFFER_SIZE = 15,            ///< Invalid buffer size
-    ZER_RESULT_INVALID_MEM_OBJECT = 16,             ///< Invalid memory object
-    ZER_RESULT_OUT_OF_RESOURCES = 17,               ///< Out of resources
-    ZER_RESULT_INVALID_EVENT = 18,                  ///< Invalid event
-    ZER_RESULT_INVALID_EVENT_WAIT_LIST = 19,        ///< Invalid event wait list
-    ZER_RESULT_MISALIGNED_SUB_BUFFER_OFFSET = 20,   ///< Misaligned sub buffer offset
-    ZER_RESULT_BUILD_PROGRAM_FAILURE = 21,          ///< Build program failure
-    ZER_RESULT_INVALID_WORK_GROUP_SIZE = 22,        ///< Invalid work group size
-    ZER_RESULT_COMPILER_NOT_AVAILABLE = 23,         ///< Compiler not available
-    ZER_RESULT_PROFILING_INFO_NOT_AVAILABLE = 24,   ///< Profiling info not available
-    ZER_RESULT_DEVICE_NOT_FOUND = 25,               ///< Device not found
-    ZER_RESULT_INVALID_WORK_ITEM_SIZE = 26,         ///< Invalid work item size
-    ZER_RESULT_INVALID_WORK_DIMENSION = 27,         ///< Invalid work dimension
-    ZER_RESULT_INVALID_KERNEL_ARGS = 28,            ///< Invalid kernel args
-    ZER_RESULT_INVALID_IMAGE_SIZE = 29,             ///< Invalid image size
-    ZER_RESULT_INVALID_IMAGE_FORMAT_DESCRIPTOR = 30,///< Invalid image format descriptor
-    ZER_RESULT_IMAGE_FORMAT_NOT_SUPPORTED = 31,     ///< Image format not supported
-    ZER_RESULT_MEM_OBJECT_ALLOCATION_FAILURE = 32,  ///< Memory object allocation failure
-    ZER_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 33,   ///< Program object parameter is invalid.
-    ZER_RESULT_ERROR_UNINITIALIZED = 0x78000001,    ///< [Validation] driver is not initialized
-    ZER_RESULT_ERROR_DEVICE_LOST = 0x78000002,      ///< Device hung, reset, was removed, or driver update occurred
-    ZER_RESULT_ERROR_OUT_OF_HOST_MEMORY = 0x78000003,   ///< Insufficient host memory to satisfy call
-    ZER_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 0x78000004, ///< Insufficient device memory to satisfy call
-    ZER_RESULT_ERROR_MODULE_BUILD_FAILURE = 0x78000005, ///< Error occurred when building module, see build log for details
-    ZER_RESULT_ERROR_MODULE_LINK_FAILURE = 0x78000006,  ///< Error occurred when linking modules, see build log for details
-    ZER_RESULT_ERROR_DEVICE_REQUIRES_RESET = 0x78000007,///< Device requires a reset
-    ZER_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 0x78000008,///< Device currently in low power state
-    ZER_RESULT_ERROR_UNSUPPORTED_VERSION = 0x78000009,  ///< [Validation] generic error code for unsupported versions
-    ZER_RESULT_ERROR_UNSUPPORTED_FEATURE = 0x7800000a,  ///< [Validation] generic error code for unsupported features
-    ZER_RESULT_ERROR_INVALID_ARGUMENT = 0x7800000b, ///< [Validation] generic error code for invalid arguments
-    ZER_RESULT_ERROR_INVALID_NULL_HANDLE = 0x7800000c,  ///< [Validation] handle argument is not valid
-    ZER_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 0x7800000d, ///< [Validation] object pointed to by handle still in-use by device
-    ZER_RESULT_ERROR_INVALID_NULL_POINTER = 0x7800000e, ///< [Validation] pointer argument may not be nullptr
-    ZER_RESULT_ERROR_INVALID_SIZE = 0x7800000f,     ///< [Validation] size argument is invalid (e.g., must not be zero)
-    ZER_RESULT_ERROR_UNSUPPORTED_SIZE = 0x78000010, ///< [Validation] size argument is not supported by the device (e.g., too
+    UR_RESULT_SUCCESS = 0,                          ///< Success
+    UR_RESULT_INVALID_KERNEL_NAME = 1,              ///< Invalid kernel name
+    UR_RESULT_INVALID_OPERATION = 2,                ///< Invalid operation
+    UR_RESULT_INVALID_KERNEL = 3,                   ///< Invalid kernel
+    UR_RESULT_INVALID_QUEUE_PROPERTIES = 4,         ///< Invalid queue properties
+    UR_RESULT_INVALID_VALUE = 5,                    ///< Invalid Value
+    UR_RESULT_INVALID_CONTEXT = 6,                  ///< Invalid context
+    UR_RESULT_INVALID_PLATFORM = 7,                 ///< Invalid platform
+    UR_RESULT_INVALID_DEVICE = 8,                   ///< Invalid device
+    UR_RESULT_INVALID_BINARY = 9,                   ///< Invalid binary
+    UR_RESULT_INVALID_QUEUE = 10,                   ///< Invalid queue
+    UR_RESULT_OUT_OF_HOST_MEMORY = 11,              ///< Out of host memory
+    UR_RESULT_INVALID_PROGRAM = 12,                 ///< Invalid program
+    UR_RESULT_INVALID_PROGRAM_EXECUTABLE = 13,      ///< Invalid program executable
+    UR_RESULT_INVALID_SAMPLER = 14,                 ///< Invalid sampler
+    UR_RESULT_INVALID_BUFFER_SIZE = 15,             ///< Invalid buffer size
+    UR_RESULT_INVALID_MEM_OBJECT = 16,              ///< Invalid memory object
+    UR_RESULT_OUT_OF_RESOURCES = 17,                ///< Out of resources
+    UR_RESULT_INVALID_EVENT = 18,                   ///< Invalid event
+    UR_RESULT_INVALID_EVENT_WAIT_LIST = 19,         ///< Invalid event wait list
+    UR_RESULT_MISALIGNED_SUB_BUFFER_OFFSET = 20,    ///< Misaligned sub buffer offset
+    UR_RESULT_BUILD_PROGRAM_FAILURE = 21,           ///< Build program failure
+    UR_RESULT_INVALID_WORK_GROUP_SIZE = 22,         ///< Invalid work group size
+    UR_RESULT_COMPILER_NOT_AVAILABLE = 23,          ///< Compiler not available
+    UR_RESULT_PROFILING_INFO_NOT_AVAILABLE = 24,    ///< Profiling info not available
+    UR_RESULT_DEVICE_NOT_FOUND = 25,                ///< Device not found
+    UR_RESULT_INVALID_WORK_ITEM_SIZE = 26,          ///< Invalid work item size
+    UR_RESULT_INVALID_WORK_DIMENSION = 27,          ///< Invalid work dimension
+    UR_RESULT_INVALID_KERNEL_ARGS = 28,             ///< Invalid kernel args
+    UR_RESULT_INVALID_IMAGE_SIZE = 29,              ///< Invalid image size
+    UR_RESULT_INVALID_IMAGE_FORMAT_DESCRIPTOR = 30, ///< Invalid image format descriptor
+    UR_RESULT_IMAGE_FORMAT_NOT_SUPPORTED = 31,      ///< Image format not supported
+    UR_RESULT_MEM_OBJECT_ALLOCATION_FAILURE = 32,   ///< Memory object allocation failure
+    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 33,///< Program object parameter is invalid.
+    UR_RESULT_ERROR_UNINITIALIZED = 0x78000001,     ///< [Validation] driver is not initialized
+    UR_RESULT_ERROR_DEVICE_LOST = 0x78000002,       ///< Device hung, reset, was removed, or driver update occurred
+    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 0x78000003,///< Insufficient host memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 0x78000004,  ///< Insufficient device memory to satisfy call
+    UR_RESULT_ERROR_MODULE_BUILD_FAILURE = 0x78000005,  ///< Error occurred when building module, see build log for details
+    UR_RESULT_ERROR_MODULE_LINK_FAILURE = 0x78000006,   ///< Error occurred when linking modules, see build log for details
+    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 0x78000007, ///< Device requires a reset
+    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 0x78000008, ///< Device currently in low power state
+    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 0x78000009,   ///< [Validation] generic error code for unsupported versions
+    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 0x7800000a,   ///< [Validation] generic error code for unsupported features
+    UR_RESULT_ERROR_INVALID_ARGUMENT = 0x7800000b,  ///< [Validation] generic error code for invalid arguments
+    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 0x7800000c,   ///< [Validation] handle argument is not valid
+    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 0x7800000d,  ///< [Validation] object pointed to by handle still in-use by device
+    UR_RESULT_ERROR_INVALID_NULL_POINTER = 0x7800000e,  ///< [Validation] pointer argument may not be nullptr
+    UR_RESULT_ERROR_INVALID_SIZE = 0x7800000f,      ///< [Validation] size argument is invalid (e.g., must not be zero)
+    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 0x78000010,  ///< [Validation] size argument is not supported by the device (e.g., too
                                                     ///< large)
-    ZER_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 0x78000011,///< [Validation] alignment argument is not supported by the device (e.g.,
+    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 0x78000011, ///< [Validation] alignment argument is not supported by the device (e.g.,
                                                     ///< too small)
-    ZER_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 0x78000012,   ///< [Validation] synchronization object in invalid state
-    ZER_RESULT_ERROR_INVALID_ENUMERATION = 0x78000013,  ///< [Validation] enumerator argument is not valid
-    ZER_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 0x78000014,  ///< [Validation] enumerator argument is not supported by the device
-    ZER_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 0x78000015, ///< [Validation] image format is not supported by the device
-    ZER_RESULT_ERROR_INVALID_NATIVE_BINARY = 0x78000016,///< [Validation] native binary is not supported by the device
-    ZER_RESULT_ERROR_INVALID_GLOBAL_NAME = 0x78000017,  ///< [Validation] global variable is not found in the module
-    ZER_RESULT_ERROR_INVALID_KERNEL_NAME = 0x78000018,  ///< [Validation] kernel name is not found in the module
-    ZER_RESULT_ERROR_INVALID_FUNCTION_NAME = 0x78000019,///< [Validation] function name is not found in the module
-    ZER_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 0x7800001a, ///< [Validation] group size dimension is not valid for the kernel or
+    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 0x78000012,///< [Validation] synchronization object in invalid state
+    UR_RESULT_ERROR_INVALID_ENUMERATION = 0x78000013,   ///< [Validation] enumerator argument is not valid
+    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 0x78000014,   ///< [Validation] enumerator argument is not supported by the device
+    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 0x78000015,  ///< [Validation] image format is not supported by the device
+    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 0x78000016, ///< [Validation] native binary is not supported by the device
+    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 0x78000017,   ///< [Validation] global variable is not found in the module
+    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 0x78000018,   ///< [Validation] kernel name is not found in the module
+    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 0x78000019, ///< [Validation] function name is not found in the module
+    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 0x7800001a,  ///< [Validation] group size dimension is not valid for the kernel or
                                                     ///< device
-    ZER_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 0x7800001b,   ///< [Validation] global width dimension is not valid for the kernel or
+    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 0x7800001b,///< [Validation] global width dimension is not valid for the kernel or
                                                     ///< device
-    ZER_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 0x7800001c,///< [Validation] kernel argument index is not valid for kernel
-    ZER_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 0x7800001d, ///< [Validation] kernel argument size does not match kernel
-    ZER_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 0x7800001e,   ///< [Validation] value of kernel attribute is not valid for the kernel or
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 0x7800001c, ///< [Validation] kernel argument index is not valid for kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 0x7800001d,  ///< [Validation] kernel argument size does not match kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 0x7800001e,///< [Validation] value of kernel attribute is not valid for the kernel or
                                                     ///< device
-    ZER_RESULT_ERROR_INVALID_MODULE_UNLINKED = 0x7800001f,  ///< [Validation] module with imports needs to be linked before kernels can
+    UR_RESULT_ERROR_INVALID_MODULE_UNLINKED = 0x7800001f,   ///< [Validation] module with imports needs to be linked before kernels can
                                                     ///< be created from it.
-    ZER_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE = 0x78000020,///< [Validation] command list type does not match command queue type
-    ZER_RESULT_ERROR_OVERLAPPING_REGIONS = 0x78000021,  ///< [Validation] copy operations do not support overlapping regions of
+    UR_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE = 0x78000020, ///< [Validation] command list type does not match command queue type
+    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 0x78000021,   ///< [Validation] copy operations do not support overlapping regions of
                                                     ///< memory
-    ZER_RESULT_INVALID_HOST_PTR = 0x78000022,       ///< Invalid host pointer
-    ZER_RESULT_INVALID_USM_SIZE = 0x78000023,       ///< Invalid USM size
-    ZER_RESULT_OBJECT_ALLOCATION_FAILURE = 0x78000024,  ///< Objection allocation failure
-    ZER_RESULT_ERROR_UNKNOWN = 0x7ffffffe,          ///< Unknown or internal error
-    ZER_RESULT_FORCE_UINT32 = 0x7fffffff
+    UR_RESULT_INVALID_HOST_PTR = 0x78000022,        ///< Invalid host pointer
+    UR_RESULT_INVALID_USM_SIZE = 0x78000023,        ///< Invalid USM size
+    UR_RESULT_OBJECT_ALLOCATION_FAILURE = 0x78000024,   ///< Objection allocation failure
+    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,           ///< Unknown or internal error
+    UR_RESULT_FORCE_UINT32 = 0x7fffffff
 
-} zer_result_t;
+} ur_result_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
-typedef enum _zer_structure_type_t
+typedef enum _ur_structure_type_t
 {
-    ZER_STRUCTURE_TYPE_IMAGE_DESC = 0,              ///< $zer_image_desc_t
-    ZER_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_STRUCTURE_TYPE_IMAGE_DESC = 0,               ///< ::ur_image_desc_t
+    UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_structure_type_t;
+} ur_structure_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Base for all properties types
-typedef struct _zer_base_properties_t
+typedef struct _ur_base_properties_t
 {
-    zer_structure_type_t stype;                     ///< [in] type of this structure
+    ur_structure_type_t stype;                      ///< [in] type of this structure
     void* pNext;                                    ///< [in,out][optional] pointer to extension-specific structure
 
-} zer_base_properties_t;
+} ur_base_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Base for all descriptor types
-typedef struct _zer_base_desc_t
+typedef struct _ur_base_desc_t
 {
-    zer_structure_type_t stype;                     ///< [in] type of this structure
+    ur_structure_type_t stype;                      ///< [in] type of this structure
     const void* pNext;                              ///< [in][optional] pointer to extension-specific structure
 
-} zer_base_desc_t;
+} ur_base_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief 3D offset argument passed to buffer rect operations
-typedef struct _zer_rect_offset_t
+typedef struct _ur_rect_offset_t
 {
     uint64_t x;                                     ///< [in] x offset (bytes)
     uint64_t y;                                     ///< [in] y offset (scalar)
     uint64_t z;                                     ///< [in] z offset (scalar)
 
-} zer_rect_offset_t;
+} ur_rect_offset_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief 3D region argument passed to buffer rect operations
-typedef struct _zer_rect_region_t
+typedef struct _ur_rect_region_t
 {
     uint64_t width;                                 ///< [in] width (bytes)
     uint64_t height;                                ///< [in] height (scalar)
     uint64_t depth;                                 ///< [in] scalar (scalar)
 
-} zer_rect_region_t;
+} ur_rect_region_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_base_properties_t
-typedef struct _zer_base_properties_t zer_base_properties_t;
+/// @brief Forward-declare ur_base_properties_t
+typedef struct _ur_base_properties_t ur_base_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_base_desc_t
-typedef struct _zer_base_desc_t zer_base_desc_t;
+/// @brief Forward-declare ur_base_desc_t
+typedef struct _ur_base_desc_t ur_base_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_rect_offset_t
-typedef struct _zer_rect_offset_t zer_rect_offset_t;
+/// @brief Forward-declare ur_rect_offset_t
+typedef struct _ur_rect_offset_t ur_rect_offset_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_rect_region_t
-typedef struct _zer_rect_region_t zer_rect_region_t;
+/// @brief Forward-declare ur_rect_region_t
+typedef struct _ur_rect_region_t ur_rect_region_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_image_format_t
-typedef struct _zer_image_format_t zer_image_format_t;
+/// @brief Forward-declare ur_image_format_t
+typedef struct _ur_image_format_t ur_image_format_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_image_desc_t
-typedef struct _zer_image_desc_t zer_image_desc_t;
+/// @brief Forward-declare ur_image_desc_t
+typedef struct _ur_image_desc_t ur_image_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_buffer_region_t
-typedef struct _zer_buffer_region_t zer_buffer_region_t;
+/// @brief Forward-declare ur_buffer_region_t
+typedef struct _ur_buffer_region_t ur_buffer_region_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_sampler_property_value_t
-typedef struct _zer_sampler_property_value_t zer_sampler_property_value_t;
+/// @brief Forward-declare ur_sampler_property_value_t
+typedef struct _ur_sampler_property_value_t ur_sampler_property_value_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare zer_device_partition_property_value_t
-typedef struct _zer_device_partition_property_value_t zer_device_partition_property_value_t;
+/// @brief Forward-declare ur_device_partition_property_value_t
+typedef struct _ur_device_partition_property_value_t ur_device_partition_property_value_t;
 
 
 #if !defined(__GNUC__)
@@ -323,7 +323,7 @@ typedef struct _zer_device_partition_property_value_t zer_device_partition_prope
 ///     - Context also serves for resource isolation such that resources do not
 ///       cross context boundaries.
 ///     - The returned context is a reference and must be released with a
-///       subsequent call to ::zerContextRelease.
+///       subsequent call to ::urContextRelease.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function must be thread-safe.
 /// 
@@ -332,24 +332,24 @@ typedef struct _zer_device_partition_property_value_t zer_device_partition_prope
 ///     - **clCreateContext**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phDevices`
 ///         + `nullptr == phContext`
-///     - ::ZER_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerContextCreate(
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextCreate(
     uint32_t DeviceCount,                           ///< [in] the number of devices given in phDevices
-    zer_device_handle_t* phDevices,                 ///< [in][range(0, DeviceCount)] array of handle of devices.
-    zer_context_handle_t* phContext                 ///< [out] pointer to handle of context object created
+    ur_device_handle_t* phDevices,                  ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t* phContext                  ///< [out] pointer to handle of context object created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Makes a reference of the context handle indicating it's in use until
-///        paired ::zerContextRelease is called
+///        paired ::urContextRelease is called
 /// 
 /// @details
 ///     - It is not valid to use a context handle, which has all of its
@@ -363,26 +363,26 @@ zerContextCreate(
 ///     - **clRetainContext**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerContextGetReference(
-    zer_context_handle_t hContext                   ///< [in] handle of the context to get a reference of.
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetReference(
+    ur_context_handle_t hContext                    ///< [in] handle of the context to get a reference of.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported context info
-typedef enum _zer_context_info_t
+typedef enum _ur_context_info_t
 {
-    ZER_CONTEXT_INFO_NUM_DEVICES = 1,               ///< [uint32_t] The number of the devices in the context
-    ZER_CONTEXT_INFO_DEVICES = 2,                   ///< [::zer_context_handle_t...] The array of the device handles in the
+    UR_CONTEXT_INFO_NUM_DEVICES = 1,                ///< [uint32_t] The number of the devices in the context
+    UR_CONTEXT_INFO_DEVICES = 2,                    ///< [::ur_context_handle_t...] The array of the device handles in the
                                                     ///< context
-    ZER_CONTEXT_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_CONTEXT_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_context_info_t;
+} ur_context_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Releases the context handle reference indicating end of its usage
@@ -397,14 +397,14 @@ typedef enum _zer_context_info_t
 ///     - **clReleaseContext**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerContextRelease(
-    zer_context_handle_t hContext                   ///< [in] handle of the context to release.
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextRelease(
+    ur_context_handle_t hContext                    ///< [in] handle of the context to release.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -419,26 +419,26 @@ zerContextRelease(
 ///     - **clGetContextInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_CONTEXT_INFO_DEVICES < ContextInfoType`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_CONTEXT_INFO_DEVICES < ContextInfoType`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pSize`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerContextGetInfo(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context
-    zer_context_info_t ContextInfoType,             ///< [in] type of the info to retrieve
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetInfo(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context
+    ur_context_info_t ContextInfoType,              ///< [in] type of the info to retrieve
     size_t* pSize,                                  ///< [in,out] pointer to the number of bytes needed to return info queried.
                                                     ///< the call shall update it with the real number of bytes needed to
                                                     ///< return the info
     void* pContextInfo                              ///< [out][optional] array of bytes holding the info.
                                                     ///< if *pSize is not equal to the real number of bytes needed to return
-                                                    ///< the info then the ::ZER_RESULT_ERROR_INVALID_SIZE error is returned
-                                                    ///< and pContextInfo is not used.
+                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pContextInfo is not used.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -454,17 +454,17 @@ zerContextGetInfo(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeContext`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerContextGetNativeHandle(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context.
-    zer_native_handle_t* phNativeContext            ///< [out] a pointer to the native handle of the context.
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context.
+    ur_native_handle_t* phNativeContext             ///< [out] a pointer to the native handle of the context.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -477,19 +477,19 @@ zerContextGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativeContext`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phContext`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerContextCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativeContext,             ///< [in] the native handle of the context.
-    zer_context_handle_t* phContext                 ///< [out] pointer to the handle of the context object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeContext,              ///< [in] the native handle of the context.
+    ur_context_handle_t* phContext                  ///< [out] pointer to the handle of the context object created.
     );
 
 #if !defined(__GNUC__)
@@ -507,28 +507,28 @@ zerContextCreateWithNativeHandle(
 ///     - **clEnqueueNDRangeKernel**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hKernel`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == globalWorkOffset`
 ///         + `nullptr == globalWorkSize`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_KERNEL
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_WORK_DIMENSION
-///     - ::ZER_RESULT_INVALID_WORK_GROUP_SIZE
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueKernelLaunch(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_KERNEL
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
     uint32_t workDim,                               ///< [in] number of dimensions, from 1 to 3, to specify the global and
                                                     ///< work-group work-items
     const size_t* globalWorkOffset,                 ///< [in] pointer to an array of workDim unsigned values that specify the
@@ -542,11 +542,11 @@ zerEnqueueKernelLaunch(
                                                     ///< If nullptr, the runtime implementation will choose the work-group
                                                     ///< size. 
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                                     ///< event. 
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular kernel
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular kernel
                                                     ///< execution instance.
                                                     ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
                                                     ///< TODO: change to allow nullptr.
@@ -566,28 +566,28 @@ zerEnqueueKernelLaunch(
 ///     - **clEnqueueMarkerWithWaitList**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueEventsWait(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -609,28 +609,28 @@ zerEnqueueEventsWait(
 ///     - **clEnqueueBarrierWithWaitList**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueEventsWaitWithBarrier(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -648,34 +648,34 @@ zerEnqueueEventsWaitWithBarrier(
 ///     - **clEnqueueReadBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBuffer`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == dst`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferRead(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBuffer,                       ///< [in] handle of the buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
     bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
     size_t offset,                                  ///< [in] offset in bytes in the buffer object
     size_t size,                                    ///< [in] size in bytes of data being read
     void* dst,                                      ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -693,34 +693,34 @@ zerEnqueueMemBufferRead(
 ///     - **clEnqueueWriteBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBuffer`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == src`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferWrite(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBuffer,                       ///< [in] handle of the buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
     bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
     size_t offset,                                  ///< [in] offset in bytes in the buffer object
     size_t size,                                    ///< [in] size in bytes of data being written
     const void* src,                                ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -741,28 +741,28 @@ zerEnqueueMemBufferWrite(
 ///     - **clEnqueueReadBufferRect**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBuffer`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == dst`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferReadRect(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBuffer,                       ///< [in] handle of the buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
     bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
-    zer_rect_offset_t bufferOffset,                 ///< [in] 3D offset in the buffer
-    zer_rect_offset_t hostOffset,                   ///< [in] 3D offset in the host region
-    zer_rect_region_t region,                       ///< [in] 3D rectangular region descriptor: width, height, depth
+    ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being read
     size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
@@ -771,11 +771,11 @@ zerEnqueueMemBufferReadRect(
                                                     ///< pointed by dst
     void* dst,                                      ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -796,28 +796,28 @@ zerEnqueueMemBufferReadRect(
 ///     - **clEnqueueWriteBufferRect**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBuffer`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == src`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferWriteRect(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBuffer,                       ///< [in] handle of the buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
     bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
-    zer_rect_offset_t bufferOffset,                 ///< [in] 3D offset in the buffer
-    zer_rect_offset_t hostOffset,                   ///< [in] 3D offset in the host region
-    zer_rect_region_t region,                       ///< [in] 3D rectangular region descriptor: width, height, depth
+    ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being
                                                     ///< written
@@ -827,11 +827,11 @@ zerEnqueueMemBufferWriteRect(
                                                     ///< pointed by src
     void* src,                                      ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -845,32 +845,32 @@ zerEnqueueMemBufferWriteRect(
 ///     - **clEnqueueCopyBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBufferSrc`
 ///         + `nullptr == hBufferDst`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferCopy(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBufferSrc,                    ///< [in] handle of the src buffer object
-    zer_mem_handle_t hBufferDst,                    ///< [in] handle of the dest buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
     size_t size,                                    ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -885,38 +885,38 @@ zerEnqueueMemBufferCopy(
 ///     - **clEnqueueCopyBufferRect**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBufferSrc`
 ///         + `nullptr == hBufferDst`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferCopyRect(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBufferSrc,                    ///< [in] handle of the source buffer object
-    zer_mem_handle_t hBufferDst,                    ///< [in] handle of the dest buffer object
-    zer_rect_offset_t srcOrigin,                    ///< [in] 3D offset in the source buffer
-    zer_rect_offset_t dstOrigin,                    ///< [in] 3D offset in the destination buffer
-    zer_rect_region_t srcRegion,                    ///< [in] source 3D rectangular region descriptor: width, height, depth
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,                     ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,                     ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,                     ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                             ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                           ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                             ///< [in] length of each row in bytes in the destination buffer object
     size_t dstSlicePitch,                           ///< [in] length of each 2D slice in bytes in the destination buffer object
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -931,34 +931,34 @@ zerEnqueueMemBufferCopyRect(
 ///     - **clEnqueueFillBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hBuffer`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pattern`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferFill(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hBuffer,                       ///< [in] handle of the buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
     const void* pattern,                            ///< [in] pointer to the fill pattern
     size_t patternSize,                             ///< [in] size in bytes of the pattern
     size_t offset,                                  ///< [in] offset into the buffer
     size_t size,                                    ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -977,37 +977,37 @@ zerEnqueueMemBufferFill(
 ///     - **clEnqueueReadImage**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hImage`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == dst`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemImageRead(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hImage,                        ///< [in] handle of the image object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                         ///< [in] handle of the image object
     bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
-    zer_rect_offset_t origin,                       ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    zer_rect_region_t region,                       ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+    ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                                     ///< image
     size_t rowPitch,                                ///< [in] length of each row in bytes
     size_t slicePitch,                              ///< [in] length of each 2D slice of the 3D image
     void* dst,                                      ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1026,37 +1026,37 @@ zerEnqueueMemImageRead(
 ///     - **clEnqueueWriteImage**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hImage`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == src`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemImageWrite(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hImage,                        ///< [in] handle of the image object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                         ///< [in] handle of the image object
     bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
-    zer_rect_offset_t origin,                       ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    zer_rect_region_t region,                       ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+    ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                                     ///< image
     size_t inputRowPitch,                           ///< [in] length of each row in bytes
     size_t inputSlicePitch,                         ///< [in] length of each 2D slice of the 3D image
     void* src,                                      ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1070,37 +1070,37 @@ zerEnqueueMemImageWrite(
 ///     - **clEnqueueCopyImage**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hImageSrc`
 ///         + `nullptr == hImageDst`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemImageCopy(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hImageSrc,                     ///< [in] handle of the src image object
-    zer_mem_handle_t hImageDst,                     ///< [in] handle of the dest image object
-    zer_rect_offset_t srcOrigin,                    ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                      ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                      ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
                                                     ///< image
-    zer_rect_offset_t dstOrigin,                    ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+    ur_rect_offset_t dstOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
                                                     ///< or 3D image
-    zer_rect_region_t region,                       ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                                     ///< image
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1108,24 +1108,24 @@ zerEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map flags
-typedef uint32_t zer_map_flags_t;
-typedef enum _zer_map_flag_t
+typedef uint32_t ur_map_flags_t;
+typedef enum _ur_map_flag_t
 {
-    ZER_MAP_FLAG_READ = ZER_BIT(0),                 ///< Map for read access
-    ZER_MAP_FLAG_WRITE = ZER_BIT(1),                ///< Map for write access
-    ZER_MAP_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_MAP_FLAG_READ = UR_BIT(0),                   ///< Map for read access
+    UR_MAP_FLAG_WRITE = UR_BIT(1),                  ///< Map for write access
+    UR_MAP_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_map_flag_t;
+} ur_map_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map flags
-typedef uint32_t zer_usm_migration_flags_t;
-typedef enum _zer_usm_migration_flag_t
+typedef uint32_t ur_usm_migration_flags_t;
+typedef enum _ur_usm_migration_flag_t
 {
-    ZER_USM_MIGRATION_FLAG_DEFAULT = ZER_BIT(0),    ///< Default migration TODO: Add more enums! 
-    ZER_USM_MIGRATION_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_USM_MIGRATION_FLAG_DEFAULT = UR_BIT(0),      ///< Default migration TODO: Add more enums! 
+    UR_USM_MIGRATION_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_usm_migration_flag_t;
+} ur_usm_migration_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to map a region of the buffer object into the host
@@ -1143,36 +1143,36 @@ typedef enum _zer_usm_migration_flag_t
 ///     - **clEnqueueMapBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == buffer`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3 < mapFlags`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == event`
 ///         + `nullptr == retMap`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemBufferMap(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t buffer,                        ///< [in] handle of the buffer object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t buffer,                         ///< [in] handle of the buffer object
     bool blockingMap,                               ///< [in] indicates blocking (true), non-blocking (false)
-    zer_map_flags_t mapFlags,                       ///< [in] flags for read, write, readwrite mapping
+    ur_map_flags_t mapFlags,                        ///< [in] flags for read, write, readwrite mapping
     size_t offset,                                  ///< [in] offset in bytes of the buffer region being mapped
     size_t size,                                    ///< [in] size in bytes of the buffer region being mapped
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event,                      ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event,                       ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1189,31 +1189,31 @@ zerEnqueueMemBufferMap(
 ///     - **clEnqueueUnmapMemObject**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hMem`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == mappedPtr`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueMemUnmap(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_mem_handle_t hMem,                          ///< [in] handle of the memory (buffer or image) object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                           ///< [in] handle of the memory (buffer or image) object
     void* mappedPtr,                                ///< [in] mapped host address
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1223,31 +1223,31 @@ zerEnqueueMemUnmap(
 /// @brief Enqueue a command to set USM memory object value
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == ptr`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueUSMMemset(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     void* ptr,                                      ///< [in] pointer to USM memory object
     int8_t byteValue,                               ///< [in] byte value to fill
     size_t count,                                   ///< [in] size in bytes to be set
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1257,33 +1257,33 @@ zerEnqueueUSMMemset(
 /// @brief Enqueue a command to copy USM memory
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == dstPrt`
 ///         + `nullptr == srcPrt`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueUSMMemcpy(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     bool blocking,                                  ///< [in] blocking or non-blocking copy
     void* dstPrt,                                   ///< [in] pointer to the destination USM memory object
     const void* srcPrt,                             ///< [in] pointer to the source USM memory object
     size_t size,                                    ///< [in] size in bytes to be copied
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1293,33 +1293,33 @@ zerEnqueueUSMMemcpy(
 /// @brief Enqueue a command to prefetch USM memory
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == ptr`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < flags`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueUSMPrefetch(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     const void* ptr,                                ///< [in] pointer to the USM memory object
     size_t size,                                    ///< [in] size in bytes to be fetched
-    zer_usm_migration_flags_t flags,                ///< [in] USM prefetch flags
+    ur_usm_migration_flags_t flags,                 ///< [in] USM prefetch flags
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const zer_event_handle_t* eventWaitList,        ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    const ur_event_handle_t* eventWaitList,         ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1327,39 +1327,39 @@ zerEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory advice
-typedef enum _zer_mem_advice_t
+typedef enum _ur_mem_advice_t
 {
-    ZER_MEM_ADVICE_MEM_ADVICE_DEFAULT = 0,          ///< The USM memory advice is default
-    ZER_MEM_ADVICE_FORCE_UINT32 = 0x7fffffff
+    UR_MEM_ADVICE_MEM_ADVICE_DEFAULT = 0,           ///< The USM memory advice is default
+    UR_MEM_ADVICE_FORCE_UINT32 = 0x7fffffff
 
-} zer_mem_advice_t;
+} ur_mem_advice_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to set USM memory advice
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == ptr`
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_MEM_ADVICE_MEM_ADVICE_DEFAULT < advice`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEnqueueUSMMemAdvice(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_MEM_ADVICE_MEM_ADVICE_DEFAULT < advice`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueUSMMemAdvice(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     const void* ptr,                                ///< [in] pointer to the USM memory object
     size_t size,                                    ///< [in] size in bytes to be adviced
-    zer_mem_advice_t advice,                        ///< [in] USM memory advice
-    zer_event_handle_t* event                       ///< [in,out] return an event object that identifies this particular
+    ur_mem_advice_t advice,                         ///< [in] USM memory advice
+    ur_event_handle_t* event                        ///< [in,out] return an event object that identifies this particular
                                                     ///< command instance.
                                                     ///< Input can not be a nullptr.
                                                     ///< TODO: change to allow nullptr. 
@@ -1374,32 +1374,32 @@ zerEnqueueUSMMemAdvice(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event query information type
-typedef enum _zer_event_info_t
+typedef enum _ur_event_info_t
 {
-    ZER_EVENT_INFO_EVENT_INFO_COMMAND_QUEUE = 0,    ///< Command queue information of an event object
-    ZER_EVENT_INFO_EVENT_INFO_CONTEXT = 1,          ///< Context information of an event object
-    ZER_EVENT_INFO_EVENT_INFO_COMMAND_TYPE = 2,     ///< Command type information of an event object
-    ZER_EVENT_INFO_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3, ///< Command execution status of an event object
-    ZER_EVENT_INFO_EVENT_INFO_REFERENCE_COUNT = 4,  ///< Reference count of an event object
-    ZER_EVENT_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_EVENT_INFO_EVENT_INFO_COMMAND_QUEUE = 0,     ///< Command queue information of an event object
+    UR_EVENT_INFO_EVENT_INFO_CONTEXT = 1,           ///< Context information of an event object
+    UR_EVENT_INFO_EVENT_INFO_COMMAND_TYPE = 2,      ///< Command type information of an event object
+    UR_EVENT_INFO_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3,  ///< Command execution status of an event object
+    UR_EVENT_INFO_EVENT_INFO_REFERENCE_COUNT = 4,   ///< Reference count of an event object
+    UR_EVENT_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_event_info_t;
+} ur_event_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Profiling query information type
-typedef enum _zer_profiling_info_t
+typedef enum _ur_profiling_info_t
 {
-    ZER_PROFILING_INFO_PROFILING_INFO_COMMAND_QUEUED = 0,   ///< A 64-bit value of current device counter in nanoseconds when the event
+    UR_PROFILING_INFO_PROFILING_INFO_COMMAND_QUEUED = 0,///< A 64-bit value of current device counter in nanoseconds when the event
                                                     ///< is enqueued
-    ZER_PROFILING_INFO_PROFILING_INFO_COMMAND_SUBMIT = 1,   ///< A 64-bit value of current device counter in nanoseconds when the event
+    UR_PROFILING_INFO_PROFILING_INFO_COMMAND_SUBMIT = 1,///< A 64-bit value of current device counter in nanoseconds when the event
                                                     ///< is submitted
-    ZER_PROFILING_INFO_PROFILING_INFO_COMMAND_START = 2,///< A 64-bit value of current device counter in nanoseconds when the event
+    UR_PROFILING_INFO_PROFILING_INFO_COMMAND_START = 2, ///< A 64-bit value of current device counter in nanoseconds when the event
                                                     ///< starts execution
-    ZER_PROFILING_INFO_PROFILING_INFO_COMMAND_END = 3,  ///< A 64-bit value of current device counter in nanoseconds when the event
+    UR_PROFILING_INFO_PROFILING_INFO_COMMAND_END = 3,   ///< A 64-bit value of current device counter in nanoseconds when the event
                                                     ///< has finished execution
-    ZER_PROFILING_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_PROFILING_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_profiling_info_t;
+} ur_profiling_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create an event object. Events allow applications to enqueue commands
@@ -1410,20 +1410,20 @@ typedef enum _zer_profiling_info_t
 ///     - **clCreateUserEvent**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == context`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pEvent`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventCreate(
-    zer_context_handle_t context,                   ///< [in] handle of the context object
-    zer_event_handle_t* pEvent                      ///< [out] pointer to handle of the event object created
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventCreate(
+    ur_context_handle_t context,                    ///< [in] handle of the context object
+    ur_event_handle_t* pEvent                       ///< [out] pointer to handle of the event object created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1434,24 +1434,24 @@ zerEventCreate(
 ///     - **clGetEventInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_EVENT_INFO_EVENT_INFO_REFERENCE_COUNT < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EVENT_INFO_EVENT_INFO_REFERENCE_COUNT < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
 ///         + `nullptr == propValueSizeRet`
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventGetInfo(
-    zer_event_handle_t event,                       ///< [in] handle of the event object
-    zer_event_info_t propName,                      ///< [in] the name of the event property to query
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventGetInfo(
+    ur_event_handle_t event,                        ///< [in] handle of the event object
+    ur_event_info_t propName,                       ///< [in] the name of the event property to query
     size_t propValueSize,                           ///< [in] size in bytes of the event property value
     void* propValue,                                ///< [out] value of the event property
     size_t* propValueSizeRet                        ///< [out] bytes returned in event property
@@ -1466,23 +1466,23 @@ zerEventGetInfo(
 ///     - **clGetEventProfilingInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_PROFILING_INFO_PROFILING_INFO_COMMAND_END < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PROFILING_INFO_PROFILING_INFO_COMMAND_END < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventGetProfilingInfo(
-    zer_event_handle_t event,                       ///< [in] handle of the event object
-    zer_profiling_info_t propName,                  ///< [in] the name of the profiling property to query
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t event,                        ///< [in] handle of the event object
+    ur_profiling_info_t propName,                   ///< [in] the name of the profiling property to query
     size_t propValueSize,                           ///< [in] size in bytes of the profiling property value
     void* propValue,                                ///< [out] value of the profiling property
     size_t propValueSizeRet                         ///< [out] bytes returned in profiling property
@@ -1496,20 +1496,20 @@ zerEventGetProfilingInfo(
 ///     - **clWaitForEvent**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == eventList`
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventWait(
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventWait(
     uint32_t numEvents,                             ///< [in] number of events in the event list
-    const zer_event_handle_t* eventList             ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+    const ur_event_handle_t* eventList              ///< [in][range(0, numEvents)] pointer to a list of events to wait for
                                                     ///< completion
     );
 
@@ -1522,17 +1522,17 @@ zerEventWait(
 ///     - **clRetainEvent**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventGetReference(
-    zer_event_handle_t event                        ///< [in] handle of the event object
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventGetReference(
+    ur_event_handle_t event                         ///< [in] handle of the event object
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1544,17 +1544,17 @@ zerEventGetReference(
 ///     - **clReleaseEvent**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == event`
-///     - ::ZER_RESULT_INVALID_EVENT
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventRelease(
-    zer_event_handle_t event                        ///< [in] handle of the event object
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventRelease(
+    ur_event_handle_t event                         ///< [in] handle of the event object
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1570,17 +1570,17 @@ zerEventRelease(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hEvent`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeEvent`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventGetNativeHandle(
-    zer_event_handle_t hEvent,                      ///< [in] handle of the event.
-    zer_native_handle_t* phNativeEvent              ///< [out] a pointer to the native handle of the event.
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,                       ///< [in] handle of the event.
+    ur_native_handle_t* phNativeEvent               ///< [out] a pointer to the native handle of the event.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1593,19 +1593,19 @@ zerEventGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativeEvent`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phEvent`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerEventCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativeEvent,               ///< [in] the native handle of the event.
-    zer_event_handle_t* phEvent                     ///< [out] pointer to the handle of the event object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeEvent,                ///< [in] the native handle of the event.
+    ur_event_handle_t* phEvent                      ///< [out] pointer to the handle of the event object created.
     );
 
 #if !defined(__GNUC__)
@@ -1617,97 +1617,97 @@ zerEventCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory flags
-typedef uint32_t zer_mem_flags_t;
-typedef enum _zer_mem_flag_t
+typedef uint32_t ur_mem_flags_t;
+typedef enum _ur_mem_flag_t
 {
-    ZER_MEM_FLAG_MEM_READ_WRITE = ZER_BIT(0),       ///< The memory object will be read and written by a kernel. This is the
+    UR_MEM_FLAG_MEM_READ_WRITE = UR_BIT(0),         ///< The memory object will be read and written by a kernel. This is the
                                                     ///< default
-    ZER_MEM_FLAG_MEM_WRITE_ONLY = ZER_BIT(1),       ///< The memory object will be written but not read by a kernel
-    ZER_MEM_FLAG_MEM_READ_ONLY = ZER_BIT(2),        ///< The memory object is a read-only inside a kernel
-    ZER_MEM_FLAG_MEM_USE_HOST_POINTER = ZER_BIT(3), ///< Use memory pointed by a host pointer parameter as the storage bits for
+    UR_MEM_FLAG_MEM_WRITE_ONLY = UR_BIT(1),         ///< The memory object will be written but not read by a kernel
+    UR_MEM_FLAG_MEM_READ_ONLY = UR_BIT(2),          ///< The memory object is a read-only inside a kernel
+    UR_MEM_FLAG_MEM_USE_HOST_POINTER = UR_BIT(3),   ///< Use memory pointed by a host pointer parameter as the storage bits for
                                                     ///< the memory object
-    ZER_MEM_FLAG_MEM_ALLOC_HOST_POINTER = ZER_BIT(4),   ///< Allocate memory object from host accessible memory
-    ZER_MEM_FLAG_MEM_ALLOC_COPY_HOST_POINTER = ZER_BIT(5),  ///< Allocate memory and copy the data from host pointer pointed memory
-    ZER_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_MEM_FLAG_MEM_ALLOC_HOST_POINTER = UR_BIT(4), ///< Allocate memory object from host accessible memory
+    UR_MEM_FLAG_MEM_ALLOC_COPY_HOST_POINTER = UR_BIT(5),///< Allocate memory and copy the data from host pointer pointed memory
+    UR_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_mem_flag_t;
+} ur_mem_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory types
-typedef enum _zer_mem_type_t
+typedef enum _ur_mem_type_t
 {
-    ZER_MEM_TYPE_MEM_TYPE_BUFFER = 0,               ///< Buffer object
-    ZER_MEM_TYPE_MEM_TYPE_IMAGE2D = 1,              ///< 2D image object
-    ZER_MEM_TYPE_MEM_TYPE_IMAGE3D = 2,              ///< 3D image object
-    ZER_MEM_TYPE_MEM_TYPE_IMAGE2D_ARRAY = 3,        ///< 2D image array object
-    ZER_MEM_TYPE_MEM_TYPE_IMAGE1D = 4,              ///< 1D image object
-    ZER_MEM_TYPE_MEM_TYPE_IMAGE1D_ARRAY = 5,        ///< 1D image array object
-    ZER_MEM_TYPE_MEM_TYPE_IMAGE1D_BUFFER = 6,       ///< 1D image buffer object
-    ZER_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_MEM_TYPE_MEM_TYPE_BUFFER = 0,                ///< Buffer object
+    UR_MEM_TYPE_MEM_TYPE_IMAGE2D = 1,               ///< 2D image object
+    UR_MEM_TYPE_MEM_TYPE_IMAGE3D = 2,               ///< 3D image object
+    UR_MEM_TYPE_MEM_TYPE_IMAGE2D_ARRAY = 3,         ///< 2D image array object
+    UR_MEM_TYPE_MEM_TYPE_IMAGE1D = 4,               ///< 1D image object
+    UR_MEM_TYPE_MEM_TYPE_IMAGE1D_ARRAY = 5,         ///< 1D image array object
+    UR_MEM_TYPE_MEM_TYPE_IMAGE1D_BUFFER = 6,        ///< 1D image buffer object
+    UR_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_mem_type_t;
+} ur_mem_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel order info: number of channels and the channel layout
-typedef enum _zer_image_channel_order_t
+typedef enum _ur_image_channel_order_t
 {
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_A = 0,    ///< channel order A
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_R = 1,    ///< channel order R
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RG = 2,   ///< channel order RG
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RA = 3,   ///< channel order RA
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGB = 4,  ///< channel order RGB
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGBA = 5, ///< channel order RGBA
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_BGRA = 6, ///< channel order BGRA
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_ARGB = 7, ///< channel order ARGB
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_INTENSITY = 8,///< channel order intensity
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_LUMINANCE = 9,///< channel order luminance
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RX = 10,  ///< channel order Rx
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGX = 11, ///< channel order RGx
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGBX = 12,///< channel order RGBx
-    ZER_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_SRGBA = 13,   ///< channel order sRGBA
-    ZER_IMAGE_CHANNEL_ORDER_FORCE_UINT32 = 0x7fffffff
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_A = 0,     ///< channel order A
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_R = 1,     ///< channel order R
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RG = 2,    ///< channel order RG
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RA = 3,    ///< channel order RA
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGB = 4,   ///< channel order RGB
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGBA = 5,  ///< channel order RGBA
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_BGRA = 6,  ///< channel order BGRA
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_ARGB = 7,  ///< channel order ARGB
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_INTENSITY = 8, ///< channel order intensity
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_LUMINANCE = 9, ///< channel order luminance
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RX = 10,   ///< channel order Rx
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGX = 11,  ///< channel order RGx
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_RGBX = 12, ///< channel order RGBx
+    UR_IMAGE_CHANNEL_ORDER_CHANNEL_ORDER_SRGBA = 13,///< channel order sRGBA
+    UR_IMAGE_CHANNEL_ORDER_FORCE_UINT32 = 0x7fffffff
 
-} zer_image_channel_order_t;
+} ur_image_channel_order_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel type info: describe the size of the channel data type
-typedef enum _zer_image_channel_type_t
+typedef enum _ur_image_channel_type_t
 {
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SNORM_INT8 = 0, ///< channel type snorm int8
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SNORM_INT16 = 1,///< channel type snorm int16
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_INT8 = 2, ///< channel type unorm int8
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_INT16 = 3,///< channel type unorm int16
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_SHORT_565 = 4,///< channel type unorm short 565
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_SHORT_555 = 5,///< channel type unorm short 555
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_INT_101010 = 6, ///< channel type int 101010
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SIGNED_INT8 = 7,///< channel type signed int8
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SIGNED_INT16 = 8,   ///< channel type signed int16
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SIGNED_INT32 = 9,   ///< channel type signed int32
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNSIGNED_INT8 = 10, ///< channel type unsigned int8
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNSIGNED_INT16 = 11,///< channel type unsigned int16
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNSIGNED_INT32 = 12,///< channel type unsigned int32
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_HALF_FLOAT = 13,///< channel type half float
-    ZER_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_FLOAT = 14, ///< channel type float
-    ZER_IMAGE_CHANNEL_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SNORM_INT8 = 0,  ///< channel type snorm int8
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SNORM_INT16 = 1, ///< channel type snorm int16
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_INT8 = 2,  ///< channel type unorm int8
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_INT16 = 3, ///< channel type unorm int16
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_SHORT_565 = 4, ///< channel type unorm short 565
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNORM_SHORT_555 = 5, ///< channel type unorm short 555
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_INT_101010 = 6,  ///< channel type int 101010
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SIGNED_INT8 = 7, ///< channel type signed int8
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SIGNED_INT16 = 8,///< channel type signed int16
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_SIGNED_INT32 = 9,///< channel type signed int32
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNSIGNED_INT8 = 10,  ///< channel type unsigned int8
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNSIGNED_INT16 = 11, ///< channel type unsigned int16
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_UNSIGNED_INT32 = 12, ///< channel type unsigned int32
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_HALF_FLOAT = 13, ///< channel type half float
+    UR_IMAGE_CHANNEL_TYPE_CHANNEL_TYPE_FLOAT = 14,  ///< channel type float
+    UR_IMAGE_CHANNEL_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_image_channel_type_t;
+} ur_image_channel_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image format including channel layout and data type
-typedef struct _zer_image_format_t
+typedef struct _ur_image_format_t
 {
-    zer_image_channel_order_t channelOrder;         ///< [in] image channel order
-    zer_image_channel_type_t channelType;           ///< [in] image channel type
+    ur_image_channel_order_t channelOrder;          ///< [in] image channel order
+    ur_image_channel_type_t channelType;            ///< [in] image channel type
 
-} zer_image_format_t;
+} ur_image_format_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image descriptor type.
-typedef struct _zer_image_desc_t
+typedef struct _ur_image_desc_t
 {
-    zer_structure_type_t stype;                     ///< [in] type of this structure
+    ur_structure_type_t stype;                      ///< [in] type of this structure
     const void* pNext;                              ///< [in][optional] pointer to extension-specific structure
-    zer_mem_type_t type;                            ///< [in] memory object type
+    ur_mem_type_t type;                             ///< [in] memory object type
     size_t width;                                   ///< [in] image width
     size_t height;                                  ///< [in] image height
     size_t depth;                                   ///< [in] image depth
@@ -1717,7 +1717,7 @@ typedef struct _zer_image_desc_t
     uint32_t numMipLevel;                           ///< [in] number of MIP levels
     uint32_t numSamples;                            ///< [in] number of samples
 
-} zer_image_desc_t;
+} ur_image_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create an image object
@@ -1727,35 +1727,35 @@ typedef struct _zer_image_desc_t
 ///     - **clCreateImage**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3f < flags`
-///         + `::ZER_MEM_TYPE_MEM_TYPE_IMAGE1D_BUFFER < imageDesc->type`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `::UR_MEM_TYPE_MEM_TYPE_IMAGE1D_BUFFER < imageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == imageFormat`
 ///         + `nullptr == imageDesc`
 ///         + `nullptr == hostPtr`
 ///         + `nullptr == phMem`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///     - ::ZER_RESULT_INVALID_IMAGE_SIZE
-///     - ::ZER_RESULT_INVALID_OPERATION
-///     - ::ZER_RESULT_INVALID_HOST_PTR
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemImageCreate(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context object
-    zer_mem_flags_t flags,                          ///< [in] allocation and usage information flags
-    const zer_image_format_t* imageFormat,          ///< [in] pointer to image format specification
-    const zer_image_desc_t* imageDesc,              ///< [in] pointer to image description
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///     - ::UR_RESULT_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_INVALID_OPERATION
+///     - ::UR_RESULT_INVALID_HOST_PTR
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+    const ur_image_format_t* imageFormat,           ///< [in] pointer to image format specification
+    const ur_image_desc_t* imageDesc,               ///< [in] pointer to image description
     void* hostPtr,                                  ///< [in] pointer to the buffer data
-    zer_mem_handle_t* phMem                         ///< [out] pointer to handle of image object created
+    ur_mem_handle_t* phMem                          ///< [out] pointer to handle of image object created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1766,29 +1766,29 @@ zerMemImageCreate(
 ///     - **clCreateBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3f < flags`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == hostPtr`
 ///         + `nullptr == phBuffer`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_BUFFER_SIZE
-///     - ::ZER_RESULT_INVALID_HOST_PTR
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemBufferCreate(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context object
-    zer_mem_flags_t flags,                          ///< [in] allocation and usage information flags
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_BUFFER_SIZE
+///     - ::UR_RESULT_INVALID_HOST_PTR
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemBufferCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
     size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
     void* hostPtr,                                  ///< [in] pointer to the buffer data
-    zer_mem_handle_t* phBuffer                      ///< [out] pointer to handle of the memory buffer created
+    ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1804,17 +1804,17 @@ zerMemBufferCreate(
 ///     - **clRetainMemoryObject**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hMem`
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemGetReference(
-    zer_mem_handle_t hMem                           ///< [in] handle of the memory object to get access
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemGetReference(
+    ur_mem_handle_t hMem                            ///< [in] handle of the memory object to get access
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1826,35 +1826,35 @@ zerMemGetReference(
 ///     - **clReleaseMemoryObject**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hMem`
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemRelease(
-    zer_mem_handle_t hMem                           ///< [in] handle of the memory object to release
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemRelease(
+    ur_mem_handle_t hMem                            ///< [in] handle of the memory object to release
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Buffer region type, used to describe a sub buffer
-typedef struct _zer_buffer_region_t
+typedef struct _ur_buffer_region_t
 {
     size_t origin;                                  ///< [in] buffer origin offset
     size_t size;                                    ///< [in] size of the buffer region
 
-} zer_buffer_region_t;
+} ur_buffer_region_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Buffer creation type
-typedef enum _zer_buffer_create_type_t
+typedef enum _ur_buffer_create_type_t
 {
-    ZER_BUFFER_CREATE_TYPE_BUFFER_CREATE_TYPE_REGION = 0,   ///< buffer create type is region
-    ZER_BUFFER_CREATE_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_BUFFER_CREATE_TYPE_BUFFER_CREATE_TYPE_REGION = 0,///< buffer create type is region
+    UR_BUFFER_CREATE_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_buffer_create_type_t;
+} ur_buffer_create_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sub buffer representing a region in an existing buffer
@@ -1864,31 +1864,31 @@ typedef enum _zer_buffer_create_type_t
 ///     - **clCreateSubBuffer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hBuffer`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3f < flags`
-///         + `::ZER_BUFFER_CREATE_TYPE_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `::UR_BUFFER_CREATE_TYPE_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pBufferCreateInfo`
 ///         + `nullptr == phMem`
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OBJECT_ALLOCATION_FAILURE
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_BUFFER_SIZE
-///     - ::ZER_RESULT_INVALID_HOST_PTR
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemBufferPartition(
-    zer_mem_handle_t hBuffer,                       ///< [in] handle of the buffer object to allocate from
-    zer_mem_flags_t flags,                          ///< [in] allocation and usage information flags
-    zer_buffer_create_type_t bufferCreateType,      ///< [in] buffer creation type
-    zer_buffer_region_t* pBufferCreateInfo,         ///< [in] pointer to buffer create region information
-    zer_mem_handle_t* phMem                         ///< [out] pointer to the handle of sub buffer created
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OBJECT_ALLOCATION_FAILURE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_BUFFER_SIZE
+///     - ::UR_RESULT_INVALID_HOST_PTR
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+    ur_buffer_create_type_t bufferCreateType,       ///< [in] buffer creation type
+    ur_buffer_region_t* pBufferCreateInfo,          ///< [in] pointer to buffer create region information
+    ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of sub buffer created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1904,17 +1904,17 @@ zerMemBufferPartition(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hMem`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeMem`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemGetNativeHandle(
-    zer_mem_handle_t hMem,                          ///< [in] handle of the mem.
-    zer_native_handle_t* phNativeMem                ///< [out] a pointer to the native handle of the mem.
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,                           ///< [in] handle of the mem.
+    ur_native_handle_t* phNativeMem                 ///< [out] a pointer to the native handle of the mem.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1927,19 +1927,19 @@ zerMemGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativeMem`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phMem`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativeMem,                 ///< [in] the native handle of the mem.
-    zer_mem_handle_t* phMem                         ///< [out] pointer to the handle of the mem object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeMem,                  ///< [in] the native handle of the mem.
+    ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of the mem object created.
     );
 
 #if !defined(__GNUC__)
@@ -1953,14 +1953,14 @@ zerMemCreateWithNativeHandle(
 /// @brief Tear down L0 runtime instance and release all its resources
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pParams`
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerTearDown(
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urTearDown(
     void* pParams                                   ///< [in] pointer to tear down parameters
     );
 
@@ -1973,30 +1973,30 @@ zerTearDown(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query queue info
-typedef enum _zer_queue_info_t
+typedef enum _ur_queue_info_t
 {
-    ZER_QUEUE_INFO_CONTEXT = 0,                     ///< Queue context info
-    ZER_QUEUE_INFO_DEVICE = 1,                      ///< Queue device info
-    ZER_QUEUE_INFO_DEVICE_DEFAULT = 2,              ///< Queue device default info
-    ZER_QUEUE_INFO_PROPERTIES = 3,                  ///< Queue properties info
-    ZER_QUEUE_INFO_REFERENCE_COUNT = 4,             ///< Queue reference count
-    ZER_QUEUE_INFO_SIZE = 5,                        ///< Queue size info
-    ZER_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_QUEUE_INFO_CONTEXT = 0,                      ///< Queue context info
+    UR_QUEUE_INFO_DEVICE = 1,                       ///< Queue device info
+    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,               ///< Queue device default info
+    UR_QUEUE_INFO_PROPERTIES = 3,                   ///< Queue properties info
+    UR_QUEUE_INFO_REFERENCE_COUNT = 4,              ///< Queue reference count
+    UR_QUEUE_INFO_SIZE = 5,                         ///< Queue size info
+    UR_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_queue_info_t;
+} ur_queue_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue properties
-typedef uint32_t zer_queue_flags_t;
-typedef enum _zer_queue_flag_t
+typedef uint32_t ur_queue_flags_t;
+typedef enum _ur_queue_flag_t
 {
-    ZER_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE = ZER_BIT(0),  ///< Enable/disable out of order execution
-    ZER_QUEUE_FLAG_PROFILING_ENABLE = ZER_BIT(1),   ///< Enable/disable profiling
-    ZER_QUEUE_FLAG_ON_DEVICE = ZER_BIT(2),          ///< Is a device queue
-    ZER_QUEUE_FLAG_ON_DEVICE_DEFAULT = ZER_BIT(3),  ///< Is the default queue for a device
-    ZER_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE = UR_BIT(0),///< Enable/disable out of order execution
+    UR_QUEUE_FLAG_PROFILING_ENABLE = UR_BIT(1),     ///< Enable/disable profiling
+    UR_QUEUE_FLAG_ON_DEVICE = UR_BIT(2),            ///< Is a device queue
+    UR_QUEUE_FLAG_ON_DEVICE_DEFAULT = UR_BIT(3),    ///< Is the default queue for a device
+    UR_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_queue_flag_t;
+} ur_queue_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
@@ -2006,24 +2006,24 @@ typedef enum _zer_queue_flag_t
 ///     - **clGetCommandQueueInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_QUEUE_INFO_SIZE < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_QUEUE_INFO_SIZE < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
 ///         + `nullptr == pSize`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerQueueGetInfo(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue object
-    zer_queue_info_t propName,                      ///< [in] name of the queue property to query
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueGetInfo(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_queue_info_t propName,                       ///< [in] name of the queue property to query
     size_t propValueSize,                           ///< [in] size in bytes of the queue property value provided
     void* propValue,                                ///< [out] value of the queue property
     size_t* pSize                                   ///< [out] size in bytes returned in queue property value
@@ -2037,29 +2037,29 @@ zerQueueGetInfo(
 ///     - **clCreateCommandQueueWithProperties**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0xf < props`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phQueue`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_DEVICE
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_QUEUE_PROPERTIES
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerQueueCreate(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context object
-    zer_device_handle_t hDevice,                    ///< [in] handle of the device object
-    zer_queue_flags_t props,                        ///< [in] initialization properties.
-                                                    ///< must be 0 (default) or a combination of ::zer_queue_flags_t.
-    zer_queue_handle_t* phQueue                     ///< [out] pointer to handle of queue object created
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_DEVICE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_QUEUE_PROPERTIES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+    ur_queue_flags_t props,                         ///< [in] initialization properties.
+                                                    ///< must be 0 (default) or a combination of ::ur_queue_flags_t.
+    ur_queue_handle_t* phQueue                      ///< [out] pointer to handle of queue object created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2075,17 +2075,17 @@ zerQueueCreate(
 ///     - **clRetainCommandQueue**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerQueueGetReference(
-    zer_queue_handle_t hQueue                       ///< [in] handle of the queue object to get access
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueGetReference(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to get access
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2103,17 +2103,17 @@ zerQueueGetReference(
 ///     - **clReleaseCommandQueue**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_INVALID_QUEUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerQueueRelease(
-    zer_queue_handle_t hQueue                       ///< [in] handle of the queue object to release
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueRelease(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to release
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2129,17 +2129,17 @@ zerQueueRelease(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeQueue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerQueueGetNativeHandle(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue.
-    zer_native_handle_t* phNativeQueue              ///< [out] a pointer to the native handle of the queue.
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue.
+    ur_native_handle_t* phNativeQueue               ///< [out] a pointer to the native handle of the queue.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2152,19 +2152,19 @@ zerQueueGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hQueue`
 ///         + `nullptr == hNativeQueue`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phQueue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerQueueCreateWithNativeHandle(
-    zer_queue_handle_t hQueue,                      ///< [in] handle of the queue instance
-    zer_native_handle_t hNativeQueue,               ///< [in] the native handle of the queue.
-    zer_queue_handle_t* phQueue                     ///< [out] pointer to the handle of the queue object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue instance
+    ur_native_handle_t hNativeQueue,                ///< [in] the native handle of the queue.
+    ur_queue_handle_t* phQueue                      ///< [out] pointer to the handle of the queue object created.
     );
 
 #if !defined(__GNUC__)
@@ -2176,39 +2176,39 @@ zerQueueCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get sample object information
-typedef enum _zer_sampler_info_t
+typedef enum _ur_sampler_info_t
 {
-    ZER_SAMPLER_INFO_SAMPLER_INFO_REFERENCE_COUNT = 0,  ///< Sampler reference count info
-    ZER_SAMPLER_INFO_SAMPLER_INFO_CONTEXT = 1,      ///< Sampler context info
-    ZER_SAMPLER_INFO_SAMPLER_INFO_NORMALIZED_COORDS = 2,///< Sampler normalized coordindate setting
-    ZER_SAMPLER_INFO_SAMPLER_INFO_ADDRESSING_MODE = 3,  ///< Sampler addressing mode setting
-    ZER_SAMPLER_INFO_SAMPLER_INFO_FILTER_MODE = 4,  ///< Sampler filter mode setting
-    ZER_SAMPLER_INFO_SAMPLER_INFO_MIP_FILTER_MODE = 5,  ///< Sampler MIP filter mode setting
-    ZER_SAMPLER_INFO_SAMPLER_INFO_LOD_MIN = 6,      ///< Sampler LOD Min value
-    ZER_SAMPLER_INFO_SAMPLER_INFO_LOD_MAX = 7,      ///< Sampler LOD Max value
-    ZER_SAMPLER_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_SAMPLER_INFO_SAMPLER_INFO_REFERENCE_COUNT = 0,   ///< Sampler reference count info
+    UR_SAMPLER_INFO_SAMPLER_INFO_CONTEXT = 1,       ///< Sampler context info
+    UR_SAMPLER_INFO_SAMPLER_INFO_NORMALIZED_COORDS = 2, ///< Sampler normalized coordindate setting
+    UR_SAMPLER_INFO_SAMPLER_INFO_ADDRESSING_MODE = 3,   ///< Sampler addressing mode setting
+    UR_SAMPLER_INFO_SAMPLER_INFO_FILTER_MODE = 4,   ///< Sampler filter mode setting
+    UR_SAMPLER_INFO_SAMPLER_INFO_MIP_FILTER_MODE = 5,   ///< Sampler MIP filter mode setting
+    UR_SAMPLER_INFO_SAMPLER_INFO_LOD_MIN = 6,       ///< Sampler LOD Min value
+    UR_SAMPLER_INFO_SAMPLER_INFO_LOD_MAX = 7,       ///< Sampler LOD Max value
+    UR_SAMPLER_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_sampler_info_t;
+} ur_sampler_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler properties
-typedef enum _zer_sampler_properties_t
+typedef enum _ur_sampler_properties_t
 {
-    ZER_SAMPLER_PROPERTIES_SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0,///< Sampler normalized coordinates
-    ZER_SAMPLER_PROPERTIES_SAMPLER_PROPERTIES_ADDRESSING_MODE = 1,  ///< Sampler addressing mode
-    ZER_SAMPLER_PROPERTIES_SAMPLER_PROPERTIES_FILTER_MODE = 2,  ///< Sampler filter mode
-    ZER_SAMPLER_PROPERTIES_FORCE_UINT32 = 0x7fffffff
+    UR_SAMPLER_PROPERTIES_SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0, ///< Sampler normalized coordinates
+    UR_SAMPLER_PROPERTIES_SAMPLER_PROPERTIES_ADDRESSING_MODE = 1,   ///< Sampler addressing mode
+    UR_SAMPLER_PROPERTIES_SAMPLER_PROPERTIES_FILTER_MODE = 2,   ///< Sampler filter mode
+    UR_SAMPLER_PROPERTIES_FORCE_UINT32 = 0x7fffffff
 
-} zer_sampler_properties_t;
+} ur_sampler_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler properties <name, value> pair
-typedef struct _zer_sampler_property_value_t
+typedef struct _ur_sampler_property_value_t
 {
-    zer_sampler_properties_t propName;              ///< [in] Sampler property
+    ur_sampler_properties_t propName;               ///< [in] Sampler property
     uint32_t propValue;                             ///< [in] Sampler property value
 
-} zer_sampler_property_value_t;
+} ur_sampler_property_value_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sampler object in a context
@@ -2224,25 +2224,25 @@ typedef struct _zer_sampler_property_value_t
 ///     - **clCreateSamplerWithProperties**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == props`
 ///         + `nullptr == phSampler`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_OPERATION
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerSamplerCreate(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context object
-    const zer_sampler_property_value_t* props,      ///< [in] specifies a list of sampler property names and their
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_OPERATION
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    const ur_sampler_property_value_t* props,       ///< [in] specifies a list of sampler property names and their
                                                     ///< corresponding values.
-    zer_sampler_handle_t* phSampler                 ///< [out] pointer to handle of sampler object created
+    ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2254,17 +2254,17 @@ zerSamplerCreate(
 ///     - **clRetainSampler**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hSampler`
-///     - ::ZER_RESULT_INVALID_SAMPLER
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerSamplerGetReference(
-    zer_sampler_handle_t hSampler                   ///< [in] handle of the sampler object to get access
+///     - ::UR_RESULT_INVALID_SAMPLER
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerGetReference(
+    ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to get access
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2276,17 +2276,17 @@ zerSamplerGetReference(
 ///     - **clReleaseSampler**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hSampler`
-///     - ::ZER_RESULT_INVALID_SAMPLER
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerSamplerRelease(
-    zer_sampler_handle_t hSampler                   ///< [in] handle of the sampler object to release
+///     - ::UR_RESULT_INVALID_SAMPLER
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to release
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2297,24 +2297,24 @@ zerSamplerRelease(
 ///     - **clGetSamplerInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hSampler`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_SAMPLER_INFO_SAMPLER_INFO_LOD_MAX < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_SAMPLER_INFO_SAMPLER_INFO_LOD_MAX < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
 ///         + `nullptr == pSize`
-///     - ::ZER_RESULT_INVALID_SAMPLER
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerSamplerGetInfo(
-    zer_sampler_handle_t hSampler,                  ///< [in] handle of the sampler object
-    zer_sampler_info_t propName,                    ///< [in] name of the sampler property to query
+///     - ::UR_RESULT_INVALID_SAMPLER
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerGetInfo(
+    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler object
+    ur_sampler_info_t propName,                     ///< [in] name of the sampler property to query
     size_t propValueSize,                           ///< [in] size in bytes of the sampler property value provided
     void* propValue,                                ///< [out] value of the sampler property
     size_t* pSize                                   ///< [out] size in bytes returned in sampler property value
@@ -2333,17 +2333,17 @@ zerSamplerGetInfo(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hSampler`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeSampler`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerSamplerGetNativeHandle(
-    zer_sampler_handle_t hSampler,                  ///< [in] handle of the sampler.
-    zer_native_handle_t* phNativeSampler            ///< [out] a pointer to the native handle of the sampler.
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler.
+    ur_native_handle_t* phNativeSampler             ///< [out] a pointer to the native handle of the sampler.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2356,19 +2356,19 @@ zerSamplerGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hSampler`
 ///         + `nullptr == hNativeSampler`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phSampler`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerSamplerCreateWithNativeHandle(
-    zer_sampler_handle_t hSampler,                  ///< [in] handle of the sampler instance
-    zer_native_handle_t hNativeSampler,             ///< [in] the native handle of the sampler.
-    zer_sampler_handle_t* phSampler                 ///< [out] pointer to the handle of the sampler object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler instance
+    ur_native_handle_t hNativeSampler,              ///< [in] the native handle of the sampler.
+    ur_sampler_handle_t* phSampler                  ///< [out] pointer to the handle of the sampler object created.
     );
 
 #if !defined(__GNUC__)
@@ -2380,47 +2380,47 @@ zerSamplerCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory property flags
-typedef uint32_t zer_usm_mem_flags_t;
-typedef enum _zer_usm_mem_flag_t
+typedef uint32_t ur_usm_mem_flags_t;
+typedef enum _ur_usm_mem_flag_t
 {
-    ZER_USM_MEM_FLAG_MEM_ALLOC_FLAGS_INTEL = ZER_BIT(0),///< The USM memory allocation is from Intel USM
-    ZER_USM_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_USM_MEM_FLAG_MEM_ALLOC_FLAGS_INTEL = UR_BIT(0),  ///< The USM memory allocation is from Intel USM
+    UR_USM_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_usm_mem_flag_t;
+} ur_usm_mem_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory allocation information type
-typedef enum _zer_mem_info_t
+typedef enum _ur_mem_info_t
 {
-    ZER_MEM_INFO_MEM_ALLOC_TYPE = 0,                ///< Memory allocation type info
-    ZER_MEM_INFO_MEM_ALLOC_BASE_PTR = 1,            ///< Memory allocation base pointer info
-    ZER_MEM_INFO_MEM_ALLOC_SIZE = 2,                ///< Memory allocation size info
-    ZER_MEM_INFO_MEM_ALLOC_DEVICE = 3,              ///< Memory allocation device info
-    ZER_MEM_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_MEM_INFO_MEM_ALLOC_TYPE = 0,                 ///< Memory allocation type info
+    UR_MEM_INFO_MEM_ALLOC_BASE_PTR = 1,             ///< Memory allocation base pointer info
+    UR_MEM_INFO_MEM_ALLOC_SIZE = 2,                 ///< Memory allocation size info
+    UR_MEM_INFO_MEM_ALLOC_DEVICE = 3,               ///< Memory allocation device info
+    UR_MEM_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_mem_info_t;
+} ur_mem_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocate host memory
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == context`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pUSMFlag`
 ///         + `nullptr == pptr`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_USM_SIZE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerUSMHostAlloc(
-    zer_context_handle_t context,                   ///< [in] handle of the context object
-    zer_usm_mem_flags_t* pUSMFlag,                  ///< [in] USM memory allocation flags
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_USM_SIZE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMHostAlloc(
+    ur_context_handle_t context,                    ///< [in] handle of the context object
+    ur_usm_mem_flags_t* pUSMFlag,                   ///< [in] USM memory allocation flags
     size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
     uint32_t align,                                 ///< [in] alignment of the USM memory object
     void** pptr                                     ///< [out] pointer to USM host memory object
@@ -2430,25 +2430,25 @@ zerUSMHostAlloc(
 /// @brief USM allocate device memory
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == context`
 ///         + `nullptr == device`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pUSMProp`
 ///         + `nullptr == pptr`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_USM_SIZE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerUSMDeviceAlloc(
-    zer_context_handle_t context,                   ///< [in] handle of the context object
-    zer_device_handle_t device,                     ///< [in] handle of the device object
-    zer_usm_mem_flags_t* pUSMProp,                  ///< [in] USM memory properties
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_USM_SIZE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMDeviceAlloc(
+    ur_context_handle_t context,                    ///< [in] handle of the context object
+    ur_device_handle_t device,                      ///< [in] handle of the device object
+    ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
     size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
     uint32_t align,                                 ///< [in] alignment of the USM memory object
     void** pptr                                     ///< [out] pointer to USM device memory object
@@ -2458,25 +2458,25 @@ zerUSMDeviceAlloc(
 /// @brief USM allocate shared memory
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == context`
 ///         + `nullptr == device`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pUSMProp`
 ///         + `nullptr == pptr`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_USM_SIZE
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-///     - ::ZER_RESULT_OUT_OF_RESOURCES
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerUSMSharedAlloc(
-    zer_context_handle_t context,                   ///< [in] handle of the context object
-    zer_device_handle_t device,                     ///< [in] handle of the device object
-    zer_usm_mem_flags_t* pUSMProp,                  ///< [in] USM memory properties
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_USM_SIZE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMSharedAlloc(
+    ur_context_handle_t context,                    ///< [in] handle of the context object
+    ur_device_handle_t device,                      ///< [in] handle of the device object
+    ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
     size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
     uint32_t align,                                 ///< [in] alignment of the USM memory object
     void** pptr                                     ///< [out] pointer to USM shared memory object
@@ -2486,18 +2486,18 @@ zerUSMSharedAlloc(
 /// @brief Free the USM memory object
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == context`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == ptr`
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemFree(
-    zer_context_handle_t context,                   ///< [in] handle of the context object
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemFree(
+    ur_context_handle_t context,                    ///< [in] handle of the context object
     void* ptr                                       ///< [in] pointer to USM memory object
     );
 
@@ -2505,26 +2505,26 @@ zerMemFree(
 /// @brief Get USM memory object allocation information
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == context`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == ptr`
 ///         + `nullptr == propValue`
 ///         + `nullptr == propValueSizeRet`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_MEM_INFO_MEM_ALLOC_DEVICE < propName`
-///     - ::ZER_RESULT_INVALID_CONTEXT
-///     - ::ZER_RESULT_INVALID_VALUE
-///     - ::ZER_RESULT_INVALID_MEM_OBJECT
-///     - ::ZER_RESULT_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerMemGetMemAllocInfo(
-    zer_context_handle_t context,                   ///< [in] handle of the context object
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_MEM_INFO_MEM_ALLOC_DEVICE < propName`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemGetMemAllocInfo(
+    ur_context_handle_t context,                    ///< [in] handle of the context object
     const void* ptr,                                ///< [in] pointer to USM memory object
-    zer_mem_info_t propName,                        ///< [in] the name of the USM allocation property to query
+    ur_mem_info_t propName,                         ///< [in] the name of the USM allocation property to query
     size_t propValueSize,                           ///< [in] size in bytes of the USM allocation property value
     void* propValue,                                ///< [out] value of the USM allocation property
     size_t* propValueSizeRet                        ///< [out] bytes returned in USM allocation property
@@ -2539,18 +2539,18 @@ zerMemGetMemAllocInfo(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device types
-typedef enum _zer_device_type_t
+typedef enum _ur_device_type_t
 {
-    ZER_DEVICE_TYPE_DEFAULT = 1,                    ///< The default device type as preferred by the runtime
-    ZER_DEVICE_TYPE_ALL = 2,                        ///< Devices of all types
-    ZER_DEVICE_TYPE_GPU = 3,                        ///< Graphics Processing Unit
-    ZER_DEVICE_TYPE_CPU = 4,                        ///< Central Processing Unit
-    ZER_DEVICE_TYPE_FPGA = 5,                       ///< Field Programmable Gate Array
-    ZER_DEVICE_TYPE_MCA = 6,                        ///< Memory Copy Accelerator
-    ZER_DEVICE_TYPE_VPU = 7,                        ///< Vision Processing Unit
-    ZER_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_TYPE_DEFAULT = 1,                     ///< The default device type as preferred by the runtime
+    UR_DEVICE_TYPE_ALL = 2,                         ///< Devices of all types
+    UR_DEVICE_TYPE_GPU = 3,                         ///< Graphics Processing Unit
+    UR_DEVICE_TYPE_CPU = 4,                         ///< Central Processing Unit
+    UR_DEVICE_TYPE_FPGA = 5,                        ///< Field Programmable Gate Array
+    UR_DEVICE_TYPE_MCA = 6,                         ///< Memory Copy Accelerator
+    UR_DEVICE_TYPE_VPU = 7,                         ///< Vision Processing Unit
+    UR_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_type_t;
+} ur_device_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves devices within a platform
@@ -2562,7 +2562,7 @@ typedef enum _zer_device_type_t
 ///       affected by environment variables that filter devices exposed through
 ///       API.
 ///     - The returned devices are taken a reference of and must be released
-///       with a subsequent call to ::zerDeviceRelease.
+///       with a subsequent call to ::urDeviceRelease.
 ///     - The application may call this function from simultaneous threads, the
 ///       implementation must be thread-safe
 /// 
@@ -2571,144 +2571,143 @@ typedef enum _zer_device_type_t
 ///     - **clGetDeviceIDs**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_DEVICE_TYPE_VPU < DevicesType`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_DEVICE_TYPE_VPU < DevicesType`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pCount`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceGet(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_device_type_t DevicesType,                  ///< [in] the type of the devices.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceGet(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_device_type_t DevicesType,                   ///< [in] the type of the devices.
     uint32_t* pCount,                               ///< [in,out] pointer to the number of devices.
                                                     ///< If count is zero, then the call shall update the value with the total
                                                     ///< number of devices available.
                                                     ///< If count is greater than the number of devices available, then the
                                                     ///< call shall update the value with the correct number of devices available.
-    zer_device_handle_t* phDevices                  ///< [out][optional][range(0, *pCount)] array of handle of devices.
+    ur_device_handle_t* phDevices                   ///< [out][optional][range(0, *pCount)] array of handle of devices.
                                                     ///< If count is less than the number of devices available, then platform
                                                     ///< shall only retrieve that number of devices.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device info
-typedef enum _zer_device_info_t
+typedef enum _ur_device_info_t
 {
-    ZER_DEVICE_INFO_TYPE = 0,                       ///< ::zer_device_type_t: type of the device
-    ZER_DEVICE_INFO_VENDOR_ID = 1,                  ///< uint32_t: vendor Id of the device
-    ZER_DEVICE_INFO_MAX_COMPUTE_UNITS = 2,          ///< uint32_t: the number of compute units
-    ZER_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 3,   ///< uint32_t: max work item dimensions
-    ZER_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 4,        ///< size_t[]: return an array of max work item sizes
-    ZER_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 5,        ///< size_t: max work group size
-    ZER_DEVICE_INFO_SINGLE_FP_CONFIG = 6,           ///< Return a bit field of ::zer_fp_capability_flags_t: single precision
+    UR_DEVICE_INFO_TYPE = 0,                        ///< ::ur_device_type_t: type of the device
+    UR_DEVICE_INFO_VENDOR_ID = 1,                   ///< uint32_t: vendor Id of the device
+    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 2,           ///< uint32_t: the number of compute units
+    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 3,    ///< uint32_t: max work item dimensions
+    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 4,         ///< size_t[]: return an array of max work item sizes
+    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 5,         ///< size_t: max work group size
+    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 6,            ///< Return a bit field of ::ur_fp_capability_flags_t: single precision
                                                     ///< floating point capability
-    ZER_DEVICE_INFO_HALF_FP_CONFIG = 7,             ///< Return a bit field of ::zer_fp_capability_flags_t: half precsion
+    UR_DEVICE_INFO_HALF_FP_CONFIG = 7,              ///< Return a bit field of ::ur_fp_capability_flags_t: half precsion
                                                     ///< floating point capability
-    ZER_DEVICE_INFO_DOUBLE_FP_CONFIG = 8,           ///< Return a bit field of ::zer_fp_capability_flags_t: double precision
+    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 8,            ///< Return a bit field of ::ur_fp_capability_flags_t: double precision
                                                     ///< floating point capability
-    ZER_DEVICE_INFO_QUEUE_PROPERTIES = 9,           ///< Return a bit field of ::zer_queue_flags_t: command queue properties
+    UR_DEVICE_INFO_QUEUE_PROPERTIES = 9,            ///< Return a bit field of ::ur_queue_flags_t: command queue properties
                                                     ///< supported by the device
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 10,   ///< uint32_t: preferred vector width for char
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 11,  ///< uint32_t: preferred vector width for short
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 12,///< uint32_t: preferred vector width for int
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 13,   ///< uint32_t: preferred vector width for long
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 14,  ///< uint32_t: preferred vector width for float
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 15, ///< uint32_t: preferred vector width for double
-    ZER_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 16,   ///< uint32_t: preferred vector width for half float
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 17,  ///< uint32_t: native vector width for char
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 18, ///< uint32_t: native vector width for short
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 19,   ///< uint32_t: native vector width for int
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 20,  ///< uint32_t: native vector width for long
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 21, ///< uint32_t: native vector width for float
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 22,///< uint32_t: native vector width for double
-    ZER_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 23,  ///< uint32_t: native vector width for half float
-    ZER_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 24,       ///< uint32_t: max clock frequency in MHz
-    ZER_DEVICE_INFO_ADDRESS_BITS = 25,              ///< uint32_t: address bits
-    ZER_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 26,        ///< uint64_t: max memory allocation size
-    ZER_DEVICE_INFO_IMAGE_SUPPORTED = 27,           ///< bool: images are supported
-    ZER_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 28,       ///< uint32_t: max number of image objects arguments of a kernel declared
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 10,///< uint32_t: preferred vector width for char
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 11,   ///< uint32_t: preferred vector width for short
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 12, ///< uint32_t: preferred vector width for int
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 13,///< uint32_t: preferred vector width for long
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 14,   ///< uint32_t: preferred vector width for float
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 15,  ///< uint32_t: preferred vector width for double
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 16,///< uint32_t: preferred vector width for half float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 17,   ///< uint32_t: native vector width for char
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 18,  ///< uint32_t: native vector width for short
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 19,    ///< uint32_t: native vector width for int
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 20,   ///< uint32_t: native vector width for long
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 21,  ///< uint32_t: native vector width for float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 22, ///< uint32_t: native vector width for double
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 23,   ///< uint32_t: native vector width for half float
+    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 24,        ///< uint32_t: max clock frequency in MHz
+    UR_DEVICE_INFO_ADDRESS_BITS = 25,               ///< uint32_t: address bits
+    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 26,         ///< uint64_t: max memory allocation size
+    UR_DEVICE_INFO_IMAGE_SUPPORTED = 27,            ///< bool: images are supported
+    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 28,        ///< uint32_t: max number of image objects arguments of a kernel declared
                                                     ///< with the read_only qualifier
-    ZER_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 29,      ///< uint32_t: max number of image objects arguments of a kernel declared
+    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 29,       ///< uint32_t: max number of image objects arguments of a kernel declared
                                                     ///< with the write_only qualifier
-    ZER_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 30, ///< uint32_t: max number of image objects arguments of a kernel declared
+    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 30,  ///< uint32_t: max number of image objects arguments of a kernel declared
                                                     ///< with the read_write qualifier
-    ZER_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 31,         ///< size_t: max width of Image2D object
-    ZER_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 32,        ///< size_t: max heigh of Image2D object
-    ZER_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 33,         ///< size_t: max width of Image3D object
-    ZER_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 34,        ///< size_t: max height of Image3D object
-    ZER_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 35,         ///< size_t: max depth of Image3D object
-    ZER_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 36,     ///< size_t: max image buffer size
-    ZER_DEVICE_INFO_IMAGE_MAX_ARRAR_SIZE = 37,      ///< size_t: max image array size
-    ZER_DEVICE_INFO_MAX_SAMPLERS = 38,              ///< uint32_t: max number of samplers that can be used in a kernel
-    ZER_DEVICE_INFO_MAX_PARAMETER_SIZE = 39,        ///< size_t: max size in bytes of all arguments passed to a kernel
-    ZER_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 40,       ///< uint32_t: memory base address alignment
-    ZER_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 41,     ///< ::zer_device_mem_cache_type_t: global memory cache type
-    ZER_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 42, ///< uint32_t: global memory cache line size in bytes
-    ZER_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 43,     ///< uint64_t: size of global memory cache in bytes
-    ZER_DEVICE_INFO_GLOBAL_MEM_SIZE = 44,           ///< uint64_t: size of global memory in bytes
-    ZER_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 45,  ///< uint64_t: max constant buffer size in bytes
-    ZER_DEVICE_INFO_MAX_CONSTANT_ARGS = 46,         ///< uint32_t: max number of __const declared arguments in a kernel
-    ZER_DEVICE_INFO_LOCAL_MEM_TYPE = 47,            ///< ::zer_device_local_mem_type_t: local memory type
-    ZER_DEVICE_INFO_LOCAL_MEM_SIZE = 48,            ///< uint64_t: local memory size in bytes
-    ZER_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 49,  ///< bool: support error correction to gloal and local memory
-    ZER_DEVICE_INFO_HOST_UNIFIED_MEMORY = 50,       ///< bool: unifed host device memory
-    ZER_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 51,///< size_t: profiling timer resolution in nanoseconds
-    ZER_DEVICE_INFO_ENDIAN_LITTLE = 52,             ///< bool: little endian byte order
-    ZER_DEVICE_INFO_AVAILABLE = 53,                 ///< bool: device is available
-    ZER_DEVICE_INFO_COMPILER_AVAILABLE = 54,        ///< bool: device compiler is available
-    ZER_DEVICE_INFO_LINKER_AVAILABLE = 55,          ///< bool: device linker is available
-    ZER_DEVICE_INFO_EXECUTION_CAPABILITIES = 56,    ///< ::zer_device_exec_capability_flags_t: device kernel execution
+    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 31,          ///< size_t: max width of Image2D object
+    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 32,         ///< size_t: max heigh of Image2D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 33,          ///< size_t: max width of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 34,         ///< size_t: max height of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 35,          ///< size_t: max depth of Image3D object
+    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 36,      ///< size_t: max image buffer size
+    UR_DEVICE_INFO_IMAGE_MAX_ARRAR_SIZE = 37,       ///< size_t: max image array size
+    UR_DEVICE_INFO_MAX_SAMPLERS = 38,               ///< uint32_t: max number of samplers that can be used in a kernel
+    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 39,         ///< size_t: max size in bytes of all arguments passed to a kernel
+    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 40,        ///< uint32_t: memory base address alignment
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 41,      ///< ::ur_device_mem_cache_type_t: global memory cache type
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 42,  ///< uint32_t: global memory cache line size in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 43,      ///< uint64_t: size of global memory cache in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 44,            ///< uint64_t: size of global memory in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 45,   ///< uint64_t: max constant buffer size in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 46,          ///< uint32_t: max number of __const declared arguments in a kernel
+    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 47,             ///< ::ur_device_local_mem_type_t: local memory type
+    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 48,             ///< uint64_t: local memory size in bytes
+    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 49,   ///< bool: support error correction to gloal and local memory
+    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 50,        ///< bool: unifed host device memory
+    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 51, ///< size_t: profiling timer resolution in nanoseconds
+    UR_DEVICE_INFO_ENDIAN_LITTLE = 52,              ///< bool: little endian byte order
+    UR_DEVICE_INFO_AVAILABLE = 53,                  ///< bool: device is available
+    UR_DEVICE_INFO_COMPILER_AVAILABLE = 54,         ///< bool: device compiler is available
+    UR_DEVICE_INFO_LINKER_AVAILABLE = 55,           ///< bool: device linker is available
+    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 56,     ///< ::ur_device_exec_capability_flags_t: device kernel execution
                                                     ///< capability bit-field
-    ZER_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 57,///< ::zer_queue_flags_t: device command queue property bit-field
-    ZER_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 58,  ///< ::zer_queue_flags_t: host queue property bit-field
-    ZER_DEVICE_INFO_BUILT_IN_KERNELS = 59,          ///< char[]: a semi-colon separated list of built-in kernels
-    ZER_DEVICE_INFO_PLATFORM = 60,                  ///< ::zer_platform_handle_t: the platform associated with the device
-    ZER_DEVICE_INFO_REFERENCE_COUNT = 61,           ///< uint32_t: reference count
-    ZER_DEVICE_INFO_IL_VERSION = 62,                ///< char[]: IL version
-    ZER_DEVICE_INFO_NAME = 63,                      ///< char[]: Device name
-    ZER_DEVICE_INFO_VENDOR = 64,                    ///< char[]: Device vendor
-    ZER_DEVICE_INFO_DRIVER_VERSION = 65,            ///< char[]: Driver version
-    ZER_DEVICE_INFO_PROFILE = 66,                   ///< char[]: Device profile
-    ZER_DEVICE_INFO_VERSION = 67,                   ///< char[]: Device version
-    ZER_DEVICE_INFO_OPENCL_C_VERSION = 68,          ///< char[]: OpenCL C version
-    ZER_DEVICE_INFO_EXTENSIONS = 69,                ///< char[]: Return a space separated list of extension names
-    ZER_DEVICE_INFO_PRINTF_BUFFER_SIZE = 70,        ///< size_t: Maximum size in bytes of internal printf buffer
-    ZER_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 71,   ///< bool: prefer user synchronization when sharing object with other API
-    ZER_DEVICE_INFO_PARENT_DEVICE = 72,             ///< ::zer_device_handle_t: return parent device handle
-    ZER_DEVICE_INFO_PARTITION_PROPERTIES = 73,      ///< uint32_t: return a bit-field of partition properties
-                                                    ///< ::zer_device_partition_property_flags_t
-    ZER_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 74, ///< uint32_t: maximum number of sub-devices when the device is partitioned
-    ZER_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 75, ///< uint32_t: return a bit-field of affinity domain
-                                                    ///< ::zer_device_affinity_domain_flags_t
-    ZER_DEVICE_INFO_PARTITION_TYPE = 76,            ///< uint32_t: return a bit-field of
-                                                    ///< ::zer_device_partition_property_flags_t for properties specified in
-                                                    ///< ::zerDevicePartition
-    ZER_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 77,        ///< uint32_t: max number of sub groups
-    ZER_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 78,///< bool: support sub group independent forward progress
-    ZER_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 79,     ///< uint32_t[]: return an array of sub group sizes supported on Intel
+    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 57, ///< ::ur_queue_flags_t: device command queue property bit-field
+    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 58,   ///< ::ur_queue_flags_t: host queue property bit-field
+    UR_DEVICE_INFO_BUILT_IN_KERNELS = 59,           ///< char[]: a semi-colon separated list of built-in kernels
+    UR_DEVICE_INFO_PLATFORM = 60,                   ///< ::ur_platform_handle_t: the platform associated with the device
+    UR_DEVICE_INFO_REFERENCE_COUNT = 61,            ///< uint32_t: reference count
+    UR_DEVICE_INFO_IL_VERSION = 62,                 ///< char[]: IL version
+    UR_DEVICE_INFO_NAME = 63,                       ///< char[]: Device name
+    UR_DEVICE_INFO_VENDOR = 64,                     ///< char[]: Device vendor
+    UR_DEVICE_INFO_DRIVER_VERSION = 65,             ///< char[]: Driver version
+    UR_DEVICE_INFO_PROFILE = 66,                    ///< char[]: Device profile
+    UR_DEVICE_INFO_VERSION = 67,                    ///< char[]: Device version
+    UR_DEVICE_INFO_OPENCL_C_VERSION = 68,           ///< char[]: OpenCL C version
+    UR_DEVICE_INFO_EXTENSIONS = 69,                 ///< char[]: Return a space separated list of extension names
+    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 70,         ///< size_t: Maximum size in bytes of internal printf buffer
+    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 71,///< bool: prefer user synchronization when sharing object with other API
+    UR_DEVICE_INFO_PARENT_DEVICE = 72,              ///< ::ur_device_handle_t: return parent device handle
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 73,       ///< uint32_t: return a bit-field of partition properties
+                                                    ///< ::ur_device_partition_property_flags_t
+    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 74,  ///< uint32_t: maximum number of sub-devices when the device is partitioned
+    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 75,  ///< uint32_t: return a bit-field of affinity domain
+                                                    ///< ::ur_device_affinity_domain_flags_t
+    UR_DEVICE_INFO_PARTITION_TYPE = 76,             ///< uint32_t: return a bit-field of ::ur_device_partition_property_flags_t
+                                                    ///< for properties specified in ::urDevicePartition
+    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 77,         ///< uint32_t: max number of sub groups
+    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 78, ///< bool: support sub group independent forward progress
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 79,      ///< uint32_t[]: return an array of sub group sizes supported on Intel
                                                     ///< device
-    ZER_DEVICE_INFO_USM_HOST_SUPPORT = 80,          ///< bool: support USM host memory access
-    ZER_DEVICE_INFO_USM_DEVICE_SUPPORT = 81,        ///< bool: support USM device memory access
-    ZER_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 82, ///< bool: support USM single device shared memory access
-    ZER_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 83,  ///< bool: support USM cross device shared memory access
-    ZER_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 84, ///< bool: support USM system wide shared memory access
-    ZER_DEVICE_INFO_UUID = 85,                      ///< char[]: return device UUID
-    ZER_DEVICE_INFO_PCI_ADDRESS = 86,               ///< char[]: return device PCI address
-    ZER_DEVICE_INFO_GPU_EU_COUNT = 87,              ///< uint32_t: return Intel GPU EU count
-    ZER_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 88,         ///< uint32_t: return Intel GPU EU SIMD width
-    ZER_DEVICE_INFO_GPU_EU_SLICES = 89,             ///< uint32_t: return Intel GPU number of slices
-    ZER_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 90,   ///< uint32_t: return Intel GPU number of subslices per slice
-    ZER_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 91,      ///< uint32_t: return max memory bandwidth in Mb/s
-    ZER_DEVICE_INFO_IMAGE_SRGB = 92,                ///< bool: image is SRGB
-    ZER_DEVICE_INFO_ATOMIC_64 = 93,                 ///< bool: support 64 bit atomics
-    ZER_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 94,  ///< uint32_t: atomics memory order capabilities
-    ZER_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_INFO_USM_HOST_SUPPORT = 80,           ///< bool: support USM host memory access
+    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 81,         ///< bool: support USM device memory access
+    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 82,  ///< bool: support USM single device shared memory access
+    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 83,   ///< bool: support USM cross device shared memory access
+    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 84,  ///< bool: support USM system wide shared memory access
+    UR_DEVICE_INFO_UUID = 85,                       ///< char[]: return device UUID
+    UR_DEVICE_INFO_PCI_ADDRESS = 86,                ///< char[]: return device PCI address
+    UR_DEVICE_INFO_GPU_EU_COUNT = 87,               ///< uint32_t: return Intel GPU EU count
+    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 88,          ///< uint32_t: return Intel GPU EU SIMD width
+    UR_DEVICE_INFO_GPU_EU_SLICES = 89,              ///< uint32_t: return Intel GPU number of slices
+    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 90,    ///< uint32_t: return Intel GPU number of subslices per slice
+    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 91,       ///< uint32_t: return max memory bandwidth in Mb/s
+    UR_DEVICE_INFO_IMAGE_SRGB = 92,                 ///< bool: image is SRGB
+    UR_DEVICE_INFO_ATOMIC_64 = 93,                  ///< bool: support 64 bit atomics
+    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 94,   ///< uint32_t: atomics memory order capabilities
+    UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_info_t;
+} ur_device_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about device
@@ -2722,32 +2721,32 @@ typedef enum _zer_device_info_t
 ///     - **clGetDeviceInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES < infoType`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES < infoType`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pSize`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceGetInfo(
-    zer_device_handle_t hDevice,                    ///< [in] handle of the device instance
-    zer_device_info_t infoType,                     ///< [in] type of the info to retrieve
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceGetInfo(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
+    ur_device_info_t infoType,                      ///< [in] type of the info to retrieve
     size_t* pSize,                                  ///< [in,out] pointer to the number of bytes needed to return info queried.
                                                     ///< The call shall update it with the real number of bytes needed to
                                                     ///< return the info
     void* pDeviceInfo                               ///< [out][optional] array of bytes holding the info.
                                                     ///< If *pSize input is not 0 and not equal to the real number of bytes
                                                     ///< needed to return the info
-                                                    ///< then the ::ZER_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
                                                     ///< pDeviceInfo is not used.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Makes a reference of the device handle indicating it's in use until
-///        paired ::zerDeviceRelease is called
+///        paired ::urDeviceRelease is called
 /// 
 /// @details
 ///     - It is not valid to use the device handle, which has all of its
@@ -2761,14 +2760,14 @@ zerDeviceGetInfo(
 ///     - **clRetainDevice**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceGetReference(
-    zer_device_handle_t hDevice                     ///< [in] handle of the device to get a reference of.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceGetReference(
+    ur_device_handle_t hDevice                      ///< [in] handle of the device to get a reference of.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2784,36 +2783,36 @@ zerDeviceGetReference(
 ///     - **clReleaseDevice**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceRelease(
-    zer_device_handle_t hDevice                     ///< [in] handle of the device to release.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceRelease(
+    ur_device_handle_t hDevice                      ///< [in] handle of the device to release.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device partition property
-typedef uint32_t zer_device_partition_property_flags_t;
-typedef enum _zer_device_partition_property_flag_t
+typedef uint32_t ur_device_partition_property_flags_t;
+typedef enum _ur_device_partition_property_flag_t
 {
-    ZER_DEVICE_PARTITION_PROPERTY_FLAG_EQUALLY = ZER_BIT(0),///< Support equal partition
-    ZER_DEVICE_PARTITION_PROPERTY_FLAG_BY_COUNTS = ZER_BIT(1),  ///< Support partition by count
-    ZER_DEVICE_PARTITION_PROPERTY_FLAG_BY_AFFINITY_DOMAIN = ZER_BIT(2), ///< Support partition by affinity domain
-    ZER_DEVICE_PARTITION_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_PARTITION_PROPERTY_FLAG_EQUALLY = UR_BIT(0),  ///< Support equal partition
+    UR_DEVICE_PARTITION_PROPERTY_FLAG_BY_COUNTS = UR_BIT(1),///< Support partition by count
+    UR_DEVICE_PARTITION_PROPERTY_FLAG_BY_AFFINITY_DOMAIN = UR_BIT(2),   ///< Support partition by affinity domain
+    UR_DEVICE_PARTITION_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_partition_property_flag_t;
+} ur_device_partition_property_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition property value
-typedef struct _zer_device_partition_property_value_t
+typedef struct _ur_device_partition_property_value_t
 {
-    zer_device_partition_property_flags_t property; ///< [in] device partition property flags
+    ur_device_partition_property_flags_t property;  ///< [in] device partition property flags
     uint32_t value;                                 ///< [in] partition value
 
-} zer_device_partition_property_value_t;
+} ur_device_partition_property_value_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition the device into sub-devices
@@ -2832,24 +2831,24 @@ typedef struct _zer_device_partition_property_value_t
 ///     - **clCreateSubDevices**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == Properties`
 ///         + `nullptr == pCount`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDevicePartition(
-    zer_device_handle_t hDevice,                    ///< [in] handle of the device to partition.
-    zer_device_partition_property_value_t* Properties,  ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
+    ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
     uint32_t* pCount,                               ///< [in,out] pointer to the number of sub-devices.
                                                     ///< If count is zero, then the function shall update the value with the
                                                     ///< total number of sub-devices available.
                                                     ///< If count is greater than the number of sub-devices available, then the
                                                     ///< function shall update the value with the correct number of sub-devices available.
-    zer_device_handle_t* phSubDevices               ///< [out][optional][range(0, *pCount)] array of handle of devices.
+    ur_device_handle_t* phSubDevices                ///< [out][optional][range(0, *pCount)] array of handle of devices.
                                                     ///< If count is less than the number of sub-devices available, then the
                                                     ///< function shall only retrieve that number of sub-devices.
     );
@@ -2869,16 +2868,16 @@ zerDevicePartition(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == Binaries`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceSelectBinary(
-    zer_device_handle_t hDevice,                    ///< [in] handle of the device to select binary for.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
     uint32_t NumBinaries,                           ///< [in] the number of binaries passed in Binaries. Must greater or equal
                                                     ///< than zero.
     const uint8_t** Binaries,                       ///< [in] the array of binaries to select from.
@@ -2888,62 +2887,62 @@ zerDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief FP capabilities
-typedef uint32_t zer_fp_capability_flags_t;
-typedef enum _zer_fp_capability_flag_t
+typedef uint32_t ur_fp_capability_flags_t;
+typedef enum _ur_fp_capability_flag_t
 {
-    ZER_FP_CAPABILITY_FLAG_CORRECTLY_ROUNDED_DIVIDE_SQRT = ZER_BIT(0),  ///< Support correctly rounded divide and sqrt
-    ZER_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST = ZER_BIT(1),   ///< Support round to nearest
-    ZER_FP_CAPABILITY_FLAG_ROUND_TO_ZERO = ZER_BIT(2),  ///< Support round to zero
-    ZER_FP_CAPABILITY_FLAG_ROUND_TO_INF = ZER_BIT(3),   ///< Support round to infinity
-    ZER_FP_CAPABILITY_FLAG_INF_NAN = ZER_BIT(4),    ///< Support INF to NAN
-    ZER_FP_CAPABILITY_FLAG_DENORM = ZER_BIT(5),     ///< Support denorm
-    ZER_FP_CAPABILITY_FLAG_FMA = ZER_BIT(6),        ///< Support FMA
-    ZER_FP_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_FP_CAPABILITY_FLAG_CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0),///< Support correctly rounded divide and sqrt
+    UR_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST = UR_BIT(1), ///< Support round to nearest
+    UR_FP_CAPABILITY_FLAG_ROUND_TO_ZERO = UR_BIT(2),///< Support round to zero
+    UR_FP_CAPABILITY_FLAG_ROUND_TO_INF = UR_BIT(3), ///< Support round to infinity
+    UR_FP_CAPABILITY_FLAG_INF_NAN = UR_BIT(4),      ///< Support INF to NAN
+    UR_FP_CAPABILITY_FLAG_DENORM = UR_BIT(5),       ///< Support denorm
+    UR_FP_CAPABILITY_FLAG_FMA = UR_BIT(6),          ///< Support FMA
+    UR_FP_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_fp_capability_flag_t;
+} ur_fp_capability_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device memory cache type
-typedef enum _zer_device_mem_cache_type_t
+typedef enum _ur_device_mem_cache_type_t
 {
-    ZER_DEVICE_MEM_CACHE_TYPE_NONE = 0,             ///< Has none cache
-    ZER_DEVICE_MEM_CACHE_TYPE_READ_ONLY_CACHE = 1,  ///< Has read only cache
-    ZER_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE = 2, ///< Has read write cache
-    ZER_DEVICE_MEM_CACHE_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_MEM_CACHE_TYPE_NONE = 0,              ///< Has none cache
+    UR_DEVICE_MEM_CACHE_TYPE_READ_ONLY_CACHE = 1,   ///< Has read only cache
+    UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE = 2,  ///< Has read write cache
+    UR_DEVICE_MEM_CACHE_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_mem_cache_type_t;
+} ur_device_mem_cache_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device local memory type
-typedef enum _zer_device_local_mem_type_t
+typedef enum _ur_device_local_mem_type_t
 {
-    ZER_DEVICE_LOCAL_MEM_TYPE_LOCAL = 0,            ///< Dedicated local memory
-    ZER_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 1,           ///< Global memory
-    ZER_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_LOCAL_MEM_TYPE_LOCAL = 0,             ///< Dedicated local memory
+    UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 1,            ///< Global memory
+    UR_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_local_mem_type_t;
+} ur_device_local_mem_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device kernel execution capability
-typedef uint32_t zer_device_exec_capability_flags_t;
-typedef enum _zer_device_exec_capability_flag_t
+typedef uint32_t ur_device_exec_capability_flags_t;
+typedef enum _ur_device_exec_capability_flag_t
 {
-    ZER_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL = ZER_BIT(0),///< Support kernel execution
-    ZER_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL = ZER_BIT(1), ///< Support native kernel execution
-    ZER_DEVICE_EXEC_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL = UR_BIT(0),  ///< Support kernel execution
+    UR_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL = UR_BIT(1),   ///< Support native kernel execution
+    UR_DEVICE_EXEC_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_exec_capability_flag_t;
+} ur_device_exec_capability_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device affinity domain
-typedef uint32_t zer_device_affinity_domain_flags_t;
-typedef enum _zer_device_affinity_domain_flag_t
+typedef uint32_t ur_device_affinity_domain_flags_t;
+typedef enum _ur_device_affinity_domain_flag_t
 {
-    ZER_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = ZER_BIT(0),  ///< By NUMA
-    ZER_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = ZER_BIT(1),///< BY next partitionable
-    ZER_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),///< By NUMA
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1),  ///< BY next partitionable
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_affinity_domain_flag_t;
+} ur_device_affinity_domain_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native device handle.
@@ -2958,17 +2957,17 @@ typedef enum _zer_device_affinity_domain_flag_t
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeDevice`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceGetNativeHandle(
-    zer_device_handle_t hDevice,                    ///< [in] handle of the device.
-    zer_native_handle_t* phNativeDevice             ///< [out] a pointer to the native handle of the device.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device.
+    ur_native_handle_t* phNativeDevice              ///< [out] a pointer to the native handle of the device.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2981,19 +2980,19 @@ zerDeviceGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativeDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phDevice`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerDeviceCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativeDevice,              ///< [in] the native handle of the device.
-    zer_device_handle_t* phDevice                   ///< [out] pointer to the handle of the device object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeDevice,               ///< [in] the native handle of the device.
+    ur_device_handle_t* phDevice                    ///< [out] pointer to the handle of the device object created.
     );
 
 #if !defined(__GNUC__)
@@ -3013,19 +3012,19 @@ zerDeviceCreateWithNativeHandle(
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pKernelName`
 ///         + `nullptr == phKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelCreate(
-    zer_program_handle_t hProgram,                  ///< [in] handle of the program instance
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelCreate(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program instance
     const char* pKernelName,                        ///< [in] pointer to null-terminated string.
-    zer_kernel_handle_t* phKernel                   ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t* phKernel                    ///< [out] pointer to handle of kernel object created.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3041,14 +3040,14 @@ zerKernelCreate(
 ///     - **clSetKernelArg**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelSetArg(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel object
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArg(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
     uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
     size_t argSize,                                 ///< [in] size of argument type
     const void* pArgValue                           ///< [in][optional] argument value represented as matching arg type. If
@@ -3057,58 +3056,58 @@ zerKernelSetArg(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel object information
-typedef enum _zer_kernel_info_t
+typedef enum _ur_kernel_info_t
 {
-    ZER_KERNEL_INFO_FUNCTION_NAME = 0,              ///< Return Kernel function name, return type char[]
-    ZER_KERNEL_INFO_NUM_ARGS = 1,                   ///< Return Kernel number of arguments
-    ZER_KERNEL_INFO_REFERENCE_COUNT = 2,            ///< Return Kernel reference count
-    ZER_KERNEL_INFO_CONTEXT = 3,                    ///< Return Context object associated with Kernel
-    ZER_KERNEL_INFO_PROGRAM = 4,                    ///< Return Program object associated with Kernel
-    ZER_KERNEL_INFO_ATTRIBUTES = 5,                 ///< Return Kernel attributes, return type char[]
-    ZER_KERNEL_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_KERNEL_INFO_FUNCTION_NAME = 0,               ///< Return Kernel function name, return type char[]
+    UR_KERNEL_INFO_NUM_ARGS = 1,                    ///< Return Kernel number of arguments
+    UR_KERNEL_INFO_REFERENCE_COUNT = 2,             ///< Return Kernel reference count
+    UR_KERNEL_INFO_CONTEXT = 3,                     ///< Return Context object associated with Kernel
+    UR_KERNEL_INFO_PROGRAM = 4,                     ///< Return Program object associated with Kernel
+    UR_KERNEL_INFO_ATTRIBUTES = 5,                  ///< Return Kernel attributes, return type char[]
+    UR_KERNEL_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_kernel_info_t;
+} ur_kernel_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel Work Group information
-typedef enum _zer_kernel_group_info_t
+typedef enum _ur_kernel_group_info_t
 {
-    ZER_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,     ///< Return Work Group maximum global size, return type size_t[3]
-    ZER_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,      ///< Return maximum Work Group size, return type size_t
-    ZER_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,  ///< Return Work Group size required by the source code, such as
+    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,      ///< Return Work Group maximum global size, return type size_t[3]
+    UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,       ///< Return maximum Work Group size, return type size_t
+    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,   ///< Return Work Group size required by the source code, such as
                                                     ///< __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]
-    ZER_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,       ///< Return local memory required by the Kernel, return type size_t
-    ZER_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4,   ///< Return preferred multiple of Work Group size for launch, return type
+    UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,        ///< Return local memory required by the Kernel, return type size_t
+    UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4,///< Return preferred multiple of Work Group size for launch, return type
                                                     ///< size_t
-    ZER_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,     ///< Return minimum amount of private memory in bytes used by each work
+    UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,      ///< Return minimum amount of private memory in bytes used by each work
                                                     ///< item in the Kernel, return type size_t
-    ZER_KERNEL_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_KERNEL_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_kernel_group_info_t;
+} ur_kernel_group_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel SubGroup information
-typedef enum _zer_kernel_sub_group_info_t
+typedef enum _ur_kernel_sub_group_info_t
 {
-    ZER_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE = 0,   ///< Return maximum SubGroup size, return type uint32_t
-    ZER_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS = 1,   ///< Return maximum number of SubGroup, return type uint32_t
-    ZER_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2,   ///< Return number of SubGroup required by the source code, return type
+    UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE = 0,///< Return maximum SubGroup size, return type uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS = 1,///< Return maximum number of SubGroup, return type uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2,///< Return number of SubGroup required by the source code, return type
                                                     ///< uint32_t
-    ZER_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3, ///< Return SubGroup size required by Intel, return type uint32_t
-    ZER_KERNEL_SUB_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3,  ///< Return SubGroup size required by Intel, return type uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_kernel_sub_group_info_t;
+} ur_kernel_sub_group_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set additional Kernel execution information
-typedef enum _zer_kernel_exec_info_t
+typedef enum _ur_kernel_exec_info_t
 {
-    ZER_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0,   ///< Kernel might access data through USM pointer, type bool_t*
-    ZER_KERNEL_EXEC_INFO_USM_PTRS = 1,              ///< Provide an explicit list of USM pointers that the kernel will access,
+    UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0,    ///< Kernel might access data through USM pointer, type bool_t*
+    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,               ///< Provide an explicit list of USM pointers that the kernel will access,
                                                     ///< type void*[].
-    ZER_KERNEL_EXEC_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_KERNEL_EXEC_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_kernel_exec_info_t;
+} ur_kernel_exec_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Kernel object
@@ -3118,19 +3117,19 @@ typedef enum _zer_kernel_exec_info_t
 ///     - **clGetKernelInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_KERNEL_INFO_ATTRIBUTES < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propSize`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelGetInfo(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the Kernel object
-    zer_kernel_info_t propName,                     ///< [in] name of the Kernel property to query
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+    ur_kernel_info_t propName,                      ///< [in] name of the Kernel property to query
     size_t* propSize,                               ///< [in,out] pointer to the size of the Kernel property value
                                                     ///< If *propSize is 0 or greater than the number of bytes of the Kernel property,
                                                     ///< the call shall update the value with actual number of bytes of the
@@ -3148,21 +3147,21 @@ zerKernelGetInfo(
 ///     - **clGetKernelWorkGroupInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelGetGroupInfo(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the Kernel object
-    zer_device_handle_t hDevice,                    ///< [in] handle of the Device object
-    zer_kernel_group_info_t propName,               ///< [in] name of the work Group property to query
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName,                ///< [in] name of the work Group property to query
     size_t propSize,                                ///< [in] size of the Kernel Work Group property value
     void* propValue                                 ///< [in,out][range(0, propSize)] value of the Kernel Work Group property.
     );
@@ -3171,21 +3170,21 @@ zerKernelGetGroupInfo(
 /// @brief Query SubGroup information about a Kernel object
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelGetSubGroupInfo(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the Kernel object
-    zer_device_handle_t hDevice,                    ///< [in] handle of the Device object
-    zer_kernel_sub_group_info_t propName,           ///< [in] name of the SubGroup property to query
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName,            ///< [in] name of the SubGroup property to query
     size_t propSize,                                ///< [in] size of the Kernel SubGroup property value
     void* propValue                                 ///< [in,out][range(0, propSize)] value of the Kernel SubGroup property.
     );
@@ -3204,14 +3203,14 @@ zerKernelGetSubGroupInfo(
 ///     - **clRetainKernel**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelGetReference(
-    zer_kernel_handle_t hKernel                     ///< [in] handle for the Kernel to retain
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetReference(
+    ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to retain
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3228,14 +3227,14 @@ zerKernelGetReference(
 ///     - **clReleaseKernel**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelRelease(
-    zer_kernel_handle_t hKernel                     ///< [in] handle for the Kernel to release
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelRelease(
+    ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to release
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3251,14 +3250,14 @@ zerKernelRelease(
 ///     - **clSetKernelArgSVMPointer**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelSetArgPointer(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel object
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArgPointer(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
     uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
     size_t argSize,                                 ///< [in] size of argument type
     const void* pArgValue                           ///< [in][optional] SVM pointer to memory location holding the argument
@@ -3278,19 +3277,19 @@ zerKernelSetArgPointer(
 ///     - **clSetKernelExecInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_KERNEL_EXEC_INFO_USM_PTRS < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_EXEC_INFO_USM_PTRS < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propValue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelSetExecInfo(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel object
-    zer_kernel_exec_info_t propName,                ///< [in] name of the execution attribute
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetExecInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    ur_kernel_exec_info_t propName,                 ///< [in] name of the execution attribute
     size_t propSize,                                ///< [in] size in byte the attribute value
     const void* propValue                           ///< [in][range(0, propSize)] pointer to memory location holding the
                                                     ///< property value.
@@ -3305,17 +3304,17 @@ zerKernelSetExecInfo(
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
 ///         + `nullptr == pArgValue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelSetArgSampler(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel object
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
     uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    zer_sampler_handle_t pArgValue                  ///< [in] handle of Sampler object.
+    ur_sampler_handle_t pArgValue                   ///< [in] handle of Sampler object.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3327,17 +3326,17 @@ zerKernelSetArgSampler(
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
 ///         + `nullptr == pArgValue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelSetArgMemObj(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel object
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArgMemObj(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
     uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    zer_mem_handle_t pArgValue                      ///< [in] handle of Memory object.
+    ur_mem_handle_t pArgValue                       ///< [in] handle of Memory object.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3353,17 +3352,17 @@ zerKernelSetArgMemObj(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelGetNativeHandle(
-    zer_kernel_handle_t hKernel,                    ///< [in] handle of the kernel.
-    zer_native_handle_t* phNativeKernel             ///< [out] a pointer to the native handle of the kernel.
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel.
+    ur_native_handle_t* phNativeKernel              ///< [out] a pointer to the native handle of the kernel.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3376,19 +3375,19 @@ zerKernelGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativeKernel`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phKernel`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerKernelCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativeKernel,              ///< [in] the native handle of the kernel.
-    zer_kernel_handle_t* phKernel                   ///< [out] pointer to the handle of the kernel object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeKernel,               ///< [in] the native handle of the kernel.
+    ur_kernel_handle_t* phKernel                    ///< [out] pointer to the handle of the kernel object created.
     );
 
 #if !defined(__GNUC__)
@@ -3408,25 +3407,25 @@ zerKernelCreateWithNativeHandle(
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pIL`
 ///         + `nullptr == pOptions`
 ///         + `nullptr == phModule`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerModuleCreate(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context instance
+UR_APIEXPORT ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
     const void* pIL,                                ///< [in] pointer to IL string.
     uint32_t length,                                ///< [in] length of IL in bytes.
     const char* pOptions,                           ///< [in] pointer to compiler options null-terminated string.
     void** pfnNotify,                               ///< [in][optional] A function pointer to a notification routine that is
                                                     ///< called when program compilation is complete.
     void* pUserData,                                ///< [in][optional] Passed as an argument when pfnNotify is called.
-    zer_module_handle_t* phModule                   ///< [out] pointer to handle of Module object created.
+    ur_module_handle_t* phModule                    ///< [out] pointer to handle of Module object created.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3439,14 +3438,14 @@ zerModuleCreate(
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hModule`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerModuleGetReference(
-    zer_module_handle_t hModule                     ///< [in] handle for the Module to retain
+UR_APIEXPORT ur_result_t UR_APICALL
+urModuleGetReference(
+    ur_module_handle_t hModule                      ///< [in] handle for the Module to retain
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3459,14 +3458,14 @@ zerModuleGetReference(
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hModule`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerModuleRelease(
-    zer_module_handle_t hModule                     ///< [in] handle for the Module to release
+UR_APIEXPORT ur_result_t UR_APICALL
+urModuleRelease(
+    ur_module_handle_t hModule                      ///< [in] handle for the Module to release
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3482,17 +3481,17 @@ zerModuleRelease(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hModule`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeModule`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerModuleGetNativeHandle(
-    zer_module_handle_t hModule,                    ///< [in] handle of the module.
-    zer_native_handle_t* phNativeModule             ///< [out] a pointer to the native handle of the module.
+UR_APIEXPORT ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,                     ///< [in] handle of the module.
+    ur_native_handle_t* phNativeModule              ///< [out] a pointer to the native handle of the module.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3505,19 +3504,19 @@ zerModuleGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativeModule`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phModule`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerModuleCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativeModule,              ///< [in] the native handle of the module.
-    zer_module_handle_t* phModule                   ///< [out] pointer to the handle of the module object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeModule,               ///< [in] the native handle of the module.
+    ur_module_handle_t* phModule                    ///< [out] pointer to the handle of the module object created.
     );
 
 #if !defined(__GNUC__)
@@ -3541,40 +3540,40 @@ zerModuleCreateWithNativeHandle(
 ///     - **clGetPlatformIDs**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pCount`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerPlatformGet(
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGet(
     uint32_t* pCount,                               ///< [in,out] pointer to the number of platforms.
                                                     ///< if count is zero, then the call shall update the value with the total
                                                     ///< number of platforms available.
                                                     ///< if count is greater than the number of platforms available, then the
                                                     ///< call shall update the value with the correct number of platforms available.
-    zer_platform_handle_t* phPlatforms              ///< [out][optional][range(0, *pCount)] array of handle of platforms.
+    ur_platform_handle_t* phPlatforms               ///< [out][optional][range(0, *pCount)] array of handle of platforms.
                                                     ///< if count is less than the number of platforms available, then platform
                                                     ///< shall only retrieve that number of platforms.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported platform info
-typedef enum _zer_platform_info_t
+typedef enum _ur_platform_info_t
 {
-    ZER_PLATFORM_INFO_NAME = 1,                     ///< [char*] The string denoting name of the platform. The size of the info
+    UR_PLATFORM_INFO_NAME = 1,                      ///< [char*] The string denoting name of the platform. The size of the info
                                                     ///< needs to be dynamically queried.
-    ZER_PLATFORM_INFO_VENDOR_NAME = 2,              ///< [char*] The string denoting name of the vendor of the platform. The
+    UR_PLATFORM_INFO_VENDOR_NAME = 2,               ///< [char*] The string denoting name of the vendor of the platform. The
                                                     ///< size of the info needs to be dynamically queried.
-    ZER_PLATFORM_INFO_VERSION = 3,                  ///< [char*] The string denoting the version of the platform. The size of
+    UR_PLATFORM_INFO_VERSION = 3,                   ///< [char*] The string denoting the version of the platform. The size of
                                                     ///< the info needs to be dynamically queried.
-    ZER_PLATFORM_INFO_EXTENSIONS = 4,               ///< [char*] The string denoting extensions supported by the platform. The
+    UR_PLATFORM_INFO_EXTENSIONS = 4,                ///< [char*] The string denoting extensions supported by the platform. The
                                                     ///< size of the info needs to be dynamically queried.
-    ZER_PLATFORM_INFO_PROFILE = 5,                  ///< [char*] The string denoting profile of the platform. The size of the
+    UR_PLATFORM_INFO_PROFILE = 5,                   ///< [char*] The string denoting profile of the platform. The size of the
                                                     ///< info needs to be dynamically queried.
-    ZER_PLATFORM_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_PLATFORM_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_platform_info_t;
+} ur_platform_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about platform
@@ -3588,26 +3587,26 @@ typedef enum _zer_platform_info_t
 ///     - **clGetPlatformInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_PLATFORM_INFO_PROFILE < PlatformInfoType`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pSize`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerPlatformGetInfo(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform
-    zer_platform_info_t PlatformInfoType,           ///< [in] type of the info to retrieve
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetInfo(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform
+    ur_platform_info_t PlatformInfoType,            ///< [in] type of the info to retrieve
     size_t* pSize,                                  ///< [in,out] pointer to the number of bytes needed to return info queried.
                                                     ///< the call shall update it with the real number of bytes needed to
                                                     ///< return the info
     void* pPlatformInfo                             ///< [out][optional] array of bytes holding the info.
                                                     ///< if *pSize is not equal to the real number of bytes needed to return
-                                                    ///< the info then the ::ZER_RESULT_ERROR_INVALID_SIZE error is returned
-                                                    ///< and pPlatformInfo is not used.
+                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pPlatformInfo is not used.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3615,14 +3614,14 @@ zerPlatformGetInfo(
 /// 
 /// @details
 ///     - API versions contain major and minor attributes, use
-///       ::ZER_MAJOR_VERSION and ::ZER_MINOR_VERSION
-typedef enum _zer_api_version_t
+///       ::UR_MAJOR_VERSION and ::UR_MINOR_VERSION
+typedef enum _ur_api_version_t
 {
-    ZER_API_VERSION_0_9 = ZER_MAKE_VERSION( 0, 9 ), ///< version 0.9
-    ZER_API_VERSION_CURRENT = ZER_MAKE_VERSION( 0, 9 ), ///< latest known version
-    ZER_API_VERSION_FORCE_UINT32 = 0x7fffffff
+    UR_API_VERSION_0_9 = UR_MAKE_VERSION( 0, 9 ),   ///< version 0.9
+    UR_API_VERSION_CURRENT = UR_MAKE_VERSION( 0, 9 ),   ///< latest known version
+    UR_API_VERSION_FORCE_UINT32 = 0x7fffffff
 
-} zer_api_version_t;
+} ur_api_version_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Returns the API version supported by the specified platform
@@ -3632,17 +3631,17 @@ typedef enum _zer_api_version_t
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDriver`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == version`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerPlatformGetApiVersion(
-    zer_platform_handle_t hDriver,                  ///< [in] handle of the platform
-    zer_api_version_t* version                      ///< [out] api version
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetApiVersion(
+    ur_platform_handle_t hDriver,                   ///< [in] handle of the platform
+    ur_api_version_t* version                       ///< [out] api version
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3658,17 +3657,17 @@ zerPlatformGetApiVersion(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativePlatform`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerPlatformGetNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform.
-    zer_native_handle_t* phNativePlatform           ///< [out] a pointer to the native handle of the platform.
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform.
+    ur_native_handle_t* phNativePlatform            ///< [out] a pointer to the native handle of the platform.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3681,19 +3680,19 @@ zerPlatformGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hPlatform`
 ///         + `nullptr == hNativePlatform`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phPlatform`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerPlatformCreateWithNativeHandle(
-    zer_platform_handle_t hPlatform,                ///< [in] handle of the platform instance
-    zer_native_handle_t hNativePlatform,            ///< [in] the native handle of the platform.
-    zer_platform_handle_t* phPlatform               ///< [out] pointer to the handle of the platform object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativePlatform,             ///< [in] the native handle of the platform.
+    ur_platform_handle_t* phPlatform                ///< [out] pointer to the handle of the platform object created.
     );
 
 #if !defined(__GNUC__)
@@ -3714,21 +3713,21 @@ zerPlatformCreateWithNativeHandle(
 ///     - **clCreateProgram**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phModules`
 ///         + `nullptr == phProgram`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramCreate(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context instance
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
     uint32_t count,                                 ///< [in] number of module handles in module list.
-    const zer_module_handle_t* phModules,           ///< [in] pointer to array of modules.
+    const ur_module_handle_t* phModules,            ///< [in] pointer to array of modules.
     const char* pOptions,                           ///< [in][optional] pointer to linker options null-terminated string.
-    zer_program_handle_t* phProgram                 ///< [out] pointer to handle of program object created.
+    ur_program_handle_t* phProgram                  ///< [out] pointer to handle of program object created.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3742,22 +3741,22 @@ zerProgramCreate(
 ///     - **clCreateProgramWithBinary**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pBinary`
 ///         + `nullptr == phProgram`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramCreateWithBinary(
-    zer_context_handle_t hContext,                  ///< [in] handle of the context instance
-    zer_device_handle_t hDevice,                    ///< [in] handle to device associated with binary.
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                     ///< [in] handle to device associated with binary.
     uint32_t size,                                  ///< [in] size in bytes.
     const uint8_t* pBinary,                         ///< [in] pointer to binary.
-    zer_program_handle_t* phProgram                 ///< [out] pointer to handle of Program object created.
+    ur_program_handle_t* phProgram                  ///< [out] pointer to handle of Program object created.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3774,14 +3773,14 @@ zerProgramCreateWithBinary(
 ///     - **clRetainProgram**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramGetReference(
-    zer_program_handle_t hProgram                   ///< [in] handle for the Program to retain
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetReference(
+    ur_program_handle_t hProgram                    ///< [in] handle for the Program to retain
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3798,14 +3797,14 @@ zerProgramGetReference(
 ///     - **clReleaseProgram**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramRelease(
-    zer_program_handle_t hProgram                   ///< [in] handle for the Program to release
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramRelease(
+    ur_program_handle_t hProgram                    ///< [in] handle for the Program to release
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3814,7 +3813,7 @@ zerProgramRelease(
 /// @details
 ///     - Retrieves a pointer to the functions with the given name and defined
 ///       in the given program.
-///     - ::ZER_RESULT_ERROR_INVALID_FUNCTION_NAME is returned if the function
+///     - ::UR_RESULT_ERROR_INVALID_FUNCTION_NAME is returned if the function
 ///       can not be obtained.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
@@ -3825,44 +3824,44 @@ zerProgramRelease(
 ///     - **clGetDeviceFunctionPointerINTEL**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
 ///         + `nullptr == hProgram`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == pFunctionName`
 ///         + `nullptr == pFunctionPointer`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramGetFunctionPointer(
-    zer_device_handle_t hDevice,                    ///< [in] handle of the device to retrieve pointer for.
-    zer_program_handle_t hProgram,                  ///< [in] handle of the program to search for function in.
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program to search for function in.
                                                     ///< The program must already be built to the specified device, or
-                                                    ///< otherwise ::ZER_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
     const char* pFunctionName,                      ///< [in] A null-terminates string denoting the mangled function name.
     void** pFunctionPointer                         ///< [out] Returns the pointer to the function if it is found in the program.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object information
-typedef enum _zer_program_info_t
+typedef enum _ur_program_info_t
 {
-    ZER_PROGRAM_INFO_REFERENCE_COUNT = 0,           ///< Program reference count info
-    ZER_PROGRAM_INFO_CONTEXT = 1,                   ///< Program context info
-    ZER_PROGRAM_INFO_NUM_DEVICES = 2,               ///< Return number of devices associated with Program
-    ZER_PROGRAM_INFO_DEVICES = 3,                   ///< Return list of devices associated with Program, return type
+    UR_PROGRAM_INFO_REFERENCE_COUNT = 0,            ///< Program reference count info
+    UR_PROGRAM_INFO_CONTEXT = 1,                    ///< Program context info
+    UR_PROGRAM_INFO_NUM_DEVICES = 2,                ///< Return number of devices associated with Program
+    UR_PROGRAM_INFO_DEVICES = 3,                    ///< Return list of devices associated with Program, return type
                                                     ///< uint32_t[].
-    ZER_PROGRAM_INFO_SOURCE = 4,                    ///< Return program source associated with Program, return type char[].
-    ZER_PROGRAM_INFO_BINARY_SIZES = 5,              ///< Return program binary sizes for each device, return type size_t[].
-    ZER_PROGRAM_INFO_BINARIES = 6,                  ///< Return program binaries for all devices for this Program, return type
+    UR_PROGRAM_INFO_SOURCE = 4,                     ///< Return program source associated with Program, return type char[].
+    UR_PROGRAM_INFO_BINARY_SIZES = 5,               ///< Return program binary sizes for each device, return type size_t[].
+    UR_PROGRAM_INFO_BINARIES = 6,                   ///< Return program binaries for all devices for this Program, return type
                                                     ///< uchar[].
-    ZER_PROGRAM_INFO_NUM_KERNELS = 7,               ///< Number of kernels in Program, return type size_t
-    ZER_PROGRAM_INFO_KERNEL_NAMES = 8,              ///< Return a semi-colon separated list of kernel names in Program, return
+    UR_PROGRAM_INFO_NUM_KERNELS = 7,                ///< Number of kernels in Program, return type size_t
+    UR_PROGRAM_INFO_KERNEL_NAMES = 8,               ///< Return a semi-colon separated list of kernel names in Program, return
                                                     ///< type char[]
-    ZER_PROGRAM_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_PROGRAM_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_program_info_t;
+} ur_program_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Program object
@@ -3872,19 +3871,19 @@ typedef enum _zer_program_info_t
 ///     - **clGetProgramInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_PROGRAM_INFO_KERNEL_NAMES < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propSize`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramGetInfo(
-    zer_program_handle_t hProgram,                  ///< [in] handle of the Program object
-    zer_program_info_t propName,                    ///< [in] name of the Program property to query
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetInfo(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+    ur_program_info_t propName,                     ///< [in] name of the Program property to query
     size_t* propSize,                               ///< [in,out] pointer to the size of the Program property.
                                                     ///< If *propSize is 0 or greater than the number of bytes of the Program property,
                                                     ///< the call shall update the value with actual number of bytes of the
@@ -3896,39 +3895,39 @@ zerProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program object build status
-typedef enum _zer_program_build_status_t
+typedef enum _ur_program_build_status_t
 {
-    ZER_PROGRAM_BUILD_STATUS_NONE = 0,              ///< Program build status none
-    ZER_PROGRAM_BUILD_STATUS_ERROR = 1,             ///< Program build error
-    ZER_PROGRAM_BUILD_STATUS_SUCCESS = 2,           ///< Program build success
-    ZER_PROGRAM_BUILD_STATUS_IN_PROGRESS = 3,       ///< Program build in progress
-    ZER_PROGRAM_BUILD_STATUS_FORCE_UINT32 = 0x7fffffff
+    UR_PROGRAM_BUILD_STATUS_NONE = 0,               ///< Program build status none
+    UR_PROGRAM_BUILD_STATUS_ERROR = 1,              ///< Program build error
+    UR_PROGRAM_BUILD_STATUS_SUCCESS = 2,            ///< Program build success
+    UR_PROGRAM_BUILD_STATUS_IN_PROGRESS = 3,        ///< Program build in progress
+    UR_PROGRAM_BUILD_STATUS_FORCE_UINT32 = 0x7fffffff
 
-} zer_program_build_status_t;
+} ur_program_build_status_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program object binary type
-typedef enum _zer_program_binary_type_t
+typedef enum _ur_program_binary_type_t
 {
-    ZER_PROGRAM_BINARY_TYPE_NONE = 0,               ///< No program binary is associated with device
-    ZER_PROGRAM_BINARY_TYPE_COMPILED_OBJECT = 1,    ///< Program binary is compiled object
-    ZER_PROGRAM_BINARY_TYPE_LIBRARY = 2,            ///< Program binary is library object
-    ZER_PROGRAM_BINARY_TYPE_EXECUTABLE = 3,         ///< Program binary is executable
-    ZER_PROGRAM_BINARY_TYPE_FORCE_UINT32 = 0x7fffffff
+    UR_PROGRAM_BINARY_TYPE_NONE = 0,                ///< No program binary is associated with device
+    UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT = 1,     ///< Program binary is compiled object
+    UR_PROGRAM_BINARY_TYPE_LIBRARY = 2,             ///< Program binary is library object
+    UR_PROGRAM_BINARY_TYPE_EXECUTABLE = 3,          ///< Program binary is executable
+    UR_PROGRAM_BINARY_TYPE_FORCE_UINT32 = 0x7fffffff
 
-} zer_program_binary_type_t;
+} ur_program_binary_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object build information
-typedef enum _zer_program_build_info_t
+typedef enum _ur_program_build_info_t
 {
-    ZER_PROGRAM_BUILD_INFO_STATUS = 0,              ///< Program build status, return type ::zer_program_build_status_t
-    ZER_PROGRAM_BUILD_INFO_OPTIONS = 1,             ///< Program build options, return type char[]
-    ZER_PROGRAM_BUILD_INFO_LOG = 2,                 ///< Program build log, return type char[]
-    ZER_PROGRAM_BUILD_INFO_BINARY_TYPE = 3,         ///< Program binary type, return type ::zer_program_binary_type_t
-    ZER_PROGRAM_BUILD_INFO_FORCE_UINT32 = 0x7fffffff
+    UR_PROGRAM_BUILD_INFO_STATUS = 0,               ///< Program build status, return type ::ur_program_build_status_t
+    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,              ///< Program build options, return type char[]
+    UR_PROGRAM_BUILD_INFO_LOG = 2,                  ///< Program build log, return type char[]
+    UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3,          ///< Program binary type, return type ::ur_program_binary_type_t
+    UR_PROGRAM_BUILD_INFO_FORCE_UINT32 = 0x7fffffff
 
-} zer_program_build_info_t;
+} ur_program_build_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query build information about a Program object for a Device
@@ -3938,21 +3937,21 @@ typedef enum _zer_program_build_info_t
 ///     - **clGetProgramBuildInfo**
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
 ///         + `nullptr == hDevice`
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::ZER_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == propSize`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramGetBuildInfo(
-    zer_program_handle_t hProgram,                  ///< [in] handle of the Program object
-    zer_device_handle_t hDevice,                    ///< [in] handle of the Device object
-    zer_program_build_info_t propName,              ///< [in] name of the Program build info to query
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+    ur_program_build_info_t propName,               ///< [in] name of the Program build info to query
     size_t* propSize,                               ///< [in,out] pointer to the size of the Program build info property.
                                                     ///< If *propSize is 0 or greater than the number of bytes of the build
                                                     ///< info property,
@@ -3967,16 +3966,16 @@ zerProgramGetBuildInfo(
 /// @brief Set a Program object specialization constant to a specific value
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == specValue`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramSetSpecializationConstant(
-    zer_program_handle_t hProgram,                  ///< [in] handle of the Program object
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
     uint32_t specId,                                ///< [in] specification constant Id
     size_t specSize,                                ///< [in] size of the specialization constant value
     const void* specValue                           ///< [in] pointer to the specialization value bytes
@@ -3995,17 +3994,17 @@ zerProgramSetSpecializationConstant(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phNativeProgram`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramGetNativeHandle(
-    zer_program_handle_t hProgram,                  ///< [in] handle of the program.
-    zer_native_handle_t* phNativeProgram            ///< [out] a pointer to the native handle of the program.
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program.
+    ur_native_handle_t* phNativeProgram             ///< [out] a pointer to the native handle of the program.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4018,19 +4017,19 @@ zerProgramGetNativeHandle(
 ///     - The implementation of this function should be thread-safe.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_HANDLE
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
 ///         + `nullptr == hNativeProgram`
-///     - ::ZER_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `nullptr == phProgram`
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerProgramCreateWithNativeHandle(
-    zer_program_handle_t hProgram,                  ///< [in] handle of the program instance
-    zer_native_handle_t hNativeProgram,             ///< [in] the native handle of the program.
-    zer_program_handle_t* phProgram                 ///< [out] pointer to the handle of the program object created.
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program instance
+    ur_native_handle_t hNativeProgram,              ///< [in] the native handle of the program.
+    ur_program_handle_t* phProgram                  ///< [out] pointer to the handle of the program object created.
     );
 
 #if !defined(__GNUC__)
@@ -4042,23 +4041,23 @@ zerProgramCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported platform initialization flags
-typedef uint32_t zer_platform_init_flags_t;
-typedef enum _zer_platform_init_flag_t
+typedef uint32_t ur_platform_init_flags_t;
+typedef enum _ur_platform_init_flag_t
 {
-    ZER_PLATFORM_INIT_FLAG_LEVEL_ZERO = ZER_BIT(0), ///< initialize Unified Runtime platform drivers
-    ZER_PLATFORM_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_PLATFORM_INIT_FLAG_LEVEL_ZERO = UR_BIT(0),   ///< initialize Unified Runtime platform drivers
+    UR_PLATFORM_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_platform_init_flag_t;
+} ur_platform_init_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device initialization flags
-typedef uint32_t zer_device_init_flags_t;
-typedef enum _zer_device_init_flag_t
+typedef uint32_t ur_device_init_flags_t;
+typedef enum _ur_device_init_flag_t
 {
-    ZER_DEVICE_INIT_FLAG_GPU = ZER_BIT(0),          ///< initialize GPU device drivers
-    ZER_DEVICE_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_INIT_FLAG_GPU = UR_BIT(0),            ///< initialize GPU device drivers
+    UR_DEVICE_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
 
-} zer_device_init_flag_t;
+} ur_device_init_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' driver(s)
@@ -4067,7 +4066,7 @@ typedef enum _zer_device_init_flag_t
 ///     - The application must call this function before calling any other
 ///       function.
 ///     - If this function is not called then all other functions will return
-///       ::ZER_RESULT_ERROR_UNINITIALIZED.
+///       ::UR_RESULT_ERROR_UNINITIALIZED.
 ///     - Only one instance of each driver will be initialized per process.
 ///     - The application may call this function multiple times with different
 ///       flags or environment variables enabled.
@@ -4078,19 +4077,19 @@ typedef enum _zer_device_init_flag_t
 ///       where multiple libraries may initialize the driver(s) simultaneously.
 /// 
 /// @returns
-///     - ::ZER_RESULT_SUCCESS
-///     - ::ZER_RESULT_ERROR_UNINITIALIZED
-///     - ::ZER_RESULT_ERROR_DEVICE_LOST
-///     - ::ZER_RESULT_ERROR_INVALID_ENUMERATION
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < platform_flags`
 ///         + `0x1 < device_flags`
-///     - ::ZER_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ZER_APIEXPORT zer_result_t ZER_APICALL
-zerInit(
-    zer_platform_init_flags_t platform_flags,       ///< [in] platform initialization flags.
-                                                    ///< must be 0 (default) or a combination of ::zer_platform_init_flag_t.
-    zer_device_init_flags_t device_flags            ///< [in] device initialization flags.
-                                                    ///< must be 0 (default) or a combination of ::zer_device_init_flag_t.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urInit(
+    ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
+                                                    ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
+    ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
+                                                    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
     );
 
 #if !defined(__GNUC__)
@@ -4101,2710 +4100,2710 @@ zerInit(
 #pragma region callbacks
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerPlatformGet 
+/// @brief Callback function parameters for urPlatformGet 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_platform_get_params_t
+typedef struct _ur_platform_get_params_t
 {
     uint32_t** ppCount;
-    zer_platform_handle_t** pphPlatforms;
-} zer_platform_get_params_t;
+    ur_platform_handle_t** pphPlatforms;
+} ur_platform_get_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerPlatformGet 
+/// @brief Callback function-pointer for urPlatformGet 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnPlatformGetCb_t)(
-    zer_platform_get_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnPlatformGetCb_t)(
+    ur_platform_get_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerPlatformGetInfo 
+/// @brief Callback function parameters for urPlatformGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_platform_get_info_params_t
+typedef struct _ur_platform_get_info_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_platform_info_t* pPlatformInfoType;
+    ur_platform_handle_t* phPlatform;
+    ur_platform_info_t* pPlatformInfoType;
     size_t** ppSize;
     void** ppPlatformInfo;
-} zer_platform_get_info_params_t;
+} ur_platform_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerPlatformGetInfo 
+/// @brief Callback function-pointer for urPlatformGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnPlatformGetInfoCb_t)(
-    zer_platform_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnPlatformGetInfoCb_t)(
+    ur_platform_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerPlatformGetNativeHandle 
+/// @brief Callback function parameters for urPlatformGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_platform_get_native_handle_params_t
+typedef struct _ur_platform_get_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t** pphNativePlatform;
-} zer_platform_get_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t** pphNativePlatform;
+} ur_platform_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerPlatformGetNativeHandle 
+/// @brief Callback function-pointer for urPlatformGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnPlatformGetNativeHandleCb_t)(
-    zer_platform_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnPlatformGetNativeHandleCb_t)(
+    ur_platform_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerPlatformCreateWithNativeHandle 
+/// @brief Callback function parameters for urPlatformCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_platform_create_with_native_handle_params_t
+typedef struct _ur_platform_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativePlatform;
-    zer_platform_handle_t** pphPlatform;
-} zer_platform_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativePlatform;
+    ur_platform_handle_t** pphPlatform;
+} ur_platform_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerPlatformCreateWithNativeHandle 
+/// @brief Callback function-pointer for urPlatformCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnPlatformCreateWithNativeHandleCb_t)(
-    zer_platform_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnPlatformCreateWithNativeHandleCb_t)(
+    ur_platform_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerPlatformGetApiVersion 
+/// @brief Callback function parameters for urPlatformGetApiVersion 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_platform_get_api_version_params_t
+typedef struct _ur_platform_get_api_version_params_t
 {
-    zer_platform_handle_t* phDriver;
-    zer_api_version_t** pversion;
-} zer_platform_get_api_version_params_t;
+    ur_platform_handle_t* phDriver;
+    ur_api_version_t** pversion;
+} ur_platform_get_api_version_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerPlatformGetApiVersion 
+/// @brief Callback function-pointer for urPlatformGetApiVersion 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnPlatformGetApiVersionCb_t)(
-    zer_platform_get_api_version_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnPlatformGetApiVersionCb_t)(
+    ur_platform_get_api_version_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Platform callback functions pointers
-typedef struct _zer_platform_callbacks_t
+typedef struct _ur_platform_callbacks_t
 {
-    zer_pfnPlatformGetCb_t                                          pfnGetCb;
-    zer_pfnPlatformGetInfoCb_t                                      pfnGetInfoCb;
-    zer_pfnPlatformGetNativeHandleCb_t                              pfnGetNativeHandleCb;
-    zer_pfnPlatformCreateWithNativeHandleCb_t                       pfnCreateWithNativeHandleCb;
-    zer_pfnPlatformGetApiVersionCb_t                                pfnGetApiVersionCb;
-} zer_platform_callbacks_t;
+    ur_pfnPlatformGetCb_t                                           pfnGetCb;
+    ur_pfnPlatformGetInfoCb_t                                       pfnGetInfoCb;
+    ur_pfnPlatformGetNativeHandleCb_t                               pfnGetNativeHandleCb;
+    ur_pfnPlatformCreateWithNativeHandleCb_t                        pfnCreateWithNativeHandleCb;
+    ur_pfnPlatformGetApiVersionCb_t                                 pfnGetApiVersionCb;
+} ur_platform_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerContextCreate 
+/// @brief Callback function parameters for urContextCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_context_create_params_t
+typedef struct _ur_context_create_params_t
 {
     uint32_t* pDeviceCount;
-    zer_device_handle_t** pphDevices;
-    zer_context_handle_t** pphContext;
-} zer_context_create_params_t;
+    ur_device_handle_t** pphDevices;
+    ur_context_handle_t** pphContext;
+} ur_context_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerContextCreate 
+/// @brief Callback function-pointer for urContextCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnContextCreateCb_t)(
-    zer_context_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnContextCreateCb_t)(
+    ur_context_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerContextGetReference 
+/// @brief Callback function parameters for urContextGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_context_get_reference_params_t
+typedef struct _ur_context_get_reference_params_t
 {
-    zer_context_handle_t* phContext;
-} zer_context_get_reference_params_t;
+    ur_context_handle_t* phContext;
+} ur_context_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerContextGetReference 
+/// @brief Callback function-pointer for urContextGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnContextGetReferenceCb_t)(
-    zer_context_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnContextGetReferenceCb_t)(
+    ur_context_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerContextRelease 
+/// @brief Callback function parameters for urContextRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_context_release_params_t
+typedef struct _ur_context_release_params_t
 {
-    zer_context_handle_t* phContext;
-} zer_context_release_params_t;
+    ur_context_handle_t* phContext;
+} ur_context_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerContextRelease 
+/// @brief Callback function-pointer for urContextRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnContextReleaseCb_t)(
-    zer_context_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnContextReleaseCb_t)(
+    ur_context_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerContextGetInfo 
+/// @brief Callback function parameters for urContextGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_context_get_info_params_t
+typedef struct _ur_context_get_info_params_t
 {
-    zer_context_handle_t* phContext;
-    zer_context_info_t* pContextInfoType;
+    ur_context_handle_t* phContext;
+    ur_context_info_t* pContextInfoType;
     size_t** ppSize;
     void** ppContextInfo;
-} zer_context_get_info_params_t;
+} ur_context_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerContextGetInfo 
+/// @brief Callback function-pointer for urContextGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnContextGetInfoCb_t)(
-    zer_context_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnContextGetInfoCb_t)(
+    ur_context_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerContextGetNativeHandle 
+/// @brief Callback function parameters for urContextGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_context_get_native_handle_params_t
+typedef struct _ur_context_get_native_handle_params_t
 {
-    zer_context_handle_t* phContext;
-    zer_native_handle_t** pphNativeContext;
-} zer_context_get_native_handle_params_t;
+    ur_context_handle_t* phContext;
+    ur_native_handle_t** pphNativeContext;
+} ur_context_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerContextGetNativeHandle 
+/// @brief Callback function-pointer for urContextGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnContextGetNativeHandleCb_t)(
-    zer_context_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnContextGetNativeHandleCb_t)(
+    ur_context_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerContextCreateWithNativeHandle 
+/// @brief Callback function parameters for urContextCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_context_create_with_native_handle_params_t
+typedef struct _ur_context_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativeContext;
-    zer_context_handle_t** pphContext;
-} zer_context_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativeContext;
+    ur_context_handle_t** pphContext;
+} ur_context_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerContextCreateWithNativeHandle 
+/// @brief Callback function-pointer for urContextCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnContextCreateWithNativeHandleCb_t)(
-    zer_context_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnContextCreateWithNativeHandleCb_t)(
+    ur_context_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Context callback functions pointers
-typedef struct _zer_context_callbacks_t
+typedef struct _ur_context_callbacks_t
 {
-    zer_pfnContextCreateCb_t                                        pfnCreateCb;
-    zer_pfnContextGetReferenceCb_t                                  pfnGetReferenceCb;
-    zer_pfnContextReleaseCb_t                                       pfnReleaseCb;
-    zer_pfnContextGetInfoCb_t                                       pfnGetInfoCb;
-    zer_pfnContextGetNativeHandleCb_t                               pfnGetNativeHandleCb;
-    zer_pfnContextCreateWithNativeHandleCb_t                        pfnCreateWithNativeHandleCb;
-} zer_context_callbacks_t;
+    ur_pfnContextCreateCb_t                                         pfnCreateCb;
+    ur_pfnContextGetReferenceCb_t                                   pfnGetReferenceCb;
+    ur_pfnContextReleaseCb_t                                        pfnReleaseCb;
+    ur_pfnContextGetInfoCb_t                                        pfnGetInfoCb;
+    ur_pfnContextGetNativeHandleCb_t                                pfnGetNativeHandleCb;
+    ur_pfnContextCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
+} ur_context_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventCreate 
+/// @brief Callback function parameters for urEventCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_create_params_t
+typedef struct _ur_event_create_params_t
 {
-    zer_context_handle_t* pcontext;
-    zer_event_handle_t** ppEvent;
-} zer_event_create_params_t;
+    ur_context_handle_t* pcontext;
+    ur_event_handle_t** ppEvent;
+} ur_event_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventCreate 
+/// @brief Callback function-pointer for urEventCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventCreateCb_t)(
-    zer_event_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventCreateCb_t)(
+    ur_event_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventGetInfo 
+/// @brief Callback function parameters for urEventGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_get_info_params_t
+typedef struct _ur_event_get_info_params_t
 {
-    zer_event_handle_t* pevent;
-    zer_event_info_t* ppropName;
+    ur_event_handle_t* pevent;
+    ur_event_info_t* ppropName;
     size_t* ppropValueSize;
     void** ppropValue;
     size_t** ppropValueSizeRet;
-} zer_event_get_info_params_t;
+} ur_event_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventGetInfo 
+/// @brief Callback function-pointer for urEventGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventGetInfoCb_t)(
-    zer_event_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventGetInfoCb_t)(
+    ur_event_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventGetProfilingInfo 
+/// @brief Callback function parameters for urEventGetProfilingInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_get_profiling_info_params_t
+typedef struct _ur_event_get_profiling_info_params_t
 {
-    zer_event_handle_t* pevent;
-    zer_profiling_info_t* ppropName;
+    ur_event_handle_t* pevent;
+    ur_profiling_info_t* ppropName;
     size_t* ppropValueSize;
     void** ppropValue;
     size_t* ppropValueSizeRet;
-} zer_event_get_profiling_info_params_t;
+} ur_event_get_profiling_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventGetProfilingInfo 
+/// @brief Callback function-pointer for urEventGetProfilingInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventGetProfilingInfoCb_t)(
-    zer_event_get_profiling_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventGetProfilingInfoCb_t)(
+    ur_event_get_profiling_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventWait 
+/// @brief Callback function parameters for urEventWait 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_wait_params_t
+typedef struct _ur_event_wait_params_t
 {
     uint32_t* pnumEvents;
-    const zer_event_handle_t** peventList;
-} zer_event_wait_params_t;
+    const ur_event_handle_t** peventList;
+} ur_event_wait_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventWait 
+/// @brief Callback function-pointer for urEventWait 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventWaitCb_t)(
-    zer_event_wait_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventWaitCb_t)(
+    ur_event_wait_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventGetReference 
+/// @brief Callback function parameters for urEventGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_get_reference_params_t
+typedef struct _ur_event_get_reference_params_t
 {
-    zer_event_handle_t* pevent;
-} zer_event_get_reference_params_t;
+    ur_event_handle_t* pevent;
+} ur_event_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventGetReference 
+/// @brief Callback function-pointer for urEventGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventGetReferenceCb_t)(
-    zer_event_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventGetReferenceCb_t)(
+    ur_event_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventRelease 
+/// @brief Callback function parameters for urEventRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_release_params_t
+typedef struct _ur_event_release_params_t
 {
-    zer_event_handle_t* pevent;
-} zer_event_release_params_t;
+    ur_event_handle_t* pevent;
+} ur_event_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventRelease 
+/// @brief Callback function-pointer for urEventRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventReleaseCb_t)(
-    zer_event_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventReleaseCb_t)(
+    ur_event_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventGetNativeHandle 
+/// @brief Callback function parameters for urEventGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_get_native_handle_params_t
+typedef struct _ur_event_get_native_handle_params_t
 {
-    zer_event_handle_t* phEvent;
-    zer_native_handle_t** pphNativeEvent;
-} zer_event_get_native_handle_params_t;
+    ur_event_handle_t* phEvent;
+    ur_native_handle_t** pphNativeEvent;
+} ur_event_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventGetNativeHandle 
+/// @brief Callback function-pointer for urEventGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventGetNativeHandleCb_t)(
-    zer_event_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventGetNativeHandleCb_t)(
+    ur_event_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEventCreateWithNativeHandle 
+/// @brief Callback function parameters for urEventCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_event_create_with_native_handle_params_t
+typedef struct _ur_event_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativeEvent;
-    zer_event_handle_t** pphEvent;
-} zer_event_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativeEvent;
+    ur_event_handle_t** pphEvent;
+} ur_event_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEventCreateWithNativeHandle 
+/// @brief Callback function-pointer for urEventCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEventCreateWithNativeHandleCb_t)(
-    zer_event_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEventCreateWithNativeHandleCb_t)(
+    ur_event_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Event callback functions pointers
-typedef struct _zer_event_callbacks_t
+typedef struct _ur_event_callbacks_t
 {
-    zer_pfnEventCreateCb_t                                          pfnCreateCb;
-    zer_pfnEventGetInfoCb_t                                         pfnGetInfoCb;
-    zer_pfnEventGetProfilingInfoCb_t                                pfnGetProfilingInfoCb;
-    zer_pfnEventWaitCb_t                                            pfnWaitCb;
-    zer_pfnEventGetReferenceCb_t                                    pfnGetReferenceCb;
-    zer_pfnEventReleaseCb_t                                         pfnReleaseCb;
-    zer_pfnEventGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
-    zer_pfnEventCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
-} zer_event_callbacks_t;
+    ur_pfnEventCreateCb_t                                           pfnCreateCb;
+    ur_pfnEventGetInfoCb_t                                          pfnGetInfoCb;
+    ur_pfnEventGetProfilingInfoCb_t                                 pfnGetProfilingInfoCb;
+    ur_pfnEventWaitCb_t                                             pfnWaitCb;
+    ur_pfnEventGetReferenceCb_t                                     pfnGetReferenceCb;
+    ur_pfnEventReleaseCb_t                                          pfnReleaseCb;
+    ur_pfnEventGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
+    ur_pfnEventCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
+} ur_event_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramCreate 
+/// @brief Callback function parameters for urProgramCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_create_params_t
+typedef struct _ur_program_create_params_t
 {
-    zer_context_handle_t* phContext;
+    ur_context_handle_t* phContext;
     uint32_t* pcount;
-    const zer_module_handle_t** pphModules;
+    const ur_module_handle_t** pphModules;
     const char** ppOptions;
-    zer_program_handle_t** pphProgram;
-} zer_program_create_params_t;
+    ur_program_handle_t** pphProgram;
+} ur_program_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramCreate 
+/// @brief Callback function-pointer for urProgramCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramCreateCb_t)(
-    zer_program_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramCreateCb_t)(
+    ur_program_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramCreateWithBinary 
+/// @brief Callback function parameters for urProgramCreateWithBinary 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_create_with_binary_params_t
+typedef struct _ur_program_create_with_binary_params_t
 {
-    zer_context_handle_t* phContext;
-    zer_device_handle_t* phDevice;
+    ur_context_handle_t* phContext;
+    ur_device_handle_t* phDevice;
     uint32_t* psize;
     const uint8_t** ppBinary;
-    zer_program_handle_t** pphProgram;
-} zer_program_create_with_binary_params_t;
+    ur_program_handle_t** pphProgram;
+} ur_program_create_with_binary_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramCreateWithBinary 
+/// @brief Callback function-pointer for urProgramCreateWithBinary 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramCreateWithBinaryCb_t)(
-    zer_program_create_with_binary_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramCreateWithBinaryCb_t)(
+    ur_program_create_with_binary_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramGetReference 
+/// @brief Callback function parameters for urProgramGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_get_reference_params_t
+typedef struct _ur_program_get_reference_params_t
 {
-    zer_program_handle_t* phProgram;
-} zer_program_get_reference_params_t;
+    ur_program_handle_t* phProgram;
+} ur_program_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramGetReference 
+/// @brief Callback function-pointer for urProgramGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramGetReferenceCb_t)(
-    zer_program_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramGetReferenceCb_t)(
+    ur_program_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramRelease 
+/// @brief Callback function parameters for urProgramRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_release_params_t
+typedef struct _ur_program_release_params_t
 {
-    zer_program_handle_t* phProgram;
-} zer_program_release_params_t;
+    ur_program_handle_t* phProgram;
+} ur_program_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramRelease 
+/// @brief Callback function-pointer for urProgramRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramReleaseCb_t)(
-    zer_program_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramReleaseCb_t)(
+    ur_program_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramGetFunctionPointer 
+/// @brief Callback function parameters for urProgramGetFunctionPointer 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_get_function_pointer_params_t
+typedef struct _ur_program_get_function_pointer_params_t
 {
-    zer_device_handle_t* phDevice;
-    zer_program_handle_t* phProgram;
+    ur_device_handle_t* phDevice;
+    ur_program_handle_t* phProgram;
     const char** ppFunctionName;
     void*** ppFunctionPointer;
-} zer_program_get_function_pointer_params_t;
+} ur_program_get_function_pointer_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramGetFunctionPointer 
+/// @brief Callback function-pointer for urProgramGetFunctionPointer 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramGetFunctionPointerCb_t)(
-    zer_program_get_function_pointer_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramGetFunctionPointerCb_t)(
+    ur_program_get_function_pointer_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramGetInfo 
+/// @brief Callback function parameters for urProgramGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_get_info_params_t
+typedef struct _ur_program_get_info_params_t
 {
-    zer_program_handle_t* phProgram;
-    zer_program_info_t* ppropName;
+    ur_program_handle_t* phProgram;
+    ur_program_info_t* ppropName;
     size_t** ppropSize;
     void** ppropValue;
-} zer_program_get_info_params_t;
+} ur_program_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramGetInfo 
+/// @brief Callback function-pointer for urProgramGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramGetInfoCb_t)(
-    zer_program_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramGetInfoCb_t)(
+    ur_program_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramGetBuildInfo 
+/// @brief Callback function parameters for urProgramGetBuildInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_get_build_info_params_t
+typedef struct _ur_program_get_build_info_params_t
 {
-    zer_program_handle_t* phProgram;
-    zer_device_handle_t* phDevice;
-    zer_program_build_info_t* ppropName;
+    ur_program_handle_t* phProgram;
+    ur_device_handle_t* phDevice;
+    ur_program_build_info_t* ppropName;
     size_t** ppropSize;
     void** ppropValue;
-} zer_program_get_build_info_params_t;
+} ur_program_get_build_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramGetBuildInfo 
+/// @brief Callback function-pointer for urProgramGetBuildInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramGetBuildInfoCb_t)(
-    zer_program_get_build_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramGetBuildInfoCb_t)(
+    ur_program_get_build_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramSetSpecializationConstant 
+/// @brief Callback function parameters for urProgramSetSpecializationConstant 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_set_specialization_constant_params_t
+typedef struct _ur_program_set_specialization_constant_params_t
 {
-    zer_program_handle_t* phProgram;
+    ur_program_handle_t* phProgram;
     uint32_t* pspecId;
     size_t* pspecSize;
     const void** pspecValue;
-} zer_program_set_specialization_constant_params_t;
+} ur_program_set_specialization_constant_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramSetSpecializationConstant 
+/// @brief Callback function-pointer for urProgramSetSpecializationConstant 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramSetSpecializationConstantCb_t)(
-    zer_program_set_specialization_constant_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramSetSpecializationConstantCb_t)(
+    ur_program_set_specialization_constant_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramGetNativeHandle 
+/// @brief Callback function parameters for urProgramGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_get_native_handle_params_t
+typedef struct _ur_program_get_native_handle_params_t
 {
-    zer_program_handle_t* phProgram;
-    zer_native_handle_t** pphNativeProgram;
-} zer_program_get_native_handle_params_t;
+    ur_program_handle_t* phProgram;
+    ur_native_handle_t** pphNativeProgram;
+} ur_program_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramGetNativeHandle 
+/// @brief Callback function-pointer for urProgramGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramGetNativeHandleCb_t)(
-    zer_program_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramGetNativeHandleCb_t)(
+    ur_program_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerProgramCreateWithNativeHandle 
+/// @brief Callback function parameters for urProgramCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_program_create_with_native_handle_params_t
+typedef struct _ur_program_create_with_native_handle_params_t
 {
-    zer_program_handle_t* phProgram;
-    zer_native_handle_t* phNativeProgram;
-    zer_program_handle_t** pphProgram;
-} zer_program_create_with_native_handle_params_t;
+    ur_program_handle_t* phProgram;
+    ur_native_handle_t* phNativeProgram;
+    ur_program_handle_t** pphProgram;
+} ur_program_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerProgramCreateWithNativeHandle 
+/// @brief Callback function-pointer for urProgramCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnProgramCreateWithNativeHandleCb_t)(
-    zer_program_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnProgramCreateWithNativeHandleCb_t)(
+    ur_program_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Program callback functions pointers
-typedef struct _zer_program_callbacks_t
+typedef struct _ur_program_callbacks_t
 {
-    zer_pfnProgramCreateCb_t                                        pfnCreateCb;
-    zer_pfnProgramCreateWithBinaryCb_t                              pfnCreateWithBinaryCb;
-    zer_pfnProgramGetReferenceCb_t                                  pfnGetReferenceCb;
-    zer_pfnProgramReleaseCb_t                                       pfnReleaseCb;
-    zer_pfnProgramGetFunctionPointerCb_t                            pfnGetFunctionPointerCb;
-    zer_pfnProgramGetInfoCb_t                                       pfnGetInfoCb;
-    zer_pfnProgramGetBuildInfoCb_t                                  pfnGetBuildInfoCb;
-    zer_pfnProgramSetSpecializationConstantCb_t                     pfnSetSpecializationConstantCb;
-    zer_pfnProgramGetNativeHandleCb_t                               pfnGetNativeHandleCb;
-    zer_pfnProgramCreateWithNativeHandleCb_t                        pfnCreateWithNativeHandleCb;
-} zer_program_callbacks_t;
+    ur_pfnProgramCreateCb_t                                         pfnCreateCb;
+    ur_pfnProgramCreateWithBinaryCb_t                               pfnCreateWithBinaryCb;
+    ur_pfnProgramGetReferenceCb_t                                   pfnGetReferenceCb;
+    ur_pfnProgramReleaseCb_t                                        pfnReleaseCb;
+    ur_pfnProgramGetFunctionPointerCb_t                             pfnGetFunctionPointerCb;
+    ur_pfnProgramGetInfoCb_t                                        pfnGetInfoCb;
+    ur_pfnProgramGetBuildInfoCb_t                                   pfnGetBuildInfoCb;
+    ur_pfnProgramSetSpecializationConstantCb_t                      pfnSetSpecializationConstantCb;
+    ur_pfnProgramGetNativeHandleCb_t                                pfnGetNativeHandleCb;
+    ur_pfnProgramCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
+} ur_program_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerModuleCreate 
+/// @brief Callback function parameters for urModuleCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_module_create_params_t
+typedef struct _ur_module_create_params_t
 {
-    zer_context_handle_t* phContext;
+    ur_context_handle_t* phContext;
     const void** ppIL;
     uint32_t* plength;
     const char** ppOptions;
     void*** ppfnNotify;
     void** ppUserData;
-    zer_module_handle_t** pphModule;
-} zer_module_create_params_t;
+    ur_module_handle_t** pphModule;
+} ur_module_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerModuleCreate 
+/// @brief Callback function-pointer for urModuleCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnModuleCreateCb_t)(
-    zer_module_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnModuleCreateCb_t)(
+    ur_module_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerModuleGetReference 
+/// @brief Callback function parameters for urModuleGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_module_get_reference_params_t
+typedef struct _ur_module_get_reference_params_t
 {
-    zer_module_handle_t* phModule;
-} zer_module_get_reference_params_t;
+    ur_module_handle_t* phModule;
+} ur_module_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerModuleGetReference 
+/// @brief Callback function-pointer for urModuleGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnModuleGetReferenceCb_t)(
-    zer_module_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnModuleGetReferenceCb_t)(
+    ur_module_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerModuleRelease 
+/// @brief Callback function parameters for urModuleRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_module_release_params_t
+typedef struct _ur_module_release_params_t
 {
-    zer_module_handle_t* phModule;
-} zer_module_release_params_t;
+    ur_module_handle_t* phModule;
+} ur_module_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerModuleRelease 
+/// @brief Callback function-pointer for urModuleRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnModuleReleaseCb_t)(
-    zer_module_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnModuleReleaseCb_t)(
+    ur_module_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerModuleGetNativeHandle 
+/// @brief Callback function parameters for urModuleGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_module_get_native_handle_params_t
+typedef struct _ur_module_get_native_handle_params_t
 {
-    zer_module_handle_t* phModule;
-    zer_native_handle_t** pphNativeModule;
-} zer_module_get_native_handle_params_t;
+    ur_module_handle_t* phModule;
+    ur_native_handle_t** pphNativeModule;
+} ur_module_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerModuleGetNativeHandle 
+/// @brief Callback function-pointer for urModuleGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnModuleGetNativeHandleCb_t)(
-    zer_module_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnModuleGetNativeHandleCb_t)(
+    ur_module_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerModuleCreateWithNativeHandle 
+/// @brief Callback function parameters for urModuleCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_module_create_with_native_handle_params_t
+typedef struct _ur_module_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativeModule;
-    zer_module_handle_t** pphModule;
-} zer_module_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativeModule;
+    ur_module_handle_t** pphModule;
+} ur_module_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerModuleCreateWithNativeHandle 
+/// @brief Callback function-pointer for urModuleCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnModuleCreateWithNativeHandleCb_t)(
-    zer_module_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnModuleCreateWithNativeHandleCb_t)(
+    ur_module_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Module callback functions pointers
-typedef struct _zer_module_callbacks_t
+typedef struct _ur_module_callbacks_t
 {
-    zer_pfnModuleCreateCb_t                                         pfnCreateCb;
-    zer_pfnModuleGetReferenceCb_t                                   pfnGetReferenceCb;
-    zer_pfnModuleReleaseCb_t                                        pfnReleaseCb;
-    zer_pfnModuleGetNativeHandleCb_t                                pfnGetNativeHandleCb;
-    zer_pfnModuleCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
-} zer_module_callbacks_t;
+    ur_pfnModuleCreateCb_t                                          pfnCreateCb;
+    ur_pfnModuleGetReferenceCb_t                                    pfnGetReferenceCb;
+    ur_pfnModuleReleaseCb_t                                         pfnReleaseCb;
+    ur_pfnModuleGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
+    ur_pfnModuleCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
+} ur_module_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelCreate 
+/// @brief Callback function parameters for urKernelCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_create_params_t
+typedef struct _ur_kernel_create_params_t
 {
-    zer_program_handle_t* phProgram;
+    ur_program_handle_t* phProgram;
     const char** ppKernelName;
-    zer_kernel_handle_t** pphKernel;
-} zer_kernel_create_params_t;
+    ur_kernel_handle_t** pphKernel;
+} ur_kernel_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelCreate 
+/// @brief Callback function-pointer for urKernelCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelCreateCb_t)(
-    zer_kernel_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelCreateCb_t)(
+    ur_kernel_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelGetInfo 
+/// @brief Callback function parameters for urKernelGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_get_info_params_t
+typedef struct _ur_kernel_get_info_params_t
 {
-    zer_kernel_handle_t* phKernel;
-    zer_kernel_info_t* ppropName;
+    ur_kernel_handle_t* phKernel;
+    ur_kernel_info_t* ppropName;
     size_t** ppropSize;
     void** ppropValue;
-} zer_kernel_get_info_params_t;
+} ur_kernel_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelGetInfo 
+/// @brief Callback function-pointer for urKernelGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelGetInfoCb_t)(
-    zer_kernel_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelGetInfoCb_t)(
+    ur_kernel_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelGetGroupInfo 
+/// @brief Callback function parameters for urKernelGetGroupInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_get_group_info_params_t
+typedef struct _ur_kernel_get_group_info_params_t
 {
-    zer_kernel_handle_t* phKernel;
-    zer_device_handle_t* phDevice;
-    zer_kernel_group_info_t* ppropName;
+    ur_kernel_handle_t* phKernel;
+    ur_device_handle_t* phDevice;
+    ur_kernel_group_info_t* ppropName;
     size_t* ppropSize;
     void** ppropValue;
-} zer_kernel_get_group_info_params_t;
+} ur_kernel_get_group_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelGetGroupInfo 
+/// @brief Callback function-pointer for urKernelGetGroupInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelGetGroupInfoCb_t)(
-    zer_kernel_get_group_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelGetGroupInfoCb_t)(
+    ur_kernel_get_group_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelGetSubGroupInfo 
+/// @brief Callback function parameters for urKernelGetSubGroupInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_get_sub_group_info_params_t
+typedef struct _ur_kernel_get_sub_group_info_params_t
 {
-    zer_kernel_handle_t* phKernel;
-    zer_device_handle_t* phDevice;
-    zer_kernel_sub_group_info_t* ppropName;
+    ur_kernel_handle_t* phKernel;
+    ur_device_handle_t* phDevice;
+    ur_kernel_sub_group_info_t* ppropName;
     size_t* ppropSize;
     void** ppropValue;
-} zer_kernel_get_sub_group_info_params_t;
+} ur_kernel_get_sub_group_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelGetSubGroupInfo 
+/// @brief Callback function-pointer for urKernelGetSubGroupInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelGetSubGroupInfoCb_t)(
-    zer_kernel_get_sub_group_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelGetSubGroupInfoCb_t)(
+    ur_kernel_get_sub_group_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelGetReference 
+/// @brief Callback function parameters for urKernelGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_get_reference_params_t
+typedef struct _ur_kernel_get_reference_params_t
 {
-    zer_kernel_handle_t* phKernel;
-} zer_kernel_get_reference_params_t;
+    ur_kernel_handle_t* phKernel;
+} ur_kernel_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelGetReference 
+/// @brief Callback function-pointer for urKernelGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelGetReferenceCb_t)(
-    zer_kernel_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelGetReferenceCb_t)(
+    ur_kernel_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelRelease 
+/// @brief Callback function parameters for urKernelRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_release_params_t
+typedef struct _ur_kernel_release_params_t
 {
-    zer_kernel_handle_t* phKernel;
-} zer_kernel_release_params_t;
+    ur_kernel_handle_t* phKernel;
+} ur_kernel_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelRelease 
+/// @brief Callback function-pointer for urKernelRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelReleaseCb_t)(
-    zer_kernel_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelReleaseCb_t)(
+    ur_kernel_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelGetNativeHandle 
+/// @brief Callback function parameters for urKernelGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_get_native_handle_params_t
+typedef struct _ur_kernel_get_native_handle_params_t
 {
-    zer_kernel_handle_t* phKernel;
-    zer_native_handle_t** pphNativeKernel;
-} zer_kernel_get_native_handle_params_t;
+    ur_kernel_handle_t* phKernel;
+    ur_native_handle_t** pphNativeKernel;
+} ur_kernel_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelGetNativeHandle 
+/// @brief Callback function-pointer for urKernelGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelGetNativeHandleCb_t)(
-    zer_kernel_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelGetNativeHandleCb_t)(
+    ur_kernel_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelCreateWithNativeHandle 
+/// @brief Callback function parameters for urKernelCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_create_with_native_handle_params_t
+typedef struct _ur_kernel_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativeKernel;
-    zer_kernel_handle_t** pphKernel;
-} zer_kernel_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativeKernel;
+    ur_kernel_handle_t** pphKernel;
+} ur_kernel_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelCreateWithNativeHandle 
+/// @brief Callback function-pointer for urKernelCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelCreateWithNativeHandleCb_t)(
-    zer_kernel_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelCreateWithNativeHandleCb_t)(
+    ur_kernel_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelSetArg 
+/// @brief Callback function parameters for urKernelSetArg 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_set_arg_params_t
+typedef struct _ur_kernel_set_arg_params_t
 {
-    zer_kernel_handle_t* phKernel;
+    ur_kernel_handle_t* phKernel;
     uint32_t* pargIndex;
     size_t* pargSize;
     const void** ppArgValue;
-} zer_kernel_set_arg_params_t;
+} ur_kernel_set_arg_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelSetArg 
+/// @brief Callback function-pointer for urKernelSetArg 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelSetArgCb_t)(
-    zer_kernel_set_arg_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelSetArgCb_t)(
+    ur_kernel_set_arg_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelSetArgPointer 
+/// @brief Callback function parameters for urKernelSetArgPointer 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_set_arg_pointer_params_t
+typedef struct _ur_kernel_set_arg_pointer_params_t
 {
-    zer_kernel_handle_t* phKernel;
+    ur_kernel_handle_t* phKernel;
     uint32_t* pargIndex;
     size_t* pargSize;
     const void** ppArgValue;
-} zer_kernel_set_arg_pointer_params_t;
+} ur_kernel_set_arg_pointer_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelSetArgPointer 
+/// @brief Callback function-pointer for urKernelSetArgPointer 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelSetArgPointerCb_t)(
-    zer_kernel_set_arg_pointer_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelSetArgPointerCb_t)(
+    ur_kernel_set_arg_pointer_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelSetExecInfo 
+/// @brief Callback function parameters for urKernelSetExecInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_set_exec_info_params_t
+typedef struct _ur_kernel_set_exec_info_params_t
 {
-    zer_kernel_handle_t* phKernel;
-    zer_kernel_exec_info_t* ppropName;
+    ur_kernel_handle_t* phKernel;
+    ur_kernel_exec_info_t* ppropName;
     size_t* ppropSize;
     const void** ppropValue;
-} zer_kernel_set_exec_info_params_t;
+} ur_kernel_set_exec_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelSetExecInfo 
+/// @brief Callback function-pointer for urKernelSetExecInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelSetExecInfoCb_t)(
-    zer_kernel_set_exec_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelSetExecInfoCb_t)(
+    ur_kernel_set_exec_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelSetArgSampler 
+/// @brief Callback function parameters for urKernelSetArgSampler 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_set_arg_sampler_params_t
+typedef struct _ur_kernel_set_arg_sampler_params_t
 {
-    zer_kernel_handle_t* phKernel;
+    ur_kernel_handle_t* phKernel;
     uint32_t* pargIndex;
-    zer_sampler_handle_t* ppArgValue;
-} zer_kernel_set_arg_sampler_params_t;
+    ur_sampler_handle_t* ppArgValue;
+} ur_kernel_set_arg_sampler_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelSetArgSampler 
+/// @brief Callback function-pointer for urKernelSetArgSampler 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelSetArgSamplerCb_t)(
-    zer_kernel_set_arg_sampler_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelSetArgSamplerCb_t)(
+    ur_kernel_set_arg_sampler_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerKernelSetArgMemObj 
+/// @brief Callback function parameters for urKernelSetArgMemObj 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_kernel_set_arg_mem_obj_params_t
+typedef struct _ur_kernel_set_arg_mem_obj_params_t
 {
-    zer_kernel_handle_t* phKernel;
+    ur_kernel_handle_t* phKernel;
     uint32_t* pargIndex;
-    zer_mem_handle_t* ppArgValue;
-} zer_kernel_set_arg_mem_obj_params_t;
+    ur_mem_handle_t* ppArgValue;
+} ur_kernel_set_arg_mem_obj_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerKernelSetArgMemObj 
+/// @brief Callback function-pointer for urKernelSetArgMemObj 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnKernelSetArgMemObjCb_t)(
-    zer_kernel_set_arg_mem_obj_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnKernelSetArgMemObjCb_t)(
+    ur_kernel_set_arg_mem_obj_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Kernel callback functions pointers
-typedef struct _zer_kernel_callbacks_t
+typedef struct _ur_kernel_callbacks_t
 {
-    zer_pfnKernelCreateCb_t                                         pfnCreateCb;
-    zer_pfnKernelGetInfoCb_t                                        pfnGetInfoCb;
-    zer_pfnKernelGetGroupInfoCb_t                                   pfnGetGroupInfoCb;
-    zer_pfnKernelGetSubGroupInfoCb_t                                pfnGetSubGroupInfoCb;
-    zer_pfnKernelGetReferenceCb_t                                   pfnGetReferenceCb;
-    zer_pfnKernelReleaseCb_t                                        pfnReleaseCb;
-    zer_pfnKernelGetNativeHandleCb_t                                pfnGetNativeHandleCb;
-    zer_pfnKernelCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
-    zer_pfnKernelSetArgCb_t                                         pfnSetArgCb;
-    zer_pfnKernelSetArgPointerCb_t                                  pfnSetArgPointerCb;
-    zer_pfnKernelSetExecInfoCb_t                                    pfnSetExecInfoCb;
-    zer_pfnKernelSetArgSamplerCb_t                                  pfnSetArgSamplerCb;
-    zer_pfnKernelSetArgMemObjCb_t                                   pfnSetArgMemObjCb;
-} zer_kernel_callbacks_t;
+    ur_pfnKernelCreateCb_t                                          pfnCreateCb;
+    ur_pfnKernelGetInfoCb_t                                         pfnGetInfoCb;
+    ur_pfnKernelGetGroupInfoCb_t                                    pfnGetGroupInfoCb;
+    ur_pfnKernelGetSubGroupInfoCb_t                                 pfnGetSubGroupInfoCb;
+    ur_pfnKernelGetReferenceCb_t                                    pfnGetReferenceCb;
+    ur_pfnKernelReleaseCb_t                                         pfnReleaseCb;
+    ur_pfnKernelGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
+    ur_pfnKernelCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
+    ur_pfnKernelSetArgCb_t                                          pfnSetArgCb;
+    ur_pfnKernelSetArgPointerCb_t                                   pfnSetArgPointerCb;
+    ur_pfnKernelSetExecInfoCb_t                                     pfnSetExecInfoCb;
+    ur_pfnKernelSetArgSamplerCb_t                                   pfnSetArgSamplerCb;
+    ur_pfnKernelSetArgMemObjCb_t                                    pfnSetArgMemObjCb;
+} ur_kernel_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerSamplerCreate 
+/// @brief Callback function parameters for urSamplerCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_sampler_create_params_t
+typedef struct _ur_sampler_create_params_t
 {
-    zer_context_handle_t* phContext;
-    const zer_sampler_property_value_t** pprops;
-    zer_sampler_handle_t** pphSampler;
-} zer_sampler_create_params_t;
+    ur_context_handle_t* phContext;
+    const ur_sampler_property_value_t** pprops;
+    ur_sampler_handle_t** pphSampler;
+} ur_sampler_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerSamplerCreate 
+/// @brief Callback function-pointer for urSamplerCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnSamplerCreateCb_t)(
-    zer_sampler_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnSamplerCreateCb_t)(
+    ur_sampler_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerSamplerGetReference 
+/// @brief Callback function parameters for urSamplerGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_sampler_get_reference_params_t
+typedef struct _ur_sampler_get_reference_params_t
 {
-    zer_sampler_handle_t* phSampler;
-} zer_sampler_get_reference_params_t;
+    ur_sampler_handle_t* phSampler;
+} ur_sampler_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerSamplerGetReference 
+/// @brief Callback function-pointer for urSamplerGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnSamplerGetReferenceCb_t)(
-    zer_sampler_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnSamplerGetReferenceCb_t)(
+    ur_sampler_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerSamplerRelease 
+/// @brief Callback function parameters for urSamplerRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_sampler_release_params_t
+typedef struct _ur_sampler_release_params_t
 {
-    zer_sampler_handle_t* phSampler;
-} zer_sampler_release_params_t;
+    ur_sampler_handle_t* phSampler;
+} ur_sampler_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerSamplerRelease 
+/// @brief Callback function-pointer for urSamplerRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnSamplerReleaseCb_t)(
-    zer_sampler_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnSamplerReleaseCb_t)(
+    ur_sampler_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerSamplerGetInfo 
+/// @brief Callback function parameters for urSamplerGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_sampler_get_info_params_t
+typedef struct _ur_sampler_get_info_params_t
 {
-    zer_sampler_handle_t* phSampler;
-    zer_sampler_info_t* ppropName;
+    ur_sampler_handle_t* phSampler;
+    ur_sampler_info_t* ppropName;
     size_t* ppropValueSize;
     void** ppropValue;
     size_t** ppSize;
-} zer_sampler_get_info_params_t;
+} ur_sampler_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerSamplerGetInfo 
+/// @brief Callback function-pointer for urSamplerGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnSamplerGetInfoCb_t)(
-    zer_sampler_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnSamplerGetInfoCb_t)(
+    ur_sampler_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerSamplerGetNativeHandle 
+/// @brief Callback function parameters for urSamplerGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_sampler_get_native_handle_params_t
+typedef struct _ur_sampler_get_native_handle_params_t
 {
-    zer_sampler_handle_t* phSampler;
-    zer_native_handle_t** pphNativeSampler;
-} zer_sampler_get_native_handle_params_t;
+    ur_sampler_handle_t* phSampler;
+    ur_native_handle_t** pphNativeSampler;
+} ur_sampler_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerSamplerGetNativeHandle 
+/// @brief Callback function-pointer for urSamplerGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnSamplerGetNativeHandleCb_t)(
-    zer_sampler_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnSamplerGetNativeHandleCb_t)(
+    ur_sampler_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerSamplerCreateWithNativeHandle 
+/// @brief Callback function parameters for urSamplerCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_sampler_create_with_native_handle_params_t
+typedef struct _ur_sampler_create_with_native_handle_params_t
 {
-    zer_sampler_handle_t* phSampler;
-    zer_native_handle_t* phNativeSampler;
-    zer_sampler_handle_t** pphSampler;
-} zer_sampler_create_with_native_handle_params_t;
+    ur_sampler_handle_t* phSampler;
+    ur_native_handle_t* phNativeSampler;
+    ur_sampler_handle_t** pphSampler;
+} ur_sampler_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerSamplerCreateWithNativeHandle 
+/// @brief Callback function-pointer for urSamplerCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnSamplerCreateWithNativeHandleCb_t)(
-    zer_sampler_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnSamplerCreateWithNativeHandleCb_t)(
+    ur_sampler_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Sampler callback functions pointers
-typedef struct _zer_sampler_callbacks_t
+typedef struct _ur_sampler_callbacks_t
 {
-    zer_pfnSamplerCreateCb_t                                        pfnCreateCb;
-    zer_pfnSamplerGetReferenceCb_t                                  pfnGetReferenceCb;
-    zer_pfnSamplerReleaseCb_t                                       pfnReleaseCb;
-    zer_pfnSamplerGetInfoCb_t                                       pfnGetInfoCb;
-    zer_pfnSamplerGetNativeHandleCb_t                               pfnGetNativeHandleCb;
-    zer_pfnSamplerCreateWithNativeHandleCb_t                        pfnCreateWithNativeHandleCb;
-} zer_sampler_callbacks_t;
+    ur_pfnSamplerCreateCb_t                                         pfnCreateCb;
+    ur_pfnSamplerGetReferenceCb_t                                   pfnGetReferenceCb;
+    ur_pfnSamplerReleaseCb_t                                        pfnReleaseCb;
+    ur_pfnSamplerGetInfoCb_t                                        pfnGetInfoCb;
+    ur_pfnSamplerGetNativeHandleCb_t                                pfnGetNativeHandleCb;
+    ur_pfnSamplerCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
+} ur_sampler_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemImageCreate 
+/// @brief Callback function parameters for urMemImageCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_image_create_params_t
+typedef struct _ur_mem_image_create_params_t
 {
-    zer_context_handle_t* phContext;
-    zer_mem_flags_t* pflags;
-    const zer_image_format_t** pimageFormat;
-    const zer_image_desc_t** pimageDesc;
+    ur_context_handle_t* phContext;
+    ur_mem_flags_t* pflags;
+    const ur_image_format_t** pimageFormat;
+    const ur_image_desc_t** pimageDesc;
     void** phostPtr;
-    zer_mem_handle_t** pphMem;
-} zer_mem_image_create_params_t;
+    ur_mem_handle_t** pphMem;
+} ur_mem_image_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemImageCreate 
+/// @brief Callback function-pointer for urMemImageCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemImageCreateCb_t)(
-    zer_mem_image_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemImageCreateCb_t)(
+    ur_mem_image_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemBufferCreate 
+/// @brief Callback function parameters for urMemBufferCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_buffer_create_params_t
+typedef struct _ur_mem_buffer_create_params_t
 {
-    zer_context_handle_t* phContext;
-    zer_mem_flags_t* pflags;
+    ur_context_handle_t* phContext;
+    ur_mem_flags_t* pflags;
     size_t* psize;
     void** phostPtr;
-    zer_mem_handle_t** pphBuffer;
-} zer_mem_buffer_create_params_t;
+    ur_mem_handle_t** pphBuffer;
+} ur_mem_buffer_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemBufferCreate 
+/// @brief Callback function-pointer for urMemBufferCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemBufferCreateCb_t)(
-    zer_mem_buffer_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemBufferCreateCb_t)(
+    ur_mem_buffer_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemGetReference 
+/// @brief Callback function parameters for urMemGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_get_reference_params_t
+typedef struct _ur_mem_get_reference_params_t
 {
-    zer_mem_handle_t* phMem;
-} zer_mem_get_reference_params_t;
+    ur_mem_handle_t* phMem;
+} ur_mem_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemGetReference 
+/// @brief Callback function-pointer for urMemGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemGetReferenceCb_t)(
-    zer_mem_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemGetReferenceCb_t)(
+    ur_mem_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemRelease 
+/// @brief Callback function parameters for urMemRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_release_params_t
+typedef struct _ur_mem_release_params_t
 {
-    zer_mem_handle_t* phMem;
-} zer_mem_release_params_t;
+    ur_mem_handle_t* phMem;
+} ur_mem_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemRelease 
+/// @brief Callback function-pointer for urMemRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemReleaseCb_t)(
-    zer_mem_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemReleaseCb_t)(
+    ur_mem_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemBufferPartition 
+/// @brief Callback function parameters for urMemBufferPartition 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_buffer_partition_params_t
+typedef struct _ur_mem_buffer_partition_params_t
 {
-    zer_mem_handle_t* phBuffer;
-    zer_mem_flags_t* pflags;
-    zer_buffer_create_type_t* pbufferCreateType;
-    zer_buffer_region_t** ppBufferCreateInfo;
-    zer_mem_handle_t** pphMem;
-} zer_mem_buffer_partition_params_t;
+    ur_mem_handle_t* phBuffer;
+    ur_mem_flags_t* pflags;
+    ur_buffer_create_type_t* pbufferCreateType;
+    ur_buffer_region_t** ppBufferCreateInfo;
+    ur_mem_handle_t** pphMem;
+} ur_mem_buffer_partition_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemBufferPartition 
+/// @brief Callback function-pointer for urMemBufferPartition 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemBufferPartitionCb_t)(
-    zer_mem_buffer_partition_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemBufferPartitionCb_t)(
+    ur_mem_buffer_partition_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemGetNativeHandle 
+/// @brief Callback function parameters for urMemGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_get_native_handle_params_t
+typedef struct _ur_mem_get_native_handle_params_t
 {
-    zer_mem_handle_t* phMem;
-    zer_native_handle_t** pphNativeMem;
-} zer_mem_get_native_handle_params_t;
+    ur_mem_handle_t* phMem;
+    ur_native_handle_t** pphNativeMem;
+} ur_mem_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemGetNativeHandle 
+/// @brief Callback function-pointer for urMemGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemGetNativeHandleCb_t)(
-    zer_mem_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemGetNativeHandleCb_t)(
+    ur_mem_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemCreateWithNativeHandle 
+/// @brief Callback function parameters for urMemCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_create_with_native_handle_params_t
+typedef struct _ur_mem_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativeMem;
-    zer_mem_handle_t** pphMem;
-} zer_mem_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativeMem;
+    ur_mem_handle_t** pphMem;
+} ur_mem_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemCreateWithNativeHandle 
+/// @brief Callback function-pointer for urMemCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemCreateWithNativeHandleCb_t)(
-    zer_mem_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemCreateWithNativeHandleCb_t)(
+    ur_mem_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemFree 
+/// @brief Callback function parameters for urMemFree 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_free_params_t
+typedef struct _ur_mem_free_params_t
 {
-    zer_context_handle_t* pcontext;
+    ur_context_handle_t* pcontext;
     void** pptr;
-} zer_mem_free_params_t;
+} ur_mem_free_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemFree 
+/// @brief Callback function-pointer for urMemFree 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemFreeCb_t)(
-    zer_mem_free_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemFreeCb_t)(
+    ur_mem_free_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerMemGetMemAllocInfo 
+/// @brief Callback function parameters for urMemGetMemAllocInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_mem_get_mem_alloc_info_params_t
+typedef struct _ur_mem_get_mem_alloc_info_params_t
 {
-    zer_context_handle_t* pcontext;
+    ur_context_handle_t* pcontext;
     const void** pptr;
-    zer_mem_info_t* ppropName;
+    ur_mem_info_t* ppropName;
     size_t* ppropValueSize;
     void** ppropValue;
     size_t** ppropValueSizeRet;
-} zer_mem_get_mem_alloc_info_params_t;
+} ur_mem_get_mem_alloc_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerMemGetMemAllocInfo 
+/// @brief Callback function-pointer for urMemGetMemAllocInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnMemGetMemAllocInfoCb_t)(
-    zer_mem_get_mem_alloc_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnMemGetMemAllocInfoCb_t)(
+    ur_mem_get_mem_alloc_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Mem callback functions pointers
-typedef struct _zer_mem_callbacks_t
+typedef struct _ur_mem_callbacks_t
 {
-    zer_pfnMemImageCreateCb_t                                       pfnImageCreateCb;
-    zer_pfnMemBufferCreateCb_t                                      pfnBufferCreateCb;
-    zer_pfnMemGetReferenceCb_t                                      pfnGetReferenceCb;
-    zer_pfnMemReleaseCb_t                                           pfnReleaseCb;
-    zer_pfnMemBufferPartitionCb_t                                   pfnBufferPartitionCb;
-    zer_pfnMemGetNativeHandleCb_t                                   pfnGetNativeHandleCb;
-    zer_pfnMemCreateWithNativeHandleCb_t                            pfnCreateWithNativeHandleCb;
-    zer_pfnMemFreeCb_t                                              pfnFreeCb;
-    zer_pfnMemGetMemAllocInfoCb_t                                   pfnGetMemAllocInfoCb;
-} zer_mem_callbacks_t;
+    ur_pfnMemImageCreateCb_t                                        pfnImageCreateCb;
+    ur_pfnMemBufferCreateCb_t                                       pfnBufferCreateCb;
+    ur_pfnMemGetReferenceCb_t                                       pfnGetReferenceCb;
+    ur_pfnMemReleaseCb_t                                            pfnReleaseCb;
+    ur_pfnMemBufferPartitionCb_t                                    pfnBufferPartitionCb;
+    ur_pfnMemGetNativeHandleCb_t                                    pfnGetNativeHandleCb;
+    ur_pfnMemCreateWithNativeHandleCb_t                             pfnCreateWithNativeHandleCb;
+    ur_pfnMemFreeCb_t                                               pfnFreeCb;
+    ur_pfnMemGetMemAllocInfoCb_t                                    pfnGetMemAllocInfoCb;
+} ur_mem_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueKernelLaunch 
+/// @brief Callback function parameters for urEnqueueKernelLaunch 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_kernel_launch_params_t
+typedef struct _ur_enqueue_kernel_launch_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_kernel_handle_t* phKernel;
+    ur_queue_handle_t* phQueue;
+    ur_kernel_handle_t* phKernel;
     uint32_t* pworkDim;
     const size_t** pglobalWorkOffset;
     const size_t** pglobalWorkSize;
     const size_t** plocalWorkSize;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_kernel_launch_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_kernel_launch_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueKernelLaunch 
+/// @brief Callback function-pointer for urEnqueueKernelLaunch 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueKernelLaunchCb_t)(
-    zer_enqueue_kernel_launch_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueKernelLaunchCb_t)(
+    ur_enqueue_kernel_launch_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueEventsWait 
+/// @brief Callback function parameters for urEnqueueEventsWait 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_events_wait_params_t
+typedef struct _ur_enqueue_events_wait_params_t
 {
-    zer_queue_handle_t* phQueue;
+    ur_queue_handle_t* phQueue;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_events_wait_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_events_wait_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueEventsWait 
+/// @brief Callback function-pointer for urEnqueueEventsWait 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueEventsWaitCb_t)(
-    zer_enqueue_events_wait_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueEventsWaitCb_t)(
+    ur_enqueue_events_wait_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueEventsWaitWithBarrier 
+/// @brief Callback function parameters for urEnqueueEventsWaitWithBarrier 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_events_wait_with_barrier_params_t
+typedef struct _ur_enqueue_events_wait_with_barrier_params_t
 {
-    zer_queue_handle_t* phQueue;
+    ur_queue_handle_t* phQueue;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_events_wait_with_barrier_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_events_wait_with_barrier_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueEventsWaitWithBarrier 
+/// @brief Callback function-pointer for urEnqueueEventsWaitWithBarrier 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueEventsWaitWithBarrierCb_t)(
-    zer_enqueue_events_wait_with_barrier_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueEventsWaitWithBarrierCb_t)(
+    ur_enqueue_events_wait_with_barrier_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferRead 
+/// @brief Callback function parameters for urEnqueueMemBufferRead 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_read_params_t
+typedef struct _ur_enqueue_mem_buffer_read_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBuffer;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBuffer;
     bool* pblockingRead;
     size_t* poffset;
     size_t* psize;
     void** pdst;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_read_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_read_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferRead 
+/// @brief Callback function-pointer for urEnqueueMemBufferRead 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferReadCb_t)(
-    zer_enqueue_mem_buffer_read_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferReadCb_t)(
+    ur_enqueue_mem_buffer_read_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferWrite 
+/// @brief Callback function parameters for urEnqueueMemBufferWrite 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_write_params_t
+typedef struct _ur_enqueue_mem_buffer_write_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBuffer;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBuffer;
     bool* pblockingWrite;
     size_t* poffset;
     size_t* psize;
     const void** psrc;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_write_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_write_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferWrite 
+/// @brief Callback function-pointer for urEnqueueMemBufferWrite 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferWriteCb_t)(
-    zer_enqueue_mem_buffer_write_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferWriteCb_t)(
+    ur_enqueue_mem_buffer_write_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferReadRect 
+/// @brief Callback function parameters for urEnqueueMemBufferReadRect 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_read_rect_params_t
+typedef struct _ur_enqueue_mem_buffer_read_rect_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBuffer;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBuffer;
     bool* pblockingRead;
-    zer_rect_offset_t* pbufferOffset;
-    zer_rect_offset_t* phostOffset;
-    zer_rect_region_t* pregion;
+    ur_rect_offset_t* pbufferOffset;
+    ur_rect_offset_t* phostOffset;
+    ur_rect_region_t* pregion;
     size_t* pbufferRowPitch;
     size_t* pbufferSlicePitch;
     size_t* phostRowPitch;
     size_t* phostSlicePitch;
     void** pdst;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_read_rect_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_read_rect_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferReadRect 
+/// @brief Callback function-pointer for urEnqueueMemBufferReadRect 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferReadRectCb_t)(
-    zer_enqueue_mem_buffer_read_rect_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferReadRectCb_t)(
+    ur_enqueue_mem_buffer_read_rect_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferWriteRect 
+/// @brief Callback function parameters for urEnqueueMemBufferWriteRect 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_write_rect_params_t
+typedef struct _ur_enqueue_mem_buffer_write_rect_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBuffer;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBuffer;
     bool* pblockingWrite;
-    zer_rect_offset_t* pbufferOffset;
-    zer_rect_offset_t* phostOffset;
-    zer_rect_region_t* pregion;
+    ur_rect_offset_t* pbufferOffset;
+    ur_rect_offset_t* phostOffset;
+    ur_rect_region_t* pregion;
     size_t* pbufferRowPitch;
     size_t* pbufferSlicePitch;
     size_t* phostRowPitch;
     size_t* phostSlicePitch;
     void** psrc;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_write_rect_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_write_rect_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferWriteRect 
+/// @brief Callback function-pointer for urEnqueueMemBufferWriteRect 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferWriteRectCb_t)(
-    zer_enqueue_mem_buffer_write_rect_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferWriteRectCb_t)(
+    ur_enqueue_mem_buffer_write_rect_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferCopy 
+/// @brief Callback function parameters for urEnqueueMemBufferCopy 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_copy_params_t
+typedef struct _ur_enqueue_mem_buffer_copy_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBufferSrc;
-    zer_mem_handle_t* phBufferDst;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBufferSrc;
+    ur_mem_handle_t* phBufferDst;
     size_t* psize;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_copy_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_copy_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferCopy 
+/// @brief Callback function-pointer for urEnqueueMemBufferCopy 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferCopyCb_t)(
-    zer_enqueue_mem_buffer_copy_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferCopyCb_t)(
+    ur_enqueue_mem_buffer_copy_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferCopyRect 
+/// @brief Callback function parameters for urEnqueueMemBufferCopyRect 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_copy_rect_params_t
+typedef struct _ur_enqueue_mem_buffer_copy_rect_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBufferSrc;
-    zer_mem_handle_t* phBufferDst;
-    zer_rect_offset_t* psrcOrigin;
-    zer_rect_offset_t* pdstOrigin;
-    zer_rect_region_t* psrcRegion;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBufferSrc;
+    ur_mem_handle_t* phBufferDst;
+    ur_rect_offset_t* psrcOrigin;
+    ur_rect_offset_t* pdstOrigin;
+    ur_rect_region_t* psrcRegion;
     size_t* psrcRowPitch;
     size_t* psrcSlicePitch;
     size_t* pdstRowPitch;
     size_t* pdstSlicePitch;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_copy_rect_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_copy_rect_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferCopyRect 
+/// @brief Callback function-pointer for urEnqueueMemBufferCopyRect 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferCopyRectCb_t)(
-    zer_enqueue_mem_buffer_copy_rect_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferCopyRectCb_t)(
+    ur_enqueue_mem_buffer_copy_rect_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferFill 
+/// @brief Callback function parameters for urEnqueueMemBufferFill 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_fill_params_t
+typedef struct _ur_enqueue_mem_buffer_fill_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phBuffer;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phBuffer;
     const void** ppattern;
     size_t* ppatternSize;
     size_t* poffset;
     size_t* psize;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_buffer_fill_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_buffer_fill_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferFill 
+/// @brief Callback function-pointer for urEnqueueMemBufferFill 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferFillCb_t)(
-    zer_enqueue_mem_buffer_fill_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferFillCb_t)(
+    ur_enqueue_mem_buffer_fill_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemImageRead 
+/// @brief Callback function parameters for urEnqueueMemImageRead 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_image_read_params_t
+typedef struct _ur_enqueue_mem_image_read_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phImage;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phImage;
     bool* pblockingRead;
-    zer_rect_offset_t* porigin;
-    zer_rect_region_t* pregion;
+    ur_rect_offset_t* porigin;
+    ur_rect_region_t* pregion;
     size_t* prowPitch;
     size_t* pslicePitch;
     void** pdst;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_image_read_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_image_read_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemImageRead 
+/// @brief Callback function-pointer for urEnqueueMemImageRead 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemImageReadCb_t)(
-    zer_enqueue_mem_image_read_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemImageReadCb_t)(
+    ur_enqueue_mem_image_read_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemImageWrite 
+/// @brief Callback function parameters for urEnqueueMemImageWrite 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_image_write_params_t
+typedef struct _ur_enqueue_mem_image_write_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phImage;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phImage;
     bool* pblockingWrite;
-    zer_rect_offset_t* porigin;
-    zer_rect_region_t* pregion;
+    ur_rect_offset_t* porigin;
+    ur_rect_region_t* pregion;
     size_t* pinputRowPitch;
     size_t* pinputSlicePitch;
     void** psrc;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_image_write_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_image_write_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemImageWrite 
+/// @brief Callback function-pointer for urEnqueueMemImageWrite 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemImageWriteCb_t)(
-    zer_enqueue_mem_image_write_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemImageWriteCb_t)(
+    ur_enqueue_mem_image_write_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemImageCopy 
+/// @brief Callback function parameters for urEnqueueMemImageCopy 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_image_copy_params_t
+typedef struct _ur_enqueue_mem_image_copy_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phImageSrc;
-    zer_mem_handle_t* phImageDst;
-    zer_rect_offset_t* psrcOrigin;
-    zer_rect_offset_t* pdstOrigin;
-    zer_rect_region_t* pregion;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phImageSrc;
+    ur_mem_handle_t* phImageDst;
+    ur_rect_offset_t* psrcOrigin;
+    ur_rect_offset_t* pdstOrigin;
+    ur_rect_region_t* pregion;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_image_copy_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_image_copy_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemImageCopy 
+/// @brief Callback function-pointer for urEnqueueMemImageCopy 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemImageCopyCb_t)(
-    zer_enqueue_mem_image_copy_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemImageCopyCb_t)(
+    ur_enqueue_mem_image_copy_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemBufferMap 
+/// @brief Callback function parameters for urEnqueueMemBufferMap 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_buffer_map_params_t
+typedef struct _ur_enqueue_mem_buffer_map_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* pbuffer;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* pbuffer;
     bool* pblockingMap;
-    zer_map_flags_t* pmapFlags;
+    ur_map_flags_t* pmapFlags;
     size_t* poffset;
     size_t* psize;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
     void*** pretMap;
-} zer_enqueue_mem_buffer_map_params_t;
+} ur_enqueue_mem_buffer_map_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemBufferMap 
+/// @brief Callback function-pointer for urEnqueueMemBufferMap 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemBufferMapCb_t)(
-    zer_enqueue_mem_buffer_map_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemBufferMapCb_t)(
+    ur_enqueue_mem_buffer_map_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueMemUnmap 
+/// @brief Callback function parameters for urEnqueueMemUnmap 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_mem_unmap_params_t
+typedef struct _ur_enqueue_mem_unmap_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_mem_handle_t* phMem;
+    ur_queue_handle_t* phQueue;
+    ur_mem_handle_t* phMem;
     void** pmappedPtr;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_mem_unmap_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_mem_unmap_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueMemUnmap 
+/// @brief Callback function-pointer for urEnqueueMemUnmap 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueMemUnmapCb_t)(
-    zer_enqueue_mem_unmap_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueMemUnmapCb_t)(
+    ur_enqueue_mem_unmap_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueUSMMemset 
+/// @brief Callback function parameters for urEnqueueUSMMemset 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_usm_memset_params_t
+typedef struct _ur_enqueue_usm_memset_params_t
 {
-    zer_queue_handle_t* phQueue;
+    ur_queue_handle_t* phQueue;
     void** pptr;
     int8_t* pbyteValue;
     size_t* pcount;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_usm_memset_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_usm_memset_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueUSMMemset 
+/// @brief Callback function-pointer for urEnqueueUSMMemset 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueUSMMemsetCb_t)(
-    zer_enqueue_usm_memset_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueUSMMemsetCb_t)(
+    ur_enqueue_usm_memset_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueUSMMemcpy 
+/// @brief Callback function parameters for urEnqueueUSMMemcpy 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_usm_memcpy_params_t
+typedef struct _ur_enqueue_usm_memcpy_params_t
 {
-    zer_queue_handle_t* phQueue;
+    ur_queue_handle_t* phQueue;
     bool* pblocking;
     void** pdstPrt;
     const void** psrcPrt;
     size_t* psize;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_usm_memcpy_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_usm_memcpy_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueUSMMemcpy 
+/// @brief Callback function-pointer for urEnqueueUSMMemcpy 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueUSMMemcpyCb_t)(
-    zer_enqueue_usm_memcpy_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueUSMMemcpyCb_t)(
+    ur_enqueue_usm_memcpy_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueUSMPrefetch 
+/// @brief Callback function parameters for urEnqueueUSMPrefetch 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_usm_prefetch_params_t
+typedef struct _ur_enqueue_usm_prefetch_params_t
 {
-    zer_queue_handle_t* phQueue;
+    ur_queue_handle_t* phQueue;
     const void** pptr;
     size_t* psize;
-    zer_usm_migration_flags_t* pflags;
+    ur_usm_migration_flags_t* pflags;
     uint32_t* pnumEventsInWaitList;
-    const zer_event_handle_t** peventWaitList;
-    zer_event_handle_t** pevent;
-} zer_enqueue_usm_prefetch_params_t;
+    const ur_event_handle_t** peventWaitList;
+    ur_event_handle_t** pevent;
+} ur_enqueue_usm_prefetch_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueUSMPrefetch 
+/// @brief Callback function-pointer for urEnqueueUSMPrefetch 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueUSMPrefetchCb_t)(
-    zer_enqueue_usm_prefetch_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueUSMPrefetchCb_t)(
+    ur_enqueue_usm_prefetch_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerEnqueueUSMMemAdvice 
+/// @brief Callback function parameters for urEnqueueUSMMemAdvice 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_enqueue_usm_mem_advice_params_t
+typedef struct _ur_enqueue_usm_mem_advice_params_t
 {
-    zer_queue_handle_t* phQueue;
+    ur_queue_handle_t* phQueue;
     const void** pptr;
     size_t* psize;
-    zer_mem_advice_t* padvice;
-    zer_event_handle_t** pevent;
-} zer_enqueue_usm_mem_advice_params_t;
+    ur_mem_advice_t* padvice;
+    ur_event_handle_t** pevent;
+} ur_enqueue_usm_mem_advice_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerEnqueueUSMMemAdvice 
+/// @brief Callback function-pointer for urEnqueueUSMMemAdvice 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnEnqueueUSMMemAdviceCb_t)(
-    zer_enqueue_usm_mem_advice_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnEnqueueUSMMemAdviceCb_t)(
+    ur_enqueue_usm_mem_advice_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Enqueue callback functions pointers
-typedef struct _zer_enqueue_callbacks_t
+typedef struct _ur_enqueue_callbacks_t
 {
-    zer_pfnEnqueueKernelLaunchCb_t                                  pfnKernelLaunchCb;
-    zer_pfnEnqueueEventsWaitCb_t                                    pfnEventsWaitCb;
-    zer_pfnEnqueueEventsWaitWithBarrierCb_t                         pfnEventsWaitWithBarrierCb;
-    zer_pfnEnqueueMemBufferReadCb_t                                 pfnMemBufferReadCb;
-    zer_pfnEnqueueMemBufferWriteCb_t                                pfnMemBufferWriteCb;
-    zer_pfnEnqueueMemBufferReadRectCb_t                             pfnMemBufferReadRectCb;
-    zer_pfnEnqueueMemBufferWriteRectCb_t                            pfnMemBufferWriteRectCb;
-    zer_pfnEnqueueMemBufferCopyCb_t                                 pfnMemBufferCopyCb;
-    zer_pfnEnqueueMemBufferCopyRectCb_t                             pfnMemBufferCopyRectCb;
-    zer_pfnEnqueueMemBufferFillCb_t                                 pfnMemBufferFillCb;
-    zer_pfnEnqueueMemImageReadCb_t                                  pfnMemImageReadCb;
-    zer_pfnEnqueueMemImageWriteCb_t                                 pfnMemImageWriteCb;
-    zer_pfnEnqueueMemImageCopyCb_t                                  pfnMemImageCopyCb;
-    zer_pfnEnqueueMemBufferMapCb_t                                  pfnMemBufferMapCb;
-    zer_pfnEnqueueMemUnmapCb_t                                      pfnMemUnmapCb;
-    zer_pfnEnqueueUSMMemsetCb_t                                     pfnUSMMemsetCb;
-    zer_pfnEnqueueUSMMemcpyCb_t                                     pfnUSMMemcpyCb;
-    zer_pfnEnqueueUSMPrefetchCb_t                                   pfnUSMPrefetchCb;
-    zer_pfnEnqueueUSMMemAdviceCb_t                                  pfnUSMMemAdviceCb;
-} zer_enqueue_callbacks_t;
+    ur_pfnEnqueueKernelLaunchCb_t                                   pfnKernelLaunchCb;
+    ur_pfnEnqueueEventsWaitCb_t                                     pfnEventsWaitCb;
+    ur_pfnEnqueueEventsWaitWithBarrierCb_t                          pfnEventsWaitWithBarrierCb;
+    ur_pfnEnqueueMemBufferReadCb_t                                  pfnMemBufferReadCb;
+    ur_pfnEnqueueMemBufferWriteCb_t                                 pfnMemBufferWriteCb;
+    ur_pfnEnqueueMemBufferReadRectCb_t                              pfnMemBufferReadRectCb;
+    ur_pfnEnqueueMemBufferWriteRectCb_t                             pfnMemBufferWriteRectCb;
+    ur_pfnEnqueueMemBufferCopyCb_t                                  pfnMemBufferCopyCb;
+    ur_pfnEnqueueMemBufferCopyRectCb_t                              pfnMemBufferCopyRectCb;
+    ur_pfnEnqueueMemBufferFillCb_t                                  pfnMemBufferFillCb;
+    ur_pfnEnqueueMemImageReadCb_t                                   pfnMemImageReadCb;
+    ur_pfnEnqueueMemImageWriteCb_t                                  pfnMemImageWriteCb;
+    ur_pfnEnqueueMemImageCopyCb_t                                   pfnMemImageCopyCb;
+    ur_pfnEnqueueMemBufferMapCb_t                                   pfnMemBufferMapCb;
+    ur_pfnEnqueueMemUnmapCb_t                                       pfnMemUnmapCb;
+    ur_pfnEnqueueUSMMemsetCb_t                                      pfnUSMMemsetCb;
+    ur_pfnEnqueueUSMMemcpyCb_t                                      pfnUSMMemcpyCb;
+    ur_pfnEnqueueUSMPrefetchCb_t                                    pfnUSMPrefetchCb;
+    ur_pfnEnqueueUSMMemAdviceCb_t                                   pfnUSMMemAdviceCb;
+} ur_enqueue_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerUSMHostAlloc 
+/// @brief Callback function parameters for urUSMHostAlloc 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_usm_host_alloc_params_t
+typedef struct _ur_usm_host_alloc_params_t
 {
-    zer_context_handle_t* pcontext;
-    zer_usm_mem_flags_t** ppUSMFlag;
+    ur_context_handle_t* pcontext;
+    ur_usm_mem_flags_t** ppUSMFlag;
     size_t* psize;
     uint32_t* palign;
     void*** ppptr;
-} zer_usm_host_alloc_params_t;
+} ur_usm_host_alloc_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerUSMHostAlloc 
+/// @brief Callback function-pointer for urUSMHostAlloc 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnUSMHostAllocCb_t)(
-    zer_usm_host_alloc_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnUSMHostAllocCb_t)(
+    ur_usm_host_alloc_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerUSMDeviceAlloc 
+/// @brief Callback function parameters for urUSMDeviceAlloc 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_usm_device_alloc_params_t
+typedef struct _ur_usm_device_alloc_params_t
 {
-    zer_context_handle_t* pcontext;
-    zer_device_handle_t* pdevice;
-    zer_usm_mem_flags_t** ppUSMProp;
+    ur_context_handle_t* pcontext;
+    ur_device_handle_t* pdevice;
+    ur_usm_mem_flags_t** ppUSMProp;
     size_t* psize;
     uint32_t* palign;
     void*** ppptr;
-} zer_usm_device_alloc_params_t;
+} ur_usm_device_alloc_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerUSMDeviceAlloc 
+/// @brief Callback function-pointer for urUSMDeviceAlloc 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnUSMDeviceAllocCb_t)(
-    zer_usm_device_alloc_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnUSMDeviceAllocCb_t)(
+    ur_usm_device_alloc_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerUSMSharedAlloc 
+/// @brief Callback function parameters for urUSMSharedAlloc 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_usm_shared_alloc_params_t
+typedef struct _ur_usm_shared_alloc_params_t
 {
-    zer_context_handle_t* pcontext;
-    zer_device_handle_t* pdevice;
-    zer_usm_mem_flags_t** ppUSMProp;
+    ur_context_handle_t* pcontext;
+    ur_device_handle_t* pdevice;
+    ur_usm_mem_flags_t** ppUSMProp;
     size_t* psize;
     uint32_t* palign;
     void*** ppptr;
-} zer_usm_shared_alloc_params_t;
+} ur_usm_shared_alloc_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerUSMSharedAlloc 
+/// @brief Callback function-pointer for urUSMSharedAlloc 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnUSMSharedAllocCb_t)(
-    zer_usm_shared_alloc_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnUSMSharedAllocCb_t)(
+    ur_usm_shared_alloc_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of USM callback functions pointers
-typedef struct _zer_usm_callbacks_t
+typedef struct _ur_usm_callbacks_t
 {
-    zer_pfnUSMHostAllocCb_t                                         pfnHostAllocCb;
-    zer_pfnUSMDeviceAllocCb_t                                       pfnDeviceAllocCb;
-    zer_pfnUSMSharedAllocCb_t                                       pfnSharedAllocCb;
-} zer_usm_callbacks_t;
+    ur_pfnUSMHostAllocCb_t                                          pfnHostAllocCb;
+    ur_pfnUSMDeviceAllocCb_t                                        pfnDeviceAllocCb;
+    ur_pfnUSMSharedAllocCb_t                                        pfnSharedAllocCb;
+} ur_usm_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerTearDown 
+/// @brief Callback function parameters for urTearDown 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_tear_down_params_t
+typedef struct _ur_tear_down_params_t
 {
     void** ppParams;
-} zer_tear_down_params_t;
+} ur_tear_down_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerTearDown 
+/// @brief Callback function-pointer for urTearDown 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnTearDownCb_t)(
-    zer_tear_down_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnTearDownCb_t)(
+    ur_tear_down_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerInit 
+/// @brief Callback function parameters for urInit 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_init_params_t
+typedef struct _ur_init_params_t
 {
-    zer_platform_init_flags_t* pplatform_flags;
-    zer_device_init_flags_t* pdevice_flags;
-} zer_init_params_t;
+    ur_platform_init_flags_t* pplatform_flags;
+    ur_device_init_flags_t* pdevice_flags;
+} ur_init_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerInit 
+/// @brief Callback function-pointer for urInit 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnInitCb_t)(
-    zer_init_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnInitCb_t)(
+    ur_init_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Global callback functions pointers
-typedef struct _zer_global_callbacks_t
+typedef struct _ur_global_callbacks_t
 {
-    zer_pfnTearDownCb_t                                             pfnTearDownCb;
-    zer_pfnInitCb_t                                                 pfnInitCb;
-} zer_global_callbacks_t;
+    ur_pfnTearDownCb_t                                              pfnTearDownCb;
+    ur_pfnInitCb_t                                                  pfnInitCb;
+} ur_global_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerQueueGetInfo 
+/// @brief Callback function parameters for urQueueGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_queue_get_info_params_t
+typedef struct _ur_queue_get_info_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_queue_info_t* ppropName;
+    ur_queue_handle_t* phQueue;
+    ur_queue_info_t* ppropName;
     size_t* ppropValueSize;
     void** ppropValue;
     size_t** ppSize;
-} zer_queue_get_info_params_t;
+} ur_queue_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerQueueGetInfo 
+/// @brief Callback function-pointer for urQueueGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnQueueGetInfoCb_t)(
-    zer_queue_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnQueueGetInfoCb_t)(
+    ur_queue_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerQueueCreate 
+/// @brief Callback function parameters for urQueueCreate 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_queue_create_params_t
+typedef struct _ur_queue_create_params_t
 {
-    zer_context_handle_t* phContext;
-    zer_device_handle_t* phDevice;
-    zer_queue_flags_t* pprops;
-    zer_queue_handle_t** pphQueue;
-} zer_queue_create_params_t;
+    ur_context_handle_t* phContext;
+    ur_device_handle_t* phDevice;
+    ur_queue_flags_t* pprops;
+    ur_queue_handle_t** pphQueue;
+} ur_queue_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerQueueCreate 
+/// @brief Callback function-pointer for urQueueCreate 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnQueueCreateCb_t)(
-    zer_queue_create_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnQueueCreateCb_t)(
+    ur_queue_create_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerQueueGetReference 
+/// @brief Callback function parameters for urQueueGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_queue_get_reference_params_t
+typedef struct _ur_queue_get_reference_params_t
 {
-    zer_queue_handle_t* phQueue;
-} zer_queue_get_reference_params_t;
+    ur_queue_handle_t* phQueue;
+} ur_queue_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerQueueGetReference 
+/// @brief Callback function-pointer for urQueueGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnQueueGetReferenceCb_t)(
-    zer_queue_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnQueueGetReferenceCb_t)(
+    ur_queue_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerQueueRelease 
+/// @brief Callback function parameters for urQueueRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_queue_release_params_t
+typedef struct _ur_queue_release_params_t
 {
-    zer_queue_handle_t* phQueue;
-} zer_queue_release_params_t;
+    ur_queue_handle_t* phQueue;
+} ur_queue_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerQueueRelease 
+/// @brief Callback function-pointer for urQueueRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnQueueReleaseCb_t)(
-    zer_queue_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnQueueReleaseCb_t)(
+    ur_queue_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerQueueGetNativeHandle 
+/// @brief Callback function parameters for urQueueGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_queue_get_native_handle_params_t
+typedef struct _ur_queue_get_native_handle_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_native_handle_t** pphNativeQueue;
-} zer_queue_get_native_handle_params_t;
+    ur_queue_handle_t* phQueue;
+    ur_native_handle_t** pphNativeQueue;
+} ur_queue_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerQueueGetNativeHandle 
+/// @brief Callback function-pointer for urQueueGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnQueueGetNativeHandleCb_t)(
-    zer_queue_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnQueueGetNativeHandleCb_t)(
+    ur_queue_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerQueueCreateWithNativeHandle 
+/// @brief Callback function parameters for urQueueCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_queue_create_with_native_handle_params_t
+typedef struct _ur_queue_create_with_native_handle_params_t
 {
-    zer_queue_handle_t* phQueue;
-    zer_native_handle_t* phNativeQueue;
-    zer_queue_handle_t** pphQueue;
-} zer_queue_create_with_native_handle_params_t;
+    ur_queue_handle_t* phQueue;
+    ur_native_handle_t* phNativeQueue;
+    ur_queue_handle_t** pphQueue;
+} ur_queue_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerQueueCreateWithNativeHandle 
+/// @brief Callback function-pointer for urQueueCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnQueueCreateWithNativeHandleCb_t)(
-    zer_queue_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnQueueCreateWithNativeHandleCb_t)(
+    ur_queue_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Queue callback functions pointers
-typedef struct _zer_queue_callbacks_t
+typedef struct _ur_queue_callbacks_t
 {
-    zer_pfnQueueGetInfoCb_t                                         pfnGetInfoCb;
-    zer_pfnQueueCreateCb_t                                          pfnCreateCb;
-    zer_pfnQueueGetReferenceCb_t                                    pfnGetReferenceCb;
-    zer_pfnQueueReleaseCb_t                                         pfnReleaseCb;
-    zer_pfnQueueGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
-    zer_pfnQueueCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
-} zer_queue_callbacks_t;
+    ur_pfnQueueGetInfoCb_t                                          pfnGetInfoCb;
+    ur_pfnQueueCreateCb_t                                           pfnCreateCb;
+    ur_pfnQueueGetReferenceCb_t                                     pfnGetReferenceCb;
+    ur_pfnQueueReleaseCb_t                                          pfnReleaseCb;
+    ur_pfnQueueGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
+    ur_pfnQueueCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
+} ur_queue_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceGet 
+/// @brief Callback function parameters for urDeviceGet 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_get_params_t
+typedef struct _ur_device_get_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_device_type_t* pDevicesType;
+    ur_platform_handle_t* phPlatform;
+    ur_device_type_t* pDevicesType;
     uint32_t** ppCount;
-    zer_device_handle_t** pphDevices;
-} zer_device_get_params_t;
+    ur_device_handle_t** pphDevices;
+} ur_device_get_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceGet 
+/// @brief Callback function-pointer for urDeviceGet 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceGetCb_t)(
-    zer_device_get_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceGetCb_t)(
+    ur_device_get_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceGetInfo 
+/// @brief Callback function parameters for urDeviceGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_get_info_params_t
+typedef struct _ur_device_get_info_params_t
 {
-    zer_device_handle_t* phDevice;
-    zer_device_info_t* pinfoType;
+    ur_device_handle_t* phDevice;
+    ur_device_info_t* pinfoType;
     size_t** ppSize;
     void** ppDeviceInfo;
-} zer_device_get_info_params_t;
+} ur_device_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceGetInfo 
+/// @brief Callback function-pointer for urDeviceGetInfo 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceGetInfoCb_t)(
-    zer_device_get_info_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceGetInfoCb_t)(
+    ur_device_get_info_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceGetReference 
+/// @brief Callback function parameters for urDeviceGetReference 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_get_reference_params_t
+typedef struct _ur_device_get_reference_params_t
 {
-    zer_device_handle_t* phDevice;
-} zer_device_get_reference_params_t;
+    ur_device_handle_t* phDevice;
+} ur_device_get_reference_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceGetReference 
+/// @brief Callback function-pointer for urDeviceGetReference 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceGetReferenceCb_t)(
-    zer_device_get_reference_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceGetReferenceCb_t)(
+    ur_device_get_reference_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceRelease 
+/// @brief Callback function parameters for urDeviceRelease 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_release_params_t
+typedef struct _ur_device_release_params_t
 {
-    zer_device_handle_t* phDevice;
-} zer_device_release_params_t;
+    ur_device_handle_t* phDevice;
+} ur_device_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceRelease 
+/// @brief Callback function-pointer for urDeviceRelease 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceReleaseCb_t)(
-    zer_device_release_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceReleaseCb_t)(
+    ur_device_release_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDevicePartition 
+/// @brief Callback function parameters for urDevicePartition 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_partition_params_t
+typedef struct _ur_device_partition_params_t
 {
-    zer_device_handle_t* phDevice;
-    zer_device_partition_property_value_t** pProperties;
+    ur_device_handle_t* phDevice;
+    ur_device_partition_property_value_t** pProperties;
     uint32_t** ppCount;
-    zer_device_handle_t** pphSubDevices;
-} zer_device_partition_params_t;
+    ur_device_handle_t** pphSubDevices;
+} ur_device_partition_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDevicePartition 
+/// @brief Callback function-pointer for urDevicePartition 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDevicePartitionCb_t)(
-    zer_device_partition_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDevicePartitionCb_t)(
+    ur_device_partition_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceSelectBinary 
+/// @brief Callback function parameters for urDeviceSelectBinary 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_select_binary_params_t
+typedef struct _ur_device_select_binary_params_t
 {
-    zer_device_handle_t* phDevice;
+    ur_device_handle_t* phDevice;
     uint32_t* pNumBinaries;
     const uint8_t*** pBinaries;
     uint32_t* pSelectedBinary;
-} zer_device_select_binary_params_t;
+} ur_device_select_binary_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceSelectBinary 
+/// @brief Callback function-pointer for urDeviceSelectBinary 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceSelectBinaryCb_t)(
-    zer_device_select_binary_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceSelectBinaryCb_t)(
+    ur_device_select_binary_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceGetNativeHandle 
+/// @brief Callback function parameters for urDeviceGetNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_get_native_handle_params_t
+typedef struct _ur_device_get_native_handle_params_t
 {
-    zer_device_handle_t* phDevice;
-    zer_native_handle_t** pphNativeDevice;
-} zer_device_get_native_handle_params_t;
+    ur_device_handle_t* phDevice;
+    ur_native_handle_t** pphNativeDevice;
+} ur_device_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceGetNativeHandle 
+/// @brief Callback function-pointer for urDeviceGetNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceGetNativeHandleCb_t)(
-    zer_device_get_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceGetNativeHandleCb_t)(
+    ur_device_get_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for zerDeviceCreateWithNativeHandle 
+/// @brief Callback function parameters for urDeviceCreateWithNativeHandle 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _zer_device_create_with_native_handle_params_t
+typedef struct _ur_device_create_with_native_handle_params_t
 {
-    zer_platform_handle_t* phPlatform;
-    zer_native_handle_t* phNativeDevice;
-    zer_device_handle_t** pphDevice;
-} zer_device_create_with_native_handle_params_t;
+    ur_platform_handle_t* phPlatform;
+    ur_native_handle_t* phNativeDevice;
+    ur_device_handle_t** pphDevice;
+} ur_device_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for zerDeviceCreateWithNativeHandle 
+/// @brief Callback function-pointer for urDeviceCreateWithNativeHandle 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (ZER_APICALL *zer_pfnDeviceCreateWithNativeHandleCb_t)(
-    zer_device_create_with_native_handle_params_t* params,
-    zer_result_t result,
+typedef void (UR_APICALL *ur_pfnDeviceCreateWithNativeHandleCb_t)(
+    ur_device_create_with_native_handle_params_t* params,
+    ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
     );
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Device callback functions pointers
-typedef struct _zer_device_callbacks_t
+typedef struct _ur_device_callbacks_t
 {
-    zer_pfnDeviceGetCb_t                                            pfnGetCb;
-    zer_pfnDeviceGetInfoCb_t                                        pfnGetInfoCb;
-    zer_pfnDeviceGetReferenceCb_t                                   pfnGetReferenceCb;
-    zer_pfnDeviceReleaseCb_t                                        pfnReleaseCb;
-    zer_pfnDevicePartitionCb_t                                      pfnPartitionCb;
-    zer_pfnDeviceSelectBinaryCb_t                                   pfnSelectBinaryCb;
-    zer_pfnDeviceGetNativeHandleCb_t                                pfnGetNativeHandleCb;
-    zer_pfnDeviceCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
-} zer_device_callbacks_t;
+    ur_pfnDeviceGetCb_t                                             pfnGetCb;
+    ur_pfnDeviceGetInfoCb_t                                         pfnGetInfoCb;
+    ur_pfnDeviceGetReferenceCb_t                                    pfnGetReferenceCb;
+    ur_pfnDeviceReleaseCb_t                                         pfnReleaseCb;
+    ur_pfnDevicePartitionCb_t                                       pfnPartitionCb;
+    ur_pfnDeviceSelectBinaryCb_t                                    pfnSelectBinaryCb;
+    ur_pfnDeviceGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
+    ur_pfnDeviceCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
+} ur_device_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Container for all callbacks
-typedef struct _zer_callbacks_t
+typedef struct _ur_callbacks_t
 {
-    zer_platform_callbacks_t            Platform;
-    zer_context_callbacks_t             Context;
-    zer_event_callbacks_t               Event;
-    zer_program_callbacks_t             Program;
-    zer_module_callbacks_t              Module;
-    zer_kernel_callbacks_t              Kernel;
-    zer_sampler_callbacks_t             Sampler;
-    zer_mem_callbacks_t                 Mem;
-    zer_enqueue_callbacks_t             Enqueue;
-    zer_usm_callbacks_t                 USM;
-    zer_global_callbacks_t              Global;
-    zer_queue_callbacks_t               Queue;
-    zer_device_callbacks_t              Device;
-} zer_callbacks_t;
+    ur_platform_callbacks_t             Platform;
+    ur_context_callbacks_t              Context;
+    ur_event_callbacks_t                Event;
+    ur_program_callbacks_t              Program;
+    ur_module_callbacks_t               Module;
+    ur_kernel_callbacks_t               Kernel;
+    ur_sampler_callbacks_t              Sampler;
+    ur_mem_callbacks_t                  Mem;
+    ur_enqueue_callbacks_t              Enqueue;
+    ur_usm_callbacks_t                  USM;
+    ur_global_callbacks_t               Global;
+    ur_queue_callbacks_t                Queue;
+    ur_device_callbacks_t               Device;
+} ur_callbacks_t;
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -6814,4 +6813,4 @@ typedef struct _zer_callbacks_t
 } // extern "C"
 #endif
 
-#endif // _ZER_API_H
+#endif // _UR_API_H

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1,0 +1,1418 @@
+/*
+ *
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ur_ddi.h
+ * @version v0.5-r0.5
+ *
+ */
+#ifndef _UR_DDI_H
+#define _UR_DDI_H
+#if defined(__cplusplus)
+#pragma once
+#endif
+#include "ur_api.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urPlatformGet 
+typedef ur_result_t (UR_APICALL *ur_pfnPlatformGet_t)(
+    uint32_t*,
+    ur_platform_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urPlatformGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnPlatformGetInfo_t)(
+    ur_platform_handle_t,
+    ur_platform_info_t,
+    size_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urPlatformGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnPlatformGetNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urPlatformCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_platform_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urPlatformGetApiVersion 
+typedef ur_result_t (UR_APICALL *ur_pfnPlatformGetApiVersion_t)(
+    ur_platform_handle_t,
+    ur_api_version_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Platform functions pointers
+typedef struct _ur_platform_dditable_t
+{
+    ur_pfnPlatformGet_t                                         pfnGet;
+    ur_pfnPlatformGetInfo_t                                     pfnGetInfo;
+    ur_pfnPlatformGetNativeHandle_t                             pfnGetNativeHandle;
+    ur_pfnPlatformCreateWithNativeHandle_t                      pfnCreateWithNativeHandle;
+    ur_pfnPlatformGetApiVersion_t                               pfnGetApiVersion;
+} ur_platform_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Platform table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetPlatformProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_platform_dditable_t* pDdiTable               ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetPlatformProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetPlatformProcAddrTable_t)(
+    ur_api_version_t,
+    ur_platform_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urContextCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnContextCreate_t)(
+    uint32_t,
+    ur_device_handle_t*,
+    ur_context_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urContextGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnContextGetReference_t)(
+    ur_context_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urContextRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnContextRelease_t)(
+    ur_context_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urContextGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnContextGetInfo_t)(
+    ur_context_handle_t,
+    ur_context_info_t,
+    size_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urContextGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnContextGetNativeHandle_t)(
+    ur_context_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urContextCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnContextCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_context_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Context functions pointers
+typedef struct _ur_context_dditable_t
+{
+    ur_pfnContextCreate_t                                       pfnCreate;
+    ur_pfnContextGetReference_t                                 pfnGetReference;
+    ur_pfnContextRelease_t                                      pfnRelease;
+    ur_pfnContextGetInfo_t                                      pfnGetInfo;
+    ur_pfnContextGetNativeHandle_t                              pfnGetNativeHandle;
+    ur_pfnContextCreateWithNativeHandle_t                       pfnCreateWithNativeHandle;
+} ur_context_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Context table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetContextProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_context_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetContextProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetContextProcAddrTable_t)(
+    ur_api_version_t,
+    ur_context_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnEventCreate_t)(
+    ur_context_handle_t,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnEventGetInfo_t)(
+    ur_event_handle_t,
+    ur_event_info_t,
+    size_t,
+    void*,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventGetProfilingInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnEventGetProfilingInfo_t)(
+    ur_event_handle_t,
+    ur_profiling_info_t,
+    size_t,
+    void*,
+    size_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventWait 
+typedef ur_result_t (UR_APICALL *ur_pfnEventWait_t)(
+    uint32_t,
+    const ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnEventGetReference_t)(
+    ur_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnEventRelease_t)(
+    ur_event_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnEventGetNativeHandle_t)(
+    ur_event_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEventCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnEventCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Event functions pointers
+typedef struct _ur_event_dditable_t
+{
+    ur_pfnEventCreate_t                                         pfnCreate;
+    ur_pfnEventGetInfo_t                                        pfnGetInfo;
+    ur_pfnEventGetProfilingInfo_t                               pfnGetProfilingInfo;
+    ur_pfnEventWait_t                                           pfnWait;
+    ur_pfnEventGetReference_t                                   pfnGetReference;
+    ur_pfnEventRelease_t                                        pfnRelease;
+    ur_pfnEventGetNativeHandle_t                                pfnGetNativeHandle;
+    ur_pfnEventCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
+} ur_event_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Event table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEventProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_event_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetEventProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetEventProcAddrTable_t)(
+    ur_api_version_t,
+    ur_event_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramCreate_t)(
+    ur_context_handle_t,
+    uint32_t,
+    const ur_module_handle_t*,
+    const char*,
+    ur_program_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramCreateWithBinary 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramCreateWithBinary_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    uint32_t,
+    const uint8_t*,
+    ur_program_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramGetReference_t)(
+    ur_program_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramRelease_t)(
+    ur_program_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramGetFunctionPointer 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramGetFunctionPointer_t)(
+    ur_device_handle_t,
+    ur_program_handle_t,
+    const char*,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramGetInfo_t)(
+    ur_program_handle_t,
+    ur_program_info_t,
+    size_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramGetBuildInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramGetBuildInfo_t)(
+    ur_program_handle_t,
+    ur_device_handle_t,
+    ur_program_build_info_t,
+    size_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramSetSpecializationConstant 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramSetSpecializationConstant_t)(
+    ur_program_handle_t,
+    uint32_t,
+    size_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramGetNativeHandle_t)(
+    ur_program_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramCreateWithNativeHandle_t)(
+    ur_program_handle_t,
+    ur_native_handle_t,
+    ur_program_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Program functions pointers
+typedef struct _ur_program_dditable_t
+{
+    ur_pfnProgramCreate_t                                       pfnCreate;
+    ur_pfnProgramCreateWithBinary_t                             pfnCreateWithBinary;
+    ur_pfnProgramGetReference_t                                 pfnGetReference;
+    ur_pfnProgramRelease_t                                      pfnRelease;
+    ur_pfnProgramGetFunctionPointer_t                           pfnGetFunctionPointer;
+    ur_pfnProgramGetInfo_t                                      pfnGetInfo;
+    ur_pfnProgramGetBuildInfo_t                                 pfnGetBuildInfo;
+    ur_pfnProgramSetSpecializationConstant_t                    pfnSetSpecializationConstant;
+    ur_pfnProgramGetNativeHandle_t                              pfnGetNativeHandle;
+    ur_pfnProgramCreateWithNativeHandle_t                       pfnCreateWithNativeHandle;
+} ur_program_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Program table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetProgramProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_program_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetProgramProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetProgramProcAddrTable_t)(
+    ur_api_version_t,
+    ur_program_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urModuleCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnModuleCreate_t)(
+    ur_context_handle_t,
+    const void*,
+    uint32_t,
+    const char*,
+    void**,
+    void*,
+    ur_module_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urModuleGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnModuleGetReference_t)(
+    ur_module_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urModuleRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnModuleRelease_t)(
+    ur_module_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urModuleGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnModuleGetNativeHandle_t)(
+    ur_module_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urModuleCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnModuleCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_module_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Module functions pointers
+typedef struct _ur_module_dditable_t
+{
+    ur_pfnModuleCreate_t                                        pfnCreate;
+    ur_pfnModuleGetReference_t                                  pfnGetReference;
+    ur_pfnModuleRelease_t                                       pfnRelease;
+    ur_pfnModuleGetNativeHandle_t                               pfnGetNativeHandle;
+    ur_pfnModuleCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
+} ur_module_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Module table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetModuleProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_module_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetModuleProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetModuleProcAddrTable_t)(
+    ur_api_version_t,
+    ur_module_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelCreate_t)(
+    ur_program_handle_t,
+    const char*,
+    ur_kernel_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelGetInfo_t)(
+    ur_kernel_handle_t,
+    ur_kernel_info_t,
+    size_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelGetGroupInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelGetGroupInfo_t)(
+    ur_kernel_handle_t,
+    ur_device_handle_t,
+    ur_kernel_group_info_t,
+    size_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelGetSubGroupInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelGetSubGroupInfo_t)(
+    ur_kernel_handle_t,
+    ur_device_handle_t,
+    ur_kernel_sub_group_info_t,
+    size_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelGetReference_t)(
+    ur_kernel_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelRelease_t)(
+    ur_kernel_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelGetNativeHandle_t)(
+    ur_kernel_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_kernel_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelSetArg 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArg_t)(
+    ur_kernel_handle_t,
+    uint32_t,
+    size_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelSetArgPointer 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgPointer_t)(
+    ur_kernel_handle_t,
+    uint32_t,
+    size_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelSetExecInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelSetExecInfo_t)(
+    ur_kernel_handle_t,
+    ur_kernel_exec_info_t,
+    size_t,
+    const void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelSetArgSampler 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgSampler_t)(
+    ur_kernel_handle_t,
+    uint32_t,
+    ur_sampler_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urKernelSetArgMemObj 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgMemObj_t)(
+    ur_kernel_handle_t,
+    uint32_t,
+    ur_mem_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Kernel functions pointers
+typedef struct _ur_kernel_dditable_t
+{
+    ur_pfnKernelCreate_t                                        pfnCreate;
+    ur_pfnKernelGetInfo_t                                       pfnGetInfo;
+    ur_pfnKernelGetGroupInfo_t                                  pfnGetGroupInfo;
+    ur_pfnKernelGetSubGroupInfo_t                               pfnGetSubGroupInfo;
+    ur_pfnKernelGetReference_t                                  pfnGetReference;
+    ur_pfnKernelRelease_t                                       pfnRelease;
+    ur_pfnKernelGetNativeHandle_t                               pfnGetNativeHandle;
+    ur_pfnKernelCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
+    ur_pfnKernelSetArg_t                                        pfnSetArg;
+    ur_pfnKernelSetArgPointer_t                                 pfnSetArgPointer;
+    ur_pfnKernelSetExecInfo_t                                   pfnSetExecInfo;
+    ur_pfnKernelSetArgSampler_t                                 pfnSetArgSampler;
+    ur_pfnKernelSetArgMemObj_t                                  pfnSetArgMemObj;
+} ur_kernel_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Kernel table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetKernelProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_kernel_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetKernelProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetKernelProcAddrTable_t)(
+    ur_api_version_t,
+    ur_kernel_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urSamplerCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreate_t)(
+    ur_context_handle_t,
+    const ur_sampler_property_value_t*,
+    ur_sampler_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urSamplerGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerGetReference_t)(
+    ur_sampler_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urSamplerRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerRelease_t)(
+    ur_sampler_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urSamplerGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerGetInfo_t)(
+    ur_sampler_handle_t,
+    ur_sampler_info_t,
+    size_t,
+    void*,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urSamplerGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerGetNativeHandle_t)(
+    ur_sampler_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urSamplerCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreateWithNativeHandle_t)(
+    ur_sampler_handle_t,
+    ur_native_handle_t,
+    ur_sampler_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Sampler functions pointers
+typedef struct _ur_sampler_dditable_t
+{
+    ur_pfnSamplerCreate_t                                       pfnCreate;
+    ur_pfnSamplerGetReference_t                                 pfnGetReference;
+    ur_pfnSamplerRelease_t                                      pfnRelease;
+    ur_pfnSamplerGetInfo_t                                      pfnGetInfo;
+    ur_pfnSamplerGetNativeHandle_t                              pfnGetNativeHandle;
+    ur_pfnSamplerCreateWithNativeHandle_t                       pfnCreateWithNativeHandle;
+} ur_sampler_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Sampler table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetSamplerProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_sampler_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetSamplerProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetSamplerProcAddrTable_t)(
+    ur_api_version_t,
+    ur_sampler_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemImageCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnMemImageCreate_t)(
+    ur_context_handle_t,
+    ur_mem_flags_t,
+    const ur_image_format_t*,
+    const ur_image_desc_t*,
+    void*,
+    ur_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemBufferCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnMemBufferCreate_t)(
+    ur_context_handle_t,
+    ur_mem_flags_t,
+    size_t,
+    void*,
+    ur_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnMemGetReference_t)(
+    ur_mem_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnMemRelease_t)(
+    ur_mem_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemBufferPartition 
+typedef ur_result_t (UR_APICALL *ur_pfnMemBufferPartition_t)(
+    ur_mem_handle_t,
+    ur_mem_flags_t,
+    ur_buffer_create_type_t,
+    ur_buffer_region_t*,
+    ur_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnMemGetNativeHandle_t)(
+    ur_mem_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnMemCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_mem_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemFree 
+typedef ur_result_t (UR_APICALL *ur_pfnMemFree_t)(
+    ur_context_handle_t,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemGetMemAllocInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnMemGetMemAllocInfo_t)(
+    ur_context_handle_t,
+    const void*,
+    ur_mem_info_t,
+    size_t,
+    void*,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Mem functions pointers
+typedef struct _ur_mem_dditable_t
+{
+    ur_pfnMemImageCreate_t                                      pfnImageCreate;
+    ur_pfnMemBufferCreate_t                                     pfnBufferCreate;
+    ur_pfnMemGetReference_t                                     pfnGetReference;
+    ur_pfnMemRelease_t                                          pfnRelease;
+    ur_pfnMemBufferPartition_t                                  pfnBufferPartition;
+    ur_pfnMemGetNativeHandle_t                                  pfnGetNativeHandle;
+    ur_pfnMemCreateWithNativeHandle_t                           pfnCreateWithNativeHandle;
+    ur_pfnMemFree_t                                             pfnFree;
+    ur_pfnMemGetMemAllocInfo_t                                  pfnGetMemAllocInfo;
+} ur_mem_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Mem table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_mem_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetMemProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetMemProcAddrTable_t)(
+    ur_api_version_t,
+    ur_mem_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueKernelLaunch 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueKernelLaunch_t)(
+    ur_queue_handle_t,
+    ur_kernel_handle_t,
+    uint32_t,
+    const size_t*,
+    const size_t*,
+    const size_t*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueEventsWait 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueEventsWait_t)(
+    ur_queue_handle_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueEventsWaitWithBarrier 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueEventsWaitWithBarrier_t)(
+    ur_queue_handle_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferRead 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferRead_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    size_t,
+    size_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferWrite 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferWrite_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    size_t,
+    size_t,
+    const void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferReadRect 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferReadRect_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    size_t,
+    size_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferWriteRect 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferWriteRect_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    size_t,
+    size_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferCopy 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopy_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    ur_mem_handle_t,
+    size_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferCopyRect 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopyRect_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    ur_mem_handle_t,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    size_t,
+    size_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferFill 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferFill_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    const void*,
+    size_t,
+    size_t,
+    size_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemImageRead 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageRead_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemImageWrite 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageWrite_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemImageCopy 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageCopy_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    ur_mem_handle_t,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemBufferMap 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferMap_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    ur_map_flags_t,
+    size_t,
+    size_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemUnmap 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemUnmap_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueUSMMemset 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemset_t)(
+    ur_queue_handle_t,
+    void*,
+    int8_t,
+    size_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueUSMMemcpy 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemcpy_t)(
+    ur_queue_handle_t,
+    bool,
+    void*,
+    const void*,
+    size_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueUSMPrefetch 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMPrefetch_t)(
+    ur_queue_handle_t,
+    const void*,
+    size_t,
+    ur_usm_migration_flags_t,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueUSMMemAdvice 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemAdvice_t)(
+    ur_queue_handle_t,
+    const void*,
+    size_t,
+    ur_mem_advice_t,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Enqueue functions pointers
+typedef struct _ur_enqueue_dditable_t
+{
+    ur_pfnEnqueueKernelLaunch_t                                 pfnKernelLaunch;
+    ur_pfnEnqueueEventsWait_t                                   pfnEventsWait;
+    ur_pfnEnqueueEventsWaitWithBarrier_t                        pfnEventsWaitWithBarrier;
+    ur_pfnEnqueueMemBufferRead_t                                pfnMemBufferRead;
+    ur_pfnEnqueueMemBufferWrite_t                               pfnMemBufferWrite;
+    ur_pfnEnqueueMemBufferReadRect_t                            pfnMemBufferReadRect;
+    ur_pfnEnqueueMemBufferWriteRect_t                           pfnMemBufferWriteRect;
+    ur_pfnEnqueueMemBufferCopy_t                                pfnMemBufferCopy;
+    ur_pfnEnqueueMemBufferCopyRect_t                            pfnMemBufferCopyRect;
+    ur_pfnEnqueueMemBufferFill_t                                pfnMemBufferFill;
+    ur_pfnEnqueueMemImageRead_t                                 pfnMemImageRead;
+    ur_pfnEnqueueMemImageWrite_t                                pfnMemImageWrite;
+    ur_pfnEnqueueMemImageCopy_t                                 pfnMemImageCopy;
+    ur_pfnEnqueueMemBufferMap_t                                 pfnMemBufferMap;
+    ur_pfnEnqueueMemUnmap_t                                     pfnMemUnmap;
+    ur_pfnEnqueueUSMMemset_t                                    pfnUSMMemset;
+    ur_pfnEnqueueUSMMemcpy_t                                    pfnUSMMemcpy;
+    ur_pfnEnqueueUSMPrefetch_t                                  pfnUSMPrefetch;
+    ur_pfnEnqueueUSMMemAdvice_t                                 pfnUSMMemAdvice;
+} ur_enqueue_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Enqueue table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEnqueueProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_enqueue_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetEnqueueProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetEnqueueProcAddrTable_t)(
+    ur_api_version_t,
+    ur_enqueue_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMHostAlloc 
+typedef ur_result_t (UR_APICALL *ur_pfnUSMHostAlloc_t)(
+    ur_context_handle_t,
+    ur_usm_mem_flags_t*,
+    size_t,
+    uint32_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMDeviceAlloc 
+typedef ur_result_t (UR_APICALL *ur_pfnUSMDeviceAlloc_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    ur_usm_mem_flags_t*,
+    size_t,
+    uint32_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMSharedAlloc 
+typedef ur_result_t (UR_APICALL *ur_pfnUSMSharedAlloc_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    ur_usm_mem_flags_t*,
+    size_t,
+    uint32_t,
+    void**
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of USM functions pointers
+typedef struct _ur_usm_dditable_t
+{
+    ur_pfnUSMHostAlloc_t                                        pfnHostAlloc;
+    ur_pfnUSMDeviceAlloc_t                                      pfnDeviceAlloc;
+    ur_pfnUSMSharedAlloc_t                                      pfnSharedAlloc;
+} ur_usm_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USM table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_usm_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetUSMProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
+    ur_api_version_t,
+    ur_usm_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urTearDown 
+typedef ur_result_t (UR_APICALL *ur_pfnTearDown_t)(
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urInit 
+typedef ur_result_t (UR_APICALL *ur_pfnInit_t)(
+    ur_platform_init_flags_t,
+    ur_device_init_flags_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Global functions pointers
+typedef struct _ur_global_dditable_t
+{
+    ur_pfnTearDown_t                                            pfnTearDown;
+    ur_pfnInit_t                                                pfnInit;
+} ur_global_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Global table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetGlobalProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_global_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetGlobalProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
+    ur_api_version_t,
+    ur_global_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueGetInfo_t)(
+    ur_queue_handle_t,
+    ur_queue_info_t,
+    size_t,
+    void*,
+    size_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueCreate 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueCreate_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    ur_queue_flags_t,
+    ur_queue_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueGetReference_t)(
+    ur_queue_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueRelease_t)(
+    ur_queue_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueGetNativeHandle_t)(
+    ur_queue_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueCreateWithNativeHandle_t)(
+    ur_queue_handle_t,
+    ur_native_handle_t,
+    ur_queue_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Queue functions pointers
+typedef struct _ur_queue_dditable_t
+{
+    ur_pfnQueueGetInfo_t                                        pfnGetInfo;
+    ur_pfnQueueCreate_t                                         pfnCreate;
+    ur_pfnQueueGetReference_t                                   pfnGetReference;
+    ur_pfnQueueRelease_t                                        pfnRelease;
+    ur_pfnQueueGetNativeHandle_t                                pfnGetNativeHandle;
+    ur_pfnQueueCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
+} ur_queue_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Queue table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetQueueProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_queue_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetQueueProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
+    ur_api_version_t,
+    ur_queue_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceGet 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceGet_t)(
+    ur_platform_handle_t,
+    ur_device_type_t,
+    uint32_t*,
+    ur_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceGetInfo 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetInfo_t)(
+    ur_device_handle_t,
+    ur_device_info_t,
+    size_t*,
+    void*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceGetReference 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetReference_t)(
+    ur_device_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceRelease 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceRelease_t)(
+    ur_device_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDevicePartition 
+typedef ur_result_t (UR_APICALL *ur_pfnDevicePartition_t)(
+    ur_device_handle_t,
+    ur_device_partition_property_value_t*,
+    uint32_t*,
+    ur_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceSelectBinary 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceSelectBinary_t)(
+    ur_device_handle_t,
+    uint32_t,
+    const uint8_t**,
+    uint32_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceGetNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetNativeHandle_t)(
+    ur_device_handle_t,
+    ur_native_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urDeviceCreateWithNativeHandle 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceCreateWithNativeHandle_t)(
+    ur_platform_handle_t,
+    ur_native_handle_t,
+    ur_device_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Device functions pointers
+typedef struct _ur_device_dditable_t
+{
+    ur_pfnDeviceGet_t                                           pfnGet;
+    ur_pfnDeviceGetInfo_t                                       pfnGetInfo;
+    ur_pfnDeviceGetReference_t                                  pfnGetReference;
+    ur_pfnDeviceRelease_t                                       pfnRelease;
+    ur_pfnDevicePartition_t                                     pfnPartition;
+    ur_pfnDeviceSelectBinary_t                                  pfnSelectBinary;
+    ur_pfnDeviceGetNativeHandle_t                               pfnGetNativeHandle;
+    ur_pfnDeviceCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
+} ur_device_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Device table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetDeviceProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_device_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetDeviceProcAddrTable
+typedef ur_result_t (UR_APICALL *ur_pfnGetDeviceProcAddrTable_t)(
+    ur_api_version_t,
+    ur_device_dditable_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Container for all DDI tables
+typedef struct _ur_dditable_t
+{
+    ur_platform_dditable_t              Platform;
+    ur_context_dditable_t               Context;
+    ur_event_dditable_t                 Event;
+    ur_program_dditable_t               Program;
+    ur_module_dditable_t                Module;
+    ur_kernel_dditable_t                Kernel;
+    ur_sampler_dditable_t               Sampler;
+    ur_mem_dditable_t                   Mem;
+    ur_enqueue_dditable_t               Enqueue;
+    ur_usm_dditable_t                   USM;
+    ur_global_dditable_t                Global;
+    ur_queue_dditable_t                 Queue;
+    ur_device_dditable_t                Device;
+} ur_dditable_t;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _UR_DDI_H

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -166,13 +166,13 @@ class: $xClsName
 
 ```c
 /// @brief A brief description...
-typedef void* zer_name_t;
+typedef void* ur_name_t;
 ```
 </td>
 <td>
 
 ```cpp
-namespace zer {
+namespace ur {
   class ClsName
   {
     /// @brief A brief description...
@@ -184,7 +184,7 @@ namespace zer {
 
 ```python
 ## @brief A brief description...
-class zer_name_t(c_void_p):
+class ur_name_t(c_void_p):
     pass
 ```
 </td></tr>
@@ -217,13 +217,13 @@ name: $x_name_handle_t
 <td>
 
 ```c
-typedef struct _zer_name_handle_t *zer_name_handle_t;
+typedef struct _ur_name_handle_t *ur_name_handle_t;
 ```
 </td>
 <td>
 
 ```cpp
-namespace zer {
+namespace ur {
   struct _name_handle_t;
   using name_handle_t = _name_handle_t*;
 
@@ -233,7 +233,7 @@ namespace zer {
 
 ```python
 ## @brief A brief description...
-class zer_name_handle_t(c_void_p):
+class ur_name_handle_t(c_void_p):
     pass
 ```
 </td></tr>
@@ -249,13 +249,13 @@ class: $xClsName
 <td>
 
 ```c
-typedef struct _zer_name_handle_t *zer_name_handle_t;
+typedef struct _ur_name_handle_t *ur_name_handle_t;
 ```
 </td>
 <td>
 
 ```cpp
-namespace zer {
+namespace ur {
   class ClsName;
 ```
 </td>
@@ -263,7 +263,7 @@ namespace zer {
 
 ```python
 ## @brief A brief description...
-class zer_name_handle_t(c_void_p):
+class ur_name_handle_t(c_void_p):
     pass
 ```
 </td></tr>
@@ -311,17 +311,17 @@ etors:
 
 ```c
 /// @brief A brief description...
-typedef enum _zer_name_t
+typedef enum _ur_name_t
 {
     ZE_NAME_VALUE_0 = 0, ///< brief description
     ZE_NAME_VALUE_1      ///< brief description
-} zer_name_t;
+} ur_name_t;
 ```
 </td>
 <td>
 
 ```cpp
-namespace zer {
+namespace ur {
   class ClsName
   {
     /// @brief A brief description...
@@ -336,7 +336,7 @@ namespace zer {
 
 ```python
 ## @brief A brief description...
-class zer_name_v(IntEnum):
+class ur_name_v(IntEnum):
     VALUE_0 = 0,        ## brief description
     VALUE_1 = auto()    ## brief description
 
@@ -360,18 +360,18 @@ etors:
 
 ```c
 /// @brief A brief description...
-typedef uint32_t zer_name_flags_t;
-typedef enum _zer_name_flag_t
+typedef uint32_t ur_name_flags_t;
+typedef enum _ur_name_flag_t
 {
     ZE_NAME_FLAG_VALUE_0 = ZE_BIT(0), ///< brief description
     ZE_NAME_FLAG_VALUE_1 = ZE_BIT(1)  ///< brief description
-} zer_name_flag_t;
+} ur_name_flag_t;
 ```
 </td>
 <td>
 
 ```cpp
-namespace zer {
+namespace ur {
   class ClsName
   {
     /// @brief A brief description...
@@ -391,7 +391,7 @@ namespace zer {
 
 ```python
 ## @brief A brief description...
-class zer_name_flags_v(IntEnum):
+class ur_name_flags_v(IntEnum):
     VALUE_0 = 1h,   ## brief description
     VALUE_1 = 2h    ## brief description
 
@@ -453,11 +453,11 @@ members:
 
 ```c
 /// @brief A brief description...
-typedef struct _zer_name_t
+typedef struct _ur_name_t
 {
    uint32_t val0; ///< brief description
    float    val1; ///< brief description
-} zer_name_t;
+} ur_name_t;
 ```
 </td>
 <td>
@@ -478,7 +478,7 @@ namespace ze {
 
 ```python
 ## @brief A brief description...
-class zer_name_t(Structure):
+class ur_name_t(Structure):
     _fields_ = [
         ("val0", c_ulong),  ## brief description
         ("val1", c_float)   ## brief description
@@ -505,11 +505,11 @@ members:
 
 ```c
 /// @brief A brief description...
-typedef union _zer_name_t
+typedef union _ur_name_t
 {
    uint32_t val0; ///< brief description
    float    val1; ///< brief description
-} zer_name_t;
+} ur_name_t;
 ```
 </td>
 <td>
@@ -530,7 +530,7 @@ namespace ze {
 
 ```python
 ## @brief A brief description...
-class zer_name_t(Structure):
+class ur_name_t(Structure):
     _fields_ = [
         ("val0", c_ulong),  ## brief description
         ("val1", c_float)   ## brief description
@@ -625,9 +625,9 @@ params:
 ///     - ZE_RESULT_ERROR_INVALID_ARGUMENT
 ///         + `0 == value`
 ///     - ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
-__zer_api_export zer_result_t __zecall
+__ur_api_export ur_result_t __zecall
 zeClsNameFnName(
-    zer_cls_handle_t hClsName,   ///< [in] handle to class
+    ur_cls_handle_t hClsName,   ///< [in] handle to class
     uint32_t count,             ///< [in] brief description
     uint32_t* values,           ///< [in][range(0,count)] brief description
     uint32_t* result            ///< [out] result of function
@@ -659,7 +659,7 @@ namespace ze {
 
 ```python
 ## @brief A brief description...
-_zeClsNameFnName_t = CFUNCTYPE( zer_result_t, zer_cls_handle_t, c_ulong, POINTER(c_ulong), POINTER(c_ulong) )
+_urClsNameFnName_t = CFUNCTYPE( ur_result_t, ur_cls_handle_t, c_ulong, POINTER(c_ulong), POINTER(c_ulong) )
 ```
 </td></tr>
 </table>
@@ -710,11 +710,11 @@ namespace ze {
     class ClsName
     {
     protected:
-        zer_cls_handle_t m_handle;
+        ur_cls_handle_t m_handle;
 
     public:
         ClsName() = delete;
-        ClsName( zer_cls_handle_t handle );
+        ClsName( ur_cls_handle_t handle );
 
         ~ClsName( void ) = default;
 

--- a/scripts/config.ini
+++ b/scripts/config.ini
@@ -1,6 +1,5 @@
 [core]
 OneApi='oneAPI'
-namespace=zer
+namespace=ur
 tags=OneApi,x
 x=${namespace}
-

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -272,7 +272,7 @@ desc: "Defines structure types"
 name: $x_structure_type_t
 etors:
     - name: IMAGE_DESC
-      desc: $zer_image_desc_t
+      desc: $x_image_desc_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -152,7 +152,7 @@ params:
     - type: $x_platform_handle_t
       name: hPlatform
       desc: "[in] handle of the platform instance"
-      todo: "Replace the platform with array of devices similar to what's in zerContextCreate"
+      todo: "Replace the platform with array of devices similar to what's in urContextCreate"
     - type: $x_native_handle_t
       name: hNativeContext
       desc: |

--- a/scripts/templates/api.py.mako
+++ b/scripts/templates/api.py.mako
@@ -129,7 +129,7 @@ ${"#############################################################################
 ${"##"} @brief ${n} device-driver interfaces
 class ${N}_DDI:
     def __init__(self, version : ${x}_api_version_t):
-        # load the zer_loader library
+        # load the ${x}_loader library
         if "Windows" == platform.uname()[0]:
             self.__dll = WinDLL("${x}_loader.dll")
         else:

--- a/scripts/templates/conf.py.mako
+++ b/scripts/templates/conf.py.mako
@@ -205,9 +205,9 @@ epub_exclude_files = ['search.html']
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-cpp_index_common_prefix = ['zer::', 'zert::']
+cpp_index_common_prefix = ['ur::', 'urt::']
 
-cpp_id_attributes = ['ZER_APIEXPORT', 'ZER_APICALL']
+cpp_id_attributes = ['UR_APIEXPORT', 'UR_APICALL']
 
 breathe_projects = { "UnifiedRuntime": "../xml" }
 breathe_default_project = "UnifiedRuntime"

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,8 +1,8 @@
-set(TARGET_NAME ze_test)
+set(TARGET_NAME ur_test)
 
 add_library(${TARGET_NAME}
     STATIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/zer_api.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ur_api.cpp
 )
 
 target_link_libraries(${TARGET_NAME}

--- a/source/zer_api.cpp
+++ b/source/zer_api.cpp
@@ -1,1 +1,0 @@
-// Placeholder to fix FetchContent issues for projects from outside


### PR DESCRIPTION
This patch replaces the zer/ZER namespace prefix with ur/UR to match the Unified Runtime naming of the project.

Fixes #6.