### PR TITLE
Add missing affinity domains

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -791,7 +791,11 @@ class ur_device_exec_capability_flags_t(c_int):
 ## @brief Device affinity domain
 class ur_device_affinity_domain_flags_v(IntEnum):
     NUMA = UR_BIT(0)                                ## By NUMA
-    NEXT_PARTITIONABLE = UR_BIT(1)                  ## BY next partitionable
+    NEXT_PARTITIONABLE = UR_BIT(1)                  ## By next partitionable
+    L4_CACHE = UR_BIT(2)                            ## By L4 Cache
+    L3_CACHE = UR_BIT(3)                            ## By L3 Cache
+    L2_CACHE = UR_BIT(4)                            ## By L2 Cache
+    L1_CACHE = UR_BIT(5)                            ## By L1 Cache
 
 class ur_device_affinity_domain_flags_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3092,7 +3092,11 @@ typedef uint32_t ur_device_affinity_domain_flags_t;
 typedef enum ur_device_affinity_domain_flag_t
 {
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),///< By NUMA
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1),  ///< BY next partitionable
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1),  ///< By next partitionable
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE = UR_BIT(2),///< By L4 Cache
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE = UR_BIT(3),///< By L3 Cache
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE = UR_BIT(4),///< By L2 Cache
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE = UR_BIT(5),///< By L1 Cache
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_affinity_domain_flag_t;

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -509,8 +509,20 @@ etors:
       desc: "By NUMA"
       value: "$X_BIT(0)"
     - name: NEXT_PARTITIONABLE
-      desc: "BY next partitionable"
+      desc: "By next partitionable"
       value: "$X_BIT(1)"
+    - name: L4_CACHE
+      desc: "By L4 Cache"
+      value: "$X_BIT(2)"
+    - name: L3_CACHE
+      desc: "By L3 Cache"
+      value: "$X_BIT(3)"
+    - name: L2_CACHE
+      desc: "By L2 Cache"
+      value: "$X_BIT(4)"
+    - name: L1_CACHE
+      desc: "By L1 Cache"
+      value: "$X_BIT(5)"
 --- #--------------------------------------------------------------------------
 type: class
 desc: "C++ wrapper for a device"


### PR DESCRIPTION
Add missing cache affinity domains to device affinity domains
enumeration. Fixes https://github.com/oneapi-src/unified-runtime/issues/115.