### PR TITLE
Use PATH env var to pass .dll location to tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.0 FATAL_ERROR)
 project(unified-runtime VERSION 0.5.0)
 
 include(GNUInstallDirs)

--- a/include/ur.py
+++ b/include/ur.py
@@ -2017,9 +2017,8 @@ class UR_DDI:
     def __init__(self, version : ur_api_version_t):
         # load the ur_loader library
         if "Windows" == platform.uname()[0]:
-            os.add_dll_directory(os.getenv("UR_ADAPTERS_SEARCH_DIR"))
-            LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-            self.__dll = WinDLL("ur_loader.dll", winmode=LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+            os.add_dll_directory(os.getenv("PATH").split(";")[0])
+            self.__dll = WinDLL("ur_loader.dll", winmode=0)
         else:
             self.__dll = CDLL("libur_loader.so")
 

--- a/scripts/templates/api.py.mako
+++ b/scripts/templates/api.py.mako
@@ -163,9 +163,8 @@ class ${N}_DDI:
     def __init__(self, version : ${x}_api_version_t):
         # load the ${x}_loader library
         if "Windows" == platform.uname()[0]:
-            os.add_dll_directory(os.getenv("UR_ADAPTERS_SEARCH_DIR"))
-            LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
-            self.__dll = WinDLL("${x}_loader.dll", winmode=LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
+            os.add_dll_directory(os.getenv("PATH").split(";")[0])
+            self.__dll = WinDLL("${x}_loader.dll", winmode=0)
         else:
             self.__dll = CDLL("lib${x}_loader.so")
 

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -6,14 +6,14 @@ add_test(NAME python-basic
         COMMAND ${Python3_EXECUTABLE} -B -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/basic.py
 )
 
-# python uses LD_LIBRARY_PATH to search for dynamic libraries, so set it to
-# the location where it can find the loader.
+# python uses LD_LIBRARY_PATH (PATH on Windows) to search for dynamic libraries,
+# so set it to the location where it can find the loader.
 if(UNIX)
         set_property(TEST python-basic PROPERTY
                 ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 else()
         set_property(TEST python-basic PROPERTY
-                     ENVIRONMENT "UR_ADAPTERS_SEARCH_DIR=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+                     ENVIRONMENT_MODIFICATION "PATH=cmake_list_prepend:${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 endif()
 
 # this is for importing the include/ur.py module in other python files


### PR DESCRIPTION
Removes extra env var UR_ADAPTERS_SEARCH_DIR and bumps the minimum required cmake version to 3.22.