### PR TITLE
ur: Fix undefined Doxygen reference to urPlatform

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3728,7 +3728,7 @@ urPlatformGet(
                                                     ///< If phPlatforms is not NULL, then NumEntries but be greater than zero.
     ur_platform_handle_t* phPlatforms,              ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
                                                     ///< If NumEntries is less than the number of platforms available, then
-                                                    ///< ::urPlatform shall only retrieve that number of platforms.
+                                                    ///< ::urPlatformGet shall only retrieve that number of platforms.
     uint32_t* pNumPlatforms                         ///< [out][optional] returns the total number of platforms available. 
     );
 

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -31,7 +31,7 @@ params:
       name: phPlatforms
       desc: |
             [out][optional][range(0, NumEntries)] array of handle of platforms.
-            If NumEntries is less than the number of platforms available, then $xPlatform shall only retrieve that number of platforms.
+            If NumEntries is less than the number of platforms available, then $xPlatformGet shall only retrieve that number of platforms.
     - type: "uint32_t*"
       name: "pNumPlatforms"
       desc: |

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3146,7 +3146,7 @@ urPlatformGet(
                                                     ///< If phPlatforms is not NULL, then NumEntries but be greater than zero.
     ur_platform_handle_t* phPlatforms,              ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
                                                     ///< If NumEntries is less than the number of platforms available, then
-                                                    ///< ::urPlatform shall only retrieve that number of platforms.
+                                                    ///< ::urPlatformGet shall only retrieve that number of platforms.
     uint32_t* pNumPlatforms                         ///< [out][optional] returns the total number of platforms available. 
     )
 {


### PR DESCRIPTION
Fix a typo in the `urPlatformGet` documentation wihch references `urPlatform` rather than `urPlatformGet`.