### PR TITLE
[ur] Add entrypoints to support device globals

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1751,6 +1751,20 @@ if __use_win_types:
 else:
     _urEnqueueUSMMemcpy2D_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_bool, c_void_p, c_size_t, c_void_p, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 
+###############################################################################
+## @brief Function-pointer for urEnqueueDeviceGlobalVariableWrite
+if __use_win_types:
+    _urEnqueueDeviceGlobalVariableWrite_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_program_handle_t, c_char_p, c_bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueDeviceGlobalVariableWrite_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_program_handle_t, c_char_p, c_bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urEnqueueDeviceGlobalVariableRead
+if __use_win_types:
+    _urEnqueueDeviceGlobalVariableRead_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_program_handle_t, c_char_p, c_bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urEnqueueDeviceGlobalVariableRead_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_program_handle_t, c_char_p, c_bool, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
 
 ###############################################################################
 ## @brief Table of Enqueue functions pointers
@@ -1777,7 +1791,9 @@ class ur_enqueue_dditable_t(Structure):
         ("pfnUSMMemAdvice", c_void_p),                                  ## _urEnqueueUSMMemAdvice_t
         ("pfnUSMFill2D", c_void_p),                                     ## _urEnqueueUSMFill2D_t
         ("pfnUSMMemset2D", c_void_p),                                   ## _urEnqueueUSMMemset2D_t
-        ("pfnUSMMemcpy2D", c_void_p)                                    ## _urEnqueueUSMMemcpy2D_t
+        ("pfnUSMMemcpy2D", c_void_p),                                   ## _urEnqueueUSMMemcpy2D_t
+        ("pfnDeviceGlobalVariableWrite", c_void_p),                     ## _urEnqueueDeviceGlobalVariableWrite_t
+        ("pfnDeviceGlobalVariableRead", c_void_p)                       ## _urEnqueueDeviceGlobalVariableRead_t
     ]
 
 ###############################################################################
@@ -2194,6 +2210,8 @@ class UR_DDI:
         self.urEnqueueUSMFill2D = _urEnqueueUSMFill2D_t(self.__dditable.Enqueue.pfnUSMFill2D)
         self.urEnqueueUSMMemset2D = _urEnqueueUSMMemset2D_t(self.__dditable.Enqueue.pfnUSMMemset2D)
         self.urEnqueueUSMMemcpy2D = _urEnqueueUSMMemcpy2D_t(self.__dditable.Enqueue.pfnUSMMemcpy2D)
+        self.urEnqueueDeviceGlobalVariableWrite = _urEnqueueDeviceGlobalVariableWrite_t(self.__dditable.Enqueue.pfnDeviceGlobalVariableWrite)
+        self.urEnqueueDeviceGlobalVariableRead = _urEnqueueDeviceGlobalVariableRead_t(self.__dditable.Enqueue.pfnDeviceGlobalVariableRead)
 
         # call driver to get function pointers
         USM = ur_usm_dditable_t()

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1454,6 +1454,68 @@ urEnqueueUSMMemcpy2D(
                                                     ///< particular kernel execution instance.
     );
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to write data from host to device global variable
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == name`
+///         + `NULL == pSrc`
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    const char* name,                               ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                             ///< [in] indicates if this operation should block.
+    size_t count,                                   ///< [in] the number of bytes to copy.
+    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+    const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to read data from a device global variable to host
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == name`
+///         + `NULL == pDst`
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    const char* name,                               ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                              ///< [in] indicates if this operation should block.
+    size_t count,                                   ///< [in] the number of bytes to copy.
+    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+    void* pDst,                                     ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.    
+    );
+
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
@@ -6819,6 +6881,68 @@ typedef void (UR_APICALL *ur_pfnEnqueueUSMMemcpy2DCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for urEnqueueDeviceGlobalVariableWrite 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_enqueue_device_global_variable_write_params_t
+{
+    ur_queue_handle_t* phQueue;
+    ur_program_handle_t* phProgram;
+    const char** pname;
+    bool* pblockingWrite;
+    size_t* pcount;
+    size_t* poffset;
+    const void** ppSrc;
+    uint32_t* pnumEventsInWaitList;
+    const ur_event_handle_t** pphEventWaitList;
+    ur_event_handle_t** pphEvent;
+} ur_enqueue_device_global_variable_write_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for urEnqueueDeviceGlobalVariableWrite 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableWriteCb_t)(
+    ur_enqueue_device_global_variable_write_params_t* params,
+    ur_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function parameters for urEnqueueDeviceGlobalVariableRead 
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_enqueue_device_global_variable_read_params_t
+{
+    ur_queue_handle_t* phQueue;
+    ur_program_handle_t* phProgram;
+    const char** pname;
+    bool* pblockingRead;
+    size_t* pcount;
+    size_t* poffset;
+    void** ppDst;
+    uint32_t* pnumEventsInWaitList;
+    const ur_event_handle_t** pphEventWaitList;
+    ur_event_handle_t** pphEvent;
+} ur_enqueue_device_global_variable_read_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function-pointer for urEnqueueDeviceGlobalVariableRead 
+/// @param[in] params Parameters passed to this instance
+/// @param[in] result Return value
+/// @param[in] pTracerUserData Per-Tracer user data
+/// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
+typedef void (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableReadCb_t)(
+    ur_enqueue_device_global_variable_read_params_t* params,
+    ur_result_t result,
+    void* pTracerUserData,
+    void** ppTracerInstanceUserData
+    );
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Enqueue callback functions pointers
 typedef struct ur_enqueue_callbacks_t
 {
@@ -6844,6 +6968,8 @@ typedef struct ur_enqueue_callbacks_t
     ur_pfnEnqueueUSMFill2DCb_t                                      pfnUSMFill2DCb;
     ur_pfnEnqueueUSMMemset2DCb_t                                    pfnUSMMemset2DCb;
     ur_pfnEnqueueUSMMemcpy2DCb_t                                    pfnUSMMemcpy2DCb;
+    ur_pfnEnqueueDeviceGlobalVariableWriteCb_t                      pfnDeviceGlobalVariableWriteCb;
+    ur_pfnEnqueueDeviceGlobalVariableReadCb_t                       pfnDeviceGlobalVariableReadCb;
 } ur_enqueue_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1455,7 +1455,8 @@ urEnqueueUSMMemcpy2D(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command to write data from host to device global variable
+/// @brief Enqueue a command to write data from the host to device global
+///        variable.
 /// 
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1470,13 +1471,13 @@ urEnqueueUSMMemcpy2D(
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
     const char* name,                               ///< [in] the unique identifier for the device global variable.
     bool blockingWrite,                             ///< [in] indicates if this operation should block.
     size_t count,                                   ///< [in] the number of bytes to copy.
     size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
     const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
@@ -1486,7 +1487,8 @@ urEnqueueDeviceGlobalVariableWrite(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command to read data from a device global variable to host
+/// @brief Enqueue a command to read data from a device global variable to the
+///        host.
 /// 
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1501,13 +1503,13 @@ urEnqueueDeviceGlobalVariableWrite(
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
     const char* name,                               ///< [in] the unique identifier for the device global variable.
     bool blockingRead,                              ///< [in] indicates if this operation should block.
     size_t count,                                   ///< [in] the number of bytes to copy.
     size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
     void* pDst,                                     ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1154,6 +1154,36 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemcpy2D_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueDeviceGlobalVariableWrite 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableWrite_t)(
+    ur_queue_handle_t,
+    ur_program_handle_t,
+    const char*,
+    bool,
+    size_t,
+    size_t,
+    const void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueDeviceGlobalVariableRead 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableRead_t)(
+    ur_queue_handle_t,
+    ur_program_handle_t,
+    const char*,
+    bool,
+    size_t,
+    size_t,
+    void*,
+    uint32_t,
+    const ur_event_handle_t*,
+    ur_event_handle_t*
+    );
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Enqueue functions pointers
 typedef struct ur_enqueue_dditable_t
 {
@@ -1179,6 +1209,8 @@ typedef struct ur_enqueue_dditable_t
     ur_pfnEnqueueUSMFill2D_t                                    pfnUSMFill2D;
     ur_pfnEnqueueUSMMemset2D_t                                  pfnUSMMemset2D;
     ur_pfnEnqueueUSMMemcpy2D_t                                  pfnUSMMemcpy2D;
+    ur_pfnEnqueueDeviceGlobalVariableWrite_t                    pfnDeviceGlobalVariableWrite;
+    ur_pfnEnqueueDeviceGlobalVariableRead_t                     pfnDeviceGlobalVariableRead;
 } ur_enqueue_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -1175,3 +1175,83 @@ params:
             [in,out][optional] return an event object that identifies this particular kernel execution instance.
 returns:
   - $X_RESULT_ERROR_UNSUPPORTED_FEATURE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Enqueue a command to write data from host to device global variable"
+class: $xEnqueue
+name: DeviceGlobalVariableWrite
+ordinal: "0"
+params:
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] handle of the queue to submit to."
+    - type: $x_program_handle_t
+      name: hProgram
+      desc: "[in] the program containing the device global."
+    - type: const char*
+      name: name
+      desc: "[in] the unique identifier for the device global variable."
+    - type: bool
+      name: blockingWrite
+      desc: "[in] indicates if this operation should block."
+    - type: size_t
+      name: count
+      desc: "[in] the number of bytes to copy."
+    - type: size_t
+      name: offset
+      desc: "[in] the byte offset into the device global variable to start copying."
+    - type: const void*
+      name: pSrc
+      desc: "[in] pointer to where the data must be copied from."
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before the kernel execution.
+            If nullptr, the numEventsInWaitList must be 0, indicating that no wait event. 
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [in,out][optional] return an event object that identifies this particular kernel execution instance.
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Enqueue a command to read data from a device global variable to host"
+class: $xEnqueue
+name: DeviceGlobalVariableRead
+ordinal: "0"
+params:
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] handle of the queue to submit to."
+    - type: $x_program_handle_t
+      name: hProgram
+      desc: "[in] the program containing the device global."
+    - type: const char*
+      name: name
+      desc: "[in] the unique identifier for the device global variable."
+    - type: bool
+      name: blockingRead
+      desc: "[in] indicates if this operation should block."
+    - type: size_t
+      name: count
+      desc: "[in] the number of bytes to copy."
+    - type: size_t
+      name: offset
+      desc: "[in] the byte offset into the device global variable to start copying."
+    - type: void*
+      name: pDst
+      desc: "[in] pointer to where the data must be copied to."
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before the kernel execution.
+            If nullptr, the numEventsInWaitList must be 0, indicating that no wait event. 
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [in,out][optional] return an event object that identifies this particular kernel execution instance.    

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -1187,7 +1187,7 @@ params:
       desc: "[in] handle of the queue to submit to."
     - type: $x_program_handle_t
       name: hProgram
-      desc: "[in] the program containing the device global."
+      desc: "[in] handle of the program containing the device global variable."
     - type: const char*
       name: name
       desc: "[in] the unique identifier for the device global variable."
@@ -1205,7 +1205,7 @@ params:
       desc: "[in] pointer to where the data must be copied from."
     - type: uint32_t
       name: numEventsInWaitList
-      desc: "[in] size of the event wait list"
+      desc: "[in] size of the event wait list."
     - type: "const $x_event_handle_t*"
       name: phEventWaitList
       desc: |
@@ -1217,7 +1217,7 @@ params:
             [in,out][optional] return an event object that identifies this particular kernel execution instance.
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Enqueue a command to read data from a device global variable to host"
+desc: "Enqueue a command to read data from a device global variable to the host."
 class: $xEnqueue
 name: DeviceGlobalVariableRead
 ordinal: "0"
@@ -1227,7 +1227,7 @@ params:
       desc: "[in] handle of the queue to submit to."
     - type: $x_program_handle_t
       name: hProgram
-      desc: "[in] the program containing the device global."
+      desc: "[in] handle of the program containing the device global variable."
     - type: const char*
       name: name
       desc: "[in] the unique identifier for the device global variable."
@@ -1245,7 +1245,7 @@ params:
       desc: "[in] pointer to where the data must be copied to."
     - type: uint32_t
       name: numEventsInWaitList
-      desc: "[in] size of the event wait list"
+      desc: "[in] size of the event wait list."
     - type: "const $x_event_handle_t*"
       name: phEventWaitList
       desc: |

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -1177,7 +1177,7 @@ returns:
   - $X_RESULT_ERROR_UNSUPPORTED_FEATURE
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Enqueue a command to write data from host to device global variable"
+desc: "Enqueue a command to write data from the host to device global variable."
 class: $xEnqueue
 name: DeviceGlobalVariableWrite
 ordinal: "0"

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -1061,6 +1061,82 @@ namespace driver
     }
 
     ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueDeviceGlobalVariableWrite(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        const char* name,                               ///< [in] the unique identifier for the device global variable.
+        bool blockingWrite,                             ///< [in] indicates if this operation should block.
+        size_t count,                                   ///< [in] the number of bytes to copy.
+        size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+        const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        ur_result_t result = UR_RESULT_SUCCESS;
+
+        // if the driver has created a custom function, then call it instead of using the generic path
+        auto pfnDeviceGlobalVariableWrite = d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+        if( nullptr != pfnDeviceGlobalVariableWrite )
+        {
+            result = pfnDeviceGlobalVariableWrite( hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+        }
+        else
+        {
+            // generic implementation
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+
+        }
+
+        return result;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueDeviceGlobalVariableRead(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        const char* name,                               ///< [in] the unique identifier for the device global variable.
+        bool blockingRead,                              ///< [in] indicates if this operation should block.
+        size_t count,                                   ///< [in] the number of bytes to copy.
+        size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+        void* pDst,                                     ///< [in] pointer to where the data must be copied to.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.    
+        )
+    {
+        ur_result_t result = UR_RESULT_SUCCESS;
+
+        // if the driver has created a custom function, then call it instead of using the generic path
+        auto pfnDeviceGlobalVariableRead = d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+        if( nullptr != pfnDeviceGlobalVariableRead )
+        {
+            result = pfnDeviceGlobalVariableRead( hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+        }
+        else
+        {
+            // generic implementation
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+
+        }
+
+        return result;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for urEventGetInfo
     __urdlllocal ur_result_t UR_APICALL
     urEventGetInfo(
@@ -3391,6 +3467,10 @@ urGetEnqueueProcAddrTable(
     pDdiTable->pfnUSMMemset2D                            = driver::urEnqueueUSMMemset2D;
 
     pDdiTable->pfnUSMMemcpy2D                            = driver::urEnqueueUSMMemcpy2D;
+
+    pDdiTable->pfnDeviceGlobalVariableWrite              = driver::urEnqueueDeviceGlobalVariableWrite;
+
+    pDdiTable->pfnDeviceGlobalVariableRead               = driver::urEnqueueDeviceGlobalVariableRead;
 
     return result;
 }

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -1065,13 +1065,13 @@ namespace driver
     __urdlllocal ur_result_t UR_APICALL
     urEnqueueDeviceGlobalVariableWrite(
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
         const char* name,                               ///< [in] the unique identifier for the device global variable.
         bool blockingWrite,                             ///< [in] indicates if this operation should block.
         size_t count,                                   ///< [in] the number of bytes to copy.
         size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
         const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
-        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
         const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                         ///< events that must be complete before the kernel execution.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
@@ -1103,13 +1103,13 @@ namespace driver
     __urdlllocal ur_result_t UR_APICALL
     urEnqueueDeviceGlobalVariableRead(
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
         const char* name,                               ///< [in] the unique identifier for the device global variable.
         bool blockingRead,                              ///< [in] indicates if this operation should block.
         size_t count,                                   ///< [in] the number of bytes to copy.
         size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
         void* pDst,                                     ///< [in] pointer to where the data must be copied to.
-        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
         const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                         ///< events that must be complete before the kernel execution.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1583,6 +1583,128 @@ namespace loader
     }
 
     ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueDeviceGlobalVariableWrite(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        const char* name,                               ///< [in] the unique identifier for the device global variable.
+        bool blockingWrite,                             ///< [in] indicates if this operation should block.
+        size_t count,                                   ///< [in] the number of bytes to copy.
+        size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+        const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        ur_result_t result = UR_RESULT_SUCCESS;
+
+        // extract platform's function pointer table
+        auto dditable = reinterpret_cast<ur_queue_object_t*>( hQueue )->dditable;
+        auto pfnDeviceGlobalVariableWrite = dditable->ur.Enqueue.pfnDeviceGlobalVariableWrite;
+        if( nullptr == pfnDeviceGlobalVariableWrite )
+            return UR_RESULT_ERROR_UNINITIALIZED;
+
+        // convert loader handle to platform handle
+        hQueue = reinterpret_cast<ur_queue_object_t*>( hQueue )->handle;
+
+        // convert loader handle to platform handle
+        hProgram = reinterpret_cast<ur_program_object_t*>( hProgram )->handle;
+
+        // convert loader handles to platform handles
+        auto phEventWaitListLocal = new ur_event_handle_t [numEventsInWaitList];
+        for( size_t i = 0; ( nullptr != phEventWaitList ) && ( i < numEventsInWaitList ); ++i )
+            phEventWaitListLocal[ i ] = reinterpret_cast<ur_event_object_t*>( phEventWaitList[ i ] )->handle;
+
+        // forward to device-platform
+        result = pfnDeviceGlobalVariableWrite( hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+        delete []phEventWaitListLocal;
+
+        if( UR_RESULT_SUCCESS != result )
+            return result;
+
+        try
+        {
+            // convert platform handle to loader handle
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
+        }
+        catch( std::bad_alloc& )
+        {
+            result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        return result;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueDeviceGlobalVariableRead(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        const char* name,                               ///< [in] the unique identifier for the device global variable.
+        bool blockingRead,                              ///< [in] indicates if this operation should block.
+        size_t count,                                   ///< [in] the number of bytes to copy.
+        size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+        void* pDst,                                     ///< [in] pointer to where the data must be copied to.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.    
+        )
+    {
+        ur_result_t result = UR_RESULT_SUCCESS;
+
+        // extract platform's function pointer table
+        auto dditable = reinterpret_cast<ur_queue_object_t*>( hQueue )->dditable;
+        auto pfnDeviceGlobalVariableRead = dditable->ur.Enqueue.pfnDeviceGlobalVariableRead;
+        if( nullptr == pfnDeviceGlobalVariableRead )
+            return UR_RESULT_ERROR_UNINITIALIZED;
+
+        // convert loader handle to platform handle
+        hQueue = reinterpret_cast<ur_queue_object_t*>( hQueue )->handle;
+
+        // convert loader handle to platform handle
+        hProgram = reinterpret_cast<ur_program_object_t*>( hProgram )->handle;
+
+        // convert loader handles to platform handles
+        auto phEventWaitListLocal = new ur_event_handle_t [numEventsInWaitList];
+        for( size_t i = 0; ( nullptr != phEventWaitList ) && ( i < numEventsInWaitList ); ++i )
+            phEventWaitListLocal[ i ] = reinterpret_cast<ur_event_object_t*>( phEventWaitList[ i ] )->handle;
+
+        // forward to device-platform
+        result = pfnDeviceGlobalVariableRead( hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+        delete []phEventWaitListLocal;
+
+        if( UR_RESULT_SUCCESS != result )
+            return result;
+
+        try
+        {
+            // convert platform handle to loader handle
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
+        }
+        catch( std::bad_alloc& )
+        {
+            result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        return result;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for urEventGetInfo
     __urdlllocal ur_result_t UR_APICALL
     urEventGetInfo(
@@ -4507,6 +4629,8 @@ urGetEnqueueProcAddrTable(
             pDdiTable->pfnUSMFill2D                                = loader::urEnqueueUSMFill2D;
             pDdiTable->pfnUSMMemset2D                              = loader::urEnqueueUSMMemset2D;
             pDdiTable->pfnUSMMemcpy2D                              = loader::urEnqueueUSMMemcpy2D;
+            pDdiTable->pfnDeviceGlobalVariableWrite                = loader::urEnqueueDeviceGlobalVariableWrite;
+            pDdiTable->pfnDeviceGlobalVariableRead                 = loader::urEnqueueDeviceGlobalVariableRead;
         }
         else
         {

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1587,13 +1587,13 @@ namespace loader
     __urdlllocal ur_result_t UR_APICALL
     urEnqueueDeviceGlobalVariableWrite(
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
         const char* name,                               ///< [in] the unique identifier for the device global variable.
         bool blockingWrite,                             ///< [in] indicates if this operation should block.
         size_t count,                                   ///< [in] the number of bytes to copy.
         size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
         const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
-        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
         const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                         ///< events that must be complete before the kernel execution.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
@@ -1648,13 +1648,13 @@ namespace loader
     __urdlllocal ur_result_t UR_APICALL
     urEnqueueDeviceGlobalVariableRead(
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-        ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
         const char* name,                               ///< [in] the unique identifier for the device global variable.
         bool blockingRead,                              ///< [in] indicates if this operation should block.
         size_t count,                                   ///< [in] the number of bytes to copy.
         size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
         void* pDst,                                     ///< [in] pointer to where the data must be copied to.
-        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
         const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                         ///< events that must be complete before the kernel execution.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1337,7 +1337,8 @@ urEnqueueUSMMemcpy2D(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command to write data from host to device global variable
+/// @brief Enqueue a command to write data from the host to device global
+///        variable.
 /// 
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1352,13 +1353,13 @@ urEnqueueUSMMemcpy2D(
 ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
     const char* name,                               ///< [in] the unique identifier for the device global variable.
     bool blockingWrite,                             ///< [in] indicates if this operation should block.
     size_t count,                                   ///< [in] the number of bytes to copy.
     size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
     const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
@@ -1375,7 +1376,8 @@ urEnqueueDeviceGlobalVariableWrite(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command to read data from a device global variable to host
+/// @brief Enqueue a command to read data from a device global variable to the
+///        host.
 /// 
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1390,13 +1392,13 @@ urEnqueueDeviceGlobalVariableWrite(
 ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
     const char* name,                               ///< [in] the unique identifier for the device global variable.
     bool blockingRead,                              ///< [in] indicates if this operation should block.
     size_t count,                                   ///< [in] the number of bytes to copy.
     size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
     void* pDst,                                     ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1337,6 +1337,82 @@ urEnqueueUSMMemcpy2D(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to write data from host to device global variable
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == name`
+///         + `NULL == pSrc`
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    const char* name,                               ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                             ///< [in] indicates if this operation should block.
+    size_t count,                                   ///< [in] the number of bytes to copy.
+    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+    const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.
+    )
+{
+    auto pfnDeviceGlobalVariableWrite = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    if( nullptr == pfnDeviceGlobalVariableWrite )
+        return UR_RESULT_ERROR_UNINITIALIZED;
+
+    return pfnDeviceGlobalVariableWrite( hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to read data from a device global variable to host
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == name`
+///         + `NULL == pDst`
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    const char* name,                               ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                              ///< [in] indicates if this operation should block.
+    size_t count,                                   ///< [in] the number of bytes to copy.
+    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+    void* pDst,                                     ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.    
+    )
+{
+    auto pfnDeviceGlobalVariableRead = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    if( nullptr == pfnDeviceGlobalVariableRead )
+        return UR_RESULT_ERROR_UNINITIALIZED;
+
+    return pfnDeviceGlobalVariableRead( hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
 /// 
 /// @remarks

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1247,7 +1247,8 @@ urEnqueueUSMMemcpy2D(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command to write data from host to device global variable
+/// @brief Enqueue a command to write data from the host to device global
+///        variable.
 /// 
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1262,13 +1263,13 @@ urEnqueueUSMMemcpy2D(
 ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
     const char* name,                               ///< [in] the unique identifier for the device global variable.
     bool blockingWrite,                             ///< [in] indicates if this operation should block.
     size_t count,                                   ///< [in] the number of bytes to copy.
     size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
     const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
@@ -1282,7 +1283,8 @@ urEnqueueDeviceGlobalVariableWrite(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command to read data from a device global variable to host
+/// @brief Enqueue a command to read data from a device global variable to the
+///        host.
 /// 
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1297,13 +1299,13 @@ urEnqueueDeviceGlobalVariableWrite(
 ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
     const char* name,                               ///< [in] the unique identifier for the device global variable.
     bool blockingRead,                              ///< [in] indicates if this operation should block.
     size_t count,                                   ///< [in] the number of bytes to copy.
     size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
     void* pDst,                                     ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1247,6 +1247,76 @@ urEnqueueUSMMemcpy2D(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to write data from host to device global variable
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == name`
+///         + `NULL == pSrc`
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    const char* name,                               ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                             ///< [in] indicates if this operation should block.
+    size_t count,                                   ///< [in] the number of bytes to copy.
+    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+    const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command to read data from a device global variable to host
+/// 
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == name`
+///         + `NULL == pDst`
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,                   ///< [in] the program containing the device global.
+    const char* name,                               ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                              ///< [in] indicates if this operation should block.
+    size_t count,                                   ///< [in] the number of bytes to copy.
+    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+    void* pDst,                                     ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                    ///< events that must be complete before the kernel execution.
+                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                    ///< event. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.    
+    )
+{
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
 /// 
 /// @remarks


### PR DESCRIPTION
Introduces:
* `urEnqueueDeviceGlobalVariableWrite`
* `UrEnqueueDeviceGlobalVariableRead`

To match requirements from [intel/llvm/7797](https://github.com/intel/llvm/pull/7797)

Closes #150 