### PR TITLE
add platform argument to GetLastResult

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1727,9 +1727,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urGetLastResult
 if __use_win_types:
-    _urGetLastResult_t = WINFUNCTYPE( ur_result_t, POINTER(c_char_p) )
+    _urGetLastResult_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
 else:
-    _urGetLastResult_t = CFUNCTYPE( ur_result_t, POINTER(c_char_p) )
+    _urGetLastResult_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
 
 ###############################################################################
 ## @brief Function-pointer for urInit

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2016,36 +2016,6 @@ urTearDown(
     void* pParams                                   ///< [in] pointer to tear down parameters
     );
 
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Retrieve string representation of the underlying adapter specific
-///        result reported by the the last API that returned
-///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
-///        return an adapter specific result.
-/// 
-/// @details
-///     - The string returned via the ppMessage is a NULL terminated C style
-///       string.
-///     - The string returned via the ppMessage is thread local.
-///     - The entry point will return UR_RESULT_SUCCESS if the result being
-///       reported is to be considered a warning. Any other result code returned
-///       indicates that the adapter specific result is an error.
-///     - The memory in the string returned via the ppMessage is owned by the
-///       adapter.
-///     - The application may call this function from simultaneous threads.
-///     - The implementation of this function should be lock-free.
-/// 
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == ppMessage`
-UR_APIEXPORT ur_result_t UR_APICALL
-urGetLastResult(
-    const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
-                                                    ///< representation.
-    );
-
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
@@ -3822,6 +3792,39 @@ urPlatformCreateWithNativeHandle(
     ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
     ur_native_handle_t hNativePlatform,             ///< [in] the native handle of the platform.
     ur_platform_handle_t* phPlatform                ///< [out] pointer to the handle of the platform object created.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve string representation of the underlying adapter specific
+///        result reported by the the last API that returned
+///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
+///        return an adapter specific result.
+/// 
+/// @details
+///     - The string returned via the ppMessage is a NULL terminated C style
+///       string.
+///     - The string returned via the ppMessage is thread local.
+///     - The entry point will return UR_RESULT_SUCCESS if the result being
+///       reported is to be considered a warning. Any other result code returned
+///       indicates that the adapter specific result is an error.
+///     - The memory in the string returned via the ppMessage is owned by the
+///       adapter.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMessage`
+UR_APIEXPORT ur_result_t UR_APICALL
+urGetLastResult(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
+                                                    ///< representation.
     );
 
 #if !defined(__GNUC__)
@@ -6588,6 +6591,7 @@ typedef void (UR_APICALL *ur_pfnTearDownCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_get_last_result_params_t
 {
+    ur_platform_handle_t* phPlatform;
     const char*** pppMessage;
 } ur_get_last_result_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1206,6 +1206,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnTearDown_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetLastResult 
 typedef ur_result_t (UR_APICALL *ur_pfnGetLastResult_t)(
+    ur_platform_handle_t,
     const char**
     );
 

--- a/scripts/core/misc.yml
+++ b/scripts/core/misc.yml
@@ -22,29 +22,3 @@ params:
       desc: "[in] pointer to tear down parameters"
 returns:
     - $X_RESULT_OUT_OF_HOST_MEMORY
---- #--------------------------------------------------------------------------
-type: function
-desc: "Retrieve string representation of the underlying adapter specific result
-       reported by the the last API that returned UR_RESULT_ADAPTER_SPECIFIC.
-       Allows for an adapter independent way to return an adapter
-       specific result."
-class: $x
-name: GetLastResult
-decl: static
-ordinal: "0"
-details:
-    - "The string returned via the ppMessage is a NULL terminated C style string."
-    - "The string returned via the ppMessage is thread local."
-    - "The entry point will return UR_RESULT_SUCCESS if the result being
-       reported is to be considered a warning. Any other result code returned
-       indicates that the adapter specific result is an error."
-    -  "The memory in the string returned via the ppMessage is owned by the
-       adapter."
-    - "The application may call this function from simultaneous
-       threads."
-    - "The implementation of this function should be lock-free."
-params:
-    - type: const char**
-      name: ppMessage
-      desc: "[out] pointer to a string containing adapter specific result
-             in string representation."

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -162,3 +162,32 @@ params:
       name: phPlatform
       desc: |
             [out] pointer to the handle of the platform object created.
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieve string representation of the underlying adapter specific result
+       reported by the the last API that returned UR_RESULT_ADAPTER_SPECIFIC.
+       Allows for an adapter independent way to return an adapter
+       specific result."
+class: $x
+name: GetLastResult
+decl: static
+ordinal: "0"
+details:
+    - "The string returned via the ppMessage is a NULL terminated C style string."
+    - "The string returned via the ppMessage is thread local."
+    - "The entry point will return UR_RESULT_SUCCESS if the result being
+       reported is to be considered a warning. Any other result code returned
+       indicates that the adapter specific result is an error."
+    -  "The memory in the string returned via the ppMessage is owned by the
+       adapter."
+    - "The application may call this function from simultaneous
+       threads."
+    - "The implementation of this function should be lock-free."
+params:
+    - type: $x_platform_handle_t
+      name: hPlatform
+      desc: "[in] handle of the platform instance"
+    - type: const char**
+      name: ppMessage
+      desc: "[out] pointer to a string containing adapter specific result
+             in string representation."

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1670,40 +1670,6 @@ urTearDown(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Retrieve string representation of the underlying adapter specific
-///        result reported by the the last API that returned
-///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
-///        return an adapter specific result.
-/// 
-/// @details
-///     - The string returned via the ppMessage is a NULL terminated C style
-///       string.
-///     - The string returned via the ppMessage is thread local.
-///     - The entry point will return UR_RESULT_SUCCESS if the result being
-///       reported is to be considered a warning. Any other result code returned
-///       indicates that the adapter specific result is an error.
-///     - The memory in the string returned via the ppMessage is owned by the
-///       adapter.
-///     - The application may call this function from simultaneous threads.
-///     - The implementation of this function should be lock-free.
-/// 
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == ppMessage`
-ur_result_t UR_APICALL
-urGetLastResult(
-    const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
-                                                    ///< representation.
-    )
-{
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
 /// 
 /// @remarks
@@ -3238,6 +3204,43 @@ urPlatformCreateWithNativeHandle(
     ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
     ur_native_handle_t hNativePlatform,             ///< [in] the native handle of the platform.
     ur_platform_handle_t* phPlatform                ///< [out] pointer to the handle of the platform object created.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve string representation of the underlying adapter specific
+///        result reported by the the last API that returned
+///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
+///        return an adapter specific result.
+/// 
+/// @details
+///     - The string returned via the ppMessage is a NULL terminated C style
+///       string.
+///     - The string returned via the ppMessage is thread local.
+///     - The entry point will return UR_RESULT_SUCCESS if the result being
+///       reported is to be considered a warning. Any other result code returned
+///       indicates that the adapter specific result is an error.
+///     - The memory in the string returned via the ppMessage is owned by the
+///       adapter.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hPlatform`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMessage`
+ur_result_t UR_APICALL
+urGetLastResult(
+    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+    const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
+                                                    ///< representation.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;


### PR DESCRIPTION
This makes it possible to have a simple passthrough implementation for this method in the loader. Otherwise we'd have to have a copy of the last error in the loader itself.