### PR TITLE
Fix include directories for loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 project(unified-runtime VERSION 0.5.0)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_subdirectory(hello_world)

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -16,7 +16,7 @@ if(MSVC)
     )
 endif()
 
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(${TARGET_NAME} PRIVATE
     ${PROJECT_NAME}::loader
     ${CMAKE_DL_LIBS}
 )

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
+
 set(TARGET_NAME hello_world)
 
 add_executable(${TARGET_NAME}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_definitions(-DUR_VERSION="${PROJECT_VERSION_MAJOR}")
 add_definitions(-DUR_VALIDATION_LAYER_SUPPORTED_VERSION="${PROJECT_VERSION_MAJOR}")
 
+add_subdirectory(common)
 add_subdirectory(loader)
 #add_subdirectory(layers)
 add_subdirectory(drivers)

--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+add_library(common INTERFACE)
+add_library(${PROJECT_NAME}::common ALIAS common)
+
+target_include_directories(common INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/source/drivers/CMakeLists.txt
+++ b/source/drivers/CMakeLists.txt
@@ -1,1 +1,4 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
+
 add_subdirectory(null)

--- a/source/drivers/null/CMakeLists.txt
+++ b/source/drivers/null/CMakeLists.txt
@@ -12,11 +12,9 @@ set_target_properties(${TARGET_NAME} PROPERTIES
     SOVERSION "${PROJECT_VERSION_MAJOR}"
 )
 
-target_include_directories(${TARGET_NAME}
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_SOURCE_DIR}/include
-        ${CMAKE_SOURCE_DIR}/source/common
+target_link_libraries(${TARGET_NAME} PRIVATE
+    ${PROJECT_NAME}::headers
+    ${PROJECT_NAME}::common
 )
 
 if(UNIX)

--- a/source/drivers/null/CMakeLists.txt
+++ b/source/drivers/null/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
+
 set(TARGET_NAME ur_null)
 
 add_library(${TARGET_NAME}

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -18,18 +18,15 @@ set_target_properties(loader PROPERTIES
 
 add_library(${PROJECT_NAME}::loader ALIAS loader)
 
-target_include_directories(loader PRIVATE
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/source/common
-    ${CMAKE_SOURCE_DIR}/source/loader
-)
+target_include_directories(loader PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_target_properties(loader PROPERTIES
     VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
     SOVERSION "${PROJECT_VERSION_MAJOR}"
 )
 
-target_link_libraries(loader
+target_link_libraries(loader PRIVATE
+    ${PROJECT_NAME}::common
     ${PROJECT_NAME}::headers
     ${CMAKE_DL_LIBS}
 )
@@ -38,11 +35,11 @@ if (UNIX)
     set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
     set(THREADS_PREFER_PTHREAD_FLAG TRUE)
     find_package(Threads REQUIRED)
-    target_link_libraries(loader Threads::Threads)
+    target_link_libraries(loader PRIVATE Threads::Threads)
 endif()
 
 if(WIN32)
-    target_link_libraries(loader cfgmgr32.lib)
+    target_link_libraries(loader PRIVATE cfgmgr32.lib)
 endif()
 
 if(UNIX)

--- a/source/loader/linux/platform_discovery_lin.cpp
+++ b/source/loader/linux/platform_discovery_lin.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "source/loader/platform_discovery.h"
+#include "platform_discovery.h"
 
 #include "ur_util.h"
 #include <iostream>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,1 +1,3 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: MIT
 # Placeholder to fix FetchContent issues for projects from outside


### PR DESCRIPTION
When unified-runtime is built as part of another CMakeProject (through add_subdirectory) the paths will not be correct. It's better to use relative paths.

CMAKE_SOURCE_DIR would point to the top level of the other project directory, not unified-runtime top level dir.