### PR TITLE
Add dummy files to fix FetchContent issues

### DIFF
--- a/source/zer_api.cpp
+++ b/source/zer_api.cpp
@@ -1,0 +1,1 @@
+// Placeholder to fix FetchContent issues for projects from outside

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,1 @@
+# Placeholder to fix FetchContent issues for projects from outside


### PR DESCRIPTION
If other project (e.g. DPC++) is trying to fetch unified_runtime repo it fails due to cmake errors. In DPC++ we currently need includes only so actuall content of these files doesn't matter today.