### PR TITLE
Rename UR_ENABLE_ALT_DRIVERS env var

### DIFF
--- a/source/loader/linux/platform_discovery_lin.cpp
+++ b/source/loader/linux/platform_discovery_lin.cpp
@@ -23,8 +23,8 @@ std::vector<PlatformLibraryPath> discoverEnabledPlatforms() {
   std::vector<PlatformLibraryPath> enabledPlatforms;
   const char *altPlatforms = nullptr;
 
-  // UR_ENABLE_ALT_DRIVERS is for development/debug only
-  altPlatforms = getenv("UR_ENABLE_ALT_DRIVERS");
+  // UR_ADAPTERS_FORCE_LOAD  is for development/debug only
+  altPlatforms = getenv("UR_ADAPTERS_FORCE_LOAD ");
   if (altPlatforms == nullptr) {
     for (auto path : knownPlatformNames) {
       enabledPlatforms.emplace_back(path);

--- a/source/loader/windows/platform_discovery_win.cpp
+++ b/source/loader/windows/platform_discovery_win.cpp
@@ -28,8 +28,8 @@ static const char *knownAdaptersNames[] = {
 std::vector<PlatformLibraryPath> discoverEnabledPlatforms() {
     std::vector<PlatformLibraryPath> enabledPlatforms;
 
-    // UR_ENABLE_ALT_DRIVERS is for development/debug only
-    const char *altPlatforms = getenv("UR_ENABLE_ALT_DRIVERS");
+    // UR_ADAPTERS_FORCE_LOAD  is for development/debug only
+    const char *altPlatforms = getenv("UR_ADAPTERS_FORCE_LOAD ");
     
     if (altPlatforms == nullptr) {
         for (auto libName : knownAdaptersNames) {


### PR DESCRIPTION
Rename it so the new name describes better what is it for and doesn't
mention 'drivers' as it's taken from level-zero loader.