### PR TITLE
Replace GetReference with Retain

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -970,11 +970,11 @@ else:
     _urContextCreate_t = CFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urContextGetReference
+## @brief Function-pointer for urContextRetain
 if __use_win_types:
-    _urContextGetReference_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t )
+    _urContextRetain_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t )
 else:
-    _urContextGetReference_t = CFUNCTYPE( ur_result_t, ur_context_handle_t )
+    _urContextRetain_t = CFUNCTYPE( ur_result_t, ur_context_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urContextRelease
@@ -1010,7 +1010,7 @@ else:
 class _ur_context_dditable_t(Structure):
     _fields_ = [
         ("pfnCreate", c_void_p),                                        ## _urContextCreate_t
-        ("pfnGetReference", c_void_p),                                  ## _urContextGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urContextRetain_t
         ("pfnRelease", c_void_p),                                       ## _urContextRelease_t
         ("pfnGetInfo", c_void_p),                                       ## _urContextGetInfo_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urContextGetNativeHandle_t
@@ -1046,11 +1046,11 @@ else:
     _urEventWait_t = CFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_event_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urEventGetReference
+## @brief Function-pointer for urEventRetain
 if __use_win_types:
-    _urEventGetReference_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t )
+    _urEventRetain_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t )
 else:
-    _urEventGetReference_t = CFUNCTYPE( ur_result_t, ur_event_handle_t )
+    _urEventRetain_t = CFUNCTYPE( ur_result_t, ur_event_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urEventRelease
@@ -1082,7 +1082,7 @@ class _ur_event_dditable_t(Structure):
         ("pfnGetInfo", c_void_p),                                       ## _urEventGetInfo_t
         ("pfnGetProfilingInfo", c_void_p),                              ## _urEventGetProfilingInfo_t
         ("pfnWait", c_void_p),                                          ## _urEventWait_t
-        ("pfnGetReference", c_void_p),                                  ## _urEventGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urEventRetain_t
         ("pfnRelease", c_void_p),                                       ## _urEventRelease_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urEventGetNativeHandle_t
         ("pfnCreateWithNativeHandle", c_void_p)                         ## _urEventCreateWithNativeHandle_t
@@ -1103,11 +1103,11 @@ else:
     _urProgramCreateWithBinary_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(c_ubyte), POINTER(ur_program_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urProgramGetReference
+## @brief Function-pointer for urProgramRetain
 if __use_win_types:
-    _urProgramGetReference_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t )
+    _urProgramRetain_t = WINFUNCTYPE( ur_result_t, ur_program_handle_t )
 else:
-    _urProgramGetReference_t = CFUNCTYPE( ur_result_t, ur_program_handle_t )
+    _urProgramRetain_t = CFUNCTYPE( ur_result_t, ur_program_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urProgramRelease
@@ -1165,7 +1165,7 @@ class _ur_program_dditable_t(Structure):
     _fields_ = [
         ("pfnCreate", c_void_p),                                        ## _urProgramCreate_t
         ("pfnCreateWithBinary", c_void_p),                              ## _urProgramCreateWithBinary_t
-        ("pfnGetReference", c_void_p),                                  ## _urProgramGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urProgramRetain_t
         ("pfnRelease", c_void_p),                                       ## _urProgramRelease_t
         ("pfnGetFunctionPointer", c_void_p),                            ## _urProgramGetFunctionPointer_t
         ("pfnGetInfo", c_void_p),                                       ## _urProgramGetInfo_t
@@ -1183,11 +1183,11 @@ else:
     _urModuleCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_ulong, c_char_p, POINTER(c_void_p), c_void_p, POINTER(ur_module_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urModuleGetReference
+## @brief Function-pointer for urModuleRetain
 if __use_win_types:
-    _urModuleGetReference_t = WINFUNCTYPE( ur_result_t, ur_module_handle_t )
+    _urModuleRetain_t = WINFUNCTYPE( ur_result_t, ur_module_handle_t )
 else:
-    _urModuleGetReference_t = CFUNCTYPE( ur_result_t, ur_module_handle_t )
+    _urModuleRetain_t = CFUNCTYPE( ur_result_t, ur_module_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urModuleRelease
@@ -1216,7 +1216,7 @@ else:
 class _ur_module_dditable_t(Structure):
     _fields_ = [
         ("pfnCreate", c_void_p),                                        ## _urModuleCreate_t
-        ("pfnGetReference", c_void_p),                                  ## _urModuleGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urModuleRetain_t
         ("pfnRelease", c_void_p),                                       ## _urModuleRelease_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urModuleGetNativeHandle_t
         ("pfnCreateWithNativeHandle", c_void_p)                         ## _urModuleCreateWithNativeHandle_t
@@ -1251,11 +1251,11 @@ else:
     _urKernelGetSubGroupInfo_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t, ur_device_handle_t, ur_kernel_sub_group_info_t, c_size_t, c_void_p )
 
 ###############################################################################
-## @brief Function-pointer for urKernelGetReference
+## @brief Function-pointer for urKernelRetain
 if __use_win_types:
-    _urKernelGetReference_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t )
+    _urKernelRetain_t = WINFUNCTYPE( ur_result_t, ur_kernel_handle_t )
 else:
-    _urKernelGetReference_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t )
+    _urKernelRetain_t = CFUNCTYPE( ur_result_t, ur_kernel_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urKernelRelease
@@ -1322,7 +1322,7 @@ class _ur_kernel_dditable_t(Structure):
         ("pfnGetInfo", c_void_p),                                       ## _urKernelGetInfo_t
         ("pfnGetGroupInfo", c_void_p),                                  ## _urKernelGetGroupInfo_t
         ("pfnGetSubGroupInfo", c_void_p),                               ## _urKernelGetSubGroupInfo_t
-        ("pfnGetReference", c_void_p),                                  ## _urKernelGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urKernelRetain_t
         ("pfnRelease", c_void_p),                                       ## _urKernelRelease_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urKernelGetNativeHandle_t
         ("pfnCreateWithNativeHandle", c_void_p),                        ## _urKernelCreateWithNativeHandle_t
@@ -1341,11 +1341,11 @@ else:
     _urSamplerCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_value_t), POINTER(ur_sampler_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urSamplerGetReference
+## @brief Function-pointer for urSamplerRetain
 if __use_win_types:
-    _urSamplerGetReference_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t )
+    _urSamplerRetain_t = WINFUNCTYPE( ur_result_t, ur_sampler_handle_t )
 else:
-    _urSamplerGetReference_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t )
+    _urSamplerRetain_t = CFUNCTYPE( ur_result_t, ur_sampler_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urSamplerRelease
@@ -1381,7 +1381,7 @@ else:
 class _ur_sampler_dditable_t(Structure):
     _fields_ = [
         ("pfnCreate", c_void_p),                                        ## _urSamplerCreate_t
-        ("pfnGetReference", c_void_p),                                  ## _urSamplerGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urSamplerRetain_t
         ("pfnRelease", c_void_p),                                       ## _urSamplerRelease_t
         ("pfnGetInfo", c_void_p),                                       ## _urSamplerGetInfo_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urSamplerGetNativeHandle_t
@@ -1403,11 +1403,11 @@ else:
     _urMemBufferCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, c_void_p, POINTER(ur_mem_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urMemGetReference
+## @brief Function-pointer for urMemRetain
 if __use_win_types:
-    _urMemGetReference_t = WINFUNCTYPE( ur_result_t, ur_mem_handle_t )
+    _urMemRetain_t = WINFUNCTYPE( ur_result_t, ur_mem_handle_t )
 else:
-    _urMemGetReference_t = CFUNCTYPE( ur_result_t, ur_mem_handle_t )
+    _urMemRetain_t = CFUNCTYPE( ur_result_t, ur_mem_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urMemRelease
@@ -1458,7 +1458,7 @@ class _ur_mem_dditable_t(Structure):
     _fields_ = [
         ("pfnImageCreate", c_void_p),                                   ## _urMemImageCreate_t
         ("pfnBufferCreate", c_void_p),                                  ## _urMemBufferCreate_t
-        ("pfnGetReference", c_void_p),                                  ## _urMemGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urMemRetain_t
         ("pfnRelease", c_void_p),                                       ## _urMemRelease_t
         ("pfnBufferPartition", c_void_p),                               ## _urMemBufferPartition_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urMemGetNativeHandle_t
@@ -1695,11 +1695,11 @@ else:
     _urQueueCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, ur_queue_flags_t, POINTER(ur_queue_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urQueueGetReference
+## @brief Function-pointer for urQueueRetain
 if __use_win_types:
-    _urQueueGetReference_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t )
+    _urQueueRetain_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t )
 else:
-    _urQueueGetReference_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t )
+    _urQueueRetain_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urQueueRelease
@@ -1729,7 +1729,7 @@ class _ur_queue_dditable_t(Structure):
     _fields_ = [
         ("pfnGetInfo", c_void_p),                                       ## _urQueueGetInfo_t
         ("pfnCreate", c_void_p),                                        ## _urQueueCreate_t
-        ("pfnGetReference", c_void_p),                                  ## _urQueueGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urQueueRetain_t
         ("pfnRelease", c_void_p),                                       ## _urQueueRelease_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urQueueGetNativeHandle_t
         ("pfnCreateWithNativeHandle", c_void_p)                         ## _urQueueCreateWithNativeHandle_t
@@ -1750,11 +1750,11 @@ else:
     _urDeviceGetInfo_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, ur_device_info_t, POINTER(c_size_t), c_void_p )
 
 ###############################################################################
-## @brief Function-pointer for urDeviceGetReference
+## @brief Function-pointer for urDeviceRetain
 if __use_win_types:
-    _urDeviceGetReference_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t )
+    _urDeviceRetain_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t )
 else:
-    _urDeviceGetReference_t = CFUNCTYPE( ur_result_t, ur_device_handle_t )
+    _urDeviceRetain_t = CFUNCTYPE( ur_result_t, ur_device_handle_t )
 
 ###############################################################################
 ## @brief Function-pointer for urDeviceRelease
@@ -1798,7 +1798,7 @@ class _ur_device_dditable_t(Structure):
     _fields_ = [
         ("pfnGet", c_void_p),                                           ## _urDeviceGet_t
         ("pfnGetInfo", c_void_p),                                       ## _urDeviceGetInfo_t
-        ("pfnGetReference", c_void_p),                                  ## _urDeviceGetReference_t
+        ("pfnRetain", c_void_p),                                        ## _urDeviceRetain_t
         ("pfnRelease", c_void_p),                                       ## _urDeviceRelease_t
         ("pfnPartition", c_void_p),                                     ## _urDevicePartition_t
         ("pfnSelectBinary", c_void_p),                                  ## _urDeviceSelectBinary_t
@@ -1860,7 +1860,7 @@ class UR_DDI:
 
         # attach function interface to function address
         self.urContextCreate = _urContextCreate_t(self.__dditable.Context.pfnCreate)
-        self.urContextGetReference = _urContextGetReference_t(self.__dditable.Context.pfnGetReference)
+        self.urContextRetain = _urContextRetain_t(self.__dditable.Context.pfnRetain)
         self.urContextRelease = _urContextRelease_t(self.__dditable.Context.pfnRelease)
         self.urContextGetInfo = _urContextGetInfo_t(self.__dditable.Context.pfnGetInfo)
         self.urContextGetNativeHandle = _urContextGetNativeHandle_t(self.__dditable.Context.pfnGetNativeHandle)
@@ -1878,7 +1878,7 @@ class UR_DDI:
         self.urEventGetInfo = _urEventGetInfo_t(self.__dditable.Event.pfnGetInfo)
         self.urEventGetProfilingInfo = _urEventGetProfilingInfo_t(self.__dditable.Event.pfnGetProfilingInfo)
         self.urEventWait = _urEventWait_t(self.__dditable.Event.pfnWait)
-        self.urEventGetReference = _urEventGetReference_t(self.__dditable.Event.pfnGetReference)
+        self.urEventRetain = _urEventRetain_t(self.__dditable.Event.pfnRetain)
         self.urEventRelease = _urEventRelease_t(self.__dditable.Event.pfnRelease)
         self.urEventGetNativeHandle = _urEventGetNativeHandle_t(self.__dditable.Event.pfnGetNativeHandle)
         self.urEventCreateWithNativeHandle = _urEventCreateWithNativeHandle_t(self.__dditable.Event.pfnCreateWithNativeHandle)
@@ -1893,7 +1893,7 @@ class UR_DDI:
         # attach function interface to function address
         self.urProgramCreate = _urProgramCreate_t(self.__dditable.Program.pfnCreate)
         self.urProgramCreateWithBinary = _urProgramCreateWithBinary_t(self.__dditable.Program.pfnCreateWithBinary)
-        self.urProgramGetReference = _urProgramGetReference_t(self.__dditable.Program.pfnGetReference)
+        self.urProgramRetain = _urProgramRetain_t(self.__dditable.Program.pfnRetain)
         self.urProgramRelease = _urProgramRelease_t(self.__dditable.Program.pfnRelease)
         self.urProgramGetFunctionPointer = _urProgramGetFunctionPointer_t(self.__dditable.Program.pfnGetFunctionPointer)
         self.urProgramGetInfo = _urProgramGetInfo_t(self.__dditable.Program.pfnGetInfo)
@@ -1911,7 +1911,7 @@ class UR_DDI:
 
         # attach function interface to function address
         self.urModuleCreate = _urModuleCreate_t(self.__dditable.Module.pfnCreate)
-        self.urModuleGetReference = _urModuleGetReference_t(self.__dditable.Module.pfnGetReference)
+        self.urModuleRetain = _urModuleRetain_t(self.__dditable.Module.pfnRetain)
         self.urModuleRelease = _urModuleRelease_t(self.__dditable.Module.pfnRelease)
         self.urModuleGetNativeHandle = _urModuleGetNativeHandle_t(self.__dditable.Module.pfnGetNativeHandle)
         self.urModuleCreateWithNativeHandle = _urModuleCreateWithNativeHandle_t(self.__dditable.Module.pfnCreateWithNativeHandle)
@@ -1928,7 +1928,7 @@ class UR_DDI:
         self.urKernelGetInfo = _urKernelGetInfo_t(self.__dditable.Kernel.pfnGetInfo)
         self.urKernelGetGroupInfo = _urKernelGetGroupInfo_t(self.__dditable.Kernel.pfnGetGroupInfo)
         self.urKernelGetSubGroupInfo = _urKernelGetSubGroupInfo_t(self.__dditable.Kernel.pfnGetSubGroupInfo)
-        self.urKernelGetReference = _urKernelGetReference_t(self.__dditable.Kernel.pfnGetReference)
+        self.urKernelRetain = _urKernelRetain_t(self.__dditable.Kernel.pfnRetain)
         self.urKernelRelease = _urKernelRelease_t(self.__dditable.Kernel.pfnRelease)
         self.urKernelGetNativeHandle = _urKernelGetNativeHandle_t(self.__dditable.Kernel.pfnGetNativeHandle)
         self.urKernelCreateWithNativeHandle = _urKernelCreateWithNativeHandle_t(self.__dditable.Kernel.pfnCreateWithNativeHandle)
@@ -1947,7 +1947,7 @@ class UR_DDI:
 
         # attach function interface to function address
         self.urSamplerCreate = _urSamplerCreate_t(self.__dditable.Sampler.pfnCreate)
-        self.urSamplerGetReference = _urSamplerGetReference_t(self.__dditable.Sampler.pfnGetReference)
+        self.urSamplerRetain = _urSamplerRetain_t(self.__dditable.Sampler.pfnRetain)
         self.urSamplerRelease = _urSamplerRelease_t(self.__dditable.Sampler.pfnRelease)
         self.urSamplerGetInfo = _urSamplerGetInfo_t(self.__dditable.Sampler.pfnGetInfo)
         self.urSamplerGetNativeHandle = _urSamplerGetNativeHandle_t(self.__dditable.Sampler.pfnGetNativeHandle)
@@ -1963,7 +1963,7 @@ class UR_DDI:
         # attach function interface to function address
         self.urMemImageCreate = _urMemImageCreate_t(self.__dditable.Mem.pfnImageCreate)
         self.urMemBufferCreate = _urMemBufferCreate_t(self.__dditable.Mem.pfnBufferCreate)
-        self.urMemGetReference = _urMemGetReference_t(self.__dditable.Mem.pfnGetReference)
+        self.urMemRetain = _urMemRetain_t(self.__dditable.Mem.pfnRetain)
         self.urMemRelease = _urMemRelease_t(self.__dditable.Mem.pfnRelease)
         self.urMemBufferPartition = _urMemBufferPartition_t(self.__dditable.Mem.pfnBufferPartition)
         self.urMemGetNativeHandle = _urMemGetNativeHandle_t(self.__dditable.Mem.pfnGetNativeHandle)
@@ -2032,7 +2032,7 @@ class UR_DDI:
         # attach function interface to function address
         self.urQueueGetInfo = _urQueueGetInfo_t(self.__dditable.Queue.pfnGetInfo)
         self.urQueueCreate = _urQueueCreate_t(self.__dditable.Queue.pfnCreate)
-        self.urQueueGetReference = _urQueueGetReference_t(self.__dditable.Queue.pfnGetReference)
+        self.urQueueRetain = _urQueueRetain_t(self.__dditable.Queue.pfnRetain)
         self.urQueueRelease = _urQueueRelease_t(self.__dditable.Queue.pfnRelease)
         self.urQueueGetNativeHandle = _urQueueGetNativeHandle_t(self.__dditable.Queue.pfnGetNativeHandle)
         self.urQueueCreateWithNativeHandle = _urQueueCreateWithNativeHandle_t(self.__dditable.Queue.pfnCreateWithNativeHandle)
@@ -2047,7 +2047,7 @@ class UR_DDI:
         # attach function interface to function address
         self.urDeviceGet = _urDeviceGet_t(self.__dditable.Device.pfnGet)
         self.urDeviceGetInfo = _urDeviceGetInfo_t(self.__dditable.Device.pfnGetInfo)
-        self.urDeviceGetReference = _urDeviceGetReference_t(self.__dditable.Device.pfnGetReference)
+        self.urDeviceRetain = _urDeviceRetain_t(self.__dditable.Device.pfnRetain)
         self.urDeviceRelease = _urDeviceRelease_t(self.__dditable.Device.pfnRelease)
         self.urDevicePartition = _urDevicePartition_t(self.__dditable.Device.pfnPartition)
         self.urDeviceSelectBinary = _urDeviceSelectBinary_t(self.__dditable.Device.pfnSelectBinary)

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -369,7 +369,7 @@ urContextCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hContext`
 UR_APIEXPORT ur_result_t UR_APICALL
-urContextGetReference(
+urContextRetain(
     ur_context_handle_t hContext                    ///< [in] handle of the context to get a reference of.
     );
 
@@ -1531,7 +1531,7 @@ urEventWait(
 ///     - ::UR_RESULT_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
-urEventGetReference(
+urEventRetain(
     ur_event_handle_t event                         ///< [in] handle of the event object
     );
 
@@ -1813,7 +1813,7 @@ urMemBufferCreate(
 ///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urMemGetReference(
+urMemRetain(
     ur_mem_handle_t hMem                            ///< [in] handle of the memory object to get access
     );
 
@@ -2084,7 +2084,7 @@ urQueueCreate(
 ///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urQueueGetReference(
+urQueueRetain(
     ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to get access
     );
 
@@ -2263,7 +2263,7 @@ urSamplerCreate(
 ///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urSamplerGetReference(
+urSamplerRetain(
     ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to get access
     );
 
@@ -2766,7 +2766,7 @@ urDeviceGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
-urDeviceGetReference(
+urDeviceRetain(
     ur_device_handle_t hDevice                      ///< [in] handle of the device to get a reference of.
     );
 
@@ -3209,7 +3209,7 @@ urKernelGetSubGroupInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hKernel`
 UR_APIEXPORT ur_result_t UR_APICALL
-urKernelGetReference(
+urKernelRetain(
     ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to retain
     );
 
@@ -3444,7 +3444,7 @@ urModuleCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hModule`
 UR_APIEXPORT ur_result_t UR_APICALL
-urModuleGetReference(
+urModuleRetain(
     ur_module_handle_t hModule                      ///< [in] handle for the Module to retain
     );
 
@@ -3779,7 +3779,7 @@ urProgramCreateWithBinary(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `nullptr == hProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
-urProgramGetReference(
+urProgramRetain(
     ur_program_handle_t hProgram                    ///< [in] handle for the Program to retain
     );
 
@@ -4253,22 +4253,22 @@ typedef void (UR_APICALL *ur_pfnContextCreateCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextGetReference 
+/// @brief Callback function parameters for urContextRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_context_get_reference_params_t
+typedef struct _ur_context_retain_params_t
 {
     ur_context_handle_t* phContext;
-} ur_context_get_reference_params_t;
+} ur_context_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextGetReference 
+/// @brief Callback function-pointer for urContextRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextGetReferenceCb_t)(
-    ur_context_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnContextRetainCb_t)(
+    ur_context_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -4373,7 +4373,7 @@ typedef void (UR_APICALL *ur_pfnContextCreateWithNativeHandleCb_t)(
 typedef struct _ur_context_callbacks_t
 {
     ur_pfnContextCreateCb_t                                         pfnCreateCb;
-    ur_pfnContextGetReferenceCb_t                                   pfnGetReferenceCb;
+    ur_pfnContextRetainCb_t                                         pfnRetainCb;
     ur_pfnContextReleaseCb_t                                        pfnReleaseCb;
     ur_pfnContextGetInfoCb_t                                        pfnGetInfoCb;
     ur_pfnContextGetNativeHandleCb_t                                pfnGetNativeHandleCb;
@@ -4479,22 +4479,22 @@ typedef void (UR_APICALL *ur_pfnEventWaitCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventGetReference 
+/// @brief Callback function parameters for urEventRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_event_get_reference_params_t
+typedef struct _ur_event_retain_params_t
 {
     ur_event_handle_t* pevent;
-} ur_event_get_reference_params_t;
+} ur_event_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventGetReference 
+/// @brief Callback function-pointer for urEventRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventGetReferenceCb_t)(
-    ur_event_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnEventRetainCb_t)(
+    ur_event_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -4577,7 +4577,7 @@ typedef struct _ur_event_callbacks_t
     ur_pfnEventGetInfoCb_t                                          pfnGetInfoCb;
     ur_pfnEventGetProfilingInfoCb_t                                 pfnGetProfilingInfoCb;
     ur_pfnEventWaitCb_t                                             pfnWaitCb;
-    ur_pfnEventGetReferenceCb_t                                     pfnGetReferenceCb;
+    ur_pfnEventRetainCb_t                                           pfnRetainCb;
     ur_pfnEventReleaseCb_t                                          pfnReleaseCb;
     ur_pfnEventGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
     ur_pfnEventCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
@@ -4636,22 +4636,22 @@ typedef void (UR_APICALL *ur_pfnProgramCreateWithBinaryCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramGetReference 
+/// @brief Callback function parameters for urProgramRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_program_get_reference_params_t
+typedef struct _ur_program_retain_params_t
 {
     ur_program_handle_t* phProgram;
-} ur_program_get_reference_params_t;
+} ur_program_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramGetReference 
+/// @brief Callback function-pointer for urProgramRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramGetReferenceCb_t)(
-    ur_program_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnProgramRetainCb_t)(
+    ur_program_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -4833,7 +4833,7 @@ typedef struct _ur_program_callbacks_t
 {
     ur_pfnProgramCreateCb_t                                         pfnCreateCb;
     ur_pfnProgramCreateWithBinaryCb_t                               pfnCreateWithBinaryCb;
-    ur_pfnProgramGetReferenceCb_t                                   pfnGetReferenceCb;
+    ur_pfnProgramRetainCb_t                                         pfnRetainCb;
     ur_pfnProgramReleaseCb_t                                        pfnReleaseCb;
     ur_pfnProgramGetFunctionPointerCb_t                             pfnGetFunctionPointerCb;
     ur_pfnProgramGetInfoCb_t                                        pfnGetInfoCb;
@@ -4872,22 +4872,22 @@ typedef void (UR_APICALL *ur_pfnModuleCreateCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urModuleGetReference 
+/// @brief Callback function parameters for urModuleRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_module_get_reference_params_t
+typedef struct _ur_module_retain_params_t
 {
     ur_module_handle_t* phModule;
-} ur_module_get_reference_params_t;
+} ur_module_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urModuleGetReference 
+/// @brief Callback function-pointer for urModuleRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnModuleGetReferenceCb_t)(
-    ur_module_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnModuleRetainCb_t)(
+    ur_module_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -4967,7 +4967,7 @@ typedef void (UR_APICALL *ur_pfnModuleCreateWithNativeHandleCb_t)(
 typedef struct _ur_module_callbacks_t
 {
     ur_pfnModuleCreateCb_t                                          pfnCreateCb;
-    ur_pfnModuleGetReferenceCb_t                                    pfnGetReferenceCb;
+    ur_pfnModuleRetainCb_t                                          pfnRetainCb;
     ur_pfnModuleReleaseCb_t                                         pfnReleaseCb;
     ur_pfnModuleGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
     ur_pfnModuleCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
@@ -5075,22 +5075,22 @@ typedef void (UR_APICALL *ur_pfnKernelGetSubGroupInfoCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelGetReference 
+/// @brief Callback function parameters for urKernelRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_kernel_get_reference_params_t
+typedef struct _ur_kernel_retain_params_t
 {
     ur_kernel_handle_t* phKernel;
-} ur_kernel_get_reference_params_t;
+} ur_kernel_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelGetReference 
+/// @brief Callback function-pointer for urKernelRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelGetReferenceCb_t)(
-    ur_kernel_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnKernelRetainCb_t)(
+    ur_kernel_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -5296,7 +5296,7 @@ typedef struct _ur_kernel_callbacks_t
     ur_pfnKernelGetInfoCb_t                                         pfnGetInfoCb;
     ur_pfnKernelGetGroupInfoCb_t                                    pfnGetGroupInfoCb;
     ur_pfnKernelGetSubGroupInfoCb_t                                 pfnGetSubGroupInfoCb;
-    ur_pfnKernelGetReferenceCb_t                                    pfnGetReferenceCb;
+    ur_pfnKernelRetainCb_t                                          pfnRetainCb;
     ur_pfnKernelReleaseCb_t                                         pfnReleaseCb;
     ur_pfnKernelGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
     ur_pfnKernelCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
@@ -5332,22 +5332,22 @@ typedef void (UR_APICALL *ur_pfnSamplerCreateCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerGetReference 
+/// @brief Callback function parameters for urSamplerRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_sampler_get_reference_params_t
+typedef struct _ur_sampler_retain_params_t
 {
     ur_sampler_handle_t* phSampler;
-} ur_sampler_get_reference_params_t;
+} ur_sampler_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerGetReference 
+/// @brief Callback function-pointer for urSamplerRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerGetReferenceCb_t)(
-    ur_sampler_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnSamplerRetainCb_t)(
+    ur_sampler_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -5453,7 +5453,7 @@ typedef void (UR_APICALL *ur_pfnSamplerCreateWithNativeHandleCb_t)(
 typedef struct _ur_sampler_callbacks_t
 {
     ur_pfnSamplerCreateCb_t                                         pfnCreateCb;
-    ur_pfnSamplerGetReferenceCb_t                                   pfnGetReferenceCb;
+    ur_pfnSamplerRetainCb_t                                         pfnRetainCb;
     ur_pfnSamplerReleaseCb_t                                        pfnReleaseCb;
     ur_pfnSamplerGetInfoCb_t                                        pfnGetInfoCb;
     ur_pfnSamplerGetNativeHandleCb_t                                pfnGetNativeHandleCb;
@@ -5514,22 +5514,22 @@ typedef void (UR_APICALL *ur_pfnMemBufferCreateCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemGetReference 
+/// @brief Callback function parameters for urMemRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_mem_get_reference_params_t
+typedef struct _ur_mem_retain_params_t
 {
     ur_mem_handle_t* phMem;
-} ur_mem_get_reference_params_t;
+} ur_mem_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemGetReference 
+/// @brief Callback function-pointer for urMemRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemGetReferenceCb_t)(
-    ur_mem_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnMemRetainCb_t)(
+    ur_mem_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -5686,7 +5686,7 @@ typedef struct _ur_mem_callbacks_t
 {
     ur_pfnMemImageCreateCb_t                                        pfnImageCreateCb;
     ur_pfnMemBufferCreateCb_t                                       pfnBufferCreateCb;
-    ur_pfnMemGetReferenceCb_t                                       pfnGetReferenceCb;
+    ur_pfnMemRetainCb_t                                             pfnRetainCb;
     ur_pfnMemReleaseCb_t                                            pfnReleaseCb;
     ur_pfnMemBufferPartitionCb_t                                    pfnBufferPartitionCb;
     ur_pfnMemGetNativeHandleCb_t                                    pfnGetNativeHandleCb;
@@ -6479,22 +6479,22 @@ typedef void (UR_APICALL *ur_pfnQueueCreateCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueGetReference 
+/// @brief Callback function parameters for urQueueRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_queue_get_reference_params_t
+typedef struct _ur_queue_retain_params_t
 {
     ur_queue_handle_t* phQueue;
-} ur_queue_get_reference_params_t;
+} ur_queue_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueGetReference 
+/// @brief Callback function-pointer for urQueueRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueGetReferenceCb_t)(
-    ur_queue_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnQueueRetainCb_t)(
+    ur_queue_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -6575,7 +6575,7 @@ typedef struct _ur_queue_callbacks_t
 {
     ur_pfnQueueGetInfoCb_t                                          pfnGetInfoCb;
     ur_pfnQueueCreateCb_t                                           pfnCreateCb;
-    ur_pfnQueueGetReferenceCb_t                                     pfnGetReferenceCb;
+    ur_pfnQueueRetainCb_t                                           pfnRetainCb;
     ur_pfnQueueReleaseCb_t                                          pfnReleaseCb;
     ur_pfnQueueGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
     ur_pfnQueueCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
@@ -6632,22 +6632,22 @@ typedef void (UR_APICALL *ur_pfnDeviceGetInfoCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceGetReference 
+/// @brief Callback function parameters for urDeviceRetain 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct _ur_device_get_reference_params_t
+typedef struct _ur_device_retain_params_t
 {
     ur_device_handle_t* phDevice;
-} ur_device_get_reference_params_t;
+} ur_device_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceGetReference 
+/// @brief Callback function-pointer for urDeviceRetain 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceGetReferenceCb_t)(
-    ur_device_get_reference_params_t* params,
+typedef void (UR_APICALL *ur_pfnDeviceRetainCb_t)(
+    ur_device_retain_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -6778,7 +6778,7 @@ typedef struct _ur_device_callbacks_t
 {
     ur_pfnDeviceGetCb_t                                             pfnGetCb;
     ur_pfnDeviceGetInfoCb_t                                         pfnGetInfoCb;
-    ur_pfnDeviceGetReferenceCb_t                                    pfnGetReferenceCb;
+    ur_pfnDeviceRetainCb_t                                          pfnRetainCb;
     ur_pfnDeviceReleaseCb_t                                         pfnReleaseCb;
     ur_pfnDevicePartitionCb_t                                       pfnPartitionCb;
     ur_pfnDeviceSelectBinaryCb_t                                    pfnSelectBinaryCb;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -99,8 +99,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnContextCreate_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnContextGetReference_t)(
+/// @brief Function-pointer for urContextRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnContextRetain_t)(
     ur_context_handle_t
     );
 
@@ -139,7 +139,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnContextCreateWithNativeHandle_t)(
 typedef struct _ur_context_dditable_t
 {
     ur_pfnContextCreate_t                                       pfnCreate;
-    ur_pfnContextGetReference_t                                 pfnGetReference;
+    ur_pfnContextRetain_t                                       pfnRetain;
     ur_pfnContextRelease_t                                      pfnRelease;
     ur_pfnContextGetInfo_t                                      pfnGetInfo;
     ur_pfnContextGetNativeHandle_t                              pfnGetNativeHandle;
@@ -203,8 +203,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnEventWait_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnEventGetReference_t)(
+/// @brief Function-pointer for urEventRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnEventRetain_t)(
     ur_event_handle_t
     );
 
@@ -237,7 +237,7 @@ typedef struct _ur_event_dditable_t
     ur_pfnEventGetInfo_t                                        pfnGetInfo;
     ur_pfnEventGetProfilingInfo_t                               pfnGetProfilingInfo;
     ur_pfnEventWait_t                                           pfnWait;
-    ur_pfnEventGetReference_t                                   pfnGetReference;
+    ur_pfnEventRetain_t                                         pfnRetain;
     ur_pfnEventRelease_t                                        pfnRelease;
     ur_pfnEventGetNativeHandle_t                                pfnGetNativeHandle;
     ur_pfnEventCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
@@ -286,8 +286,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnProgramCreateWithBinary_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramGetReference_t)(
+/// @brief Function-pointer for urProgramRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnProgramRetain_t)(
     ur_program_handle_t
     );
 
@@ -355,7 +355,7 @@ typedef struct _ur_program_dditable_t
 {
     ur_pfnProgramCreate_t                                       pfnCreate;
     ur_pfnProgramCreateWithBinary_t                             pfnCreateWithBinary;
-    ur_pfnProgramGetReference_t                                 pfnGetReference;
+    ur_pfnProgramRetain_t                                       pfnRetain;
     ur_pfnProgramRelease_t                                      pfnRelease;
     ur_pfnProgramGetFunctionPointer_t                           pfnGetFunctionPointer;
     ur_pfnProgramGetInfo_t                                      pfnGetInfo;
@@ -400,8 +400,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnModuleCreate_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urModuleGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnModuleGetReference_t)(
+/// @brief Function-pointer for urModuleRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnModuleRetain_t)(
     ur_module_handle_t
     );
 
@@ -431,7 +431,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnModuleCreateWithNativeHandle_t)(
 typedef struct _ur_module_dditable_t
 {
     ur_pfnModuleCreate_t                                        pfnCreate;
-    ur_pfnModuleGetReference_t                                  pfnGetReference;
+    ur_pfnModuleRetain_t                                        pfnRetain;
     ur_pfnModuleRelease_t                                       pfnRelease;
     ur_pfnModuleGetNativeHandle_t                               pfnGetNativeHandle;
     ur_pfnModuleCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
@@ -497,8 +497,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnKernelGetSubGroupInfo_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelGetReference_t)(
+/// @brief Function-pointer for urKernelRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnKernelRetain_t)(
     ur_kernel_handle_t
     );
 
@@ -574,7 +574,7 @@ typedef struct _ur_kernel_dditable_t
     ur_pfnKernelGetInfo_t                                       pfnGetInfo;
     ur_pfnKernelGetGroupInfo_t                                  pfnGetGroupInfo;
     ur_pfnKernelGetSubGroupInfo_t                               pfnGetSubGroupInfo;
-    ur_pfnKernelGetReference_t                                  pfnGetReference;
+    ur_pfnKernelRetain_t                                        pfnRetain;
     ur_pfnKernelRelease_t                                       pfnRelease;
     ur_pfnKernelGetNativeHandle_t                               pfnGetNativeHandle;
     ur_pfnKernelCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
@@ -616,8 +616,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreate_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerGetReference_t)(
+/// @brief Function-pointer for urSamplerRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnSamplerRetain_t)(
     ur_sampler_handle_t
     );
 
@@ -657,7 +657,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreateWithNativeHandle_t)(
 typedef struct _ur_sampler_dditable_t
 {
     ur_pfnSamplerCreate_t                                       pfnCreate;
-    ur_pfnSamplerGetReference_t                                 pfnGetReference;
+    ur_pfnSamplerRetain_t                                       pfnRetain;
     ur_pfnSamplerRelease_t                                      pfnRelease;
     ur_pfnSamplerGetInfo_t                                      pfnGetInfo;
     ur_pfnSamplerGetNativeHandle_t                              pfnGetNativeHandle;
@@ -708,8 +708,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnMemBufferCreate_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnMemGetReference_t)(
+/// @brief Function-pointer for urMemRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnMemRetain_t)(
     ur_mem_handle_t
     );
 
@@ -768,7 +768,7 @@ typedef struct _ur_mem_dditable_t
 {
     ur_pfnMemImageCreate_t                                      pfnImageCreate;
     ur_pfnMemBufferCreate_t                                     pfnBufferCreate;
-    ur_pfnMemGetReference_t                                     pfnGetReference;
+    ur_pfnMemRetain_t                                           pfnRetain;
     ur_pfnMemRelease_t                                          pfnRelease;
     ur_pfnMemBufferPartition_t                                  pfnBufferPartition;
     ur_pfnMemGetNativeHandle_t                                  pfnGetNativeHandle;
@@ -1233,8 +1233,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnQueueCreate_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueGetReference_t)(
+/// @brief Function-pointer for urQueueRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueRetain_t)(
     ur_queue_handle_t
     );
 
@@ -1265,7 +1265,7 @@ typedef struct _ur_queue_dditable_t
 {
     ur_pfnQueueGetInfo_t                                        pfnGetInfo;
     ur_pfnQueueCreate_t                                         pfnCreate;
-    ur_pfnQueueGetReference_t                                   pfnGetReference;
+    ur_pfnQueueRetain_t                                         pfnRetain;
     ur_pfnQueueRelease_t                                        pfnRelease;
     ur_pfnQueueGetNativeHandle_t                                pfnGetNativeHandle;
     ur_pfnQueueCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
@@ -1312,8 +1312,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetInfo_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceGetReference 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetReference_t)(
+/// @brief Function-pointer for urDeviceRetain 
+typedef ur_result_t (UR_APICALL *ur_pfnDeviceRetain_t)(
     ur_device_handle_t
     );
 
@@ -1362,7 +1362,7 @@ typedef struct _ur_device_dditable_t
 {
     ur_pfnDeviceGet_t                                           pfnGet;
     ur_pfnDeviceGetInfo_t                                       pfnGetInfo;
-    ur_pfnDeviceGetReference_t                                  pfnGetReference;
+    ur_pfnDeviceRetain_t                                        pfnRetain;
     ur_pfnDeviceRelease_t                                       pfnRelease;
     ur_pfnDevicePartition_t                                     pfnPartition;
     ur_pfnDeviceSelectBinary_t                                  pfnSelectBinary;

--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -69,7 +69,7 @@ Initialization and Discovery
 Device handle lifetime
 ----------------------
 
-The device objects are reference-counted, and there are ${x}DeviceGetReference and ${x}DeviceRelease.
+The device objects are reference-counted, and there are ${x}DeviceRetain and ${x}DeviceRelease.
 The ref-count of a device is automatically incremented when device is obtained by ${x}DeviceGet.
 After device is no longer needed to the application it must call to ${x}DeviceRelease.
 When ref-count of the underlying device handle becomes zero then that device object is deleted.
@@ -233,7 +233,7 @@ Queue object lifetime
 
 Queue objects are reference-counted. If an application or thread needs to
 retain access to a queue created by another application or thread, it can call
-${x}QueueGetReference. An application must call ${x}QueueRelease
+${x}QueueRetain. An application must call ${x}QueueRelease
 when a queue object is no longer needed. When a queue object's reference count becomes
 zero, it is deleted by the runtime.
 

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -44,7 +44,7 @@ returns:
 type: function
 desc: "Makes a reference of the context handle indicating it's in use until paired $xContextRelease is called"
 class: $xContext
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 analogue:

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -294,7 +294,7 @@ params:
 type: function
 desc: "Makes a reference of the device handle indicating it's in use until paired $xDeviceRelease is called"
 class: $xDevice
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 analogue:

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -142,7 +142,7 @@ returns:
 type: function
 desc: "Get a reference to an event handle. Increment the event object's reference count."
 class: $xEvent
-name: GetReference
+name: Retain
 ordinal: "0"
 analogue:
     - "**clRetainEvent**"

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -190,7 +190,7 @@ params:
 type: function
 desc: "Get a reference to the Kernel object."
 class: $xKernel
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 analogue:

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -240,7 +240,7 @@ returns:
 type: function
 desc: "Get a reference the memory object. Increment the memory object's reference count"
 class: $xMem
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 analogue:

--- a/scripts/core/module.yml
+++ b/scripts/core/module.yml
@@ -46,7 +46,7 @@ params:
 type: function
 desc: "Get a reference to the Module object."
 class: $xModule
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 details:

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -67,7 +67,7 @@ params:
 type: function
 desc: "Get a reference to the Program object."
 class: $xProgram
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 analogue:

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -109,7 +109,7 @@ returns:
 type: function
 desc: "Get a reference to the command queue handle. Increment the command queue's reference count"
 class: $xQueue
-name: GetReference
+name: Retain
 decl: static
 ordinal: "0"
 analogue:

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -87,7 +87,7 @@ returns:
 type: function
 desc: "Get a reference to the sampler object handle. Increment its reference count"
 class: $xSampler
-name: GetReference
+name: Retain
 ordinal: "0"
 analogue:
     - "**clRetainSampler**"


### PR DESCRIPTION
* UR uses the API `ur{object}GetReference` to increment the reference
  count on an object and `ur{object}Release` to decrement the reference
  count. This is inconsistent. We should make this consistent. To match
  OpenCL (which uses Retain/Release) replace the
  `ur{object}GetReference` APIs with `ur{object}Retain`.
