### PR TITLE
[ur] urEnqueueMemBufferCopy is analagous to OpenCL

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1649,9 +1649,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urEnqueueMemBufferCopy
 if __use_win_types:
-    _urEnqueueMemBufferCopy_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+    _urEnqueueMemBufferCopy_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 else:
-    _urEnqueueMemBufferCopy_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+    _urEnqueueMemBufferCopy_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urEnqueueMemBufferCopyRect

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -861,6 +861,8 @@ urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
     ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+    size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
     size_t size,                                    ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6379,6 +6381,8 @@ typedef struct ur_enqueue_mem_buffer_copy_params_t
     ur_queue_handle_t* phQueue;
     ur_mem_handle_t* phBufferSrc;
     ur_mem_handle_t* phBufferDst;
+    size_t* psrcOffset;
+    size_t* pdstOffset;
     size_t* psize;
     uint32_t* pnumEventsInWaitList;
     const ur_event_handle_t** pphEventWaitList;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -952,6 +952,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopy_t)(
     ur_mem_handle_t,
     ur_mem_handle_t,
     size_t,
+    size_t,
+    size_t,
     uint32_t,
     const ur_event_handle_t*,
     ur_event_handle_t*

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -381,6 +381,12 @@ params:
       name: hBufferDst
       desc: "[in] handle of the dest buffer object"
     - type: size_t
+      name: srcOffset
+      desc: "[in] offset into hBufferSrc to begin copying from"
+    - type: size_t 
+      name: dstOffset
+      desc: "[in] offset info hBufferDst to begin copying into"
+    - type: size_t
       name: size
       desc: "[in] size in bytes of data being copied"
     - type: uint32_t

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -487,6 +487,8 @@ namespace driver
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
         ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
         ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+        size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
+        size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
         size_t size,                                    ///< [in] size in bytes of data being copied
         uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
         const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -505,7 +507,7 @@ namespace driver
         auto pfnMemBufferCopy = d_context.urDdiTable.Enqueue.pfnMemBufferCopy;
         if( nullptr != pfnMemBufferCopy )
         {
-            result = pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, size, numEventsInWaitList, phEventWaitList, phEvent );
+            result = pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent );
         }
         else
         {

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -694,6 +694,8 @@ namespace loader
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
         ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
         ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+        size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
+        size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
         size_t size,                                    ///< [in] size in bytes of data being copied
         uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
         const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -729,7 +731,7 @@ namespace loader
             phEventWaitListLocal[ i ] = reinterpret_cast<ur_event_object_t*>( phEventWaitList[ i ] )->handle;
 
         // forward to device-platform
-        result = pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, size, numEventsInWaitList, phEventWaitList, phEvent );
+        result = pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent );
         delete []phEventWaitListLocal;
 
         if( UR_RESULT_SUCCESS != result )

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -668,6 +668,8 @@ urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
     ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+    size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
     size_t size,                                    ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -684,7 +686,7 @@ urEnqueueMemBufferCopy(
     if( nullptr == pfnMemBufferCopy )
         return UR_RESULT_ERROR_UNINITIALIZED;
 
-    return pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, size, numEventsInWaitList, phEventWaitList, phEvent );
+    return pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent );
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -623,6 +623,8 @@ urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
     ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+    size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
     size_t size,                                    ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
     const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of


### PR DESCRIPTION
urEnqueueMemBufferCopy now has additional offset parameters to match the OpenCL analogue function `clEnqueueCopyBuffer`

Closes #8 