### PR TITLE
[ur] Make host/device time parameters optional

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3291,15 +3291,12 @@ urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDeviceTimestamp`
-///         + `NULL == pHostTimestamp`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-    uint64_t* pDeviceTimestamp,                     ///< [out] pointer to the Device's global timestamp that 
+    uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
                                                     ///< correlates with the Host's global timestamp value
-    uint64_t* pHostTimestamp                        ///< [out] pointer to the Host's global timestamp that 
+    uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
                                                     ///< correlates with the Device's global timestamp value
     );
 

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -592,10 +592,10 @@ params:
     - type: "uint64_t*"
       name: pDeviceTimestamp
       desc: | 
-            [out] pointer to the Device's global timestamp that 
+            [out][optional] pointer to the Device's global timestamp that 
             correlates with the Host's global timestamp value
     - type: "uint64_t*"
       name: pHostTimestamp
       desc: |
-            [out] pointer to the Host's global timestamp that 
+            [out][optional] pointer to the Host's global timestamp that 
             correlates with the Device's global timestamp value

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2260,9 +2260,9 @@ namespace driver
     __urdlllocal ur_result_t UR_APICALL
     urDeviceGetGlobalTimestamps(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-        uint64_t* pDeviceTimestamp,                     ///< [out] pointer to the Device's global timestamp that 
+        uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
                                                         ///< correlates with the Host's global timestamp value
-        uint64_t* pHostTimestamp                        ///< [out] pointer to the Host's global timestamp that 
+        uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
                                                         ///< correlates with the Device's global timestamp value
         )
     {

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3052,9 +3052,9 @@ namespace loader
     __urdlllocal ur_result_t UR_APICALL
     urDeviceGetGlobalTimestamps(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-        uint64_t* pDeviceTimestamp,                     ///< [out] pointer to the Device's global timestamp that 
+        uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
                                                         ///< correlates with the Host's global timestamp value
-        uint64_t* pHostTimestamp                        ///< [out] pointer to the Host's global timestamp that 
+        uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
                                                         ///< correlates with the Device's global timestamp value
         )
     {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2918,15 +2918,12 @@ urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDeviceTimestamp`
-///         + `NULL == pHostTimestamp`
 ur_result_t UR_APICALL
 urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-    uint64_t* pDeviceTimestamp,                     ///< [out] pointer to the Device's global timestamp that 
+    uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
                                                     ///< correlates with the Host's global timestamp value
-    uint64_t* pHostTimestamp                        ///< [out] pointer to the Host's global timestamp that 
+    uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
                                                     ///< correlates with the Device's global timestamp value
     )
 {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2693,15 +2693,12 @@ urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDeviceTimestamp`
-///         + `NULL == pHostTimestamp`
 ur_result_t UR_APICALL
 urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-    uint64_t* pDeviceTimestamp,                     ///< [out] pointer to the Device's global timestamp that 
+    uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
                                                     ///< correlates with the Host's global timestamp value
-    uint64_t* pHostTimestamp                        ///< [out] pointer to the Host's global timestamp that 
+    uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
                                                     ///< correlates with the Device's global timestamp value
     )
 {


### PR DESCRIPTION
We should make device and host timer parameters optional in `urDeviceGetGlobalTimestamps` to allow it to be used as an analogue of both `clGetDeviceAndHostTimer` and `clGetHostTimer`.

See more detailed comment in #88 