### PR TITLE
ur: Remove user event creation

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -324,12 +324,11 @@ class ur_profiling_info_t(c_int):
 ###############################################################################
 ## @brief Event states for all events.
 class ur_execution_info_v(IntEnum):
-    EXECUTION_INFO_COMPLETE = 0                     ## Indicates that the event has completed
-    EXECUTION_INFO_RUNNING = 1                      ## Indicates that the device has started processing this event
-    EXECUTION_INFO_SUBMITTED = 2                    ## Indicates that the event has been submitted by the host to the device,
-                                                    ## this is the inital state of user events
+    EXECUTION_INFO_COMPLETE = 0                     ## Indicates that the event has completed.
+    EXECUTION_INFO_RUNNING = 1                      ## Indicates that the device has started processing this event.
+    EXECUTION_INFO_SUBMITTED = 2                    ## Indicates that the event has been submitted by the host to the device.
     EXECUTION_INFO_QUEUED = 3                       ## Indicates that the event has been queued, this is the initial state of
-                                                    ## all events except user events.
+                                                    ## events.
 
 class ur_execution_info_t(c_int):
     def __str__(self):
@@ -1089,13 +1088,6 @@ class ur_context_dditable_t(Structure):
     ]
 
 ###############################################################################
-## @brief Function-pointer for urEventCreate
-if __use_win_types:
-    _urEventCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_event_handle_t) )
-else:
-    _urEventCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_event_handle_t) )
-
-###############################################################################
 ## @brief Function-pointer for urEventGetInfo
 if __use_win_types:
     _urEventGetInfo_t = WINFUNCTYPE( ur_result_t, ur_event_handle_t, ur_event_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
@@ -1156,7 +1148,6 @@ else:
 ## @brief Table of Event functions pointers
 class ur_event_dditable_t(Structure):
     _fields_ = [
-        ("pfnCreate", c_void_p),                                        ## _urEventCreate_t
         ("pfnGetInfo", c_void_p),                                       ## _urEventGetInfo_t
         ("pfnGetProfilingInfo", c_void_p),                              ## _urEventGetProfilingInfo_t
         ("pfnWait", c_void_p),                                          ## _urEventWait_t
@@ -1994,7 +1985,6 @@ class UR_DDI:
         self.__dditable.Event = Event
 
         # attach function interface to function address
-        self.urEventCreate = _urEventCreate_t(self.__dditable.Event.pfnCreate)
         self.urEventGetInfo = _urEventGetInfo_t(self.__dditable.Event.pfnGetInfo)
         self.urEventGetProfilingInfo = _urEventGetProfilingInfo_t(self.__dditable.Event.pfnGetProfilingInfo)
         self.urEventWait = _urEventWait_t(self.__dditable.Event.pfnWait)

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1393,31 +1393,6 @@ typedef enum ur_profiling_info_t
 } ur_profiling_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Create an event object. Events allow applications to enqueue commands
-///        that wait on an event to finish or signal a command completion.
-/// 
-/// @remarks
-///   _Analogues_
-///     - **clCreateUserEvent**
-/// 
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urEventCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_event_handle_t* phEvent                      ///< [out] pointer to handle of the event object created
-    );
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
 /// 
 /// @remarks
@@ -1602,12 +1577,11 @@ urEventCreateWithNativeHandle(
 /// @brief Event states for all events.
 typedef enum ur_execution_info_t
 {
-    UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE = 0,  ///< Indicates that the event has completed
-    UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING = 1,   ///< Indicates that the device has started processing this event
-    UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED = 2, ///< Indicates that the event has been submitted by the host to the device,
-                                                    ///< this is the inital state of user events
+    UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE = 0,  ///< Indicates that the event has completed.
+    UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING = 1,   ///< Indicates that the device has started processing this event.
+    UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED = 2, ///< Indicates that the event has been submitted by the host to the device.
     UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED = 3,    ///< Indicates that the event has been queued, this is the initial state of
-                                                    ///< all events except user events.
+                                                    ///< events.
     UR_EXECUTION_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_execution_info_t;
@@ -4605,29 +4579,6 @@ typedef struct ur_context_callbacks_t
 } ur_context_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventCreate 
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_create_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_event_handle_t** pphEvent;
-} ur_event_create_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventCreate 
-/// @param[in] params Parameters passed to this instance
-/// @param[in] result Return value
-/// @param[in] pTracerUserData Per-Tracer user data
-/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventCreateCb_t)(
-    ur_event_create_params_t* params,
-    ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Callback function parameters for urEventGetInfo 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -4822,7 +4773,6 @@ typedef void (UR_APICALL *ur_pfnEventSetCallbackCb_t)(
 /// @brief Table of Event callback functions pointers
 typedef struct ur_event_callbacks_t
 {
-    ur_pfnEventCreateCb_t                                           pfnCreateCb;
     ur_pfnEventGetInfoCb_t                                          pfnGetInfoCb;
     ur_pfnEventGetProfilingInfoCb_t                                 pfnGetProfilingInfoCb;
     ur_pfnEventWaitCb_t                                             pfnWaitCb;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -179,13 +179,6 @@ typedef ur_result_t (UR_APICALL *ur_pfnGetContextProcAddrTable_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnEventCreate_t)(
-    ur_context_handle_t,
-    ur_event_handle_t*
-    );
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urEventGetInfo 
 typedef ur_result_t (UR_APICALL *ur_pfnEventGetInfo_t)(
     ur_event_handle_t,
@@ -252,7 +245,6 @@ typedef ur_result_t (UR_APICALL *ur_pfnEventSetCallback_t)(
 /// @brief Table of Event functions pointers
 typedef struct ur_event_dditable_t
 {
-    ur_pfnEventCreate_t                                         pfnCreate;
     ur_pfnEventGetInfo_t                                        pfnGetInfo;
     ur_pfnEventGetProfilingInfo_t                               pfnGetProfilingInfo;
     ur_pfnEventWait_t                                           pfnWait;

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -41,25 +41,6 @@ etors:
       desc: "A 64-bit value of current device counter in nanoseconds when the event has finished execution"
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Create an event object. Events allow applications to enqueue commands that wait on an event to finish or signal a command completion."
-class: $xEvent
-name: Create
-ordinal: "0"
-analogue:
-    - "**clCreateUserEvent**"
-params:
-    - type: $x_context_handle_t
-      name: hContext
-      desc: "[in] handle of the context object"
-    - type: $x_event_handle_t*
-      name: phEvent
-      desc: "[out] pointer to handle of the event object created"
-returns:      
-    - $X_RESULT_ERROR_INVALID_CONTEXT
-    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
-    - $X_RESULT_ERROR_OUT_OF_RESOURCES
---- #--------------------------------------------------------------------------
-type: function
 desc: "Get event object information"
 class: $xEvent
 name: GetInfo
@@ -221,13 +202,13 @@ class: $xEvent
 name: $x_execution_info_t
 etors:
     - name: EXECUTION_INFO_COMPLETE
-      desc: "Indicates that the event has completed"
+      desc: "Indicates that the event has completed."
     - name: EXECUTION_INFO_RUNNING
-      desc: "Indicates that the device has started processing this event"
+      desc: "Indicates that the device has started processing this event."
     - name: EXECUTION_INFO_SUBMITTED
-      desc: "Indicates that the event has been submitted by the host to the device, this is the inital state of user events"
+      desc: "Indicates that the event has been submitted by the host to the device."
     - name: EXECUTION_INFO_QUEUED
-      desc: "Indicates that the event has been queued, this is the initial state of all events except user events."
+      desc: "Indicates that the event has been queued, this is the initial state of events."
 --- #--------------------------------------------------------------------------
 type: fptr_typedef
 desc: "Event callback function that can be registered by the application."

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1143,35 +1143,6 @@ urEnqueueUSMMemAdvice(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Create an event object. Events allow applications to enqueue commands
-///        that wait on an event to finish or signal a command completion.
-/// 
-/// @remarks
-///   _Analogues_
-///     - **clCreateUserEvent**
-/// 
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEventCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_event_handle_t* phEvent                      ///< [out] pointer to handle of the event object created
-    )
-{
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
 /// 
 /// @remarks


### PR DESCRIPTION
OpenCL user events, which `urEventCreate` was an analogue of, allow the application to force a previously enqueued command to wait for the user event to be signalled before execution can begin. User events are also the only type of event that can synchronize across contexts, requiring a separate special case code path to implement. Lastly, there is no analogue to `clSetUserEventStatus` which actually enables the application to change a user events status, making this feature incomplete.

Until such a time as they are deemed absolutely necessary, with no viable alternative proposed, this patch removes support for user events.

Fixes #15.