### PR TITLE
fix UR_DDI python class init

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1951,14 +1951,17 @@ class UR_DDI:
         if "Windows" == platform.uname()[0]:
             self.__dll = WinDLL("ur_loader.dll")
         else:
-            self.__dll = CDLL("ur_loader.so")
+            self.__dll = CDLL("libur_loader.so")
 
         # fill the ddi tables
         self.__dditable = ur_dditable_t()
 
+        # initialize the UR
+        self.__dll.urInit(0, 0)
+
         # call driver to get function pointers
         Platform = ur_platform_dditable_t()
-        r = ur_result_v(self.__dll.urGetPlatformProcAddrTable(version, byref(_Platform)))
+        r = ur_result_v(self.__dll.urGetPlatformProcAddrTable(version, byref(Platform)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Platform = Platform
@@ -1972,7 +1975,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Context = ur_context_dditable_t()
-        r = ur_result_v(self.__dll.urGetContextProcAddrTable(version, byref(_Context)))
+        r = ur_result_v(self.__dll.urGetContextProcAddrTable(version, byref(Context)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Context = Context
@@ -1988,7 +1991,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Event = ur_event_dditable_t()
-        r = ur_result_v(self.__dll.urGetEventProcAddrTable(version, byref(_Event)))
+        r = ur_result_v(self.__dll.urGetEventProcAddrTable(version, byref(Event)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Event = Event
@@ -2006,7 +2009,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Program = ur_program_dditable_t()
-        r = ur_result_v(self.__dll.urGetProgramProcAddrTable(version, byref(_Program)))
+        r = ur_result_v(self.__dll.urGetProgramProcAddrTable(version, byref(Program)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Program = Program
@@ -2025,7 +2028,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Module = ur_module_dditable_t()
-        r = ur_result_v(self.__dll.urGetModuleProcAddrTable(version, byref(_Module)))
+        r = ur_result_v(self.__dll.urGetModuleProcAddrTable(version, byref(Module)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Module = Module
@@ -2039,7 +2042,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Kernel = ur_kernel_dditable_t()
-        r = ur_result_v(self.__dll.urGetKernelProcAddrTable(version, byref(_Kernel)))
+        r = ur_result_v(self.__dll.urGetKernelProcAddrTable(version, byref(Kernel)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Kernel = Kernel
@@ -2061,7 +2064,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Sampler = ur_sampler_dditable_t()
-        r = ur_result_v(self.__dll.urGetSamplerProcAddrTable(version, byref(_Sampler)))
+        r = ur_result_v(self.__dll.urGetSamplerProcAddrTable(version, byref(Sampler)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Sampler = Sampler
@@ -2076,7 +2079,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Mem = ur_mem_dditable_t()
-        r = ur_result_v(self.__dll.urGetMemProcAddrTable(version, byref(_Mem)))
+        r = ur_result_v(self.__dll.urGetMemProcAddrTable(version, byref(Mem)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Mem = Mem
@@ -2096,7 +2099,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Enqueue = ur_enqueue_dditable_t()
-        r = ur_result_v(self.__dll.urGetEnqueueProcAddrTable(version, byref(_Enqueue)))
+        r = ur_result_v(self.__dll.urGetEnqueueProcAddrTable(version, byref(Enqueue)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Enqueue = Enqueue
@@ -2124,7 +2127,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         USM = ur_usm_dditable_t()
-        r = ur_result_v(self.__dll.urGetUSMProcAddrTable(version, byref(_USM)))
+        r = ur_result_v(self.__dll.urGetUSMProcAddrTable(version, byref(USM)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.USM = USM
@@ -2136,7 +2139,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Global = ur_global_dditable_t()
-        r = ur_result_v(self.__dll.urGetGlobalProcAddrTable(version, byref(_Global)))
+        r = ur_result_v(self.__dll.urGetGlobalProcAddrTable(version, byref(Global)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Global = Global
@@ -2148,7 +2151,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Queue = ur_queue_dditable_t()
-        r = ur_result_v(self.__dll.urGetQueueProcAddrTable(version, byref(_Queue)))
+        r = ur_result_v(self.__dll.urGetQueueProcAddrTable(version, byref(Queue)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Queue = Queue
@@ -2165,7 +2168,7 @@ class UR_DDI:
 
         # call driver to get function pointers
         Device = ur_device_dditable_t()
-        r = ur_result_v(self.__dll.urGetDeviceProcAddrTable(version, byref(_Device)))
+        r = ur_result_v(self.__dll.urGetDeviceProcAddrTable(version, byref(Device)))
         if r != ur_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.Device = Device

--- a/scripts/templates/api.py.mako
+++ b/scripts/templates/api.py.mako
@@ -164,15 +164,18 @@ class ${N}_DDI:
         if "Windows" == platform.uname()[0]:
             self.__dll = WinDLL("${x}_loader.dll")
         else:
-            self.__dll = CDLL("${x}_loader.so")
+            self.__dll = CDLL("lib${x}_loader.so")
 
         # fill the ddi tables
         self.__dditable = ${n}_dditable_t()
 
+        # initialize the UR
+        self.__dll.urInit(0, 0)
+
         %for tbl in tables:
         # call driver to get function pointers
         ${tbl['name']} = ${tbl['type']}()
-        r = ${x}_result_v(self.__dll.${tbl['export']['name']}(version, byref(_${tbl['name']})))
+        r = ${x}_result_v(self.__dll.${tbl['export']['name']}(version, byref(${tbl['name']})))
         if r != ${x}_result_v.SUCCESS:
             raise Exception(r)
         self.__dditable.${tbl['name']} = ${tbl['name']}


### PR DESCRIPTION
This patch fixes all issues that were preventing the python bindings from initializing the loader.