### PR TITLE
Remove forward declaration of typedefs

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -269,43 +269,6 @@ typedef struct _ur_rect_region_t
 
 } ur_rect_region_t;
 
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_base_properties_t
-typedef struct _ur_base_properties_t ur_base_properties_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_base_desc_t
-typedef struct _ur_base_desc_t ur_base_desc_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_rect_offset_t
-typedef struct _ur_rect_offset_t ur_rect_offset_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_rect_region_t
-typedef struct _ur_rect_region_t ur_rect_region_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_image_format_t
-typedef struct _ur_image_format_t ur_image_format_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_image_desc_t
-typedef struct _ur_image_desc_t ur_image_desc_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_buffer_region_t
-typedef struct _ur_buffer_region_t ur_buffer_region_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_sampler_property_value_t
-typedef struct _ur_sampler_property_value_t ur_sampler_property_value_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ur_device_partition_property_value_t
-typedef struct _ur_device_partition_property_value_t ur_device_partition_property_value_t;
-
-
 #if !defined(__GNUC__)
 #pragma endregion
 #endif

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -132,16 +132,6 @@ typedef struct _${th.subt(n, tags, obj['name'])} *${th.subt(n, tags, obj['name']
 
 %endif  # not re.match(r"class", obj['type'])
 %endfor # obj in spec['objects']
-## FORWARD-DECLARE STRUCTS ####################################################
-%if re.match(r"common", spec['name']):
-%for obj in th.extract_objs(specs, 'struct'):
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Forward-declare ${th.make_type_name(n, tags, obj)}
-typedef struct _${th.make_type_name(n, tags, obj)} ${th.make_type_name(n, tags, obj)};
-
-%endfor
-
-%endif
 %if len(spec['objects']):
 #if !defined(__GNUC__)
 #pragma endregion


### PR DESCRIPTION
Fixes #49 by removing the section which forward declares typedefs in the `api.h.mako` template. First, the forward declarations are unnecessary because the types are already defined where they appear in the header. Second, when compiling with `clang` the following warning is emitted:

```
warning: redefinition of typedef 'ur_base_properties_t' is a C11 feature
```