### PR TITLE
[ur] Add missing command type & exec status enums

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -297,13 +297,59 @@ class ur_mem_advice_t(c_int):
 
 
 ###############################################################################
+## @brief Command type
+class ur_command_v(IntEnum):
+    KERNEL_LAUNCH = 0                               ## Event created by ::urEnqueueKernelLaunch
+    EVENTS_WAIT = 1                                 ## Event created by ::urEnqueueEventsWait
+    EVENTS_WAIT_WITH_BARRIER = 2                    ## Event created by ::urEnqueueEventsWaitWithBarrier
+    MEM_BUFFER_READ = 3                             ## Event created by ::urEnqueueMemBufferRead
+    MEM_BUFFER_WRITE = 4                            ## Event created by ::urEnqueueMemBufferWrite
+    MEM_BUFFER_READ_RECT = 5                        ## Event created by ::urEnqueueMemBufferReadRect
+    MEM_BUFFER_WRITE_RECT = 6                       ## Event created by ::urEnqueueMemBufferWriteRect
+    MEM_BUFFER_COPY = 7                             ## Event created by ::urEnqueueMemBufferCopy
+    MEM_BUFFER_COPY_RECT = 8                        ## Event created by ::urEnqueueMemBufferCopyRect
+    MEM_BUFFER_FILL = 9                             ## Event created by ::urEnqueueMemBufferFill
+    MEM_IMAGE_READ = 10                             ## Event created by ::urEnqueueMemImageRead
+    MEM_IMAGE_WRITE = 11                            ## Event created by ::urEnqueueMemImageWrite
+    MEM_IMAGE_COPY = 12                             ## Event created by ::urEnqueueMemImageCopy
+    MEM_BUFFER_MAP = 14                             ## Event created by ::urEnqueueMemBufferMap
+    MEM_UNMAP = 16                                  ## Event created by ::urEnqueueMemUnmap
+    USM_MEMSET = 17                                 ## Event created by ::urEnqueueUSMMemset
+    USM_MEMCPY = 18                                 ## Event created by ::urEnqueueUSMMemcpy
+    USM_PREFETCH = 19                               ## Event created by ::urEnqueueUSMPrefetch
+    USM_MEM_ADVICE = 20                             ## Event created by ::urEnqueueUSMMemAdvice
+    USM_FILL_2D = 21                                ## Event created by ::urEnqueueUSMFill2D
+    USM_MEMSET_2D = 22                              ## Event created by ::urEnqueueUSMMemset2D
+    USM_MEMCPY_2D = 23                              ## Event created by ::urEnqueueUSMMemcpy2D
+    DEVICE_GLOBAL_VARIABLE_WRITE = 24               ## Event created by ::urEnqueueDeviceGlobalVariableWrite
+    DEVICE_GLOBAL_VARIABLE_READ = 25                ## Event created by ::urEnqueueDeviceGlobalVariableRead
+
+class ur_command_t(c_int):
+    def __str__(self):
+        return str(ur_command_v(self.value))
+
+
+###############################################################################
+## @brief Event Status
+class ur_event_status_v(IntEnum):
+    COMPLETE = 0                                    ## Command is complete
+    RUNNING = 1                                     ## Command is running
+    SUBMITTED = 2                                   ## Command is submitted
+    QUEUED = 3                                      ## Command is queued
+
+class ur_event_status_t(c_int):
+    def __str__(self):
+        return str(ur_event_status_v(self.value))
+
+
+###############################################################################
 ## @brief Event query information type
 class ur_event_info_v(IntEnum):
-    COMMAND_QUEUE = 0                               ## Command queue information of an event object
-    CONTEXT = 1                                     ## Context information of an event object
-    COMMAND_TYPE = 2                                ## Command type information of an event object
-    COMMAND_EXECUTION_STATUS = 3                    ## Command execution status of an event object
-    REFERENCE_COUNT = 4                             ## Reference count of an event object
+    COMMAND_QUEUE = 0                               ## [::ur_queue_handle_t] Command queue information of an event object
+    CONTEXT = 1                                     ## [::ur_context_handle_t] Context information of an event object
+    COMMAND_TYPE = 2                                ## [::ur_command_t] Command type information of an event object
+    COMMAND_EXECUTION_STATUS = 3                    ## [::ur_event_status_t] Command execution status of an event object
+    REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of an event object
 
 class ur_event_info_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1466,14 +1466,58 @@ urEnqueueDeviceGlobalVariableRead(
 #pragma region event
 #endif
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Command type
+typedef enum ur_command_t
+{
+    UR_COMMAND_KERNEL_LAUNCH = 0,                   ///< Event created by ::urEnqueueKernelLaunch
+    UR_COMMAND_EVENTS_WAIT = 1,                     ///< Event created by ::urEnqueueEventsWait
+    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,        ///< Event created by ::urEnqueueEventsWaitWithBarrier
+    UR_COMMAND_MEM_BUFFER_READ = 3,                 ///< Event created by ::urEnqueueMemBufferRead
+    UR_COMMAND_MEM_BUFFER_WRITE = 4,                ///< Event created by ::urEnqueueMemBufferWrite
+    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,            ///< Event created by ::urEnqueueMemBufferReadRect
+    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,           ///< Event created by ::urEnqueueMemBufferWriteRect
+    UR_COMMAND_MEM_BUFFER_COPY = 7,                 ///< Event created by ::urEnqueueMemBufferCopy
+    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,            ///< Event created by ::urEnqueueMemBufferCopyRect
+    UR_COMMAND_MEM_BUFFER_FILL = 9,                 ///< Event created by ::urEnqueueMemBufferFill
+    UR_COMMAND_MEM_IMAGE_READ = 10,                 ///< Event created by ::urEnqueueMemImageRead
+    UR_COMMAND_MEM_IMAGE_WRITE = 11,                ///< Event created by ::urEnqueueMemImageWrite
+    UR_COMMAND_MEM_IMAGE_COPY = 12,                 ///< Event created by ::urEnqueueMemImageCopy
+    UR_COMMAND_MEM_BUFFER_MAP = 14,                 ///< Event created by ::urEnqueueMemBufferMap
+    UR_COMMAND_MEM_UNMAP = 16,                      ///< Event created by ::urEnqueueMemUnmap
+    UR_COMMAND_USM_MEMSET = 17,                     ///< Event created by ::urEnqueueUSMMemset
+    UR_COMMAND_USM_MEMCPY = 18,                     ///< Event created by ::urEnqueueUSMMemcpy
+    UR_COMMAND_USM_PREFETCH = 19,                   ///< Event created by ::urEnqueueUSMPrefetch
+    UR_COMMAND_USM_MEM_ADVICE = 20,                 ///< Event created by ::urEnqueueUSMMemAdvice
+    UR_COMMAND_USM_FILL_2D = 21,                    ///< Event created by ::urEnqueueUSMFill2D
+    UR_COMMAND_USM_MEMSET_2D = 22,                  ///< Event created by ::urEnqueueUSMMemset2D
+    UR_COMMAND_USM_MEMCPY_2D = 23,                  ///< Event created by ::urEnqueueUSMMemcpy2D
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 24,   ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 25,    ///< Event created by ::urEnqueueDeviceGlobalVariableRead
+    UR_COMMAND_FORCE_UINT32 = 0x7fffffff
+
+} ur_command_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Event Status
+typedef enum ur_event_status_t
+{
+    UR_EVENT_STATUS_COMPLETE = 0,                   ///< Command is complete
+    UR_EVENT_STATUS_RUNNING = 1,                    ///< Command is running
+    UR_EVENT_STATUS_SUBMITTED = 2,                  ///< Command is submitted
+    UR_EVENT_STATUS_QUEUED = 3,                     ///< Command is queued
+    UR_EVENT_STATUS_FORCE_UINT32 = 0x7fffffff
+
+} ur_event_status_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Event query information type
 typedef enum ur_event_info_t
 {
-    UR_EVENT_INFO_COMMAND_QUEUE = 0,                ///< Command queue information of an event object
-    UR_EVENT_INFO_CONTEXT = 1,                      ///< Context information of an event object
-    UR_EVENT_INFO_COMMAND_TYPE = 2,                 ///< Command type information of an event object
-    UR_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3,     ///< Command execution status of an event object
-    UR_EVENT_INFO_REFERENCE_COUNT = 4,              ///< Reference count of an event object
+    UR_EVENT_INFO_COMMAND_QUEUE = 0,                ///< [::ur_queue_handle_t] Command queue information of an event object
+    UR_EVENT_INFO_CONTEXT = 1,                      ///< [::ur_context_handle_t] Context information of an event object
+    UR_EVENT_INFO_COMMAND_TYPE = 2,                 ///< [::ur_command_t] Command type information of an event object
+    UR_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3,     ///< [::ur_event_status_t] Command execution status of an event object
+    UR_EVENT_INFO_REFERENCE_COUNT = 4,              ///< [uint32_t] Reference count of an event object
     UR_EVENT_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_event_info_t;

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -652,7 +652,7 @@ desc: "Enqueue a command to fill an image object with specified color"
 class: $xEnqueue
 name: MemImageFill
 ordinal: "0"
-version: "9999.0"
+version: "9999.0" # see #50
 details:
     - "Currently not implemented in Level Zero"
     - "TODO: add a driver function in Level Zero?"
@@ -772,7 +772,7 @@ type: function
 desc: "Enqueue a command to map a region of the image object into the host address space and return a pointer to the mapped region" 
 class: $xEnqueue
 name: MemImageMap
-version: "9999.0"
+version: "9999.0" # See #50
 ordinal: "0"
 details:
     - "Input parameter blockingMap indicates if the map is blocking or non-blocking."

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -11,20 +11,94 @@ desc: "Intel $OneApi Level-Zero Runtime APIs"
 ordinal: "0"
 --- #--------------------------------------------------------------------------
 type: enum
+desc: "Command type"
+class: $xEvent
+name: $x_command_t
+etors:
+    - name: KERNEL_LAUNCH
+      desc: Event created by $xEnqueueKernelLaunch
+    - name: EVENTS_WAIT
+      desc: Event created by $xEnqueueEventsWait
+    - name: EVENTS_WAIT_WITH_BARRIER
+      desc: Event created by $xEnqueueEventsWaitWithBarrier
+    - name: MEM_BUFFER_READ
+      desc: Event created by $xEnqueueMemBufferRead
+    - name: MEM_BUFFER_WRITE
+      desc: Event created by $xEnqueueMemBufferWrite
+    - name: MEM_BUFFER_READ_RECT
+      desc: Event created by $xEnqueueMemBufferReadRect
+    - name: MEM_BUFFER_WRITE_RECT
+      desc: Event created by $xEnqueueMemBufferWriteRect
+    - name: MEM_BUFFER_COPY
+      desc: Event created by $xEnqueueMemBufferCopy
+    - name: MEM_BUFFER_COPY_RECT
+      desc: Event created by $xEnqueueMemBufferCopyRect
+    - name: MEM_BUFFER_FILL
+      desc: Event created by $xEnqueueMemBufferFill
+    - name: MEM_IMAGE_READ
+      desc: Event created by $xEnqueueMemImageRead
+    - name: MEM_IMAGE_WRITE
+      desc: Event created by $xEnqueueMemImageWrite
+    - name: MEM_IMAGE_COPY
+      desc: Event created by $xEnqueueMemImageCopy
+    - name: MEM_IMAGE_FILL
+      desc: Event created by $xEnqueueMemImageFill
+      version: "9999.0" # See #50
+    - name: MEM_BUFFER_MAP
+      desc: Event created by $xEnqueueMemBufferMap
+    - name: MEM_IMAGE_MAP
+      desc: Event created by $xEnqueueMemImageMap
+      version: "9999.0" # See #50
+    - name: MEM_UNMAP
+      desc: Event created by $xEnqueueMemUnmap
+    - name: USM_MEMSET
+      desc: Event created by $xEnqueueUSMMemset
+    - name: USM_MEMCPY
+      desc: Event created by $xEnqueueUSMMemcpy
+    - name: USM_PREFETCH
+      desc: Event created by $xEnqueueUSMPrefetch
+    - name: USM_MEM_ADVICE
+      desc: Event created by $xEnqueueUSMMemAdvice
+    - name: USM_FILL_2D
+      desc: Event created by $xEnqueueUSMFill2D
+    - name: USM_MEMSET_2D
+      desc: Event created by $xEnqueueUSMMemset2D
+    - name: USM_MEMCPY_2D
+      desc: Event created by $xEnqueueUSMMemcpy2D
+    - name: DEVICE_GLOBAL_VARIABLE_WRITE
+      desc: Event created by $xEnqueueDeviceGlobalVariableWrite
+    - name: DEVICE_GLOBAL_VARIABLE_READ
+      desc: Event created by $xEnqueueDeviceGlobalVariableRead
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Event Status"
+class: $xEvent
+name: $x_event_status_t
+etors:
+    - name: COMPLETE
+      desc: Command is complete
+    - name: RUNNING
+      desc: Command is running
+    - name: SUBMITTED
+      desc: Command is submitted
+    - name: QUEUED
+      desc: Command is queued
+--- #--------------------------------------------------------------------------
+type: enum
 desc: "Event query information type"
 class: $xEvent
 name: $x_event_info_t
 etors:
     - name: COMMAND_QUEUE
-      desc: "Command queue information of an event object"
+      desc: "[$x_queue_handle_t] Command queue information of an event object"
     - name: CONTEXT
-      desc: "Context information of an event object"
+      desc: "[$x_context_handle_t] Context information of an event object"
     - name: COMMAND_TYPE
-      desc: "Command type information of an event object"
+      desc: "[$x_command_t] Command type information of an event object"
     - name: COMMAND_EXECUTION_STATUS
-      desc: "Command execution status of an event object"
+      desc: "[$x_event_status_t] Command execution status of an event object"
     - name: REFERENCE_COUNT
-      desc: "Reference count of an event object"
+      desc: "[uint32_t] Reference count of an event object"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Profiling query information type"


### PR DESCRIPTION
This MR adds the following missing required enumerations to the ur spec to match PI.
* `ur_command_t` which matches PI's [`pi_command_t`](https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/detail/pi.h#L443)
* `ur_event_status_t` which matches PI's [`pi_event_status_t`](https://github.com/intel/llvm/blob/8c244de9e34140651bdfc2e6ffb4c221a4de1f23/sycl/include/sycl/detail/pi.h#L148)