### PR TITLE
[ur] Add zerQueueFlush

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1752,6 +1752,13 @@ if __use_win_types:
 else:
     _urQueueFinish_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t )
 
+###############################################################################
+## @brief Function-pointer for urQueueFlush
+if __use_win_types:
+    _urQueueFlush_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t )
+else:
+    _urQueueFlush_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t )
+
 
 ###############################################################################
 ## @brief Table of Queue functions pointers
@@ -1763,7 +1770,8 @@ class _ur_queue_dditable_t(Structure):
         ("pfnRelease", c_void_p),                                       ## _urQueueRelease_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urQueueGetNativeHandle_t
         ("pfnCreateWithNativeHandle", c_void_p),                        ## _urQueueCreateWithNativeHandle_t
-        ("pfnFinish", c_void_p)                                         ## _urQueueFinish_t
+        ("pfnFinish", c_void_p),                                        ## _urQueueFinish_t
+        ("pfnFlush", c_void_p)                                          ## _urQueueFlush_t
     ]
 
 ###############################################################################
@@ -2069,6 +2077,7 @@ class UR_DDI:
         self.urQueueGetNativeHandle = _urQueueGetNativeHandle_t(self.__dditable.Queue.pfnGetNativeHandle)
         self.urQueueCreateWithNativeHandle = _urQueueCreateWithNativeHandle_t(self.__dditable.Queue.pfnCreateWithNativeHandle)
         self.urQueueFinish = _urQueueFinish_t(self.__dditable.Queue.pfnFinish)
+        self.urQueueFlush = _urQueueFlush_t(self.__dditable.Queue.pfnFlush)
 
         # call driver to get function pointers
         _Device = _ur_device_dditable_t()

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2229,6 +2229,33 @@ urQueueFinish(
     ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be finished.
     );
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Issues all previously enqueued commands in a command queue to the
+///        device.
+/// 
+/// @details
+///     - Guarantees that all enqueued commands will be issued to the
+///       appropriate device.
+///     - There is no guarantee that they will be completed after ::urQueueFlush
+///       returns.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clFlush**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `nullptr == hQueue`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueFlush(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be flushed.
+    );
+
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
@@ -6685,6 +6712,28 @@ typedef void (UR_APICALL *ur_pfnQueueFinishCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for urQueueFlush 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct _ur_queue_flush_params_t
+{
+    ur_queue_handle_t* phQueue;
+} ur_queue_flush_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for urQueueFlush 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (UR_APICALL *ur_pfnQueueFlushCb_t)(
+    ur_queue_flush_params_t* params,
+    ur_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Queue callback functions pointers
 typedef struct _ur_queue_callbacks_t
 {
@@ -6695,6 +6744,7 @@ typedef struct _ur_queue_callbacks_t
     ur_pfnQueueGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
     ur_pfnQueueCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
     ur_pfnQueueFinishCb_t                                           pfnFinishCb;
+    ur_pfnQueueFlushCb_t                                            pfnFlushCb;
 } ur_queue_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1275,6 +1275,12 @@ typedef ur_result_t (UR_APICALL *ur_pfnQueueFinish_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueFlush 
+typedef ur_result_t (UR_APICALL *ur_pfnQueueFlush_t)(
+    ur_queue_handle_t
+    );
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Queue functions pointers
 typedef struct _ur_queue_dditable_t
 {
@@ -1285,6 +1291,7 @@ typedef struct _ur_queue_dditable_t
     ur_pfnQueueGetNativeHandle_t                                pfnGetNativeHandle;
     ur_pfnQueueCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
     ur_pfnQueueFinish_t                                         pfnFinish;
+    ur_pfnQueueFlush_t                                          pfnFlush;
 } ur_queue_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -208,3 +208,22 @@ params:
 returns:
     - $X_RESULT_INVALID_QUEUE
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Issues all previously enqueued commands in a command queue to the device."
+class: $xQueue
+name: Flush
+decl: static
+ordinal: "0"
+analogue:
+    - "**clFlush**"
+details:
+  - "Guarantees that all enqueued commands will be issued to the appropriate device."
+  - "There is no guarantee that they will be completed after $xQueueFlush returns."
+params:
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] handle of the queue to be flushed."
+returns:
+    - $X_RESULT_INVALID_QUEUE
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY


### PR DESCRIPTION
Add `zerQueueFlush` to Unified Runtime.

I've based the semantics from OpenCL, I'm not sure if we need something different for other runtimes.

Closes #41 