### PR TITLE
Add automatic code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+Language:      Cpp
+BasedOnStyle:  LLVM
+IndentWidth:   4
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
@@ -7,6 +7,9 @@ project(unified-runtime VERSION 0.5.0)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(CTest)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(helpers)
 
 find_package(Python3 COMPONENTS Interpreter)
 
@@ -17,17 +20,17 @@ if(MSVC)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/$<CONFIG>)
 endif()
 
-# define rpath for libraries so that adapters can be found automatically
+# Define rpath for libraries so that adapters can be found automatically
 set(CMAKE_BUILD_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
-#Define a path for custom commands to work around MSVC
+# Define a path for custom commands to work around MSVC
 set(CUSTOM_COMMAND_BINARY_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 if(MSVC)
-    #MSVC implicitly adds $<CONFIG> to the output path
+    # MSVC implicitly adds $<CONFIG> to the output path
     set(CUSTOM_COMMAND_BINARY_DIR ${CUSTOM_COMMAND_BINARY_DIR}/$<CONFIG>)
 endif()
 
-#CXX compiler support
+# CXX compiler support
 if(NOT MSVC)
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
@@ -42,15 +45,15 @@ if(NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -fPIC")
 endif()
 
-#MSVC compile flags
+# MSVC compile flags
 if(MSVC)
     string(REPLACE "/MDd" "/MTd" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
     string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
-    # treat warnings as errors
+    # Treat warnings as errors
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX /W3 /wd4996")
 
-    # enable multi-process compilation
+    # Enable multi-process compilation
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
 
@@ -61,6 +64,44 @@ endif()
 
 # Option to disable tests
 option(${PROJECT_NAME}_BUILD_TESTS "Build unit tests." ON)
+
+# Option to run a code formatter
+option(${PROJECT_NAME}_FORMAT_CPP_STYLE "format code style of C++ sources" OFF)
+
+find_program(CLANG_FORMAT NAMES clang-format-10 clang-format-10.0 clang-format)
+
+set(CLANG_FORMAT_REQUIRED "10.0")
+
+if(CLANG_FORMAT)
+    get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
+    message(STATUS "Found clang-format: ${CLANG_FORMAT} (version: ${CLANG_FORMAT_VERSION})")
+endif()
+
+# Check if the correct version of clang-format is available
+if(FORMAT_CPP_STYLE)
+    if(CLANG_FORMAT)
+        if(NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
+            message(FATAL_ERROR "required clang-format version is ${CLANG_FORMAT_REQUIRED}")
+        endif()
+    else()
+        message(FATAL_ERROR "FORMAT_CPP_STYLE=ON, but clang-format not found (required version: ${CLANG_FORMAT_REQUIRED})")
+    endif()
+endif()
+
+# Obtain files for clang-format
+file(GLOB_RECURSE format_src
+    "*.h"
+    "*.cpp"
+)
+
+# Exclude files from build directory to ensure they're not passed to the formatter
+list(FILTER format_src EXCLUDE REGEX "${CMAKE_CURRENT_BINARY_DIR}.")
+
+# Add code formatter target
+add_custom_target(cppformat)
+
+# Add files to the formatter
+add_cppformat(src-formatter ${format_src})
 
 add_subdirectory(${THIRD_PARTY_DIR})
 
@@ -116,16 +157,18 @@ install(
 
 set(API_JSON_FILE ${PROJECT_BINARY_DIR}/unified_runtime.json)
 
-# generate source from the specification
+# Generate source from the specification
 add_custom_target(generate
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
     COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE}
     COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
 )
 
-# generate source and check for uncommitted diffs
+# Generate source and check for uncommitted diffs
 add_custom_target(check-generated
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMAND git diff --exit-code
     DEPENDS generate
+    # Uncomment line below after docker image is integrated
+    #DEPENDS cppformat
 )

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Tools can be acquired via instructions in [third_party](/third_party/README.md).
 
 ## Building
 
+Requirements:
+- C++ compiler with C++14 support
+- cmake >= 3.14.0
+- clang-format-10.0 (for automatic code formatting)
+
 Project is defined using [CMake](https://cmake.org/).
 
 **Windows**:
@@ -72,6 +77,15 @@ $ cmake {path_to_source_dir}
 $ make
 ~~~~
 
+### CMake standard options
+
+List of options provided by CMake:
+
+| Name | Description | Values | Default |
+| - | - | - | - |
+| BUILD_TESTS | Build the tests | ON/OFF | ON |
+| FORMAT_CPP_STYLE | Format code style | ON/OFF | OFF |
+
 **General**:
 
 If you've made modifications to the specification, you can also run a custom `generate` target prior to building.
@@ -80,3 +94,8 @@ $ make generate
 ~~~~
 
 This call will automatically generate the source code.
+
+To run automated code formatting build with option `FORMAT_CPP_STYLE` and then run a custom `cppformat` target:
+~~~~
+$ make cppformat
+~~~~

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+#
+# helpers.cmake -- helper functions for top-level CMakeLists.txt
+#
+
+# Sets ${ret} to version of program specified by ${name} in major.minor format
+function(get_program_version_major_minor name ret)
+    execute_process(COMMAND ${name} --version
+        OUTPUT_VARIABLE cmd_ret
+        ERROR_QUIET)
+    STRING(REGEX MATCH "([0-9]+)\.([0-9]+)" VERSION ${cmd_ret})
+    SET(${ret} ${VERSION} PARENT_SCOPE)
+endfunction()
+
+# Generates cppformat-$name targets and attaches them
+# as dependencies of global "cppformat" target.
+# Arguments are used as files to be checked.
+# ${name} must be unique.
+function(add_cppformat name)
+    if(NOT CLANG_FORMAT OR NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
+        return()
+    endif()
+
+    if(${ARGC} EQUAL 0)
+        return()
+    else()
+        add_custom_target(cppformat-${name}
+            COMMAND ${CLANG_FORMAT}
+                --style=file
+                --i
+                ${ARGN}
+            )
+    endif()
+
+    add_dependencies(cppformat cppformat-${name})
+endfunction()

--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -1,20 +1,19 @@
 /*
  *
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2020-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
-#include <stdlib.h>
-#include <memory>
 #include <iostream>
+#include <memory>
+#include <stdlib.h>
 #include <vector>
 
 #include "ur_api.h"
 
 //////////////////////////////////////////////////////////////////////////
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     ur_result_t status;
 
     ur_platform_handle_t platform = nullptr;
@@ -22,8 +21,7 @@ int main(int argc, char *argv[])
 
     // Initialize the platform
     status = urInit(0, 0);
-    if (status != UR_RESULT_SUCCESS)
-    {
+    if (status != UR_RESULT_SUCCESS) {
         std::cout << "urInit failed with return code: " << status << std::endl;
         return 1;
     }
@@ -33,65 +31,68 @@ int main(int argc, char *argv[])
     std::vector<ur_platform_handle_t> platforms;
 
     status = urPlatformGet(1, nullptr, &platformCount);
-    if (status != UR_RESULT_SUCCESS)
-    {
-        std::cout << "urPlatformGet failed with return code: " << status << std::endl;
+    if (status != UR_RESULT_SUCCESS) {
+        std::cout << "urPlatformGet failed with return code: " << status
+                  << std::endl;
         goto out;
     }
 
     platforms.resize(platformCount);
     status = urPlatformGet(platformCount, platforms.data(), nullptr);
-    if (status != UR_RESULT_SUCCESS)
-    {
-        std::cout << "urPlatformGet failed with return code: " << status << std::endl;
+    if (status != UR_RESULT_SUCCESS) {
+        std::cout << "urPlatformGet failed with return code: " << status
+                  << std::endl;
         goto out;
     }
 
-    for (auto p : platforms)
-    {
+    for (auto p : platforms) {
         ur_api_version_t api_version = {};
         status = urPlatformGetApiVersion(platform, &api_version);
-        if (status != UR_RESULT_SUCCESS)
-        {
-            std::cout << "urPlatformGetApiVersion failed with return code: " << status << std::endl;
+        if (status != UR_RESULT_SUCCESS) {
+            std::cout << "urPlatformGetApiVersion failed with return code: "
+                      << status << std::endl;
             goto out;
         }
-        std::cout << "API version: " << UR_MAJOR_VERSION(api_version) << "." << UR_MINOR_VERSION(api_version) << std::endl;
+        std::cout << "API version: " << UR_MAJOR_VERSION(api_version) << "."
+                  << UR_MINOR_VERSION(api_version) << std::endl;
 
         uint32_t deviceCount = 0;
         status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, 0, nullptr, &deviceCount);
-        if (status != UR_RESULT_SUCCESS)
-        {
-            std::cout << "urDeviceGet failed with return code: " << status << std::endl;
+        if (status != UR_RESULT_SUCCESS) {
+            std::cout << "urDeviceGet failed with return code: " << status
+                      << std::endl;
             goto out;
         }
 
         std::vector<ur_device_handle_t> devices(deviceCount);
-        status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, deviceCount, devices.data(), nullptr);
-        if (status != UR_RESULT_SUCCESS)
-        {
-            std::cout << "urDeviceGet failed with return code: " << status << std::endl;
+        status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, deviceCount, devices.data(),
+                             nullptr);
+        if (status != UR_RESULT_SUCCESS) {
+            std::cout << "urDeviceGet failed with return code: " << status
+                      << std::endl;
             goto out;
         }
-        for (auto d : devices)
-        {
+        for (auto d : devices) {
             ur_device_type_t device_type;
-            status = urDeviceGetInfo(d, UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t), static_cast<void *>(&device_type), nullptr);
-            if (status != UR_RESULT_SUCCESS)
-            {
-                std::cout << "urDeviceGetInfo failed with return code: " << status << std::endl;
+            status = urDeviceGetInfo(
+                d, UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t),
+                static_cast<void *>(&device_type), nullptr);
+            if (status != UR_RESULT_SUCCESS) {
+                std::cout << "urDeviceGetInfo failed with return code: "
+                          << status << std::endl;
                 goto out;
             }
             static const size_t DEVICE_NAME_MAX_LEN = 1024;
             char device_name[DEVICE_NAME_MAX_LEN] = {0};
-            status = urDeviceGetInfo(d, UR_DEVICE_INFO_NAME, DEVICE_NAME_MAX_LEN - 1, static_cast<void *>(&device_name), nullptr);
-            if (status != UR_RESULT_SUCCESS)
-            {
-                std::cout << "urDeviceGetInfo failed with return code: " << status << std::endl;
+            status =
+                urDeviceGetInfo(d, UR_DEVICE_INFO_NAME, DEVICE_NAME_MAX_LEN - 1,
+                                static_cast<void *>(&device_name), nullptr);
+            if (status != UR_RESULT_SUCCESS) {
+                std::cout << "urDeviceGetInfo failed with return code: "
+                          << status << std::endl;
                 goto out;
             }
-            if (device_type == UR_DEVICE_TYPE_GPU)
-            {
+            if (device_type == UR_DEVICE_TYPE_GPU) {
                 std::cout << "Found a " << device_name << " gpu.\n";
             }
         }

--- a/source/loader/ur_loader.h
+++ b/source/loader/ur_loader.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -13,7 +13,6 @@
 
 #include "ur_ddi.h"
 
-#include "ur_util.h"
 #include "ur_object.h"
 
 #include "ur_ldrddi.h"

--- a/source/loader/ur_object.h
+++ b/source/loader/ur_object.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -12,6 +12,7 @@
 #define UR_OBJECT_H 1
 
 #include "ur_singleton.h"
+#include "ur_util.h"
 
 //////////////////////////////////////////////////////////////////////////
 struct dditable_t

--- a/test/conformance/testing/CMakeLists.txt
+++ b/test/conformance/testing/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: MIT
+
 add_library(ur_testing INTERFACE)
 target_include_directories(ur_testing INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(${PROJECT_NAME}::testing ALIAS ur_testing)


### PR DESCRIPTION
This PR adds code formatting using clang-format.
The .clang-format file was automatically generated and is based on the LLVM style so reviews about what to change/add are very welcome.
Clang-tidy will be added in the next PR for braces around single line statements since there's no such option in clang-format-10.
The rest of the cpp/header files will be formatted in another PR as well since they'd add too much clutter to this one. The hello_world.cpp file is left as a reference to how it looks after formatting.

Addresses #101 