### PR TITLE
Search for known adapter library in the current working directory on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,7 +54,11 @@ jobs:
         run: cmake -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -B ${{github.workspace}}/build
 
       - name: Generate source from spec, check for uncommitted diff
-        run: cmake --build ${{github.workspace}}/build --target check-generated
+        run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{env.BUILD_TYPE}}
 
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build
+      - name: Build all
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,12 @@ include(CTest)
 
 find_package(Python3 COMPONENTS Interpreter)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+if(MSVC)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/$<CONFIG>)
+endif()
 
 # define rpath for libraries so that adapters can be found automatically
 set(CMAKE_BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")

--- a/include/ur.py
+++ b/include/ur.py
@@ -10,6 +10,7 @@
 import platform
 from ctypes import *
 from enum import *
+import os
 
 ###############################################################################
 __version__ = "1.0"
@@ -1945,7 +1946,9 @@ class UR_DDI:
     def __init__(self, version : ur_api_version_t):
         # load the ur_loader library
         if "Windows" == platform.uname()[0]:
-            self.__dll = WinDLL("ur_loader.dll")
+            os.add_dll_directory(os.getenv("UR_ADAPTERS_SEARCH_DIR"))
+            LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
+            self.__dll = WinDLL("ur_loader.dll", winmode=LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
         else:
             self.__dll = CDLL("libur_loader.so")
 

--- a/scripts/templates/api.py.mako
+++ b/scripts/templates/api.py.mako
@@ -19,6 +19,7 @@ from templates import helper as th
 import platform
 from ctypes import *
 from enum import *
+import os
 
 ${"###############################################################################"}
 __version__ = "1.0"
@@ -162,7 +163,9 @@ class ${N}_DDI:
     def __init__(self, version : ${x}_api_version_t):
         # load the ${x}_loader library
         if "Windows" == platform.uname()[0]:
-            self.__dll = WinDLL("${x}_loader.dll")
+            os.add_dll_directory(os.getenv("UR_ADAPTERS_SEARCH_DIR"))
+            LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
+            self.__dll = WinDLL("${x}_loader.dll", winmode=LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
         else:
             self.__dll = CDLL("lib${x}_loader.so")
 

--- a/source/common/ur_util.h
+++ b/source/common/ur_util.h
@@ -18,7 +18,7 @@
 #  include <Windows.h>
 #  define MAKE_LIBRARY_NAME(NAME, VERSION)    NAME".dll"
 #  define MAKE_LAYER_NAME(NAME)    NAME".dll"
-#  define LOAD_DRIVER_LIBRARY(NAME) LoadLibraryExA(NAME, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32)
+#  define LOAD_DRIVER_LIBRARY(NAME) LoadLibraryExA(NAME, nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
 #  define FREE_DRIVER_LIBRARY(LIB)  if(LIB) FreeLibrary(LIB)
 #  define GET_FUNCTION_PTR(LIB, FUNC_NAME) GetProcAddress(LIB, FUNC_NAME)
 #  define string_copy_s strncpy_s

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(loader
 
 set_target_properties(loader PROPERTIES
     LIBRARY_OUTPUT_NAME ur_loader
+    RUNTIME_OUTPUT_NAME ur_loader
 )
 
 add_library(${PROJECT_NAME}::loader ALIAS loader)

--- a/source/loader/windows/platform_discovery_win.cpp
+++ b/source/loader/windows/platform_discovery_win.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "platform_discovery.h"
+#include "ur_util.h"
 
 #include <Windows.h>
 
@@ -20,9 +21,17 @@
 
 namespace loader {
 
+static const char *knownAdaptersNames[] = {
+  MAKE_LIBRARY_NAME("ur_null", UR_VERSION),
+};
+
 std::vector<PlatformLibraryPath> discoverEnabledPlatforms() {
-    //TODO:Enable windows driver discovery
     std::vector<PlatformLibraryPath> enabledPlatforms;
+
+    for (auto libName : knownAdaptersNames) {
+      enabledPlatforms.emplace_back(libName);
+    }
+
     return enabledPlatforms;
 }
 } // namespace loader

--- a/source/loader/windows/platform_discovery_win.cpp
+++ b/source/loader/windows/platform_discovery_win.cpp
@@ -28,10 +28,22 @@ static const char *knownAdaptersNames[] = {
 std::vector<PlatformLibraryPath> discoverEnabledPlatforms() {
     std::vector<PlatformLibraryPath> enabledPlatforms;
 
-    for (auto libName : knownAdaptersNames) {
-      enabledPlatforms.emplace_back(libName);
+    // UR_ENABLE_ALT_DRIVERS is for development/debug only
+    const char *altPlatforms = getenv("UR_ENABLE_ALT_DRIVERS");
+    
+    if (altPlatforms == nullptr) {
+        for (auto libName : knownAdaptersNames) {
+          enabledPlatforms.emplace_back(libName);
+        }
+    } else {
+        std::stringstream ss(altPlatforms);
+        while (ss.good()) {
+          std::string substr;
+          getline(ss, substr, ',');
+          enabledPlatforms.emplace_back(substr);
+        }
     }
-
     return enabledPlatforms;
 }
+
 } // namespace loader

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -11,4 +11,11 @@ add_test(NAME python-basic
 if(UNIX)
         set_property(TEST python-basic PROPERTY
                 ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+else()
+        set_property(TEST python-basic PROPERTY
+                     ENVIRONMENT "UR_ADAPTERS_SEARCH_DIR=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 endif()
+
+# this is for importing the include/ur.py module in other python files
+set_property(TEST python-basic APPEND PROPERTY
+             ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}")

--- a/test/python/basic.py
+++ b/test/python/basic.py
@@ -10,10 +10,7 @@ import pytest
 import sys
 import os
 
-# not ideal, but this solution is simple and portable. Alternative is to set
-# PYTHONPATH or test on installed sources.
-sys.path.insert(1, '../include')
-import ur
+import include.ur as ur
 
 def test_ddi():
         ddi = ur.UR_DDI(ur.ur_api_version_v.CURRENT);


### PR DESCRIPTION
This is related to the task no. 1 from the issue #128.

This PR allows us to run the hello_world example with the null adapter library on Windows. Additionally, this PR makes it possible that some more adapters could be loaded in the future (with an env var) on Windows.