### PR TITLE
[ur] Add ur_sampler_addressing_mode_t enum

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -579,6 +579,20 @@ class ur_sampler_properties_t(c_int):
 
 
 ###############################################################################
+## @brief Sampler addressing mode
+class ur_sampler_addressing_mode_v(IntEnum):
+    MIRRORED_REPEAT = 0                             ## Mirrored Repeat
+    REPEAT = 1                                      ## Repeat
+    CLAMP = 2                                       ## Clamp
+    CLAMP_TO_EDGE = 3                               ## Clamp to edge
+    NONE = 4                                        ## None
+
+class ur_sampler_addressing_mode_t(c_int):
+    def __str__(self):
+        return str(ur_sampler_addressing_mode_v(self.value))
+
+
+###############################################################################
 ## @brief Sampler properties <name, value> pair
 class ur_sampler_property_value_t(Structure):
     _fields_ = [

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2479,6 +2479,19 @@ typedef enum ur_sampler_properties_t
 } ur_sampler_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler addressing mode
+typedef enum ur_sampler_addressing_mode_t
+{
+    UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT = 0, ///< Mirrored Repeat
+    UR_SAMPLER_ADDRESSING_MODE_REPEAT = 1,          ///< Repeat
+    UR_SAMPLER_ADDRESSING_MODE_CLAMP = 2,           ///< Clamp
+    UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE = 3,   ///< Clamp to edge
+    UR_SAMPLER_ADDRESSING_MODE_NONE = 4,            ///< None
+    UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32 = 0x7fffffff
+
+} ur_sampler_addressing_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler properties <name, value> pair
 typedef struct ur_sampler_property_value_t
 {

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -44,6 +44,22 @@ etors:
     - name: FILTER_MODE
       desc: "Sampler filter mode"
 --- #--------------------------------------------------------------------------
+type: enum
+desc: "Sampler addressing mode"
+class: $xSampler
+name: $x_sampler_addressing_mode_t
+etors:
+    - name: MIRRORED_REPEAT
+      desc: "Mirrored Repeat"
+    - name: REPEAT
+      desc: "Repeat"
+    - name: CLAMP
+      desc: "Clamp"
+    - name: CLAMP_TO_EDGE
+      desc: "Clamp to edge"
+    - name: NONE
+      desc: "None"
+--- #--------------------------------------------------------------------------
 type: struct
 desc: "Sampler properties <name, value> pair"
 class: $xSampler


### PR DESCRIPTION
Defines the `ur_sampler_addressing_mode_t` enum used in PI.

Closes #105 