### PR TITLE
[ur] Mark non-required arguments as optional

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -513,7 +513,6 @@ urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pGlobalWorkOffset`
 ///         + `NULL == pGlobalWorkSize`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
@@ -543,10 +542,8 @@ urEnqueueKernelLaunch(
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                                     ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular kernel
-                                                    ///< execution instance.
-                                                    ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
-                                                    ///< TODO: change to allow nullptr.
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -568,8 +565,6 @@ urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -584,10 +579,8 @@ urEnqueueEventsWait(
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -611,8 +604,6 @@ urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -627,10 +618,8 @@ urEnqueueEventsWaitWithBarrier(
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -653,7 +642,6 @@ urEnqueueEventsWaitWithBarrier(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -672,10 +660,8 @@ urEnqueueMemBufferRead(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -698,7 +684,6 @@ urEnqueueMemBufferRead(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -717,10 +702,8 @@ urEnqueueMemBufferWrite(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -746,7 +729,6 @@ urEnqueueMemBufferWrite(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -772,10 +754,8 @@ urEnqueueMemBufferReadRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -801,7 +781,6 @@ urEnqueueMemBufferReadRect(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -828,10 +807,8 @@ urEnqueueMemBufferWriteRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -849,8 +826,6 @@ urEnqueueMemBufferWriteRect(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBufferSrc`
 ///         + `NULL == hBufferDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -867,10 +842,8 @@ urEnqueueMemBufferCopy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -889,8 +862,6 @@ urEnqueueMemBufferCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBufferSrc`
 ///         + `NULL == hBufferDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -913,10 +884,8 @@ urEnqueueMemBufferCopyRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -936,7 +905,6 @@ urEnqueueMemBufferCopyRect(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPattern`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -955,10 +923,8 @@ urEnqueueMemBufferFill(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -982,7 +948,6 @@ urEnqueueMemBufferFill(
 ///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1004,10 +969,8 @@ urEnqueueMemImageRead(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1031,7 +994,6 @@ urEnqueueMemImageRead(
 ///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1053,10 +1015,8 @@ urEnqueueMemImageWrite(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1074,8 +1034,6 @@ urEnqueueMemImageWrite(
 ///         + `NULL == hQueue`
 ///         + `NULL == hImageSrc`
 ///         + `NULL == hImageDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1097,10 +1055,8 @@ urEnqueueMemImageCopy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1149,7 +1105,6 @@ typedef enum ur_usm_migration_flag_t
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3 < mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
@@ -1169,10 +1124,8 @@ urEnqueueMemBufferMap(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent,                     ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
                                                     ///< numEventsInWaitList?
     );
@@ -1194,7 +1147,6 @@ urEnqueueMemBufferMap(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMappedPtr`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1210,10 +1162,8 @@ urEnqueueMemUnmap(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1227,7 +1177,6 @@ urEnqueueMemUnmap(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ptr`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1244,10 +1193,8 @@ urEnqueueUSMMemset(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1262,7 +1209,6 @@ urEnqueueUSMMemset(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1280,10 +1226,8 @@ urEnqueueUSMMemcpy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1297,7 +1241,6 @@ urEnqueueUSMMemcpy(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -1316,10 +1259,8 @@ urEnqueueUSMPrefetch(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1342,7 +1283,6 @@ typedef enum ur_mem_advice_t
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_ADVICE_DEFAULT < advice`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -1356,10 +1296,8 @@ urEnqueueUSMMemAdvice(
     const void* pMem,                               ///< [in] pointer to the USM memory object
     size_t size,                                    ///< [in] size in bytes to be adviced
     ur_mem_advice_t advice,                         ///< [in] USM memory advice
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1505,9 +1443,6 @@ typedef enum ur_profiling_info_t
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EVENT_INFO_REFERENCE_COUNT < propName`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pPropValue`
-///         + `NULL == pPropValueSizeRet`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -1517,8 +1452,8 @@ urEventGetInfo(
     ur_event_handle_t hEvent,                       ///< [in] handle of the event object
     ur_event_info_t propName,                       ///< [in] the name of the event property to query
     size_t propValueSize,                           ///< [in] size in bytes of the event property value
-    void* pPropValue,                               ///< [out] value of the event property
-    size_t* pPropValueSizeRet                       ///< [out] bytes returned in event property
+    void* pPropValue,                               ///< [out][optional] value of the event property
+    size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
     );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -49,9 +49,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular kernel execution instance.
-            Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
-            TODO: change to allow nullptr.
+            [in,out][optional] return an event object that identifies this particular kernel execution instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_KERNEL
@@ -88,9 +86,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -125,9 +121,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -174,9 +168,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -223,9 +215,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -288,9 +278,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -353,9 +341,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance. 
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -394,9 +380,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance. 
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -453,9 +437,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -500,9 +482,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -555,9 +535,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance. 
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -610,9 +588,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -657,9 +633,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance. 
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -707,9 +681,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance. 
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -779,9 +751,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
     - type: void**
       name: ppRetMap
       desc: "[in,out] return mapped pointer.  TODO: move it before numEventsInWaitList?"
@@ -843,9 +813,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -881,9 +849,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -920,9 +886,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance. 
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -962,9 +926,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1001,9 +963,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1040,9 +1000,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out] return an event object that identifies this particular command instance.
-            Input can not be a nullptr.
-            TODO: change to allow nullptr. 
+            [in,out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -59,10 +59,10 @@ params:
       desc: "[in] size in bytes of the event property value"
     - type: void*
       name: pPropValue
-      desc: "[out] value of the event property"
+      desc: "[out][optional] value of the event property"
     - type: size_t*
       name: pPropValueSizeRet
-      desc: "[out] bytes returned in event property"
+      desc: "[out][optional] bytes returned in event property"
 returns:
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_EVENT

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -215,10 +215,8 @@ namespace driver
                                                         ///< events that must be complete before the kernel execution.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                                         ///< event. 
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular kernel
-                                                        ///< execution instance.
-                                                        ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
-                                                        ///< TODO: change to allow nullptr.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -232,7 +230,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -250,10 +248,8 @@ namespace driver
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                         ///< previously enqueued commands
                                                         ///< must be complete. 
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -267,7 +263,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -285,10 +281,8 @@ namespace driver
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                         ///< previously enqueued commands
                                                         ///< must be complete. 
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -302,7 +296,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -324,10 +318,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -341,7 +333,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -363,10 +355,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -380,7 +370,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -409,10 +399,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -426,7 +414,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -456,10 +444,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -473,7 +459,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -493,10 +479,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -510,7 +494,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -536,10 +520,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -553,7 +535,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -575,10 +557,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -592,7 +572,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -617,10 +597,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -634,7 +612,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -659,10 +637,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -676,7 +652,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -701,10 +677,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -718,7 +692,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -740,10 +714,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent,                     ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
                                                         ///< numEventsInWaitList?
         )
@@ -759,7 +731,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -778,10 +750,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -795,7 +765,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -815,10 +785,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -832,7 +800,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -853,10 +821,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -870,7 +836,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -890,10 +856,8 @@ namespace driver
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -907,7 +871,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -922,10 +886,8 @@ namespace driver
         const void* pMem,                               ///< [in] pointer to the USM memory object
         size_t size,                                    ///< [in] size in bytes to be adviced
         ur_mem_advice_t advice,                         ///< [in] USM memory advice
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -939,7 +901,7 @@ namespace driver
         else
         {
             // generic implementation
-            *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
+            if( nullptr != phEvent ) *phEvent = reinterpret_cast<ur_event_handle_t>( d_context.get() );
 
         }
 
@@ -1067,8 +1029,8 @@ namespace driver
         ur_event_handle_t hEvent,                       ///< [in] handle of the event object
         ur_event_info_t propName,                       ///< [in] the name of the event property to query
         size_t propValueSize,                           ///< [in] size in bytes of the event property value
-        void* pPropValue,                               ///< [out] value of the event property
-        size_t* pPropValueSizeRet                       ///< [out] bytes returned in event property
+        void* pPropValue,                               ///< [out][optional] value of the event property
+        size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -274,10 +274,8 @@ namespace loader
                                                         ///< events that must be complete before the kernel execution.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                                         ///< event. 
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular kernel
-                                                        ///< execution instance.
-                                                        ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
-                                                        ///< TODO: change to allow nullptr.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -309,8 +307,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -331,10 +330,8 @@ namespace loader
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                         ///< previously enqueued commands
                                                         ///< must be complete. 
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -363,8 +360,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -385,10 +383,8 @@ namespace loader
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                         ///< previously enqueued commands
                                                         ///< must be complete. 
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -417,8 +413,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -443,10 +440,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -478,8 +473,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -504,10 +500,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -539,8 +533,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -572,10 +567,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -607,8 +600,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -641,10 +635,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -676,8 +668,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -700,10 +693,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -738,8 +729,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -768,10 +760,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -806,8 +796,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -832,10 +823,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -867,8 +856,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -896,10 +886,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -931,8 +919,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -960,10 +949,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -995,8 +982,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1024,10 +1012,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -1062,8 +1048,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1088,10 +1075,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent,                     ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
                                                         ///< numEventsInWaitList?
         )
@@ -1125,8 +1110,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1148,10 +1134,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -1183,8 +1167,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1207,10 +1192,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -1239,8 +1222,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1264,10 +1248,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -1296,8 +1278,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1320,10 +1303,8 @@ namespace loader
                                                         ///< events that must be complete before this command can be executed.
                                                         ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                         ///< command does not wait on any event to complete.
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -1352,8 +1333,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1371,10 +1353,8 @@ namespace loader
         const void* pMem,                               ///< [in] pointer to the USM memory object
         size_t size,                                    ///< [in] size in bytes to be adviced
         ur_mem_advice_t advice,                         ///< [in] USM memory advice
-        ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                        ///< command instance.
-                                                        ///< Input can not be a nullptr.
-                                                        ///< TODO: change to allow nullptr. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;
@@ -1397,8 +1377,9 @@ namespace loader
         try
         {
             // convert platform handle to loader handle
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance( *phEvent, dditable ) );
+            if( nullptr != phEvent )
+                *phEvent = reinterpret_cast<ur_event_handle_t>(
+                    ur_event_factory.getInstance( *phEvent, dditable ) );
         }
         catch( std::bad_alloc& )
         {
@@ -1589,8 +1570,8 @@ namespace loader
         ur_event_handle_t hEvent,                       ///< [in] handle of the event object
         ur_event_info_t propName,                       ///< [in] the name of the event property to query
         size_t propValueSize,                           ///< [in] size in bytes of the event property value
-        void* pPropValue,                               ///< [out] value of the event property
-        size_t* pPropValueSizeRet                       ///< [out] bytes returned in event property
+        void* pPropValue,                               ///< [out][optional] value of the event property
+        size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -271,7 +271,6 @@ urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pGlobalWorkOffset`
 ///         + `NULL == pGlobalWorkSize`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
@@ -301,10 +300,8 @@ urEnqueueKernelLaunch(
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                                     ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular kernel
-                                                    ///< execution instance.
-                                                    ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
-                                                    ///< TODO: change to allow nullptr.
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.
     )
 {
     auto pfnKernelLaunch = ur_lib::context->urDdiTable.Enqueue.pfnKernelLaunch;
@@ -333,8 +330,6 @@ urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -349,10 +344,8 @@ urEnqueueEventsWait(
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnEventsWait = ur_lib::context->urDdiTable.Enqueue.pfnEventsWait;
@@ -383,8 +376,6 @@ urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -399,10 +390,8 @@ urEnqueueEventsWaitWithBarrier(
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnEventsWaitWithBarrier = ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -432,7 +421,6 @@ urEnqueueEventsWaitWithBarrier(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -451,10 +439,8 @@ urEnqueueMemBufferRead(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemBufferRead = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
@@ -484,7 +470,6 @@ urEnqueueMemBufferRead(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -503,10 +488,8 @@ urEnqueueMemBufferWrite(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemBufferWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
@@ -539,7 +522,6 @@ urEnqueueMemBufferWrite(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -565,10 +547,8 @@ urEnqueueMemBufferReadRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemBufferReadRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -601,7 +581,6 @@ urEnqueueMemBufferReadRect(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -628,10 +607,8 @@ urEnqueueMemBufferWriteRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     auto pfnMemBufferWriteRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -656,8 +633,6 @@ urEnqueueMemBufferWriteRect(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBufferSrc`
 ///         + `NULL == hBufferDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -674,10 +649,8 @@ urEnqueueMemBufferCopy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     auto pfnMemBufferCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
@@ -703,8 +676,6 @@ urEnqueueMemBufferCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBufferSrc`
 ///         + `NULL == hBufferDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -727,10 +698,8 @@ urEnqueueMemBufferCopyRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemBufferCopyRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -757,7 +726,6 @@ urEnqueueMemBufferCopyRect(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPattern`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -776,10 +744,8 @@ urEnqueueMemBufferFill(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemBufferFill = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
@@ -810,7 +776,6 @@ urEnqueueMemBufferFill(
 ///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -832,10 +797,8 @@ urEnqueueMemImageRead(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     auto pfnMemImageRead = ur_lib::context->urDdiTable.Enqueue.pfnMemImageRead;
@@ -866,7 +829,6 @@ urEnqueueMemImageRead(
 ///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -888,10 +850,8 @@ urEnqueueMemImageWrite(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemImageWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
@@ -916,8 +876,6 @@ urEnqueueMemImageWrite(
 ///         + `NULL == hQueue`
 ///         + `NULL == hImageSrc`
 ///         + `NULL == hImageDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -939,10 +897,8 @@ urEnqueueMemImageCopy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     auto pfnMemImageCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemImageCopy;
@@ -977,7 +933,6 @@ urEnqueueMemImageCopy(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3 < mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
@@ -997,10 +952,8 @@ urEnqueueMemBufferMap(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent,                     ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
                                                     ///< numEventsInWaitList?
     )
@@ -1029,7 +982,6 @@ urEnqueueMemBufferMap(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMappedPtr`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1045,10 +997,8 @@ urEnqueueMemUnmap(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnMemUnmap = ur_lib::context->urDdiTable.Enqueue.pfnMemUnmap;
@@ -1069,7 +1019,6 @@ urEnqueueMemUnmap(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ptr`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1086,10 +1035,8 @@ urEnqueueUSMMemset(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     auto pfnUSMMemset = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemset;
@@ -1111,7 +1058,6 @@ urEnqueueUSMMemset(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1129,10 +1075,8 @@ urEnqueueUSMMemcpy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnUSMMemcpy = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy;
@@ -1153,7 +1097,6 @@ urEnqueueUSMMemcpy(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -1172,10 +1115,8 @@ urEnqueueUSMPrefetch(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnUSMPrefetch = ur_lib::context->urDdiTable.Enqueue.pfnUSMPrefetch;
@@ -1196,7 +1137,6 @@ urEnqueueUSMPrefetch(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_ADVICE_DEFAULT < advice`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -1210,10 +1150,8 @@ urEnqueueUSMMemAdvice(
     const void* pMem,                               ///< [in] pointer to the USM memory object
     size_t size,                                    ///< [in] size in bytes to be adviced
     ur_mem_advice_t advice,                         ///< [in] USM memory advice
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     auto pfnUSMMemAdvice = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvice;
@@ -1351,9 +1289,6 @@ urEnqueueUSMMemcpy2D(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EVENT_INFO_REFERENCE_COUNT < propName`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pPropValue`
-///         + `NULL == pPropValueSizeRet`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -1363,8 +1298,8 @@ urEventGetInfo(
     ur_event_handle_t hEvent,                       ///< [in] handle of the event object
     ur_event_info_t propName,                       ///< [in] the name of the event property to query
     size_t propValueSize,                           ///< [in] size in bytes of the event property value
-    void* pPropValue,                               ///< [out] value of the event property
-    size_t* pPropValueSizeRet                       ///< [out] bytes returned in event property
+    void* pPropValue,                               ///< [out][optional] value of the event property
+    size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
     )
 {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Event.pfnGetInfo;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -247,7 +247,6 @@ urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pGlobalWorkOffset`
 ///         + `NULL == pGlobalWorkSize`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
@@ -277,10 +276,8 @@ urEnqueueKernelLaunch(
                                                     ///< events that must be complete before the kernel execution.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                                     ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular kernel
-                                                    ///< execution instance.
-                                                    ///< Contrary to clEnqueueNDRangeKernel, its input can not be a nullptr. 
-                                                    ///< TODO: change to allow nullptr.
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular kernel execution instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -306,8 +303,6 @@ urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -322,10 +317,8 @@ urEnqueueEventsWait(
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -353,8 +346,6 @@ urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -369,10 +360,8 @@ urEnqueueEventsWaitWithBarrier(
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                                     ///< previously enqueued commands
                                                     ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -399,7 +388,6 @@ urEnqueueEventsWaitWithBarrier(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -418,10 +406,8 @@ urEnqueueMemBufferRead(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -448,7 +434,6 @@ urEnqueueMemBufferRead(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -467,10 +452,8 @@ urEnqueueMemBufferWrite(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -500,7 +483,6 @@ urEnqueueMemBufferWrite(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -526,10 +508,8 @@ urEnqueueMemBufferReadRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -559,7 +539,6 @@ urEnqueueMemBufferReadRect(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -586,10 +565,8 @@ urEnqueueMemBufferWriteRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -611,8 +588,6 @@ urEnqueueMemBufferWriteRect(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBufferSrc`
 ///         + `NULL == hBufferDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -629,10 +604,8 @@ urEnqueueMemBufferCopy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -655,8 +628,6 @@ urEnqueueMemBufferCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBufferSrc`
 ///         + `NULL == hBufferDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -679,10 +650,8 @@ urEnqueueMemBufferCopyRect(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -706,7 +675,6 @@ urEnqueueMemBufferCopyRect(
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPattern`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -725,10 +693,8 @@ urEnqueueMemBufferFill(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -756,7 +722,6 @@ urEnqueueMemBufferFill(
 ///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -778,10 +743,8 @@ urEnqueueMemImageRead(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -809,7 +772,6 @@ urEnqueueMemImageRead(
 ///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -831,10 +793,8 @@ urEnqueueMemImageWrite(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -856,8 +816,6 @@ urEnqueueMemImageWrite(
 ///         + `NULL == hQueue`
 ///         + `NULL == hImageSrc`
 ///         + `NULL == hImageDst`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -879,10 +837,8 @@ urEnqueueMemImageCopy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -914,7 +870,6 @@ urEnqueueMemImageCopy(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3 < mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
@@ -934,10 +889,8 @@ urEnqueueMemBufferMap(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent,                     ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
                                                     ///< numEventsInWaitList?
     )
@@ -963,7 +916,6 @@ urEnqueueMemBufferMap(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMappedPtr`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -979,10 +931,8 @@ urEnqueueMemUnmap(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1000,7 +950,6 @@ urEnqueueMemUnmap(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ptr`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1017,10 +966,8 @@ urEnqueueUSMMemset(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance. 
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1039,7 +986,6 @@ urEnqueueUSMMemset(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -1057,10 +1003,8 @@ urEnqueueUSMMemcpy(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1078,7 +1022,6 @@ urEnqueueUSMMemcpy(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -1097,10 +1040,8 @@ urEnqueueUSMPrefetch(
                                                     ///< events that must be complete before this command can be executed.
                                                     ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                                     ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1118,7 +1059,6 @@ urEnqueueUSMPrefetch(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
-///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_ADVICE_DEFAULT < advice`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -1132,10 +1072,8 @@ urEnqueueUSMMemAdvice(
     const void* pMem,                               ///< [in] pointer to the USM memory object
     size_t size,                                    ///< [in] size in bytes to be adviced
     ur_mem_advice_t advice,                         ///< [in] USM memory advice
-    ur_event_handle_t* phEvent                      ///< [in,out] return an event object that identifies this particular
-                                                    ///< command instance.
-                                                    ///< Input can not be a nullptr.
-                                                    ///< TODO: change to allow nullptr. 
+    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                    ///< particular command instance.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1261,9 +1199,6 @@ urEnqueueUSMMemcpy2D(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EVENT_INFO_REFERENCE_COUNT < propName`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pPropValue`
-///         + `NULL == pPropValueSizeRet`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -1273,8 +1208,8 @@ urEventGetInfo(
     ur_event_handle_t hEvent,                       ///< [in] handle of the event object
     ur_event_info_t propName,                       ///< [in] the name of the event property to query
     size_t propValueSize,                           ///< [in] size in bytes of the event property value
-    void* pPropValue,                               ///< [out] value of the event property
-    size_t* pPropValueSizeRet                       ///< [out] bytes returned in event property
+    void* pPropValue,                               ///< [out][optional] value of the event property
+    size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;


### PR DESCRIPTION
* `urEnqueue*` entry-points have an optional return event.
*  `urEventGetInfo` is fixed to allow optional return size and value

Closes #33 