### PR TITLE
cmake: Don't add generate to the all target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,21 +109,15 @@ install(
 set(API_JSON_FILE ${PROJECT_BINARY_DIR}/unified_runtime.json)
 
 # generate source from the specification
-add_custom_command (
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/scripts
-    DEPENDS ${CMAKE_SOURCE_DIR}/scripts/*
-    OUTPUT ${API_JSON_FILE}
+add_custom_target(generate
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
     COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE}
-    COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${CMAKE_SOURCE_DIR}
-)
-
-add_custom_target(generate ALL
-    DEPENDS ${API_JSON_FILE}
+    COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
 )
 
 # generate source and check for uncommitted diffs
 add_custom_target(check-generated
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMAND git diff --exit-code
     DEPENDS generate
 )


### PR DESCRIPTION
This patch fixes a couple of issues, first being this error:

```
$ ninja -C build
ninja: Entering directory `build'
ninja: error: '../scripts/*', needed by 'unified_runtime.json', missing and no known rule to make it
```

The error is caused by the use of a `*` wildcard which are not well supported in CMake as they only perform globing at configure time, not during the build which is usually the desired effect. This is resolved by merging the `add_custom_command` into the `generate` custom target.

Second, the `generate` target's `ALL` flag has been removed. While it may seem appealing to regenerate the source code by default this actually causes issues with build targets that depend on that generated code. Given there are no dependencies for e.g. the `loader` on the `generate` target, these could run in parallel.

This is problematic as the `loader` source files could be tramped by the `generate` target and in the worst cause causing compile or link errors. This is resolved by removing the `generate` target from being built by default i.e. removing the `ALL` flag from the custom target. Given the CI invokes the `generate` target explicitly this should only affect local development which is also when source file generation resulting in changes is most likely to occur.