### PR TITLE
cmake: Support install, find_package, & FetchContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@
 # Debug files
 scripts/**/*.json
 
-# Generated code
-source/*.cpp
-
 # Generated docs
 docs/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
-project(unified_runtime)
+project(unified-runtime VERSION 0.5.0)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -49,13 +52,47 @@ option(${PROJECT_NAME}_BUILD_TESTS "Build unit tests." ON)
 
 add_subdirectory(${THIRD_PARTY_DIR})
 
-# Copy third_party_binaries to output BIN folder
-#add_custom_target(copy_third_party_files)
+# A header only library to specify include directories in transitive
+# dependencies.
+add_library(headers INTERFACE)
+# Alias target to support FetchContent.
+add_library(${PROJECT_NAME}::headers ALIAS headers)
+target_include_directories(headers INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-#add_custom_command(
-#    TARGET copy_third_party_files
-#    POST_BUILD
-#)
+# Add the include directory and the headers target to the install.
+install(
+    DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
+    DESTINATION include COMPONENT headers)
+install(
+    TARGETS headers
+    EXPORT ${PROJECT_NAME}-targets)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_subdirectory(source)
+
+# Add the list of installed targets to the install. This includes the namespace
+# which all installed targets will be prefixed with, e.g. for the headers
+# target users will depend on ${PROJECT_NAME}::headers.
+install(
+    EXPORT ${PROJECT_NAME}-targets
+    FILE ${PROJECT_NAME}-targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION lib/cmake/${PROJECT_NAME})
+
+# Configure the package versions file for use in find_package when installed.
+write_basic_package_version_file(
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+    COMPATIBILITY SameMajorVersion)
+# Configure the package file that is searched for by find_package when
+# installed.
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+# Add the package files to the install.
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+        ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# Contents
+# Unified Runtime
+
+## Contents
+
 This repo contains the following:
+
 - API specification in YaML
 - API programming guide in RST
 - API C/C++ header files (generated)
@@ -7,20 +11,45 @@ This repo contains the following:
 - Sample C++ wrapper (generated)
 - Sample C/C++ import library (generated)
 
-# Source Code Generation
+## Integration
+
+The recommended way to integrate this project into another is via CMake's
+[FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html),
+for example:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    unified-runtime
+    GIT_REPOSITORY https://github.com/oneapi-src/unified-runtime.git
+    GIT_TAG main  # This will pull the latest changes from the main branch.
+)
+FetchContent_MakeAvailable(unified-runtime)
+
+add_executable(example example.cpp)
+target_link_libraries(example PUBLIC unified-runtime::headers)
+```
+
+## Source Code Generation
+
 Code is generated using included [Python scripts](/scripts/README.md).  
 
-# Documentation
+## Documentation
+
 Documentation is generated from source code using Sphinx.
 
-# Third-Party Tools
+## Third-Party Tools
+
 Tools can be acquired via instructions in [third_party](/third_party/README.md).
 
-# Building
+## Building
+
 Project is defined using [CMake](https://cmake.org/).
 
 **Windows**:
 Generating Visual Studio Project.  EXE and binaries will be in **build/bin/{build_config}**
+
 ~~~~
 mkdir build
 cd build
@@ -28,7 +57,9 @@ cmake {path_to_source_dir} -G "Visual Studio 15 2017 Win64"
 ~~~~
 
 **Linux**:
+
 Executable and binaries will be in **build/bin**
+
 ~~~~
 mkdir build
 cd build

--- a/cmake/unified-runtime-config.cmake.in
+++ b/cmake/unified-runtime-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${TARGET_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_api.cpp
 )
 
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(${TARGET_NAME} PRIVATE
+    ${PROJECT_NAME}::headers
     ${CMAKE_DL_LIBS}
 )

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1,0 +1,3595 @@
+/*
+ *
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ur_api.cpp
+ * @version v0.5-r0.5
+ *
+ */
+#include "ur_api.h"
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Creates a context with the given devices.
+/// 
+/// @details
+///     - All devices should be from the same platform.
+///     - Context is used for resource sharing between all the devices
+///       associated with it.
+///     - Context also serves for resource isolation such that resources do not
+///       cross context boundaries.
+///     - The returned context is a reference and must be released with a
+///       subsequent call to ::urContextRelease.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateContext**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phDevices`
+///         + `NULL == phContext`
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
+ur_result_t UR_APICALL
+urContextCreate(
+    uint32_t DeviceCount,                           ///< [in] the number of devices given in phDevices
+    ur_device_handle_t* phDevices,                  ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t* phContext                  ///< [out] pointer to handle of context object created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Makes a reference of the context handle indicating it's in use until
+///        paired ::urContextRelease is called
+/// 
+/// @details
+///     - It is not valid to use a context handle, which has all of its
+///       references released.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainContext**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+ur_result_t UR_APICALL
+urContextRetain(
+    ur_context_handle_t hContext                    ///< [in] handle of the context to get a reference of.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Releases the context handle reference indicating end of its usage
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseContext**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+ur_result_t UR_APICALL
+urContextRelease(
+    ur_context_handle_t hContext                    ///< [in] handle of the context to release.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves various information about context
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetContextInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_CONTEXT_INFO_DEVICES < ContextInfoType`
+ur_result_t UR_APICALL
+urContextGetInfo(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context
+    ur_context_info_t ContextInfoType,              ///< [in] type of the info to retrieve
+    size_t propSize,                                ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void* pContextInfo,                             ///< [out][optional] array of bytes holding the info.
+                                                    ///< if propSize is not equal to or greater than the real number of bytes
+                                                    ///< needed to return 
+                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pContextInfo is not used.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native context handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeContext`
+ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context.
+    ur_native_handle_t* phNativeContext             ///< [out] a pointer to the native handle of the context.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime context object from native context handle.
+/// 
+/// @details
+///     - Creates runtime context handle from native driver context handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativeContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phContext`
+ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeContext,              ///< [in] the native handle of the context.
+    ur_context_handle_t* phContext                  ///< [out] pointer to the handle of the context object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Call extended deleter function as callback.
+/// 
+/// @details
+///     - Calls exnteded deleter, a user-defined callback to delete context on
+///       some platforms.
+///     - This is done for performance reasons.
+///     - This API might be called directly by an application instead of a
+///       runtime backend.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pParams`
+ur_result_t UR_APICALL
+urContextSetExtendedDeleter(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
+    void* pParams                                   ///< [in][out] pointer to data to be passed to callback.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to execute a kernel
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueNDRangeKernel**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_KERNEL
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    uint32_t workDim,                               ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                                    ///< work-group work-items
+    const size_t* pGlobalWorkOffset,                ///< [in] pointer to an array of workDim unsigned values that specify the
+                                                    ///< offset used to calculate the global ID of a work-item
+    const size_t* pGlobalWorkSize,                  ///< [in] pointer to an array of workDim unsigned values that specify the
+                                                    ///< number of global work-items in workDim that will execute the kernel
+                                                    ///< function
+    const size_t* pLocalWorkSize,                   ///< [in][optional] pointer to an array of workDim unsigned values that
+                                                    ///< specify the number of local work-items forming a work-group that will
+                                                    ///< execute the kernel function.
+                                                    ///< If nullptr, the runtime implementation will choose the work-group
+                                                    ///< size. 
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular kernel
+                                                    ///< execution instance.
+                                                    ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
+                                                    ///< TODO: change to allow nullptr.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command which waits a list of events to complete before it
+///        completes
+/// 
+/// @details
+///     - If the event list is empty, it waits for all previously enqueued
+///       commands to complete.
+///     - It returns an event which can be waited on.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueMarkerWithWaitList**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                    ///< previously enqueued commands
+                                                    ///< must be complete. 
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a barrier command which waits a list of events to complete
+///        before it completes
+/// 
+/// @details
+///     - If the event list is empty, it waits for all previously enqueued
+///       commands to complete.
+///     - It blocks command execution - any following commands enqueued after it
+///       do not execute until it completes.
+///     - It returns an event which can be waited on.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueBarrierWithWaitList**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                    ///< previously enqueued commands
+                                                    ///< must be complete. 
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to read from a buffer object to host memory
+/// 
+/// @details
+///     - Input parameter blockingRead indicates if the read is blocking or
+///       non-blocking.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueReadBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+    bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                                  ///< [in] offset in bytes in the buffer object
+    size_t size,                                    ///< [in] size in bytes of data being read
+    void* pDst,                                     ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to write into a buffer object from host memory
+/// 
+/// @details
+///     - Input parameter blockingWrite indicates if the write is blocking or
+///       non-blocking.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueWriteBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+    bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                                  ///< [in] offset in bytes in the buffer object
+    size_t size,                                    ///< [in] size in bytes of data being written
+    const void* pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to read a 2D or 3D rectangular region from a buffer
+///        object to host memory
+/// 
+/// @details
+///     - Input parameter blockingRead indicates if the read is blocking or
+///       non-blocking.
+///     - The buffer and host 2D or 3D rectangular regions can have different
+///       shapes.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueReadBufferRect**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+    bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
+                                                    ///< dst
+    size_t hostSlicePitch,                          ///< [in] length of each 2D slice in bytes in the host memory region
+                                                    ///< pointed by dst
+    void* pDst,                                     ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to write a 2D or 3D rectangular region in a buffer
+///        object from host memory
+/// 
+/// @details
+///     - Input parameter blockingWrite indicates if the write is blocking or
+///       non-blocking.
+///     - The buffer and host 2D or 3D rectangular regions can have different
+///       shapes.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueWriteBufferRect**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+    bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being
+                                                    ///< written
+    size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
+                                                    ///< src
+    size_t hostSlicePitch,                          ///< [in] length of each 2D slice in bytes in the host memory region
+                                                    ///< pointed by src
+    void* pSrc,                                     ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to copy from a buffer object to another
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueCopyBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBufferSrc`
+///         + `NULL == hBufferDst`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+    size_t size,                                    ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to copy a 2D or 3D rectangular region from one
+///        buffer object to another
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueCopyBufferRect**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBufferSrc`
+///         + `NULL == hBufferDst`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,                     ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,                     ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,                     ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                             ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                           ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                             ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                           ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to fill a buffer object with a pattern of a given
+///        size
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueFillBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPattern`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+    const void* pPattern,                           ///< [in] pointer to the fill pattern
+    size_t patternSize,                             ///< [in] size in bytes of the pattern
+    size_t offset,                                  ///< [in] offset into the buffer
+    size_t size,                                    ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to read from an image or image array object to host
+///        memory
+/// 
+/// @details
+///     - Input parameter blockingRead indicates if the read is blocking or
+///       non-blocking.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueReadImage**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                         ///< [in] handle of the image object
+    bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                                    ///< image
+    size_t rowPitch,                                ///< [in] length of each row in bytes
+    size_t slicePitch,                              ///< [in] length of each 2D slice of the 3D image
+    void* pDst,                                     ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to write an image or image array object from host
+///        memory
+/// 
+/// @details
+///     - Input parameter blockingWrite indicates if the write is blocking or
+///       non-blocking.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueWriteImage**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                         ///< [in] handle of the image object
+    bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                                    ///< image
+    size_t inputRowPitch,                           ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                         ///< [in] length of each 2D slice of the 3D image
+    void* pSrc,                                     ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to copy from an image object to another
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueCopyImage**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hImageSrc`
+///         + `NULL == hImageDst`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                      ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                      ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                                    ///< image
+    ur_rect_offset_t dstOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                                    ///< or 3D image
+    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                                    ///< image
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to map a region of the buffer object into the host
+///        address space and return a pointer to the mapped region
+/// 
+/// @details
+///     - Input parameter blockingMap indicates if the map is blocking or
+///       non-blocking.
+///     - Currently, no direct support in Leverl Zero. Implemented as a shared
+///       allocation followed by copying on discrete GPU
+///     - TODO: add a driver function in Level Zero?
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueMapBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3 < mapFlags`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///         + `NULL == ppRetMap`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+    bool blockingMap,                               ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                        ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                                  ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                                    ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent,                     ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
+                                                    ///< numEventsInWaitList?
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to unmap a previously mapped region of a memory
+///        object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clEnqueueUnmapMemObject**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMappedPtr`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                           ///< [in] handle of the memory (buffer or image) object
+    void* pMappedPtr,                               ///< [in] mapped host address
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to set USM memory object value
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ptr`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    void* ptr,                                      ///< [in] pointer to USM memory object
+    int8_t byteValue,                               ///< [in] byte value to fill
+    size_t count,                                   ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to copy USM memory
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    bool blocking,                                  ///< [in] blocking or non-blocking copy
+    void* pDst,                                     ///< [in] pointer to the destination USM memory object
+    const void* pSrc,                               ///< [in] pointer to the source USM memory object
+    size_t size,                                    ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to prefetch USM memory
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1 < flags`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    const void* pMem,                               ///< [in] pointer to the USM memory object
+    size_t size,                                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,                 ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before this command can be executed.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                    ///< command does not wait on any event to complete.
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to set USM memory advice
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_MEM_ADVICE_MEM_ADVICE_DEFAULT < advice`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEnqueueUSMMemAdvice(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    const void* pMem,                               ///< [in] pointer to the USM memory object
+    size_t size,                                    ///< [in] size in bytes to be adviced
+    ur_mem_advice_t advice,                         ///< [in] USM memory advice
+    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
+                                                    ///< command instance.
+                                                    ///< Input can not be a nullptr.
+                                                    ///< TODO: change to allow nullptr. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create an event object. Events allow applications to enqueue commands
+///        that wait on an event to finish or signal a command completion.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateUserEvent**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEventCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_event_handle_t* phEvent                      ///< [out] pointer to handle of the event object created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get event object information
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetEventInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hEvent`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EVENT_INFO_EVENT_INFO_REFERENCE_COUNT < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+///         + `NULL == pPropValueSizeRet`
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urEventGetInfo(
+    ur_event_handle_t hEvent,                       ///< [in] handle of the event object
+    ur_event_info_t propName,                       ///< [in] the name of the event property to query
+    size_t propValueSize,                           ///< [in] size in bytes of the event property value
+    void* pPropValue,                               ///< [out] value of the event property
+    size_t* pPropValueSizeRet                       ///< [out] bytes returned in event property
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get profiling information for the command associated with an event
+///        object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetEventProfilingInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hEvent`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PROFILING_INFO_PROFILING_INFO_COMMAND_END < propName`
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t hEvent,                       ///< [in] handle of the event object
+    ur_profiling_info_t propName,                   ///< [in] the name of the profiling property to query
+    size_t propValueSize,                           ///< [in] size in bytes of the profiling property value
+    void* pPropValue,                               ///< [out][optional] value of the profiling property
+    size_t* pPropValueSizeRet                       ///< [out][optional] pointer to the actual size in bytes returned in
+                                                    ///< propValue
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Wait for a list of events to finish.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clWaitForEvent**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEventWaitList`
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urEventWait(
+    uint32_t numEvents,                             ///< [in] number of events in the event list
+    const ur_event_handle_t* phEventWaitList        ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                                    ///< completion
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to an event handle. Increment the event object's
+///        reference count.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainEvent**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hEvent`
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urEventRetain(
+    ur_event_handle_t hEvent                        ///< [in] handle of the event object
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the event object's reference count and delete the event
+///        object if the reference count becomes zero.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseEvent**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hEvent`
+///     - ::UR_RESULT_INVALID_EVENT
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urEventRelease(
+    ur_event_handle_t hEvent                        ///< [in] handle of the event object
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native event handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hEvent`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeEvent`
+ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,                       ///< [in] handle of the event.
+    ur_native_handle_t* phNativeEvent               ///< [out] a pointer to the native handle of the event.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime event object from native event handle.
+/// 
+/// @details
+///     - Creates runtime event handle from native driver event handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativeEvent`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeEvent,                ///< [in] the native handle of the event.
+    ur_event_handle_t* phEvent                      ///< [out] pointer to the handle of the event object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create an image object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateImage**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3f < flags`
+///         + `::UR_MEM_TYPE_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == pHost`
+///         + `NULL == phMem`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///     - ::UR_RESULT_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_INVALID_OPERATION
+///     - ::UR_RESULT_INVALID_HOST_PTR
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+    const ur_image_format_t* pImageFormat,          ///< [in] pointer to image format specification
+    const ur_image_desc_t* pImageDesc,              ///< [in] pointer to image description
+    void* pHost,                                    ///< [in] pointer to the buffer data
+    ur_mem_handle_t* phMem                          ///< [out] pointer to handle of image object created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a memory buffer
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3f < flags`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pHost`
+///         + `NULL == phBuffer`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_BUFFER_SIZE
+///     - ::UR_RESULT_INVALID_HOST_PTR
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urMemBufferCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+    size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
+    void* pHost,                                    ///< [in] pointer to the buffer data
+    ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference the memory object. Increment the memory object's
+///        reference count
+/// 
+/// @details
+///     - Useful in library function to retain access to the memory object after
+///       the caller released the object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainMemoryObject**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMem`
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urMemRetain(
+    ur_mem_handle_t hMem                            ///< [in] handle of the memory object to get access
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the memory object's reference count and delete the object if
+///        the reference count becomes zero.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseMemoryObject**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMem`
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urMemRelease(
+    ur_mem_handle_t hMem                            ///< [in] handle of the memory object to release
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a sub buffer representing a region in an existing buffer
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateSubBuffer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x3f < flags`
+///         + `::UR_BUFFER_CREATE_TYPE_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pBufferCreateInfo`
+///         + `NULL == phMem`
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OBJECT_ALLOCATION_FAILURE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_BUFFER_SIZE
+///     - ::UR_RESULT_INVALID_HOST_PTR
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+    ur_buffer_create_type_t bufferCreateType,       ///< [in] buffer creation type
+    ur_buffer_region_t* pBufferCreateInfo,          ///< [in] pointer to buffer create region information
+    ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of sub buffer created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native mem handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeMem`
+ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,                           ///< [in] handle of the mem.
+    ur_native_handle_t* phNativeMem                 ///< [out] a pointer to the native handle of the mem.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime mem object from native mem handle.
+/// 
+/// @details
+///     - Creates runtime mem handle from native driver mem handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativeMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phMem`
+ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeMem,                  ///< [in] the native handle of the mem.
+    ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of the mem object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve information about a memory object.
+/// 
+/// @details
+///     - Query information that is common to all memory objects.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetMemObjectInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMemory`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
+ur_result_t UR_APICALL
+urMemGetInfo(
+    ur_mem_handle_t hMemory,                        ///< [in] handle to the memory object being queried.
+    ur_mem_info_t MemInfoType,                      ///< [in] type of the info to retrieve.
+    size_t propSize,                                ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void* pMemInfo,                                 ///< [out][optional] array of bytes holding the info.
+                                                    ///< If propSize is less than the real number of bytes needed to return 
+                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pMemInfo is not used.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by
+                                                    ///< pMemInfo.  
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Tear down L0 runtime instance and release all its resources
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pParams`
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urTearDown(
+    void* pParams                                   ///< [in] pointer to tear down parameters
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve string representation of the underlying adapter specific
+///        result reported by the the last API that returned
+///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
+///        return an adapter specific result.
+/// 
+/// @details
+///     - The string returned via the ppMessage is a NULL terminated C style
+///       string.
+///     - The string returned via the ppMessage is thread local.
+///     - The entry point will return UR_RESULT_SUCCESS if the result being
+///       reported is to be considered a warning. Any other result code returned
+///       indicates that the adapter specific result is an error.
+///     - The memory in the string returned via the ppMessage is owned by the
+///       adapter.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMessage`
+ur_result_t UR_APICALL
+urGetLastResult(
+    const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
+                                                    ///< representation.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query information about a command queue
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetCommandQueueInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_QUEUE_INFO_SIZE < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+///         + `NULL == pPropSizeRet`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urQueueGetInfo(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+    ur_queue_info_t propName,                       ///< [in] name of the queue property to query
+    size_t propValueSize,                           ///< [in] size in bytes of the queue property value provided
+    void* pPropValue,                               ///< [out] value of the queue property
+    size_t* pPropSizeRet                            ///< [out] size in bytes returned in queue property value
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a command queue for a device in a context
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateCommandQueueWithProperties**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0xf < props`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phQueue`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_DEVICE
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_QUEUE_PROPERTIES
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+    ur_queue_flags_t props,                         ///< [in] initialization properties.
+                                                    ///< must be 0 (default) or a combination of ::ur_queue_flags_t.
+    ur_queue_handle_t* phQueue                      ///< [out] pointer to handle of queue object created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to the command queue handle. Increment the command
+///        queue's reference count
+/// 
+/// @details
+///     - Useful in library function to retain access to the command queue after
+///       the caller released the queue.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainCommandQueue**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urQueueRetain(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to get access
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command queue's reference count and delete the command
+///        queue if the reference count becomes zero.
+/// 
+/// @details
+///     - After the command queue reference count becomes zero and all queued
+///       commands in the queue have finished, the queue is deleted.
+///     - It also performs an implicit flush to issue all previously queued
+///       commands in the queue.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseCommandQueue**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urQueueRelease(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to release
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return queue native queue handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability queue extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeQueue`
+ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue.
+    ur_native_handle_t* phNativeQueue               ///< [out] a pointer to the native handle of the queue.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime queue object from native queue handle.
+/// 
+/// @details
+///     - Creates runtime queue handle from native driver queue handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hNativeQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phQueue`
+ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue instance
+    ur_native_handle_t hNativeQueue,                ///< [in] the native handle of the queue.
+    ur_queue_handle_t* phQueue                      ///< [out] pointer to the handle of the queue object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Blocks until all previously issued commands to the command queue are
+///        finished.
+/// 
+/// @details
+///     - Blocks until all previously issued commands to the command queue are
+///       issued and completed.
+///     - ::urQueueFinish does not return until all enqueued commands have been
+///       processed and finished.
+///     - ::urQueueFinish acts as a synchronization point.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clFinish**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urQueueFinish(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be finished.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Issues all previously enqueued commands in a command queue to the
+///        device.
+/// 
+/// @details
+///     - Guarantees that all enqueued commands will be issued to the
+///       appropriate device.
+///     - There is no guarantee that they will be completed after ::urQueueFlush
+///       returns.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clFlush**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urQueueFlush(
+    ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be flushed.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a sampler object in a context
+/// 
+/// @details
+///     - The props parameter specifies a list of sampler property names and
+///       their corresponding values.
+///     - The list is terminated with 0. If the list is NULL, default values
+///       will be used.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateSamplerWithProperties**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pProps`
+///         + `NULL == phSampler`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_OPERATION
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+                                                    ///< corresponding values.
+    ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to the sampler object handle. Increment its reference
+///        count
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainSampler**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_INVALID_SAMPLER
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urSamplerRetain(
+    ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to get access
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the sampler's reference count and delete the sampler if the
+///        reference count becomes zero.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseSampler**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_INVALID_SAMPLER
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to release
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query information about a sampler object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetSamplerInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_SAMPLER_INFO_SAMPLER_INFO_LOD_MAX < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+///         + `NULL == pPropSizeRet`
+///     - ::UR_RESULT_INVALID_SAMPLER
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urSamplerGetInfo(
+    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler object
+    ur_sampler_info_t propName,                     ///< [in] name of the sampler property to query
+    size_t propValueSize,                           ///< [in] size in bytes of the sampler property value provided
+    void* pPropValue,                               ///< [out] value of the sampler property
+    size_t* pPropSizeRet                            ///< [out] size in bytes returned in sampler property value
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return sampler native sampler handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability sampler extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeSampler`
+ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler.
+    ur_native_handle_t* phNativeSampler             ///< [out] a pointer to the native handle of the sampler.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime sampler object from native sampler handle.
+/// 
+/// @details
+///     - Creates runtime sampler handle from native driver sampler handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hSampler`
+///         + `NULL == hNativeSampler`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phSampler`
+ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler instance
+    ur_native_handle_t hNativeSampler,              ///< [in] the native handle of the sampler.
+    ur_sampler_handle_t* phSampler                  ///< [out] pointer to the handle of the sampler object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocate host memory
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pUSMFlag`
+///         + `NULL == ppMem`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_USM_SIZE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urUSMHostAlloc(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_usm_mem_flags_t* pUSMFlag,                   ///< [in] USM memory allocation flags
+    size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,                                 ///< [in] alignment of the USM memory object
+    void** ppMem                                    ///< [out] pointer to USM host memory object
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocate device memory
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pUSMProp`
+///         + `NULL == ppMem`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_USM_SIZE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urUSMDeviceAlloc(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+    ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
+    size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,                                 ///< [in] alignment of the USM memory object
+    void** ppMem                                    ///< [out] pointer to USM device memory object
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocate shared memory
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pUSMProp`
+///         + `NULL == ppMem`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_USM_SIZE
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_OUT_OF_RESOURCES
+ur_result_t UR_APICALL
+urUSMSharedAlloc(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+    ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
+    size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,                                 ///< [in] alignment of the USM memory object
+    void** ppMem                                    ///< [out] pointer to USM shared memory object
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free the USM memory object
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urMemFree(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    void* pMem                                      ///< [in] pointer to USM memory object
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get USM memory object allocation information
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///         + `NULL == pPropValue`
+///         + `NULL == pPropValueSizeRet`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_MEM_ALLOC_INFO_MEM_ALLOC_DEVICE < propName`
+///     - ::UR_RESULT_INVALID_CONTEXT
+///     - ::UR_RESULT_INVALID_VALUE
+///     - ::UR_RESULT_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urMemGetMemAllocInfo(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context object
+    const void* pMem,                               ///< [in] pointer to USM memory object
+    ur_mem_alloc_info_t propName,                   ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,                           ///< [in] size in bytes of the USM allocation property value
+    void* pPropValue,                               ///< [out] value of the USM allocation property
+    size_t* pPropValueSizeRet                       ///< [out] bytes returned in USM allocation property
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves devices within a platform
+/// 
+/// @details
+///     - Multiple calls to this function will return identical device handles,
+///       in the same order.
+///     - The number and order of handles returned from this function can be
+///       affected by environment variables that filter devices exposed through
+///       API.
+///     - The returned devices are taken a reference of and must be released
+///       with a subsequent call to ::urDeviceRelease.
+///     - The application may call this function from simultaneous threads, the
+///       implementation must be thread-safe
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetDeviceIDs**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
+ur_result_t UR_APICALL
+urDeviceGet(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
+    uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
+                                                    ///< If phDevices in not NULL then NumEntries should be greater than zero.
+    ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                                    ///< If NumEntries is less than the number of devices available, then
+                                                    ///< platform shall only retrieve that number of devices.
+    uint32_t* pNumDevices                           ///< [out][optional] pointer to the number of devices.
+                                                    ///< pNumDevices will be updated with the total number of devices available.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves various information about device
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetDeviceInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES < infoType`
+ur_result_t UR_APICALL
+urDeviceGetInfo(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
+    ur_device_info_t infoType,                      ///< [in] type of the info to retrieve
+    size_t propSize,                                ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
+                                                    ///< If propSize is not equal to or greater than the real number of bytes
+                                                    ///< needed to return the info
+                                                    ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pDeviceInfo is not used.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Makes a reference of the device handle indicating it's in use until
+///        paired ::urDeviceRelease is called
+/// 
+/// @details
+///     - It is not valid to use the device handle, which has all of its
+///       references released.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainDevice**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+ur_result_t UR_APICALL
+urDeviceRetain(
+    ur_device_handle_t hDevice                      ///< [in] handle of the device to get a reference of.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Releases the device handle reference indicating end of its usage
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseDevice**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+ur_result_t UR_APICALL
+urDeviceRelease(
+    ur_device_handle_t hDevice                      ///< [in] handle of the device to release.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Partition the device into sub-devices
+/// 
+/// @details
+///     - Repeated calls to this function with the same inputs will produce the
+///       same output in the same order.
+///     - The function may be called to request a further partitioning of a
+///       sub-device into sub-sub-devices, and so on.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateSubDevices**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == Properties`
+ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
+    ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+    uint32_t NumDevices,                            ///< [in] the number of sub-devices.
+    ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                    ///< If NumDevices is less than the number of sub-devices available, then
+                                                    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t* pNumDevicesRet                        ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                    ///< partitioned into according to the partitioning property.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Selects the most appropriate device binary based on runtime
+///        information and the IR characteristics.
+/// 
+/// @details
+///     - The input binaries are various AOT images, and possibly a SPIR-V
+///       binary for JIT compilation.
+///     - The selected binary will be able to be run on the target device.
+///     - If no suitable binary can be found then function returns
+///       ${X}_INVALID_BINARY.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppBinaries`
+///         + `NULL == pSelectedBinary`
+ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
+    const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
+    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
+                                                    ///< equal to zero.
+    uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
+                                                    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native device handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeDevice`
+ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device.
+    ur_native_handle_t* phNativeDevice              ///< [out] a pointer to the native handle of the device.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime device object from native device handle.
+/// 
+/// @details
+///     - Creates runtime device handle from native driver device handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativeDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phDevice`
+ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeDevice,               ///< [in] the native handle of the device.
+    ur_device_handle_t* phDevice                    ///< [out] pointer to the handle of the device object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create kernel object from a program.
+/// 
+/// @details
+///     - Multiple calls to this function will return identical device handles,
+///       in the same order.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pKernelName`
+///         + `NULL == phKernel`
+ur_result_t UR_APICALL
+urKernelCreate(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program instance
+    const char* pKernelName,                        ///< [in] pointer to null-terminated string.
+    ur_kernel_handle_t* phKernel                    ///< [out] pointer to handle of kernel object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set kernel argument for a kernel.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clSetKernelArg**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+ur_result_t UR_APICALL
+urKernelSetArg(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,                                 ///< [in] size of argument type
+    const void* pArgValue                           ///< [in][optional] argument value represented as matching arg type. If
+                                                    ///< null then argument value is considered null.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query information about a Kernel object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetKernelInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
+ur_result_t UR_APICALL
+urKernelGetInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+    ur_kernel_info_t propName,                      ///< [in] name of the Kernel property to query
+    size_t propSize,                                ///< [in] the size of the Kernel property value.           
+    void* pKernelInfo,                              ///< [in,out][optional] array of bytes holding the kernel info property.
+                                                    ///< If propSize is not equal to or greater than the real number of bytes
+                                                    ///< needed to return 
+                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pKernelInfo is not used.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                    ///< queried by propName.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query work Group information about a Kernel object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetKernelWorkGroupInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
+ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName,                ///< [in] name of the work Group property to query
+    size_t propSize,                                ///< [in] size of the Kernel Work Group property value
+    void* pPropValue,                               ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                                    ///< property.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                    ///< queried by propName.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query SubGroup information about a Kernel object
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
+ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName,            ///< [in] name of the SubGroup property to query
+    size_t propSize,                                ///< [in] size of the Kernel SubGroup property value
+    void* pPropValue,                               ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                                    ///< property.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                    ///< queried by propName.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to the Kernel object.
+/// 
+/// @details
+///     - Get a reference to the Kernel object handle. Increment its reference
+///       count
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainKernel**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+ur_result_t UR_APICALL
+urKernelRetain(
+    ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to retain
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release Kernel.
+/// 
+/// @details
+///     - Decrement reference count and destroy the Kernel if reference count
+///       becomes zero.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseKernel**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+ur_result_t UR_APICALL
+urKernelRelease(
+    ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to release
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a USM pointer as the argument value of a Kernel.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clSetKernelArgSVMPointer**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+ur_result_t UR_APICALL
+urKernelSetArgPointer(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,                                 ///< [in] size of argument type
+    const void* pArgValue                           ///< [in][optional] SVM pointer to memory location holding the argument
+                                                    ///< value. If null then argument value is considered null.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set additional Kernel execution attributes.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clSetKernelExecInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_KERNEL_EXEC_INFO_USM_PTRS < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+ur_result_t UR_APICALL
+urKernelSetExecInfo(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    ur_kernel_exec_info_t propName,                 ///< [in] name of the execution attribute
+    size_t propSize,                                ///< [in] size in byte the attribute value
+    const void* pPropValue                          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                                    ///< property value.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a Sampler object as the argument value of a Kernel.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///         + `NULL == hArgValue`
+ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+    ur_sampler_handle_t hArgValue                   ///< [in] handle of Sampler object.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a Memory object as the argument value of a Kernel.
+/// 
+/// @details
+///     - The application must **not** call this function from simultaneous
+///       threads with the same kernel handle.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///         + `NULL == hArgValue`
+ur_result_t UR_APICALL
+urKernelSetArgMemObj(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue                       ///< [in] handle of Memory object.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native kernel handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeKernel`
+ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel.
+    ur_native_handle_t* phNativeKernel              ///< [out] a pointer to the native handle of the kernel.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime kernel object from native kernel handle.
+/// 
+/// @details
+///     - Creates runtime kernel handle from native driver kernel handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativeKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phKernel`
+ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeKernel,               ///< [in] the native handle of the kernel.
+    ur_kernel_handle_t* phKernel                    ///< [out] pointer to the handle of the kernel object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create Module object from IL.
+/// 
+/// @details
+///     - Multiple calls to this function will return identical device handles,
+///       in the same order.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pIL`
+///         + `NULL == pOptions`
+///         + `NULL == phModule`
+ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context instance.
+    const void* pIL,                                ///< [in] pointer to IL string.
+    size_t length,                                  ///< [in] length of IL in bytes.
+    const char* pOptions,                           ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify,           ///< [in][optional] A function pointer to a notification routine that is
+                                                    ///< called when program compilation is complete.
+    void* pUserData,                                ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t* phModule                    ///< [out] pointer to handle of Module object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to the Module object.
+/// 
+/// @details
+///     - Get a reference to the Module object handle. Increment its reference
+///       count
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hModule`
+ur_result_t UR_APICALL
+urModuleRetain(
+    ur_module_handle_t hModule                      ///< [in] handle for the Module to retain
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release Module.
+/// 
+/// @details
+///     - Decrement reference count and destroy the Module if reference count
+///       becomes zero.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hModule`
+ur_result_t UR_APICALL
+urModuleRelease(
+    ur_module_handle_t hModule                      ///< [in] handle for the Module to release
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native module handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hModule`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeModule`
+ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,                     ///< [in] handle of the module.
+    ur_native_handle_t* phNativeModule              ///< [out] a pointer to the native handle of the module.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime module object from native module handle.
+/// 
+/// @details
+///     - Creates runtime module handle from native driver module handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativeModule`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phModule`
+ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativeModule,               ///< [in] the native handle of the module.
+    ur_module_handle_t* phModule                    ///< [out] pointer to the handle of the module object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves all available platforms
+/// 
+/// @details
+///     - Multiple calls to this function will return identical platforms
+///       handles, in the same order.
+///     - The application may call this function from simultaneous threads, the
+///       implementation must be thread-safe
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetPlatformIDs**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+ur_result_t UR_APICALL
+urPlatformGet(
+    uint32_t NumEntries,                            ///< [in] the number of platforms to be added to phPlatforms. 
+                                                    ///< If phPlatforms is not NULL, then NumEntries but be greater than zero.
+    ur_platform_handle_t* phPlatforms,              ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                                    ///< If NumEntries is less than the number of platforms available, then
+                                                    ///< ::urPlatform shall only retrieve that number of platforms.
+    uint32_t* pNumPlatforms                         ///< [out][optional] returns the total number of platforms available. 
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves various information about platform
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetPlatformInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
+ur_result_t UR_APICALL
+urPlatformGetInfo(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform
+    ur_platform_info_t PlatformInfoType,            ///< [in] type of the info to retrieve
+    size_t Size,                                    ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void* pPlatformInfo,                            ///< [out][optional] array of bytes holding the info.
+                                                    ///< If Size is not equal to or greater to the real number of bytes needed
+                                                    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                                    ///< returned and pPlatformInfo is not used.
+    size_t* pSizeRet                                ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Returns the API version supported by the specified platform
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDriver`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pVersion`
+ur_result_t UR_APICALL
+urPlatformGetApiVersion(
+    ur_platform_handle_t hDriver,                   ///< [in] handle of the platform
+    ur_api_version_t* pVersion                      ///< [out] api version
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native platform handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativePlatform`
+ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform.
+    ur_native_handle_t* phNativePlatform            ///< [out] a pointer to the native handle of the platform.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime platform object from native platform handle.
+/// 
+/// @details
+///     - Creates runtime platform handle from native driver platform handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///         + `NULL == hNativePlatform`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phPlatform`
+ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    ur_native_handle_t hNativePlatform,             ///< [in] the native handle of the platform.
+    ur_platform_handle_t* phPlatform                ///< [out] pointer to the handle of the platform object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create Program from input SPIR-V modules.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateProgram**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phModules`
+///         + `NULL == phProgram`
+ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
+    uint32_t count,                                 ///< [in] number of module handles in module list.
+    const ur_module_handle_t* phModules,            ///< [in][range(0, count)] pointer to array of modules.
+    const char* pOptions,                           ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t* phProgram                  ///< [out] pointer to handle of program object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create program object from native binary.
+/// 
+/// @details
+///     - The application may call this function from simultaneous threads.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clCreateProgramWithBinary**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pBinary`
+///         + `NULL == phProgram`
+ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                     ///< [in] handle to device associated with binary.
+    size_t size,                                    ///< [in] size in bytes.
+    const uint8_t* pBinary,                         ///< [in] pointer to binary.
+    ur_program_handle_t* phProgram                  ///< [out] pointer to handle of Program object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to the Program object.
+/// 
+/// @details
+///     - Get a reference to the Program object handle. Increment its reference
+///       count
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clRetainProgram**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+ur_result_t UR_APICALL
+urProgramRetain(
+    ur_program_handle_t hProgram                    ///< [in] handle for the Program to retain
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release Program.
+/// 
+/// @details
+///     - Decrement reference count and destroy the Program if reference count
+///       becomes zero.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clReleaseProgram**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+ur_result_t UR_APICALL
+urProgramRelease(
+    ur_program_handle_t hProgram                    ///< [in] handle for the Program to release
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a device function pointer to a user-defined function.
+/// 
+/// @details
+///     - Retrieves a pointer to the functions with the given name and defined
+///       in the given program.
+///     - ::UR_RESULT_ERROR_INVALID_FUNCTION_NAME is returned if the function
+///       can not be obtained.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetDeviceFunctionPointerINTEL**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pFunctionName`
+///         + `NULL == ppFunctionPointer`
+ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,                     ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program to search for function in.
+                                                    ///< The program must already be built to the specified device, or
+                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char* pFunctionName,                      ///< [in] A null-terminates string denoting the mangled function name.
+    void** ppFunctionPointer                        ///< [out] Returns the pointer to the function if it is found in the program.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query information about a Program object
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetProgramInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
+ur_result_t UR_APICALL
+urProgramGetInfo(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+    ur_program_info_t propName,                     ///< [in] name of the Program property to query
+    size_t propSize,                                ///< [in] the size of the Program property.
+    void* pProgramInfo,                             ///< [in,out][optional] array of bytes of holding the program info property.
+                                                    ///< If propSize is not equal to or greater than the real number of bytes
+                                                    ///< needed to return 
+                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< pProgramInfo is not used.
+    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query build information about a Program object for a Device
+/// 
+/// @remarks
+///   _Analogues_
+///     - **clGetProgramBuildInfo**
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropSize`
+ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+    ur_program_build_info_t propName,               ///< [in] name of the Program build info to query
+    size_t* pPropSize,                              ///< [in,out] pointer to the size of the Program build info property.
+                                                    ///< If *propSize is 0 or greater than the number of bytes of the build
+                                                    ///< info property,
+                                                    ///< the call shall update the value with actual number of bytes of the
+                                                    ///< build info property.
+    void* pPropValue                                ///< [in,out][optional][range(0, *propSize)] value of the Program build property.
+                                                    ///< If *propSize is less than the number of bytes for the Program build property,
+                                                    ///< only the first *propSize bytes will be returned.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a Program object specialization constant to a specific value
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSpecValue`
+ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+    uint32_t specId,                                ///< [in] specification constant Id
+    size_t specSize,                                ///< [in] size of the specialization constant value
+    const void* pSpecValue                          ///< [in] pointer to the specialization value bytes
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return program native program handle.
+/// 
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability program extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeProgram`
+ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program.
+    ur_native_handle_t* phNativeProgram             ///< [out] a pointer to the native handle of the program.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create runtime program object from native program handle.
+/// 
+/// @details
+///     - Creates runtime program handle from native driver program handle.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hProgram`
+///         + `NULL == hNativeProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phProgram`
+ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program instance
+    ur_native_handle_t hNativeProgram,              ///< [in] the native handle of the program.
+    ur_program_handle_t* phProgram                  ///< [out] pointer to the handle of the program object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Initialize the 'oneAPI' driver(s)
+/// 
+/// @details
+///     - The application must call this function before calling any other
+///       function.
+///     - If this function is not called then all other functions will return
+///       ::UR_RESULT_ERROR_UNINITIALIZED.
+///     - Only one instance of each driver will be initialized per process.
+///     - The application may call this function multiple times with different
+///       flags or environment variables enabled.
+///     - The application must call this function after forking new processes.
+///       Each forked process must call this function.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function must be thread-safe for scenarios
+///       where multiple libraries may initialize the driver(s) simultaneously.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `0x1 < platform_flags`
+///         + `0x1 < device_flags`
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL
+urInit(
+    ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
+                                                    ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
+    ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
+                                                    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+


### PR DESCRIPTION
This patch adds files to the `install` target along with CMake package configuration files. The goal of these changes is to properly support `FetchContent`, via `find_package`, to ease the integration of unified-runtime into other projects.

The `install` target will now install the following files to the directory specified by the `CMAKE_INSTALL_PREFIX` option.

```
.
├── include
│   ├── ur_api.h
│   ├── ur_ddi.h
│   └── ur.py
└── lib
    └── cmake
        └── unified-runtime
            ├── unified-runtime-config.cmake
            ├── unified-runtime-config-version.cmake
            └── unified-runtime-targets.cmake
```

It is now possible to use `find_package` with this install directory in a dependent projects `CMakeLists.txt`, as follows:

```cmake
find_package(unified-runtime 0.5.0 REQUIRED)

add_executable(example example.cpp)
target_link_libraries(example PUBLIC unified-runtime::headers)
```

> Note: The `CMAKE_PREFIX_PATH` must point to the install directory when
> `CAMKE_INSTALL_PREFIX` is not on a global search path.

The README has been updated to include a new *Integration* section which utilized `FetchContent`, repeated here for brevity.

```cmake
include(FetchContent)

FetchContent_Declare(
    unified-runtime
    GIT_REPOSITORY https://github.com/oneapi-src/unified-runtime.git
    GIT_TAG main  # This will pull the latest changes from the main branch.
)
FetchContent_MakeAvailable(unified-runtime)

add_executable(example example.cpp)
target_link_libraries(example PUBLIC unified-runtime::headers)
```

Fixes #30