### PR TITLE
Adding missing context enums

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -240,11 +240,42 @@ class ur_rect_region_t(Structure):
     ]
 
 ###############################################################################
+## @brief Supported memory order capabilities
+class ur_memory_order_flags_v(IntEnum):
+    RELAXED = UR_BIT(0)                             ## Memory order relaxed
+    ACQUIRE = UR_BIT(1)                             ## Memory order acquire
+    RELEASE = UR_BIT(2)                             ## Memory order release
+    ACQ_REL = UR_BIT(3)                             ## Memory order acquire-release
+    SEQ_CST = UR_BIT(4)                             ## Memory order sequentially-consistent
+
+class ur_memory_order_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Supported memory scopes
+class ur_memory_scope_flags_v(IntEnum):
+    WORK_ITEM = UR_BIT(0)                           ## Memory scope of work-item
+    SUB_GROUP = UR_BIT(1)                           ## Memory scope of sub-group
+    WORK_GROUP = UR_BIT(2)                          ## Memory scope of work-group
+    DEVICE = UR_BIT(3)                              ## Memory scope of device
+    SYSTEM = UR_BIT(4)                              ## Memory scope of system
+
+class ur_memory_scope_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
 ## @brief Supported context info
 class ur_context_info_v(IntEnum):
     NUM_DEVICES = 1                                 ## [uint32_t] The number of the devices in the context
-    DEVICES = 2                                     ## [::ur_context_handle_t...] The array of the device handles in the
+    DEVICES = 2                                     ## [::ur_device_handle_t...] The array of the device handles in the
                                                     ## context
+    REFERENCE_COUNT = 3                             ## [uint32_t] The reference count of the context
+    ATOMIC_MEMORY_ORDER_CAPABILITIES = 4            ## [::ur_memory_order_flags_t] Supported memory order capabilities
+    ATOMIC_MEMORY_SCOPE_CAPABILITIES = 5            ## [::ur_memory_scope_flags_t] Supported memory scopes
 
 class ur_context_info_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -335,12 +335,43 @@ urContextRetain(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported memory order capabilities
+typedef uint32_t ur_memory_order_flags_t;
+typedef enum ur_memory_order_flag_t
+{
+    UR_MEMORY_ORDER_FLAG_RELAXED = UR_BIT(0),       ///< Memory order relaxed
+    UR_MEMORY_ORDER_FLAG_ACQUIRE = UR_BIT(1),       ///< Memory order acquire
+    UR_MEMORY_ORDER_FLAG_RELEASE = UR_BIT(2),       ///< Memory order release
+    UR_MEMORY_ORDER_FLAG_ACQ_REL = UR_BIT(3),       ///< Memory order acquire-release
+    UR_MEMORY_ORDER_FLAG_SEQ_CST = UR_BIT(4),       ///< Memory order sequentially-consistent
+    UR_MEMORY_ORDER_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ur_memory_order_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Supported memory scopes
+typedef uint32_t ur_memory_scope_flags_t;
+typedef enum ur_memory_scope_flag_t
+{
+    UR_MEMORY_SCOPE_FLAG_WORK_ITEM = UR_BIT(0),     ///< Memory scope of work-item
+    UR_MEMORY_SCOPE_FLAG_SUB_GROUP = UR_BIT(1),     ///< Memory scope of sub-group
+    UR_MEMORY_SCOPE_FLAG_WORK_GROUP = UR_BIT(2),    ///< Memory scope of work-group
+    UR_MEMORY_SCOPE_FLAG_DEVICE = UR_BIT(3),        ///< Memory scope of device
+    UR_MEMORY_SCOPE_FLAG_SYSTEM = UR_BIT(4),        ///< Memory scope of system
+    UR_MEMORY_SCOPE_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ur_memory_scope_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported context info
 typedef enum ur_context_info_t
 {
     UR_CONTEXT_INFO_NUM_DEVICES = 1,                ///< [uint32_t] The number of the devices in the context
-    UR_CONTEXT_INFO_DEVICES = 2,                    ///< [::ur_context_handle_t...] The array of the device handles in the
+    UR_CONTEXT_INFO_DEVICES = 2,                    ///< [::ur_device_handle_t...] The array of the device handles in the
                                                     ///< context
+    UR_CONTEXT_INFO_REFERENCE_COUNT = 3,            ///< [uint32_t] The reference count of the context
+    UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 4,   ///< [::ur_memory_order_flags_t] Supported memory order capabilities
+    UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 5,   ///< [::ur_memory_scope_flags_t] Supported memory scopes
     UR_CONTEXT_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_context_info_t;
@@ -386,7 +417,7 @@ urContextRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_CONTEXT_INFO_DEVICES < ContextInfoType`
+///         + `::UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES < ContextInfoType`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextGetInfo(
     ur_context_handle_t hContext,                   ///< [in] handle of the context

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -60,6 +60,48 @@ params:
             [in] handle of the context to get a reference of.
 --- #--------------------------------------------------------------------------
 type: enum
+desc: "Supported memory order capabilities"
+class: $xContext
+name: $x_memory_order_flags_t
+etors:
+    - name: RELAXED
+      desc: "Memory order relaxed"
+      value: "$X_BIT(0)"
+    - name: ACQUIRE
+      desc: "Memory order acquire"
+      value: "$X_BIT(1)"
+    - name: RELEASE
+      desc: "Memory order release"
+      value: "$X_BIT(2)"
+    - name: ACQ_REL
+      desc: "Memory order acquire-release"
+      value: "$X_BIT(3)"
+    - name: SEQ_CST
+      desc: "Memory order sequentially-consistent"
+      value: "$X_BIT(4)"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Supported memory scopes"
+class: $xContext
+name: $x_memory_scope_flags_t
+etors:
+    - name: WORK_ITEM
+      desc: "Memory scope of work-item"
+      value: "$X_BIT(0)"
+    - name: SUB_GROUP
+      desc: "Memory scope of sub-group"
+      value: "$X_BIT(1)"
+    - name: WORK_GROUP
+      desc: "Memory scope of work-group"
+      value: "$X_BIT(2)"
+    - name: DEVICE
+      desc: "Memory scope of device"
+      value: "$X_BIT(3)"
+    - name: SYSTEM
+      desc: "Memory scope of system"
+      value: "$X_BIT(4)"
+--- #--------------------------------------------------------------------------
+type: enum
 desc: "Supported context info"
 class: $xContext
 name: $x_context_info_t
@@ -69,7 +111,16 @@ etors:
       desc: "[uint32_t] The number of the devices in the context"
     - name: DEVICES
       value: "2"
-      desc: "[$x_context_handle_t...] The array of the device handles in the context"
+      desc: "[$x_device_handle_t...] The array of the device handles in the context"
+    - name: REFERENCE_COUNT
+      value: "3"
+      desc: "[uint32_t] The reference count of the context"
+    - name: ATOMIC_MEMORY_ORDER_CAPABILITIES
+      value: "4"
+      desc: "[$x_memory_order_flags_t] Supported memory order capabilities"
+    - name: ATOMIC_MEMORY_SCOPE_CAPABILITIES
+      value: "5"
+      desc: "[$x_memory_scope_flags_t] Supported memory scopes"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Releases the context handle reference indicating end of its usage"

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -135,7 +135,7 @@ urContextRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_CONTEXT_INFO_DEVICES < ContextInfoType`
+///         + `::UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES < ContextInfoType`
 ur_result_t UR_APICALL
 urContextGetInfo(
     ur_context_handle_t hContext,                   ///< [in] handle of the context

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -123,7 +123,7 @@ urContextRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_CONTEXT_INFO_DEVICES < ContextInfoType`
+///         + `::UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES < ContextInfoType`
 ur_result_t UR_APICALL
 urContextGetInfo(
     ur_context_handle_t hContext,                   ///< [in] handle of the context


### PR DESCRIPTION
- PI_CONTEXT_INFO_PLATFORM - Its a useful information, used by some backend to make certain decision (device->platform->name). But this can also be done by context->getdevices->urDeviceGetInfo(UR_DEVICE_INFO_PLATFORM)->urGetPlatformInfo(PLATFORM_NAME). Not adding this.

- PI_CONTEXT_INFO_REFERENCE_COUNT - Cant find its usage. UR has the concept of context acquire/release, but no way to query its reference count. Its inconsistent, for device which also has acq/rel, we have a UR_DEVICE_INFO_REFERENCE_COUNT. Adding this to make it consistent.

- PI_CONTEXT_INFO_ATOMIC_MEMORY_[ORDER|SCOPE]_CAPABILITIES - used to populate sycl device info for order/scope capabilities.

Fixes: https://github.com/oneapi-src/unified-runtime/issues/75