### PR TITLE
Add range to phModules

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3784,7 +3784,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context instance
     uint32_t count,                                 ///< [in] number of module handles in module list.
-    const ur_module_handle_t* phModules,            ///< [in] pointer to array of modules.
+    const ur_module_handle_t* phModules,            ///< [in][range(0, count)] pointer to array of modules.
     const char* pOptions,                           ///< [in][optional] pointer to linker options null-terminated string.
     ur_program_handle_t* phProgram                  ///< [out] pointer to handle of program object created.
     );

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -29,7 +29,7 @@ params:
       desc: "[in] number of module handles in module list."
     - type: const $x_module_handle_t*
       name: phModules
-      desc: "[in] pointer to array of modules."
+      desc: "[in][range(0, count)] pointer to array of modules."
     - type: const char*
       name: pOptions
       desc: "[in][optional] pointer to linker options null-terminated string."
@@ -268,7 +268,7 @@ params:
       desc: "[in] specification constant Id"
     - type: "size_t"
       name: specSize
-      desc: "[in] size of the specialization constant value" 
+      desc: "[in] size of the specialization constant value"
     - type: "const void*"
       name: specValue
       desc: "[in] pointer to the specialization value bytes"


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/oneapi-src/unified-runtime/commit/46a649a448e3d7097662633c5d11e5086f0cd92a that broke loader scripts, range parameter is now required to properly parse phModules.