### PR TITLE
[ur] Clearly specify that SetArg is thread safe

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3339,6 +3339,8 @@ urKernelCreate(
 /// @brief Set kernel argument to a value.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3363,6 +3365,8 @@ urKernelSetArgValue(
 /// @brief Set kernel argument to a local buffer.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3568,6 +3572,8 @@ urKernelRelease(
 /// @brief Set a USM pointer as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @remarks
@@ -3626,6 +3632,8 @@ urKernelSetExecInfo(
 /// @brief Set a Sampler object as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3647,6 +3655,8 @@ urKernelSetArgSampler(
 /// @brief Set a Memory object as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -36,6 +36,7 @@ desc: "Set kernel argument to a value."
 class: $xKernel
 name: SetArgValue
 details:
+    - "The application may call this function from simultaneous threads with the same kernel handle."
     - "The implementation of this function should be lock-free."
 params:
     - type: "$x_kernel_handle_t"
@@ -59,6 +60,7 @@ desc: "Set kernel argument to a local buffer."
 class: $xKernel
 name: SetArgLocal
 details:
+    - "The application may call this function from simultaneous threads with the same kernel handle."
     - "The implementation of this function should be lock-free."
 params:
     - type: "$x_kernel_handle_t"
@@ -257,6 +259,7 @@ name: SetArgPointer
 analogue:
     - "**clSetKernelArgSVMPointer**"
 details:
+    - "The application may call this function from simultaneous threads with the same kernel handle."
     - "The implementation of this function should be lock-free."
 params:
     - type: "$x_kernel_handle_t"
@@ -303,6 +306,7 @@ desc: "Set a Sampler object as the argument value of a Kernel."
 class: $xKernel
 name: SetArgSampler
 details:
+    - "The application may call this function from simultaneous threads with the same kernel handle."
     - "The implementation of this function should be lock-free."
 params:
     - type: "$x_kernel_handle_t"
@@ -322,6 +326,7 @@ desc: "Set a Memory object as the argument value of a Kernel."
 class: $xKernel
 name: SetArgMemObj
 details:
+    - "The application may call this function from simultaneous threads with the same kernel handle."
     - "The implementation of this function should be lock-free."
 params:
     - type: "$x_kernel_handle_t"

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2973,6 +2973,8 @@ urKernelCreate(
 /// @brief Set kernel argument to a value.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3004,6 +3006,8 @@ urKernelSetArgValue(
 /// @brief Set kernel argument to a local buffer.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3196,6 +3200,8 @@ urKernelRelease(
 /// @brief Set a USM pointer as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @remarks
@@ -3268,6 +3274,8 @@ urKernelSetExecInfo(
 /// @brief Set a Sampler object as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3296,6 +3304,8 @@ urKernelSetArgSampler(
 /// @brief Set a Memory object as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2742,6 +2742,8 @@ urKernelCreate(
 /// @brief Set kernel argument to a value.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -2770,6 +2772,8 @@ urKernelSetArgValue(
 /// @brief Set kernel argument to a local buffer.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -2944,6 +2948,8 @@ urKernelRelease(
 /// @brief Set a USM pointer as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @remarks
@@ -3010,6 +3016,8 @@ urKernelSetExecInfo(
 /// @brief Set a Sampler object as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns
@@ -3035,6 +3043,8 @@ urKernelSetArgSampler(
 /// @brief Set a Memory object as the argument value of a Kernel.
 /// 
 /// @details
+///     - The application may call this function from simultaneous threads with
+///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
 /// 
 /// @returns


### PR DESCRIPTION
We have decided that unlike OpenCL the SetArg APIs in UR should be thread-safe. This was mostly completed before, but I've added an additional statement to make this clear.

Closes #14 