### PR TITLE
[ur] Add missing Queue Properties

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -521,6 +521,9 @@ class ur_queue_flags_v(IntEnum):
     PROFILING_ENABLE = UR_BIT(1)                    ## Enable/disable profiling
     ON_DEVICE = UR_BIT(2)                           ## Is a device queue
     ON_DEVICE_DEFAULT = UR_BIT(3)                   ## Is the default queue for a device
+    DISCARD_EVENTS = UR_BIT(4)                      ## Events will be discarded
+    PRIORITY_LOW = UR_BIT(5)                        ## Low priority queue
+    PRIORITY_HIGH = UR_BIT(6)                       ## High priority queue
 
 class ur_queue_flags_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2191,6 +2191,9 @@ typedef enum ur_queue_flag_t
     UR_QUEUE_FLAG_PROFILING_ENABLE = UR_BIT(1),     ///< Enable/disable profiling
     UR_QUEUE_FLAG_ON_DEVICE = UR_BIT(2),            ///< Is a device queue
     UR_QUEUE_FLAG_ON_DEVICE_DEFAULT = UR_BIT(3),    ///< Is the default queue for a device
+    UR_QUEUE_FLAG_DISCARD_EVENTS = UR_BIT(4),       ///< Events will be discarded
+    UR_QUEUE_FLAG_PRIORITY_LOW = UR_BIT(5),         ///< Low priority queue
+    UR_QUEUE_FLAG_PRIORITY_HIGH = UR_BIT(6),        ///< High priority queue
     UR_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_queue_flag_t;

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -45,6 +45,15 @@ etors:
     - name: ON_DEVICE_DEFAULT
       value: "$X_BIT(3)"
       desc: "Is the default queue for a device"
+    - name: DISCARD_EVENTS
+      value: "$X_BIT(4)"
+      desc: "Events will be discarded"
+    - name: PRIORITY_LOW
+      value: "$X_BIT(5)"
+      desc: "Low priority queue"
+    - name: PRIORITY_HIGH
+      value: "$X_BIT(6)"
+      desc: "High priority queue"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Queue Properties"


### PR DESCRIPTION
Adds Queue Properties to unified runtime to support [`sycl_ext_oneapi_discard_queue_events`](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_discard_queue_events.asciidoc) & 
[`sycl_ext_oneapi_queue_priority`](sycl_ext_oneapi_queue_priority).
Closes #112 