### PR TITLE
[ur] Disable testing against null adapter

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,10 +34,6 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
-
   windows-build:
     name: Build - Windows
     runs-on: windows-latest
@@ -60,7 +56,3 @@ jobs:
 
       - name: Build all
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
+++ b/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
@@ -5,7 +5,7 @@
 
 using urDeviceGetGlobalTimestampTest = uur::urAllDevicesTest;
 
-TEST_F(urDeviceGetGlobalTimestampTest, DISABLED_Success) {
+TEST_F(urDeviceGetGlobalTimestampTest, Success) {
   for (auto device : devices) {
     uint64_t device_time = 0;
     uint64_t host_time = 0;
@@ -17,7 +17,7 @@ TEST_F(urDeviceGetGlobalTimestampTest, DISABLED_Success) {
   }
 }
 
-TEST_F(urDeviceGetGlobalTimestampTest, DISABLED_SuccessHostTimer) {
+TEST_F(urDeviceGetGlobalTimestampTest, SuccessHostTimer) {
   for (auto device : devices) {
     uint64_t host_time = 0;
     ASSERT_SUCCESS(urDeviceGetGlobalTimestamps(device, nullptr, &host_time));

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -12,16 +12,14 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
   }
 }
 
-// TODO - re-enable -- #168
-TEST_F(urDeviceGetNativeHandleTest, DISABLED_InvalidNullDeviceHandle) {
+TEST_F(urDeviceGetNativeHandleTest, InvalidNullDeviceHandle) {
   for (auto device : devices) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urDeviceGetNativeHandle(device, nullptr));
   }
 }
 
-// TODO - re-enable -- #168
-TEST_F(urDeviceGetNativeHandleTest, DISABLED_InvalidNullNativeDeviceHandle) {
+TEST_F(urDeviceGetNativeHandleTest, InvalidNullNativeDeviceHandle) {
   ur_native_handle_t native_handle = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                    urDeviceGetNativeHandle(nullptr, &native_handle));

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -12,7 +12,7 @@ TEST_F(urDeviceReleaseTest, Success) {
 }
 
 // TODO - re-enable this test - #170
-TEST_F(urDeviceReleaseTest, DISABLED_InvalidNullHandle) {
+TEST_F(urDeviceReleaseTest, InvalidNullHandle) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                    urDeviceRelease(nullptr));
 }

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -12,8 +12,7 @@ TEST_F(urDeviceRetainTest, Success) {
   }
 }
 
-// TODO - re-enable this test - #170
-TEST_F(urDeviceRetainTest, DISABLED_InvalidNullHandle) {
+TEST_F(urDeviceRetainTest, InvalidNullHandle) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                    urDeviceRetain(nullptr));
 }

--- a/test/conformance/device/urDeviceSelectBinary.cpp
+++ b/test/conformance/device/urDeviceSelectBinary.cpp
@@ -15,8 +15,7 @@ TEST_F(urDeviceSelectBinaryTest, Success) {
   }
 }
 
-// Re-enable this test - See #171
-TEST_F(urDeviceSelectBinaryTest, DISABLED_InvalidNullHandle) {
+TEST_F(urDeviceSelectBinaryTest, InvalidNullHandle) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                    urDeviceSelectBinary(nullptr, nullptr, 0, nullptr));
 }

--- a/test/conformance/platform/urInit.cpp
+++ b/test/conformance/platform/urInit.cpp
@@ -10,7 +10,7 @@ TEST(urInitTest, Success) {
   ASSERT_SUCCESS(urTearDown(nullptr));
 }
 
-TEST(urInitTest, DISABLED_ErrorInvalidEnumerationPlatformFlags) {
+TEST(urInitTest, ErrorInvalidEnumerationPlatformFlags) {
   const ur_platform_init_flags_t platform_flags =
       UR_PLATFORM_INIT_FLAG_FORCE_UINT32;
   const ur_device_init_flags_t device_flags = 0;
@@ -18,7 +18,7 @@ TEST(urInitTest, DISABLED_ErrorInvalidEnumerationPlatformFlags) {
                    urInit(platform_flags, device_flags));
 }
 
-TEST(urInitTest, DISABLED_ErrorInvalidEnumerationDeviceFlags) {
+TEST(urInitTest, ErrorInvalidEnumerationDeviceFlags) {
   const ur_platform_init_flags_t platform_flags = 0;
   const ur_device_init_flags_t device_flags =
       UR_PLATFORM_INIT_FLAG_FORCE_UINT32;

--- a/test/conformance/platform/urTearDown.cpp
+++ b/test/conformance/platform/urTearDown.cpp
@@ -15,6 +15,6 @@ TEST_F(urTearDownTest, Success) {
   ASSERT_SUCCESS(urTearDown(&tear_down_params));
 }
 
-TEST_F(urTearDownTest, DISABLED_InvalidNullPointerParams) {
+TEST_F(urTearDownTest, InvalidNullPointerParams) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urTearDown(nullptr));
 }


### PR DESCRIPTION
We have decided that there is no purpose in running the conformance tests against the null adapter since it will never be a conformant implementation.
This MR:
 * Removes the job to run tests against the null adapter
 * Re-enables disabled tests