### PR TITLE
[ur] Install Doxygen in GH pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Install apt package
+        run: sudo apt-get install -y doxygen
+
       - name: Install prerequisites
         run: python3 -m pip install -r third_party/requirements.txt
 


### PR DESCRIPTION
Currently gh-pages is broken for API documentation because doxygen was not installed as part of the build.


Current main: https://oneapi-src.github.io/unified-runtime/core/api.html#ur-result-t
My fix: https://veselypeta.github.io/unified-runtime/core/api.html#ur-result-t 
