### PR TITLE
[ur] Fix ur_result_t references

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3351,8 +3351,8 @@ urKernelCreate(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pArgValue`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgValue(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3375,8 +3375,8 @@ urKernelSetArgValue(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgLocal(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3586,8 +3586,8 @@ urKernelRelease(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgPointer(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3643,7 +3643,7 @@ urKernelSetExecInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgSampler(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3665,7 +3665,7 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -52,8 +52,8 @@ params:
       name: pArgValue
       desc: "[in] argument value represented as matching arg type."
 returns:
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Set kernel argument to a local buffer."
@@ -73,8 +73,8 @@ params:
       name: argSize
       desc: "[in] size of the local buffer to be allocated by the runtime"
 returns:
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Get Kernel object information"
@@ -275,8 +275,8 @@ params:
       name: pArgValue
       desc: "[in][optional] SVM pointer to memory location holding the argument value. If null then argument value is considered null."
 returns:
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Set additional Kernel execution attributes."
@@ -319,7 +319,7 @@ params:
       name: hArgValue
       desc: "[in] handle of Sampler object."
 returns:
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Set a Memory object as the argument value of a Kernel."
@@ -339,7 +339,7 @@ params:
       name: hArgValue
       desc: "[in][optional] handle of Memory object."
 returns:
-    - $X_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Return platform native kernel handle."

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2985,8 +2985,8 @@ urKernelCreate(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pArgValue`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL
 urKernelSetArgValue(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3016,8 +3016,8 @@ urKernelSetArgValue(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL
 urKernelSetArgLocal(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3214,8 +3214,8 @@ urKernelRelease(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL
 urKernelSetArgPointer(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3285,7 +3285,7 @@ urKernelSetExecInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ur_result_t UR_APICALL
 urKernelSetArgSampler(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3314,7 +3314,7 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ur_result_t UR_APICALL
 urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2754,8 +2754,8 @@ urKernelCreate(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pArgValue`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL
 urKernelSetArgValue(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -2782,8 +2782,8 @@ urKernelSetArgValue(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL
 urKernelSetArgLocal(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -2962,8 +2962,8 @@ urKernelRelease(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL
 urKernelSetArgPointer(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3027,7 +3027,7 @@ urKernelSetExecInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ur_result_t UR_APICALL
 urKernelSetArgSampler(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
@@ -3053,7 +3053,7 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///     - ::UR_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ur_result_t UR_APICALL
 urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object


### PR DESCRIPTION
Result enumerations for errors all begin with `$X_RESULT_ERROR_*`, this fixes remaining unresolved references due to this.

Closes #150 