### PR TITLE
Add initial validation layer

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -118,7 +118,7 @@ def generate_api(incpath, srcpath, namespace, tags, version, revision, specs, me
     loc += _generate_api_py(incpath, namespace, tags, version, revision, specs, meta)
     print("Generated %s lines of code.\n"%loc)
 
-loader_templates_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
+templates_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 
 """
     generates c/c++ files from the specification documents
@@ -126,7 +126,7 @@ loader_templates_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 def _mako_lib_cpp(path, namespace, tags, version, specs, meta):
     loc = 0
     template = "libapi.cpp.mako"
-    fin = os.path.join(loader_templates_dir, template)
+    fin = os.path.join(templates_dir, template)
 
     name = "%s_libapi"%(namespace)
     filename = "%s.cpp"%(name)
@@ -143,7 +143,7 @@ def _mako_lib_cpp(path, namespace, tags, version, specs, meta):
         meta = meta)
 
     template = "libddi.cpp.mako"
-    fin = os.path.join(loader_templates_dir, template)
+    fin = os.path.join(templates_dir, template)
 
     name = "%s_libddi"%(namespace)
     filename = "%s.cpp"%(name)
@@ -167,7 +167,7 @@ def _mako_loader_cpp(path, namespace, tags, version, specs, meta):
     print("make_loader_cpp path %s namespace %s version %s\n" %(path, namespace, version))
     loc = 0
     template = "ldrddi.h.mako"
-    fin = os.path.join(loader_templates_dir, template)
+    fin = os.path.join(templates_dir, template)
 
     name = "%s_ldrddi"%(namespace)
     filename = "%s.h"%(name)
@@ -184,7 +184,7 @@ def _mako_loader_cpp(path, namespace, tags, version, specs, meta):
         meta=meta)
 
     template = "ldrddi.cpp.mako"
-    fin = os.path.join(loader_templates_dir, template)
+    fin = os.path.join(templates_dir, template)
 
     name = "%s_ldrddi"%(namespace)
     filename = "%s.cpp"%(name)
@@ -209,9 +209,33 @@ def _mako_null_driver_cpp(path, namespace, tags, version, specs, meta):
     os.makedirs(dstpath, exist_ok=True)
 
     template = "nullddi.cpp.mako"
-    fin = os.path.join(loader_templates_dir, template)
+    fin = os.path.join(templates_dir, template)
 
     name = "%s_nullddi"%(namespace)
+    filename = "%s.cpp"%(name)
+    fout = os.path.join(dstpath, filename)
+
+    print("Generating %s..."%fout)
+    return util.makoWrite(
+        fin, fout,
+        name=name,
+        ver=version,
+        namespace=namespace,
+        tags=tags,
+        specs=specs,
+        meta=meta)
+
+"""
+    generates c/c++ files from the specification documents
+"""
+def _mako_validation_layer_cpp(path, namespace, tags, version, specs, meta):
+    dstpath = os.path.join(path, "validation")
+    os.makedirs(dstpath, exist_ok=True)
+
+    template = "valddi.cpp.mako"
+    fin = os.path.join(templates_dir, template)
+
+    name = "%s_valddi"%(namespace)
     filename = "%s.cpp"%(name)
     fout = os.path.join(dstpath, filename)
 
@@ -261,3 +285,18 @@ def generate_drivers(path, section, namespace, tags, version, specs, meta):
     loc += _mako_null_driver_cpp(dstpath, namespace, tags, version, specs, meta)
     print("Generated %s lines of code.\n"%loc)
 
+"""
+Entry-point:
+    generates layers for unified_runtime driver
+"""
+def generate_layers(path, section, namespace, tags, version, specs, meta):
+    print("GL section %s\n"%section)
+    print("GL namespace %s\n"%namespace)
+    layer_dstpath = os.path.join(path, "layers")
+    include_dstpath = os.path.join(path, "../include")
+    os.makedirs(layer_dstpath, exist_ok=True)
+    os.makedirs(include_dstpath, exist_ok=True)
+
+    loc = 0
+    loc += _mako_validation_layer_cpp(layer_dstpath, namespace, tags, version, specs, meta)
+    print("VALIDATION Generated %s lines of code.\n"%loc)

--- a/scripts/json2src.py
+++ b/scripts/json2src.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     add_argument(parser, "lib", "generation of lib files.", True)
     add_argument(parser, "loader", "generation of loader files.", True)
-    add_argument(parser, "layers", "generation of layer files.", False)
+    add_argument(parser, "layers", "generation of layer files.", True)
     add_argument(parser, "drivers", "generation of null driver files.", True)
     parser.add_argument("--debug", action='store_true', help="dump intermediate data to disk.")
     parser.add_argument("--sections", type=list, default=None, help="Optional list of sections for which to generate source, default is all")
@@ -47,8 +47,8 @@ if __name__ == '__main__':
                 generate_code.generate_lib(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
             if args.loader:
                 generate_code.generate_loader(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
-            #if args.layers:
-            #    generate_code.generate_layers(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
+            if args.layers:
+               generate_code.generate_layers(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
             if args.drivers:
                 generate_code.generate_drivers(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
 

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -38,9 +38,9 @@ class obj_traits:
             return obj['class']
         except:
             return None
-    
 
-    
+
+
 
 """
     Extracts traits from a class name
@@ -865,10 +865,26 @@ def make_pfncb_param_type(namespace, tags, obj):
 
     return "%s_params_t"%_camel_to_snake(make_func_name(namespace, tags, obj))
 
+"""
+Public:
+    returns a dict of auto-generated c++ parameter validation checks
+"""
+def make_param_checks(namespace, tags, obj, cpp=False, meta=None):
+    checks = {}
+    for item in obj.get('returns', []):
+        for key, values in item.items():
+            key = subt(namespace, tags, key, False, cpp)
+            for val in values:
+                code = re.match(r"^\`(.*)\`$", val)
+                if code:
+                    if key not in checks:
+                        checks[key] = []
+                    checks[key].append(subt(namespace, tags, code.group(1), False, cpp))
+    return checks
 
 """
 Public:
-    returns a list of all function objs for the specified class. 
+    returns a list of all function objs for the specified class.
 """
 def get_class_function_objs(specs, cname, version = None):
     objects = []
@@ -900,10 +916,10 @@ def get_class_function_objs_exp(specs, cname):
                 else:
                     objects.append(obj)
     objects = sorted(objects, key=lambda obj: (float(obj.get('version',"1.0"))*10000) + int(obj.get('ordinal',"100")))
-    exp_objects = sorted(exp_objects, key=lambda obj: (float(obj.get('version',"1.0"))*10000) + int(obj.get('ordinal',"100")))              
+    exp_objects = sorted(exp_objects, key=lambda obj: (float(obj.get('version',"1.0"))*10000) + int(obj.get('ordinal',"100")))
     return objects, exp_objects
 
-""" 
+"""
 Public:
     returns string name of table for function object
 """
@@ -946,7 +962,7 @@ def get_pfntables(specs, meta, namespace, tags):
             pfn = "%s_pfnGet%sProcAddrTable_t"%(namespace, name)
 
             tables.append({
-                'name': name, 
+                'name': name,
                 'type': table,
                 'export': export,
                 'pfn': pfn,
@@ -976,15 +992,15 @@ def get_pfntables(specs, meta, namespace, tags):
             pfn = "%s_pfnGet%sProcAddrTable_t"%(namespace, name)
 
             tables.append({
-                'name': name, 
+                'name': name,
                 'type': table,
                 'export': export,
                 'pfn': pfn,
                 'functions': exp_objs,
                 'experimental': True
             })
-        
-        
+
+
     return tables
 
 """
@@ -1016,7 +1032,7 @@ def get_pfncbtables(specs, meta, namespace, tags):
             print(name)
             table = "%s_%s_callbacks_t"%(namespace, _camel_to_snake(name))
             tables.append({
-                'name': name, 
+                'name': name,
                 'type': table,
                 'functions': objs
             })

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -240,10 +240,10 @@ ${tbl['export']['name']}(
             continue;
         auto getTable = reinterpret_cast<${tbl['pfn']}>(
             GET_FUNCTION_PTR( platform.handle, "${tbl['export']['name']}") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.${n}.${tbl['name']});
-        if(getTableResult == ${X}_RESULT_SUCCESS) 
+        if(getTableResult == ${X}_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         %if tbl['experimental'] is False:
         else
@@ -280,6 +280,16 @@ ${tbl['export']['name']}(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.${n}.${tbl['name']};
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( ${X}_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<${tbl['pfn']}>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "${tbl['export']['name']}") );
+        if(!getTable)
+            return ${X}_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -1,0 +1,112 @@
+<%!
+import re
+from templates import helper as th
+%><%
+    n=namespace
+    N=n.upper()
+
+    x=tags['$x']
+    X=x.upper()
+%>/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ${name}.cpp
+ *
+ */
+#include "${x}_validation_layer.h"
+
+namespace validation_layer
+{
+    %for obj in th.extract_objs(specs, r"function"):
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for ${th.make_func_name(n, tags, obj)}
+    %if 'condition' in obj:
+    #if ${th.subt(n, tags, obj['condition'])}
+    %endif
+    __${x}dlllocal ${x}_result_t ${X}_APICALL
+    ${th.make_func_name(n, tags, obj)}(
+        %for line in th.make_param_lines(n, tags, obj):
+        ${line}
+        %endfor
+        )
+    {
+        auto ${th.make_pfn_name(n, tags, obj)} = context.${n}DdiTable.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)};
+
+        if( nullptr == ${th.make_pfn_name(n, tags, obj)} )
+            return ${X}_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            %for key, values in th.make_param_checks(n, tags, obj, meta=meta).items():
+            %for val in values:
+            if( ${val} )
+                return ${key};
+
+            %endfor
+            %endfor
+        }
+
+        return ${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
+    }
+    %if 'condition' in obj:
+    #endif // ${th.subt(n, tags, obj['condition'])}
+    %endif
+
+    %endfor
+} // namespace validation_layer
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+%for tbl in th.get_pfntables(specs, meta, n, tags):
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's ${tbl['name']} table
+///        with current process' addresses
+///
+/// @returns
+///     - ::${X}_RESULT_SUCCESS
+///     - ::${X}_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::${X}_RESULT_ERROR_UNSUPPORTED_VERSION
+${X}_DLLEXPORT ${x}_result_t ${X}_APICALL
+${tbl['export']['name']}(
+    %for line in th.make_param_lines(n, tags, tbl['export']):
+    ${line}
+    %endfor
+    )
+{
+    auto& dditable = validation_layer::context.${n}DdiTable.${tbl['name']};
+
+    if( nullptr == pDdiTable )
+        return ${X}_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return ${X}_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ${x}_result_t result = ${X}_RESULT_SUCCESS;
+
+    %for obj in tbl['functions']:
+    %if 'condition' in obj:
+#if ${th.subt(n, tags, obj['condition'])}
+    %endif
+    dditable.${th.append_ws(th.make_pfn_name(n, tags, obj), 43)} = pDdiTable->${th.make_pfn_name(n, tags, obj)};
+    pDdiTable->${th.append_ws(th.make_pfn_name(n, tags, obj), 41)} = validation_layer::${th.make_func_name(n, tags, obj)};
+    %if 'condition' in obj:
+#else
+    dditable.${th.append_ws(th.make_pfn_name(n, tags, obj), 43)} = nullptr;
+    pDdiTable->${th.append_ws(th.make_pfn_name(n, tags, obj), 41)} = nullptr;
+#endif
+    %endif
+
+    %endfor
+    return result;
+}
+
+%endfor
+#if defined(__cplusplus)
+};
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: MIT
 
 add_definitions(-DUR_VERSION="${PROJECT_VERSION_MAJOR}")
@@ -6,5 +6,5 @@ add_definitions(-DUR_VALIDATION_LAYER_SUPPORTED_VERSION="${PROJECT_VERSION_MAJOR
 
 add_subdirectory(common)
 add_subdirectory(loader)
-#add_subdirectory(layers)
+add_subdirectory(layers)
 add_subdirectory(drivers)

--- a/source/layers/CMakeLists.txt
+++ b/source/layers/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: MIT
+add_subdirectory(validation)

--- a/source/layers/validation/CMakeLists.txt
+++ b/source/layers/validation/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: MIT
+set(TARGET_NAME ur_validation_layer)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/UrValidationLayerVersion.rc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/UrValidationLayerVersion.rc
+    @ONLY)
+
+add_library(${TARGET_NAME}
+    SHARED
+        ${CMAKE_CURRENT_SOURCE_DIR}/ur_validation_layer.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/ur_validation_layer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ur_valddi.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/UrValidationLayerVersion.rc
+)
+
+target_include_directories(${TARGET_NAME}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${TARGET_NAME} PRIVATE
+    ${PROJECT_NAME}::headers
+    ${PROJECT_NAME}::common
+)
+
+if(UNIX)
+    set(GCC_COVERAGE_COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
+endif()
+
+set_target_properties(${TARGET_NAME} PROPERTIES
+    VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+    SOVERSION  "${PROJECT_VERSION_MAJOR}"
+)
+
+install(TARGETS ur_validation_layer
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT unified-runtime
+        NAMELINK_SKIP
+)

--- a/source/layers/validation/UrValidationLayerVersion.rc.in
+++ b/source/layers/validation/UrValidationLayerVersion.rc.in
@@ -1,0 +1,33 @@
+#define VER_FILEVERSION             @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@
+#define VER_FILEVERSION_STR         "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@\0"
+
+#define VER_PRODUCTVERSION          @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@
+#define VER_PRODUCTVERSION_STR      "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@\0"
+
+#define VER_FILEDESCRIPTION_STR     "oneAPI Unified Runtime Validation Layer for Windows(R) Unified Runtime Drivers"
+
+#define VER_PRODUCT_NAME_STR        "oneAPI Unified runtime Validation Layer for Windows(R)"
+
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2023 Intel Corporation"
+
+1 VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "FileDescription",  VER_FILEDESCRIPTION_STR
+            VALUE "FileVersion",      VER_FILEVERSION_STR
+            VALUE "ProductVersion",   VER_PRODUCTVERSION_STR
+            VALUE "ProductName",      VER_PRODUCT_NAME_STR
+            VALUE "LegalCopyright",   VER_LEGALCOPYRIGHT_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END

--- a/source/layers/validation/ur_valddi.cpp
+++ b/source/layers/validation/ur_valddi.cpp
@@ -1,0 +1,4233 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ur_valddi.cpp
+ *
+ */
+#include "ur_validation_layer.h"
+
+namespace validation_layer
+{
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urContextCreate(
+        uint32_t DeviceCount,                           ///< [in] the number of devices given in phDevices
+        ur_device_handle_t* phDevices,                  ///< [in][range(0, DeviceCount)] array of handle of devices.
+        ur_context_handle_t* phContext                  ///< [out] pointer to handle of context object created
+        )
+    {
+        auto pfnCreate = context.urDdiTable.Context.pfnCreate;
+
+        if( nullptr == pfnCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == phDevices )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phContext )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreate( DeviceCount, phDevices, phContext );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urContextRetain(
+        ur_context_handle_t hContext                    ///< [in] handle of the context to get a reference of.
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Context.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hContext );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urContextRelease(
+        ur_context_handle_t hContext                    ///< [in] handle of the context to release.
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Context.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hContext );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urContextGetInfo(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context
+        ur_context_info_t ContextInfoType,              ///< [in] type of the info to retrieve
+        size_t propSize,                                ///< [in] the number of bytes of memory pointed to by pContextInfo.
+        void* pContextInfo,                             ///< [out][optional] array of bytes holding the info.
+                                                        ///< if propSize is not equal to or greater than the real number of bytes
+                                                        ///< needed to return 
+                                                        ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< pContextInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT < ContextInfoType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urContextGetNativeHandle(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context.
+        ur_native_handle_t* phNativeContext             ///< [out] a pointer to the native handle of the context.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Context.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeContext )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hContext, phNativeContext );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urContextCreateWithNativeHandle(
+        ur_native_handle_t hNativeContext,              ///< [in] the native handle of the context.
+        ur_context_handle_t* phContext                  ///< [out] pointer to the handle of the context object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Context.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phContext )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeContext, phContext );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urContextSetExtendedDeleter
+    __urdlllocal ur_result_t UR_APICALL
+    urContextSetExtendedDeleter(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context.
+        ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
+        void* pUserData                                 ///< [in][out] pointer to data to be passed to callback.
+        )
+    {
+        auto pfnSetExtendedDeleter = context.urDdiTable.Context.pfnSetExtendedDeleter;
+
+        if( nullptr == pfnSetExtendedDeleter )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pUserData )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnSetExtendedDeleter( hContext, pfnDeleter, pUserData );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueKernelLaunch
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueKernelLaunch(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        uint32_t workDim,                               ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                                        ///< work-group work-items
+        const size_t* pGlobalWorkOffset,                ///< [in] pointer to an array of workDim unsigned values that specify the
+                                                        ///< offset used to calculate the global ID of a work-item
+        const size_t* pGlobalWorkSize,                  ///< [in] pointer to an array of workDim unsigned values that specify the
+                                                        ///< number of global work-items in workDim that will execute the kernel
+                                                        ///< function
+        const size_t* pLocalWorkSize,                   ///< [in][optional] pointer to an array of workDim unsigned values that
+                                                        ///< specify the number of local work-items forming a work-group that will
+                                                        ///< execute the kernel function.
+                                                        ///< If nullptr, the runtime implementation will choose the work-group
+                                                        ///< size. 
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
+
+        if( nullptr == pfnKernelLaunch )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pGlobalWorkOffset )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pGlobalWorkSize )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnKernelLaunch( hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueEventsWait
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueEventsWait(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                        ///< previously enqueued commands
+                                                        ///< must be complete. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
+
+        if( nullptr == pfnEventsWait )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnEventsWait( hQueue, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueEventsWaitWithBarrier(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                        ///< previously enqueued commands
+                                                        ///< must be complete. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnEventsWaitWithBarrier = context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+
+        if( nullptr == pfnEventsWaitWithBarrier )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnEventsWaitWithBarrier( hQueue, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferRead
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferRead(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+        bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
+        size_t offset,                                  ///< [in] offset in bytes in the buffer object
+        size_t size,                                    ///< [in] size in bytes of data being read
+        void* pDst,                                     ///< [in] pointer to host memory where data is to be read into
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
+
+        if( nullptr == pfnMemBufferRead )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pDst )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemBufferRead( hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferWrite
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferWrite(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+        bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
+        size_t offset,                                  ///< [in] offset in bytes in the buffer object
+        size_t size,                                    ///< [in] size in bytes of data being written
+        const void* pSrc,                               ///< [in] pointer to host memory where data is to be written from
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
+
+        if( nullptr == pfnMemBufferWrite )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemBufferWrite( hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferReadRect
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferReadRect(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+        bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
+        ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
+        ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
+        ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
+        size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
+        size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being read
+        size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
+                                                        ///< dst
+        size_t hostSlicePitch,                          ///< [in] length of each 2D slice in bytes in the host memory region
+                                                        ///< pointed by dst
+        void* pDst,                                     ///< [in] pointer to host memory where data is to be read into
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
+
+        if( nullptr == pfnMemBufferReadRect )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pDst )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemBufferReadRect( hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferWriteRect
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferWriteRect(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+        bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
+        ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
+        ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
+        ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
+        size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
+        size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being
+                                                        ///< written
+        size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
+                                                        ///< src
+        size_t hostSlicePitch,                          ///< [in] length of each 2D slice in bytes in the host memory region
+                                                        ///< pointed by src
+        void* pSrc,                                     ///< [in] pointer to host memory where data is to be written from
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
+        )
+    {
+        auto pfnMemBufferWriteRect = context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
+
+        if( nullptr == pfnMemBufferWriteRect )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemBufferWriteRect( hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferCopy
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferCopy(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
+        ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+        size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
+        size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
+        size_t size,                                    ///< [in] size in bytes of data being copied
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
+        )
+    {
+        auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
+
+        if( nullptr == pfnMemBufferCopy )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBufferSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBufferDst )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnMemBufferCopy( hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferCopyRect
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferCopyRect(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the source buffer object
+        ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
+        ur_rect_offset_t srcOrigin,                     ///< [in] 3D offset in the source buffer
+        ur_rect_offset_t dstOrigin,                     ///< [in] 3D offset in the destination buffer
+        ur_rect_region_t srcRegion,                     ///< [in] source 3D rectangular region descriptor: width, height, depth
+        size_t srcRowPitch,                             ///< [in] length of each row in bytes in the source buffer object
+        size_t srcSlicePitch,                           ///< [in] length of each 2D slice in bytes in the source buffer object
+        size_t dstRowPitch,                             ///< [in] length of each row in bytes in the destination buffer object
+        size_t dstSlicePitch,                           ///< [in] length of each 2D slice in bytes in the destination buffer object
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
+
+        if( nullptr == pfnMemBufferCopyRect )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBufferSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBufferDst )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnMemBufferCopyRect( hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferFill
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferFill(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+        const void* pPattern,                           ///< [in] pointer to the fill pattern
+        size_t patternSize,                             ///< [in] size in bytes of the pattern
+        size_t offset,                                  ///< [in] offset into the buffer
+        size_t size,                                    ///< [in] fill size in bytes, must be a multiple of patternSize
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
+
+        if( nullptr == pfnMemBufferFill )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pPattern )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemBufferFill( hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemImageRead
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemImageRead(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hImage,                         ///< [in] handle of the image object
+        bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
+        ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+        ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                                        ///< image
+        size_t rowPitch,                                ///< [in] length of each row in bytes
+        size_t slicePitch,                              ///< [in] length of each 2D slice of the 3D image
+        void* pDst,                                     ///< [in] pointer to host memory where image is to be read into
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
+        )
+    {
+        auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
+
+        if( nullptr == pfnMemImageRead )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hImage )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pDst )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemImageRead( hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemImageWrite
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemImageWrite(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hImage,                         ///< [in] handle of the image object
+        bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
+        ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+        ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                                        ///< image
+        size_t inputRowPitch,                           ///< [in] length of each row in bytes
+        size_t inputSlicePitch,                         ///< [in] length of each 2D slice of the 3D image
+        void* pSrc,                                     ///< [in] pointer to host memory where image is to be read into
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
+
+        if( nullptr == pfnMemImageWrite )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hImage )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemImageWrite( hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemImageCopy
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemImageCopy(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hImageSrc,                      ///< [in] handle of the src image object
+        ur_mem_handle_t hImageDst,                      ///< [in] handle of the dest image object
+        ur_rect_offset_t srcOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                                        ///< image
+        ur_rect_offset_t dstOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                                        ///< or 3D image
+        ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                                        ///< image
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
+        )
+    {
+        auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
+
+        if( nullptr == pfnMemImageCopy )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hImageSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hImageDst )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnMemImageCopy( hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemBufferMap
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemBufferMap(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
+        bool blockingMap,                               ///< [in] indicates blocking (true), non-blocking (false)
+        ur_map_flags_t mapFlags,                        ///< [in] flags for read, write, readwrite mapping
+        size_t offset,                                  ///< [in] offset in bytes of the buffer region being mapped
+        size_t size,                                    ///< [in] size in bytes of the buffer region being mapped
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
+                                                        ///< numEventsInWaitList?
+        )
+    {
+        auto pfnMemBufferMap = context.urDdiTable.Enqueue.pfnMemBufferMap;
+
+        if( nullptr == pfnMemBufferMap )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( 0x3 < mapFlags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == ppRetMap )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemBufferMap( hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueMemUnmap
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueMemUnmap(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_mem_handle_t hMem,                           ///< [in] handle of the memory (buffer or image) object
+        void* pMappedPtr,                               ///< [in] mapped host address
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
+
+        if( nullptr == pfnMemUnmap )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hMem )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMappedPtr )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnMemUnmap( hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMMemset
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMMemset(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        void* ptr,                                      ///< [in] pointer to USM memory object
+        int8_t byteValue,                               ///< [in] byte value to fill
+        size_t count,                                   ///< [in] size in bytes to be set
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance. 
+        )
+    {
+        auto pfnUSMMemset = context.urDdiTable.Enqueue.pfnUSMMemset;
+
+        if( nullptr == pfnUSMMemset )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == ptr )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnUSMMemset( hQueue, ptr, byteValue, count, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMMemcpy
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMMemcpy(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        bool blocking,                                  ///< [in] blocking or non-blocking copy
+        void* pDst,                                     ///< [in] pointer to the destination USM memory object
+        const void* pSrc,                               ///< [in] pointer to the source USM memory object
+        size_t size,                                    ///< [in] size in bytes to be copied
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
+
+        if( nullptr == pfnUSMMemcpy )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pDst )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnUSMMemcpy( hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMPrefetch
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMPrefetch(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        const void* pMem,                               ///< [in] pointer to the USM memory object
+        size_t size,                                    ///< [in] size in bytes to be fetched
+        ur_usm_migration_flags_t flags,                 ///< [in] USM prefetch flags
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before this command can be executed.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                                        ///< command does not wait on any event to complete.
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
+
+        if( nullptr == pfnUSMPrefetch )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( 0x1 < flags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnUSMPrefetch( hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMMemAdvice
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMMemAdvice(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        const void* pMem,                               ///< [in] pointer to the USM memory object
+        size_t size,                                    ///< [in] size in bytes to be adviced
+        ur_mem_advice_t advice,                         ///< [in] USM memory advice
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular command instance.
+        )
+    {
+        auto pfnUSMMemAdvice = context.urDdiTable.Enqueue.pfnUSMMemAdvice;
+
+        if( nullptr == pfnUSMMemAdvice )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( UR_MEM_ADVICE_DEFAULT < advice )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnUSMMemAdvice( hQueue, pMem, size, advice, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMFill2D
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMFill2D(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        void* pMem,                                     ///< [in] pointer to memory to be filled.
+        size_t pitch,                                   ///< [in] the total width of the destination memory including padding.
+        size_t patternSize,                             ///< [in] the size in bytes of the pattern.
+        const void* pPattern,                           ///< [in] pointer with the bytes of the pattern to set.
+        size_t width,                                   ///< [in] the width in bytes of each row to fill.
+        size_t height,                                  ///< [in] the height of the columns to fill.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
+
+        if( nullptr == pfnUSMFill2D )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pPattern )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnUSMFill2D( hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMMemset2D
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMMemset2D(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        void* pMem,                                     ///< [in] pointer to memory to be filled.
+        size_t pitch,                                   ///< [in] the total width of the destination memory including padding.
+        int value,                                      ///< [in] the value to fill into the region in pMem.
+        size_t width,                                   ///< [in] the width in bytes of each row to set.
+        size_t height,                                  ///< [in] the height of the columns to set.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        auto pfnUSMMemset2D = context.urDdiTable.Enqueue.pfnUSMMemset2D;
+
+        if( nullptr == pfnUSMMemset2D )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnUSMMemset2D( hQueue, pMem, pitch, value, width, height, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueUSMMemcpy2D
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueUSMMemcpy2D(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        bool blocking,                                  ///< [in] indicates if this operation should block the host.
+        void* pDst,                                     ///< [in] pointer to memory where data will be copied.
+        size_t dstPitch,                                ///< [in] the total width of the source memory including padding.
+        const void* pSrc,                               ///< [in] pointer to memory to be copied.
+        size_t srcPitch,                                ///< [in] the total width of the source memory including padding.
+        size_t width,                                   ///< [in] the width in bytes of each row to be copied.
+        size_t height,                                  ///< [in] the height of columns to be copied.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
+
+        if( nullptr == pfnUSMMemcpy2D )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pDst )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnUSMMemcpy2D( hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueDeviceGlobalVariableWrite(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
+        const char* name,                               ///< [in] the unique identifier for the device global variable.
+        bool blockingWrite,                             ///< [in] indicates if this operation should block.
+        size_t count,                                   ///< [in] the number of bytes to copy.
+        size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+        const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.
+        )
+    {
+        auto pfnDeviceGlobalVariableWrite = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+
+        if( nullptr == pfnDeviceGlobalVariableWrite )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == name )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pSrc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnDeviceGlobalVariableWrite( hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
+    __urdlllocal ur_result_t UR_APICALL
+    urEnqueueDeviceGlobalVariableRead(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
+        const char* name,                               ///< [in] the unique identifier for the device global variable.
+        bool blockingRead,                              ///< [in] indicates if this operation should block.
+        size_t count,                                   ///< [in] the number of bytes to copy.
+        size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
+        void* pDst,                                     ///< [in] pointer to where the data must be copied to.
+        uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
+        const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                        ///< events that must be complete before the kernel execution.
+                                                        ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                                        ///< event. 
+        ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
+                                                        ///< particular kernel execution instance.    
+        )
+    {
+        auto pfnDeviceGlobalVariableRead = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+
+        if( nullptr == pfnDeviceGlobalVariableRead )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == name )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pDst )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnDeviceGlobalVariableRead( hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urEventGetInfo(
+        ur_event_handle_t hEvent,                       ///< [in] handle of the event object
+        ur_event_info_t propName,                       ///< [in] the name of the event property to query
+        size_t propValueSize,                           ///< [in] size in bytes of the event property value
+        void* pPropValue,                               ///< [out][optional] value of the event property
+        size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_EVENT_INFO_REFERENCE_COUNT < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventGetProfilingInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urEventGetProfilingInfo(
+        ur_event_handle_t hEvent,                       ///< [in] handle of the event object
+        ur_profiling_info_t propName,                   ///< [in] the name of the profiling property to query
+        size_t propValueSize,                           ///< [in] size in bytes of the profiling property value
+        void* pPropValue,                               ///< [out][optional] value of the profiling property
+        size_t* pPropValueSizeRet                       ///< [out][optional] pointer to the actual size in bytes returned in
+                                                        ///< propValue
+        )
+    {
+        auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
+
+        if( nullptr == pfnGetProfilingInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_PROFILING_INFO_COMMAND_END < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetProfilingInfo( hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventWait
+    __urdlllocal ur_result_t UR_APICALL
+    urEventWait(
+        uint32_t numEvents,                             ///< [in] number of events in the event list
+        const ur_event_handle_t* phEventWaitList        ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                                        ///< completion
+        )
+    {
+        auto pfnWait = context.urDdiTable.Event.pfnWait;
+
+        if( nullptr == pfnWait )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == phEventWaitList )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnWait( numEvents, phEventWaitList );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urEventRetain(
+        ur_event_handle_t hEvent                        ///< [in] handle of the event object
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Event.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urEventRelease(
+        ur_event_handle_t hEvent                        ///< [in] handle of the event object
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Event.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urEventGetNativeHandle(
+        ur_event_handle_t hEvent,                       ///< [in] handle of the event.
+        ur_native_handle_t* phNativeEvent               ///< [out] a pointer to the native handle of the event.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Event.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hEvent, phNativeEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urEventCreateWithNativeHandle(
+        ur_native_handle_t hNativeEvent,                ///< [in] the native handle of the event.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_event_handle_t* phEvent                      ///< [out] pointer to the handle of the event object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Event.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeEvent, hContext, phEvent );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urEventSetCallback
+    __urdlllocal ur_result_t UR_APICALL
+    urEventSetCallback(
+        ur_event_handle_t hEvent,                       ///< [in] handle of the event object
+        ur_execution_info_t execStatus,                 ///< [in] execution status of the event
+        ur_event_callback_t pfnNotify,                  ///< [in] execution status of the event
+        void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
+        )
+    {
+        auto pfnSetCallback = context.urDdiTable.Event.pfnSetCallback;
+
+        if( nullptr == pfnSetCallback )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hEvent )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnSetCallback( hEvent, execStatus, pfnNotify, pUserData );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemImageCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urMemImageCreate(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+        const ur_image_format_t* pImageFormat,          ///< [in] pointer to image format specification
+        const ur_image_desc_t* pImageDesc,              ///< [in] pointer to image description
+        void* pHost,                                    ///< [in] pointer to the buffer data
+        ur_mem_handle_t* phMem                          ///< [out] pointer to handle of image object created
+        )
+    {
+        auto pfnImageCreate = context.urDdiTable.Mem.pfnImageCreate;
+
+        if( nullptr == pfnImageCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( 0x3f < flags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == pImageFormat )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pImageDesc )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pHost )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnImageCreate( hContext, flags, pImageFormat, pImageDesc, pHost, phMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemBufferCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urMemBufferCreate(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+        size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
+        void* pHost,                                    ///< [in] pointer to the buffer data
+        ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
+        )
+    {
+        auto pfnBufferCreate = context.urDdiTable.Mem.pfnBufferCreate;
+
+        if( nullptr == pfnBufferCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( 0x3f < flags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == pHost )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnBufferCreate( hContext, flags, size, pHost, phBuffer );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urMemRetain(
+        ur_mem_handle_t hMem                            ///< [in] handle of the memory object to get access
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Mem.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hMem )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urMemRelease(
+        ur_mem_handle_t hMem                            ///< [in] handle of the memory object to release
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Mem.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hMem )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemBufferPartition
+    __urdlllocal ur_result_t UR_APICALL
+    urMemBufferPartition(
+        ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object to allocate from
+        ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
+        ur_buffer_create_type_t bufferCreateType,       ///< [in] buffer creation type
+        ur_buffer_region_t* pBufferCreateInfo,          ///< [in] pointer to buffer create region information
+        ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of sub buffer created
+        )
+    {
+        auto pfnBufferPartition = context.urDdiTable.Mem.pfnBufferPartition;
+
+        if( nullptr == pfnBufferPartition )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hBuffer )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( 0x3f < flags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == pBufferCreateInfo )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnBufferPartition( hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urMemGetNativeHandle(
+        ur_mem_handle_t hMem,                           ///< [in] handle of the mem.
+        ur_native_handle_t* phNativeMem                 ///< [out] a pointer to the native handle of the mem.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Mem.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hMem )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hMem, phNativeMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urMemCreateWithNativeHandle(
+        ur_native_handle_t hNativeMem,                  ///< [in] the native handle of the mem.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of the mem object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Mem.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeMem )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeMem, hContext, phMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urMemGetInfo(
+        ur_mem_handle_t hMemory,                        ///< [in] handle to the memory object being queried.
+        ur_mem_info_t MemInfoType,                      ///< [in] type of the info to retrieve.
+        size_t propSize,                                ///< [in] the number of bytes of memory pointed to by pMemInfo.
+        void* pMemInfo,                                 ///< [out][optional] array of bytes holding the info.
+                                                        ///< If propSize is less than the real number of bytes needed to return 
+                                                        ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< pMemInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hMemory )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_MEM_INFO_CONTEXT < MemInfoType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemImageGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urMemImageGetInfo(
+        ur_mem_handle_t hMemory,                        ///< [in] handle to the image object being queried.
+        ur_image_info_t ImgInfoType,                    ///< [in] type of image info to retrieve.
+        size_t propSize,                                ///< [in] the number of bytes of memory pointer to by pImgInfo.
+        void* pImgInfo,                                 ///< [out][optional] array of bytes holding the info.
+                                                        ///< If propSize is less than the real number of bytes needed to return
+                                                        ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< pImgInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        )
+    {
+        auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
+
+        if( nullptr == pfnImageGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hMemory )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_IMAGE_INFO_DEPTH < ImgInfoType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnImageGetInfo( hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urTearDown
+    __urdlllocal ur_result_t UR_APICALL
+    urTearDown(
+        void* pParams                                   ///< [in] pointer to tear down parameters
+        )
+    {
+        auto pfnTearDown = context.urDdiTable.Global.pfnTearDown;
+
+        if( nullptr == pfnTearDown )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == pParams )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnTearDown( pParams );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueGetInfo(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
+        ur_queue_info_t propName,                       ///< [in] name of the queue property to query
+        size_t propValueSize,                           ///< [in] size in bytes of the queue property value provided
+        void* pPropValue,                               ///< [out] value of the queue property
+        size_t* pPropSizeRet                            ///< [out] size in bytes returned in queue property value
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Queue.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_QUEUE_INFO_SIZE < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == pPropValue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pPropSizeRet )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetInfo( hQueue, propName, propValueSize, pPropValue, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueCreate(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+        ur_queue_property_value_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
+                                                        ///< Each property name is immediately followed by the corresponding
+                                                        ///< desired value.
+                                                        ///< The list is terminated with a 0. 
+                                                        ///< If a property value is not specified, then its default value will be used.
+        ur_queue_handle_t* phQueue                      ///< [out] pointer to handle of queue object created
+        )
+    {
+        auto pfnCreate = context.urDdiTable.Queue.pfnCreate;
+
+        if( nullptr == pfnCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pProps )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreate( hContext, hDevice, pProps, phQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueRetain(
+        ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to get access
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Queue.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueRelease(
+        ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to release
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Queue.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueGetNativeHandle(
+        ur_queue_handle_t hQueue,                       ///< [in] handle of the queue.
+        ur_native_handle_t* phNativeQueue               ///< [out] a pointer to the native handle of the queue.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Queue.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hQueue, phNativeQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueCreateWithNativeHandle(
+        ur_native_handle_t hNativeQueue,                ///< [in] the native handle of the queue.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_queue_handle_t* phQueue                      ///< [out] pointer to the handle of the queue object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Queue.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeQueue, hContext, phQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueFinish
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueFinish(
+        ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be finished.
+        )
+    {
+        auto pfnFinish = context.urDdiTable.Queue.pfnFinish;
+
+        if( nullptr == pfnFinish )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnFinish( hQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urQueueFlush
+    __urdlllocal ur_result_t UR_APICALL
+    urQueueFlush(
+        ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be flushed.
+        )
+    {
+        auto pfnFlush = context.urDdiTable.Queue.pfnFlush;
+
+        if( nullptr == pfnFlush )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hQueue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnFlush( hQueue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urSamplerCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urSamplerCreate(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+                                                        ///< corresponding values.
+        ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
+        )
+    {
+        auto pfnCreate = context.urDdiTable.Sampler.pfnCreate;
+
+        if( nullptr == pfnCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pProps )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreate( hContext, pProps, phSampler );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urSamplerRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urSamplerRetain(
+        ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to get access
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Sampler.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hSampler );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urSamplerRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urSamplerRelease(
+        ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to release
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Sampler.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hSampler );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urSamplerGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urSamplerGetInfo(
+        ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler object
+        ur_sampler_info_t propName,                     ///< [in] name of the sampler property to query
+        size_t propValueSize,                           ///< [in] size in bytes of the sampler property value provided
+        void* pPropValue,                               ///< [out] value of the sampler property
+        size_t* pPropSizeRet                            ///< [out] size in bytes returned in sampler property value
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Sampler.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_SAMPLER_INFO_LOD_MAX < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == pPropValue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pPropSizeRet )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetInfo( hSampler, propName, propValueSize, pPropValue, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urSamplerGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urSamplerGetNativeHandle(
+        ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler.
+        ur_native_handle_t* phNativeSampler             ///< [out] a pointer to the native handle of the sampler.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Sampler.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hSampler, phNativeSampler );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urSamplerCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urSamplerCreateWithNativeHandle(
+        ur_native_handle_t hNativeSampler,              ///< [in] the native handle of the sampler.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_sampler_handle_t* phSampler                  ///< [out] pointer to the handle of the sampler object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phSampler )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeSampler, hContext, phSampler );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urUSMHostAlloc
+    __urdlllocal ur_result_t UR_APICALL
+    urUSMHostAlloc(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_usm_mem_flags_t* pUSMFlag,                   ///< [in] USM memory allocation flags
+        size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
+        uint32_t align,                                 ///< [in] alignment of the USM memory object
+        void** ppMem                                    ///< [out] pointer to USM host memory object
+        )
+    {
+        auto pfnHostAlloc = context.urDdiTable.USM.pfnHostAlloc;
+
+        if( nullptr == pfnHostAlloc )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pUSMFlag )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == ppMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnHostAlloc( hContext, pUSMFlag, size, align, ppMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urUSMDeviceAlloc
+    __urdlllocal ur_result_t UR_APICALL
+    urUSMDeviceAlloc(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+        ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
+        size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
+        uint32_t align,                                 ///< [in] alignment of the USM memory object
+        void** ppMem                                    ///< [out] pointer to USM device memory object
+        )
+    {
+        auto pfnDeviceAlloc = context.urDdiTable.USM.pfnDeviceAlloc;
+
+        if( nullptr == pfnDeviceAlloc )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pUSMProp )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == ppMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnDeviceAlloc( hContext, hDevice, pUSMProp, size, align, ppMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urUSMSharedAlloc
+    __urdlllocal ur_result_t UR_APICALL
+    urUSMSharedAlloc(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device object
+        ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
+        size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
+        uint32_t align,                                 ///< [in] alignment of the USM memory object
+        void** ppMem                                    ///< [out] pointer to USM shared memory object
+        )
+    {
+        auto pfnSharedAlloc = context.urDdiTable.USM.pfnSharedAlloc;
+
+        if( nullptr == pfnSharedAlloc )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pUSMProp )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == ppMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnSharedAlloc( hContext, hDevice, pUSMProp, size, align, ppMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemFree
+    __urdlllocal ur_result_t UR_APICALL
+    urMemFree(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        void* pMem                                      ///< [in] pointer to USM memory object
+        )
+    {
+        auto pfnFree = context.urDdiTable.Mem.pfnFree;
+
+        if( nullptr == pfnFree )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnFree( hContext, pMem );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urMemGetMemAllocInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urMemGetMemAllocInfo(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        const void* pMem,                               ///< [in] pointer to USM memory object
+        ur_mem_alloc_info_t propName,                   ///< [in] the name of the USM allocation property to query
+        size_t propValueSize,                           ///< [in] size in bytes of the USM allocation property value
+        void* pPropValue,                               ///< [out] value of the USM allocation property
+        size_t* pPropValueSizeRet                       ///< [out] bytes returned in USM allocation property
+        )
+    {
+        auto pfnGetMemAllocInfo = context.urDdiTable.Mem.pfnGetMemAllocInfo;
+
+        if( nullptr == pfnGetMemAllocInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pMem )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pPropValue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pPropValueSizeRet )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( UR_MEM_ALLOC_INFO_ALLOC_DEVICE < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetMemAllocInfo( hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceGet
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceGet(
+        ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+        ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
+        uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
+                                                        ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                                        ///< otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                        ///< will be returned.
+        ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                                        ///< If NumEntries is less than the number of devices available, then
+                                                        ///< platform shall only retrieve that number of devices.
+        uint32_t* pNumDevices                           ///< [out][optional] pointer to the number of devices.
+                                                        ///< pNumDevices will be updated with the total number of devices available.
+        )
+    {
+        auto pfnGet = context.urDdiTable.Device.pfnGet;
+
+        if( nullptr == pfnGet )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hPlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_DEVICE_TYPE_VPU < DeviceType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGet( hPlatform, DeviceType, NumEntries, phDevices, pNumDevices );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceGetInfo(
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
+        ur_device_info_t infoType,                      ///< [in] type of the info to retrieve
+        size_t propSize,                                ///< [in] the number of bytes pointed to by pDeviceInfo.
+        void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
+                                                        ///< If propSize is not equal to or greater than the real number of bytes
+                                                        ///< needed to return the info
+                                                        ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< pDeviceInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES < infoType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceRetain(
+        ur_device_handle_t hDevice                      ///< [in] handle of the device to get a reference of.
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Device.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hDevice );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceRelease(
+        ur_device_handle_t hDevice                      ///< [in] handle of the device to release.
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Device.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hDevice );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDevicePartition
+    __urdlllocal ur_result_t UR_APICALL
+    urDevicePartition(
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
+        ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+        uint32_t NumDevices,                            ///< [in] the number of sub-devices.
+        ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                        ///< If NumDevices is less than the number of sub-devices available, then
+                                                        ///< the function shall only retrieve that number of sub-devices.
+        uint32_t* pNumDevicesRet                        ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                        ///< partitioned into according to the partitioning property.
+        )
+    {
+        auto pfnPartition = context.urDdiTable.Device.pfnPartition;
+
+        if( nullptr == pfnPartition )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == Properties )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnPartition( hDevice, Properties, NumDevices, phSubDevices, pNumDevicesRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceSelectBinary
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceSelectBinary(
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
+        const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
+        uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
+                                                        ///< equal to zero.
+        uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
+                                                        ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+        )
+    {
+        auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
+
+        if( nullptr == pfnSelectBinary )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == ppBinaries )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pSelectedBinary )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnSelectBinary( hDevice, ppBinaries, NumBinaries, pSelectedBinary );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceGetNativeHandle(
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device.
+        ur_native_handle_t* phNativeDevice              ///< [out] a pointer to the native handle of the device.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Device.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hDevice, phNativeDevice );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceCreateWithNativeHandle(
+        ur_native_handle_t hNativeDevice,               ///< [in] the native handle of the device.
+        ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+        ur_device_handle_t* phDevice                    ///< [out] pointer to the handle of the device object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Device.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hPlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeDevice, hPlatform, phDevice );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urDeviceGetGlobalTimestamps
+    __urdlllocal ur_result_t UR_APICALL
+    urDeviceGetGlobalTimestamps(
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
+        uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
+                                                        ///< correlates with the Host's global timestamp value
+        uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
+                                                        ///< correlates with the Device's global timestamp value
+        )
+    {
+        auto pfnGetGlobalTimestamps = context.urDdiTable.Device.pfnGetGlobalTimestamps;
+
+        if( nullptr == pfnGetGlobalTimestamps )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnGetGlobalTimestamps( hDevice, pDeviceTimestamp, pHostTimestamp );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelCreate(
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program instance
+        const char* pKernelName,                        ///< [in] pointer to null-terminated string.
+        ur_kernel_handle_t* phKernel                    ///< [out] pointer to handle of kernel object created.
+        )
+    {
+        auto pfnCreate = context.urDdiTable.Kernel.pfnCreate;
+
+        if( nullptr == pfnCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pKernelName )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreate( hProgram, pKernelName, phKernel );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelSetArgValue
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelSetArgValue(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+        size_t argSize,                                 ///< [in] size of argument type
+        const void* pArgValue                           ///< [in] argument value represented as matching arg type.
+        )
+    {
+        auto pfnSetArgValue = context.urDdiTable.Kernel.pfnSetArgValue;
+
+        if( nullptr == pfnSetArgValue )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pArgValue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnSetArgValue( hKernel, argIndex, argSize, pArgValue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelSetArgLocal
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelSetArgLocal(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+        size_t argSize                                  ///< [in] size of the local buffer to be allocated by the runtime
+        )
+    {
+        auto pfnSetArgLocal = context.urDdiTable.Kernel.pfnSetArgLocal;
+
+        if( nullptr == pfnSetArgLocal )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnSetArgLocal( hKernel, argIndex, argSize );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelGetInfo(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+        ur_kernel_info_t propName,                      ///< [in] name of the Kernel property to query
+        size_t propSize,                                ///< [in] the size of the Kernel property value.           
+        void* pKernelInfo,                              ///< [in,out][optional] array of bytes holding the kernel info property.
+                                                        ///< If propSize is not equal to or greater than the real number of bytes
+                                                        ///< needed to return 
+                                                        ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< pKernelInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                        ///< queried by propName.
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Kernel.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_KERNEL_INFO_ATTRIBUTES < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hKernel, propName, propSize, pKernelInfo, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelGetGroupInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelGetGroupInfo(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+        ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+        ur_kernel_group_info_t propName,                ///< [in] name of the work Group property to query
+        size_t propSize,                                ///< [in] size of the Kernel Work Group property value
+        void* pPropValue,                               ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                                        ///< property.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                        ///< queried by propName.
+        )
+    {
+        auto pfnGetGroupInfo = context.urDdiTable.Kernel.pfnGetGroupInfo;
+
+        if( nullptr == pfnGetGroupInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetGroupInfo( hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelGetSubGroupInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelGetSubGroupInfo(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
+        ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+        ur_kernel_sub_group_info_t propName,            ///< [in] name of the SubGroup property to query
+        size_t propSize,                                ///< [in] size of the Kernel SubGroup property value
+        void* pPropValue,                               ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                                        ///< property.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                        ///< queried by propName.
+        )
+    {
+        auto pfnGetSubGroupInfo = context.urDdiTable.Kernel.pfnGetSubGroupInfo;
+
+        if( nullptr == pfnGetSubGroupInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetSubGroupInfo( hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelRetain(
+        ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to retain
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Kernel.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hKernel );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelRelease(
+        ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to release
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Kernel.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hKernel );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelSetArgPointer
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelSetArgPointer(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+        size_t argSize,                                 ///< [in] size of argument type
+        const void* pArgValue                           ///< [in][optional] SVM pointer to memory location holding the argument
+                                                        ///< value. If null then argument value is considered null.
+        )
+    {
+        auto pfnSetArgPointer = context.urDdiTable.Kernel.pfnSetArgPointer;
+
+        if( nullptr == pfnSetArgPointer )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnSetArgPointer( hKernel, argIndex, argSize, pArgValue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelSetExecInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelSetExecInfo(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        ur_kernel_exec_info_t propName,                 ///< [in] name of the execution attribute
+        size_t propSize,                                ///< [in] size in byte the attribute value
+        const void* pPropValue                          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                                        ///< property value.
+        )
+    {
+        auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
+
+        if( nullptr == pfnSetExecInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_KERNEL_EXEC_INFO_USM_PTRS < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( NULL == pPropValue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnSetExecInfo( hKernel, propName, propSize, pPropValue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelSetArgSampler
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelSetArgSampler(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+        ur_sampler_handle_t hArgValue                   ///< [in] handle of Sampler object.
+        )
+    {
+        auto pfnSetArgSampler = context.urDdiTable.Kernel.pfnSetArgSampler;
+
+        if( nullptr == pfnSetArgSampler )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hArgValue )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnSetArgSampler( hKernel, argIndex, hArgValue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelSetArgMemObj
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelSetArgMemObj(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+        uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
+        ur_mem_handle_t hArgValue                       ///< [in][optional] handle of Memory object.
+        )
+    {
+        auto pfnSetArgMemObj = context.urDdiTable.Kernel.pfnSetArgMemObj;
+
+        if( nullptr == pfnSetArgMemObj )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnSetArgMemObj( hKernel, argIndex, hArgValue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelGetNativeHandle(
+        ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel.
+        ur_native_handle_t* phNativeKernel              ///< [out] a pointer to the native handle of the kernel.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Kernel.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hKernel, phNativeKernel );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urKernelCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urKernelCreateWithNativeHandle(
+        ur_native_handle_t hNativeKernel,               ///< [in] the native handle of the kernel.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context object
+        ur_kernel_handle_t* phKernel                    ///< [out] pointer to the handle of the kernel object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phKernel )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeKernel, hContext, phKernel );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urModuleCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urModuleCreate(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context instance.
+        const void* pIL,                                ///< [in] pointer to IL string.
+        size_t length,                                  ///< [in] length of IL in bytes.
+        const char* pOptions,                           ///< [in] pointer to compiler options null-terminated string.
+        ur_modulecreate_callback_t pfnNotify,           ///< [in][optional] A function pointer to a notification routine that is
+                                                        ///< called when program compilation is complete.
+        void* pUserData,                                ///< [in][optional] Passed as an argument when pfnNotify is called.
+        ur_module_handle_t* phModule                    ///< [out] pointer to handle of Module object created.
+        )
+    {
+        auto pfnCreate = context.urDdiTable.Module.pfnCreate;
+
+        if( nullptr == pfnCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pIL )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == pOptions )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phModule )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreate( hContext, pIL, length, pOptions, pfnNotify, pUserData, phModule );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urModuleRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urModuleRetain(
+        ur_module_handle_t hModule                      ///< [in] handle for the Module to retain
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Module.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hModule )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hModule );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urModuleRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urModuleRelease(
+        ur_module_handle_t hModule                      ///< [in] handle for the Module to release
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Module.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hModule )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hModule );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urModuleGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urModuleGetNativeHandle(
+        ur_module_handle_t hModule,                     ///< [in] handle of the module.
+        ur_native_handle_t* phNativeModule              ///< [out] a pointer to the native handle of the module.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Module.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hModule )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeModule )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hModule, phNativeModule );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urModuleCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urModuleCreateWithNativeHandle(
+        ur_native_handle_t hNativeModule,               ///< [in] the native handle of the module.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context instance.
+        ur_module_handle_t* phModule                    ///< [out] pointer to the handle of the module object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Module.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeModule )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phModule )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeModule, hContext, phModule );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urPlatformGet
+    __urdlllocal ur_result_t UR_APICALL
+    urPlatformGet(
+        uint32_t NumEntries,                            ///< [in] the number of platforms to be added to phPlatforms. 
+                                                        ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                                        ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                        ///< will be returned.
+        ur_platform_handle_t* phPlatforms,              ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                                        ///< If NumEntries is less than the number of platforms available, then
+                                                        ///< ::urPlatformGet shall only retrieve that number of platforms.
+        uint32_t* pNumPlatforms                         ///< [out][optional] returns the total number of platforms available. 
+        )
+    {
+        auto pfnGet = context.urDdiTable.Platform.pfnGet;
+
+        if( nullptr == pfnGet )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+        }
+
+        return pfnGet( NumEntries, phPlatforms, pNumPlatforms );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urPlatformGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urPlatformGetInfo(
+        ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform
+        ur_platform_info_t PlatformInfoType,            ///< [in] type of the info to retrieve
+        size_t Size,                                    ///< [in] the number of bytes pointed to by pPlatformInfo.
+        void* pPlatformInfo,                            ///< [out][optional] array of bytes holding the info.
+                                                        ///< If Size is not equal to or greater to the real number of bytes needed
+                                                        ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                                        ///< returned and pPlatformInfo is not used.
+        size_t* pSizeRet                                ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Platform.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hPlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_PLATFORM_INFO_PROFILE < PlatformInfoType )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urPlatformGetApiVersion
+    __urdlllocal ur_result_t UR_APICALL
+    urPlatformGetApiVersion(
+        ur_platform_handle_t hDriver,                   ///< [in] handle of the platform
+        ur_api_version_t* pVersion                      ///< [out] api version
+        )
+    {
+        auto pfnGetApiVersion = context.urDdiTable.Platform.pfnGetApiVersion;
+
+        if( nullptr == pfnGetApiVersion )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDriver )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pVersion )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetApiVersion( hDriver, pVersion );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urPlatformGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urPlatformGetNativeHandle(
+        ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform.
+        ur_native_handle_t* phNativePlatform            ///< [out] a pointer to the native handle of the platform.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Platform.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hPlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativePlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hPlatform, phNativePlatform );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urPlatformCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urPlatformCreateWithNativeHandle(
+        ur_native_handle_t hNativePlatform,             ///< [in] the native handle of the platform.
+        ur_platform_handle_t* phPlatform                ///< [out] pointer to the handle of the platform object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Platform.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativePlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phPlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativePlatform, phPlatform );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urGetLastResult
+    __urdlllocal ur_result_t UR_APICALL
+    urGetLastResult(
+        ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
+        const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
+                                                        ///< representation.
+        )
+    {
+        auto pfnGetLastResult = context.urDdiTable.Global.pfnGetLastResult;
+
+        if( nullptr == pfnGetLastResult )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hPlatform )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == ppMessage )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetLastResult( hPlatform, ppMessage );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramCreate
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramCreate(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context instance
+        uint32_t count,                                 ///< [in] number of module handles in module list.
+        const ur_module_handle_t* phModules,            ///< [in][range(0, count)] pointer to array of modules.
+        const char* pOptions,                           ///< [in][optional] pointer to linker options null-terminated string.
+        ur_program_handle_t* phProgram                  ///< [out] pointer to handle of program object created.
+        )
+    {
+        auto pfnCreate = context.urDdiTable.Program.pfnCreate;
+
+        if( nullptr == pfnCreate )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phModules )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreate( hContext, count, phModules, pOptions, phProgram );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramCreateWithBinary
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramCreateWithBinary(
+        ur_context_handle_t hContext,                   ///< [in] handle of the context instance
+        ur_device_handle_t hDevice,                     ///< [in] handle to device associated with binary.
+        size_t size,                                    ///< [in] size in bytes.
+        const uint8_t* pBinary,                         ///< [in] pointer to binary.
+        ur_program_handle_t* phProgram                  ///< [out] pointer to handle of Program object created.
+        )
+    {
+        auto pfnCreateWithBinary = context.urDdiTable.Program.pfnCreateWithBinary;
+
+        if( nullptr == pfnCreateWithBinary )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pBinary )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == phProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithBinary( hContext, hDevice, size, pBinary, phProgram );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramRetain
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramRetain(
+        ur_program_handle_t hProgram                    ///< [in] handle for the Program to retain
+        )
+    {
+        auto pfnRetain = context.urDdiTable.Program.pfnRetain;
+
+        if( nullptr == pfnRetain )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRetain( hProgram );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramRelease
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramRelease(
+        ur_program_handle_t hProgram                    ///< [in] handle for the Program to release
+        )
+    {
+        auto pfnRelease = context.urDdiTable.Program.pfnRelease;
+
+        if( nullptr == pfnRelease )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+        }
+
+        return pfnRelease( hProgram );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramGetFunctionPointer
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramGetFunctionPointer(
+        ur_device_handle_t hDevice,                     ///< [in] handle of the device to retrieve pointer for.
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program to search for function in.
+                                                        ///< The program must already be built to the specified device, or
+                                                        ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+        const char* pFunctionName,                      ///< [in] A null-terminates string denoting the mangled function name.
+        void** ppFunctionPointer                        ///< [out] Returns the pointer to the function if it is found in the program.
+        )
+    {
+        auto pfnGetFunctionPointer = context.urDdiTable.Program.pfnGetFunctionPointer;
+
+        if( nullptr == pfnGetFunctionPointer )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pFunctionName )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+            if( NULL == ppFunctionPointer )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetFunctionPointer( hDevice, hProgram, pFunctionName, ppFunctionPointer );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramGetInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramGetInfo(
+        ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+        ur_program_info_t propName,                     ///< [in] name of the Program property to query
+        size_t propSize,                                ///< [in] the size of the Program property.
+        void* pProgramInfo,                             ///< [in,out][optional] array of bytes of holding the program info property.
+                                                        ///< If propSize is not equal to or greater than the real number of bytes
+                                                        ///< needed to return 
+                                                        ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< pProgramInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+        )
+    {
+        auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
+
+        if( nullptr == pfnGetInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_PROGRAM_INFO_KERNEL_NAMES < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetInfo( hProgram, propName, propSize, pProgramInfo, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramGetBuildInfo
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramGetBuildInfo(
+        ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+        ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
+        ur_program_build_info_t propName,               ///< [in] name of the Program build info to query
+        size_t propSize,                                ///< [in] size of the Program build info property.
+        void* pPropValue,                               ///< [in,out][optional] value of the Program build property.
+                                                        ///< If propSize is not equal to or greater than the real number of bytes
+                                                        ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                                        ///< error is returned and pKernelInfo is not used.
+        size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
+                                                        ///< queried by propName.
+        )
+    {
+        auto pfnGetBuildInfo = context.urDdiTable.Program.pfnGetBuildInfo;
+
+        if( nullptr == pfnGetBuildInfo )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hDevice )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnGetBuildInfo( hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramSetSpecializationConstant
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramSetSpecializationConstant(
+        ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
+        uint32_t specId,                                ///< [in] specification constant Id
+        size_t specSize,                                ///< [in] size of the specialization constant value
+        const void* pSpecValue                          ///< [in] pointer to the specialization value bytes
+        )
+    {
+        auto pfnSetSpecializationConstant = context.urDdiTable.Program.pfnSetSpecializationConstant;
+
+        if( nullptr == pfnSetSpecializationConstant )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == pSpecValue )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnSetSpecializationConstant( hProgram, specId, specSize, pSpecValue );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramGetNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramGetNativeHandle(
+        ur_program_handle_t hProgram,                   ///< [in] handle of the program.
+        ur_native_handle_t* phNativeProgram             ///< [out] a pointer to the native handle of the program.
+        )
+    {
+        auto pfnGetNativeHandle = context.urDdiTable.Program.pfnGetNativeHandle;
+
+        if( nullptr == pfnGetNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phNativeProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnGetNativeHandle( hProgram, phNativeProgram );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urProgramCreateWithNativeHandle
+    __urdlllocal ur_result_t UR_APICALL
+    urProgramCreateWithNativeHandle(
+        ur_native_handle_t hNativeProgram,              ///< [in] the native handle of the program.
+        ur_context_handle_t hContext,                   ///< [in] handle of the context instance
+        ur_program_handle_t* phProgram                  ///< [out] pointer to the handle of the program object created.
+        )
+    {
+        auto pfnCreateWithNativeHandle = context.urDdiTable.Program.pfnCreateWithNativeHandle;
+
+        if( nullptr == pfnCreateWithNativeHandle )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( NULL == hNativeProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == hContext )
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+            if( NULL == phProgram )
+                return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+        }
+
+        return pfnCreateWithNativeHandle( hNativeProgram, hContext, phProgram );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief Intercept function for urInit
+    __urdlllocal ur_result_t UR_APICALL
+    urInit(
+        ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
+                                                        ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
+        ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
+                                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+        )
+    {
+        auto pfnInit = context.urDdiTable.Global.pfnInit;
+
+        if( nullptr == pfnInit )
+            return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+        if( context.enableParameterValidation )
+        {
+            if( 0x1 < platform_flags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+            if( 0x1 < device_flags )
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+
+        }
+
+        return pfnInit( platform_flags, device_flags );
+    }
+
+} // namespace validation_layer
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Global table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetGlobalProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_global_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Global;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnTearDown                                 = pDdiTable->pfnTearDown;
+    pDdiTable->pfnTearDown                               = validation_layer::urTearDown;
+
+    dditable.pfnGetLastResult                            = pDdiTable->pfnGetLastResult;
+    pDdiTable->pfnGetLastResult                          = validation_layer::urGetLastResult;
+
+    dditable.pfnInit                                     = pDdiTable->pfnInit;
+    pDdiTable->pfnInit                                   = validation_layer::urInit;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Context table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetContextProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_context_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Context;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreate                                   = pDdiTable->pfnCreate;
+    pDdiTable->pfnCreate                                 = validation_layer::urContextCreate;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urContextRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urContextRelease;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urContextGetInfo;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urContextGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urContextCreateWithNativeHandle;
+
+    dditable.pfnSetExtendedDeleter                       = pDdiTable->pfnSetExtendedDeleter;
+    pDdiTable->pfnSetExtendedDeleter                     = validation_layer::urContextSetExtendedDeleter;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Enqueue table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEnqueueProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_enqueue_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Enqueue;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnKernelLaunch                             = pDdiTable->pfnKernelLaunch;
+    pDdiTable->pfnKernelLaunch                           = validation_layer::urEnqueueKernelLaunch;
+
+    dditable.pfnEventsWait                               = pDdiTable->pfnEventsWait;
+    pDdiTable->pfnEventsWait                             = validation_layer::urEnqueueEventsWait;
+
+    dditable.pfnEventsWaitWithBarrier                    = pDdiTable->pfnEventsWaitWithBarrier;
+    pDdiTable->pfnEventsWaitWithBarrier                  = validation_layer::urEnqueueEventsWaitWithBarrier;
+
+    dditable.pfnMemBufferRead                            = pDdiTable->pfnMemBufferRead;
+    pDdiTable->pfnMemBufferRead                          = validation_layer::urEnqueueMemBufferRead;
+
+    dditable.pfnMemBufferWrite                           = pDdiTable->pfnMemBufferWrite;
+    pDdiTable->pfnMemBufferWrite                         = validation_layer::urEnqueueMemBufferWrite;
+
+    dditable.pfnMemBufferReadRect                        = pDdiTable->pfnMemBufferReadRect;
+    pDdiTable->pfnMemBufferReadRect                      = validation_layer::urEnqueueMemBufferReadRect;
+
+    dditable.pfnMemBufferWriteRect                       = pDdiTable->pfnMemBufferWriteRect;
+    pDdiTable->pfnMemBufferWriteRect                     = validation_layer::urEnqueueMemBufferWriteRect;
+
+    dditable.pfnMemBufferCopy                            = pDdiTable->pfnMemBufferCopy;
+    pDdiTable->pfnMemBufferCopy                          = validation_layer::urEnqueueMemBufferCopy;
+
+    dditable.pfnMemBufferCopyRect                        = pDdiTable->pfnMemBufferCopyRect;
+    pDdiTable->pfnMemBufferCopyRect                      = validation_layer::urEnqueueMemBufferCopyRect;
+
+    dditable.pfnMemBufferFill                            = pDdiTable->pfnMemBufferFill;
+    pDdiTable->pfnMemBufferFill                          = validation_layer::urEnqueueMemBufferFill;
+
+    dditable.pfnMemImageRead                             = pDdiTable->pfnMemImageRead;
+    pDdiTable->pfnMemImageRead                           = validation_layer::urEnqueueMemImageRead;
+
+    dditable.pfnMemImageWrite                            = pDdiTable->pfnMemImageWrite;
+    pDdiTable->pfnMemImageWrite                          = validation_layer::urEnqueueMemImageWrite;
+
+    dditable.pfnMemImageCopy                             = pDdiTable->pfnMemImageCopy;
+    pDdiTable->pfnMemImageCopy                           = validation_layer::urEnqueueMemImageCopy;
+
+    dditable.pfnMemBufferMap                             = pDdiTable->pfnMemBufferMap;
+    pDdiTable->pfnMemBufferMap                           = validation_layer::urEnqueueMemBufferMap;
+
+    dditable.pfnMemUnmap                                 = pDdiTable->pfnMemUnmap;
+    pDdiTable->pfnMemUnmap                               = validation_layer::urEnqueueMemUnmap;
+
+    dditable.pfnUSMMemset                                = pDdiTable->pfnUSMMemset;
+    pDdiTable->pfnUSMMemset                              = validation_layer::urEnqueueUSMMemset;
+
+    dditable.pfnUSMMemcpy                                = pDdiTable->pfnUSMMemcpy;
+    pDdiTable->pfnUSMMemcpy                              = validation_layer::urEnqueueUSMMemcpy;
+
+    dditable.pfnUSMPrefetch                              = pDdiTable->pfnUSMPrefetch;
+    pDdiTable->pfnUSMPrefetch                            = validation_layer::urEnqueueUSMPrefetch;
+
+    dditable.pfnUSMMemAdvice                             = pDdiTable->pfnUSMMemAdvice;
+    pDdiTable->pfnUSMMemAdvice                           = validation_layer::urEnqueueUSMMemAdvice;
+
+    dditable.pfnUSMFill2D                                = pDdiTable->pfnUSMFill2D;
+    pDdiTable->pfnUSMFill2D                              = validation_layer::urEnqueueUSMFill2D;
+
+    dditable.pfnUSMMemset2D                              = pDdiTable->pfnUSMMemset2D;
+    pDdiTable->pfnUSMMemset2D                            = validation_layer::urEnqueueUSMMemset2D;
+
+    dditable.pfnUSMMemcpy2D                              = pDdiTable->pfnUSMMemcpy2D;
+    pDdiTable->pfnUSMMemcpy2D                            = validation_layer::urEnqueueUSMMemcpy2D;
+
+    dditable.pfnDeviceGlobalVariableWrite                = pDdiTable->pfnDeviceGlobalVariableWrite;
+    pDdiTable->pfnDeviceGlobalVariableWrite              = validation_layer::urEnqueueDeviceGlobalVariableWrite;
+
+    dditable.pfnDeviceGlobalVariableRead                 = pDdiTable->pfnDeviceGlobalVariableRead;
+    pDdiTable->pfnDeviceGlobalVariableRead               = validation_layer::urEnqueueDeviceGlobalVariableRead;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Event table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEventProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_event_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Event;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urEventGetInfo;
+
+    dditable.pfnGetProfilingInfo                         = pDdiTable->pfnGetProfilingInfo;
+    pDdiTable->pfnGetProfilingInfo                       = validation_layer::urEventGetProfilingInfo;
+
+    dditable.pfnWait                                     = pDdiTable->pfnWait;
+    pDdiTable->pfnWait                                   = validation_layer::urEventWait;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urEventRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urEventRelease;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urEventGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urEventCreateWithNativeHandle;
+
+    dditable.pfnSetCallback                              = pDdiTable->pfnSetCallback;
+    pDdiTable->pfnSetCallback                            = validation_layer::urEventSetCallback;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Kernel table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetKernelProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_kernel_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Kernel;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreate                                   = pDdiTable->pfnCreate;
+    pDdiTable->pfnCreate                                 = validation_layer::urKernelCreate;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urKernelGetInfo;
+
+    dditable.pfnGetGroupInfo                             = pDdiTable->pfnGetGroupInfo;
+    pDdiTable->pfnGetGroupInfo                           = validation_layer::urKernelGetGroupInfo;
+
+    dditable.pfnGetSubGroupInfo                          = pDdiTable->pfnGetSubGroupInfo;
+    pDdiTable->pfnGetSubGroupInfo                        = validation_layer::urKernelGetSubGroupInfo;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urKernelRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urKernelRelease;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urKernelGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urKernelCreateWithNativeHandle;
+
+    dditable.pfnSetArgValue                              = pDdiTable->pfnSetArgValue;
+    pDdiTable->pfnSetArgValue                            = validation_layer::urKernelSetArgValue;
+
+    dditable.pfnSetArgLocal                              = pDdiTable->pfnSetArgLocal;
+    pDdiTable->pfnSetArgLocal                            = validation_layer::urKernelSetArgLocal;
+
+    dditable.pfnSetArgPointer                            = pDdiTable->pfnSetArgPointer;
+    pDdiTable->pfnSetArgPointer                          = validation_layer::urKernelSetArgPointer;
+
+    dditable.pfnSetExecInfo                              = pDdiTable->pfnSetExecInfo;
+    pDdiTable->pfnSetExecInfo                            = validation_layer::urKernelSetExecInfo;
+
+    dditable.pfnSetArgSampler                            = pDdiTable->pfnSetArgSampler;
+    pDdiTable->pfnSetArgSampler                          = validation_layer::urKernelSetArgSampler;
+
+    dditable.pfnSetArgMemObj                             = pDdiTable->pfnSetArgMemObj;
+    pDdiTable->pfnSetArgMemObj                           = validation_layer::urKernelSetArgMemObj;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Mem table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_mem_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Mem;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnImageCreate                              = pDdiTable->pfnImageCreate;
+    pDdiTable->pfnImageCreate                            = validation_layer::urMemImageCreate;
+
+    dditable.pfnBufferCreate                             = pDdiTable->pfnBufferCreate;
+    pDdiTable->pfnBufferCreate                           = validation_layer::urMemBufferCreate;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urMemRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urMemRelease;
+
+    dditable.pfnBufferPartition                          = pDdiTable->pfnBufferPartition;
+    pDdiTable->pfnBufferPartition                        = validation_layer::urMemBufferPartition;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urMemGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urMemCreateWithNativeHandle;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urMemGetInfo;
+
+    dditable.pfnImageGetInfo                             = pDdiTable->pfnImageGetInfo;
+    pDdiTable->pfnImageGetInfo                           = validation_layer::urMemImageGetInfo;
+
+    dditable.pfnFree                                     = pDdiTable->pfnFree;
+    pDdiTable->pfnFree                                   = validation_layer::urMemFree;
+
+    dditable.pfnGetMemAllocInfo                          = pDdiTable->pfnGetMemAllocInfo;
+    pDdiTable->pfnGetMemAllocInfo                        = validation_layer::urMemGetMemAllocInfo;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Module table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetModuleProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_module_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Module;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreate                                   = pDdiTable->pfnCreate;
+    pDdiTable->pfnCreate                                 = validation_layer::urModuleCreate;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urModuleRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urModuleRelease;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urModuleGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urModuleCreateWithNativeHandle;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Platform table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetPlatformProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_platform_dditable_t* pDdiTable               ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Platform;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnGet                                      = pDdiTable->pfnGet;
+    pDdiTable->pfnGet                                    = validation_layer::urPlatformGet;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urPlatformGetInfo;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urPlatformGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urPlatformCreateWithNativeHandle;
+
+    dditable.pfnGetApiVersion                            = pDdiTable->pfnGetApiVersion;
+    pDdiTable->pfnGetApiVersion                          = validation_layer::urPlatformGetApiVersion;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Program table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetProgramProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_program_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Program;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreate                                   = pDdiTable->pfnCreate;
+    pDdiTable->pfnCreate                                 = validation_layer::urProgramCreate;
+
+    dditable.pfnCreateWithBinary                         = pDdiTable->pfnCreateWithBinary;
+    pDdiTable->pfnCreateWithBinary                       = validation_layer::urProgramCreateWithBinary;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urProgramRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urProgramRelease;
+
+    dditable.pfnGetFunctionPointer                       = pDdiTable->pfnGetFunctionPointer;
+    pDdiTable->pfnGetFunctionPointer                     = validation_layer::urProgramGetFunctionPointer;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urProgramGetInfo;
+
+    dditable.pfnGetBuildInfo                             = pDdiTable->pfnGetBuildInfo;
+    pDdiTable->pfnGetBuildInfo                           = validation_layer::urProgramGetBuildInfo;
+
+    dditable.pfnSetSpecializationConstant                = pDdiTable->pfnSetSpecializationConstant;
+    pDdiTable->pfnSetSpecializationConstant              = validation_layer::urProgramSetSpecializationConstant;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urProgramGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urProgramCreateWithNativeHandle;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Queue table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetQueueProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_queue_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Queue;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urQueueGetInfo;
+
+    dditable.pfnCreate                                   = pDdiTable->pfnCreate;
+    pDdiTable->pfnCreate                                 = validation_layer::urQueueCreate;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urQueueRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urQueueRelease;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urQueueGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urQueueCreateWithNativeHandle;
+
+    dditable.pfnFinish                                   = pDdiTable->pfnFinish;
+    pDdiTable->pfnFinish                                 = validation_layer::urQueueFinish;
+
+    dditable.pfnFlush                                    = pDdiTable->pfnFlush;
+    pDdiTable->pfnFlush                                  = validation_layer::urQueueFlush;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Sampler table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetSamplerProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_sampler_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Sampler;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreate                                   = pDdiTable->pfnCreate;
+    pDdiTable->pfnCreate                                 = validation_layer::urSamplerCreate;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urSamplerRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urSamplerRelease;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urSamplerGetInfo;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urSamplerGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urSamplerCreateWithNativeHandle;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USM table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_usm_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.USM;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnHostAlloc                                = pDdiTable->pfnHostAlloc;
+    pDdiTable->pfnHostAlloc                              = validation_layer::urUSMHostAlloc;
+
+    dditable.pfnDeviceAlloc                              = pDdiTable->pfnDeviceAlloc;
+    pDdiTable->pfnDeviceAlloc                            = validation_layer::urUSMDeviceAlloc;
+
+    dditable.pfnSharedAlloc                              = pDdiTable->pfnSharedAlloc;
+    pDdiTable->pfnSharedAlloc                            = validation_layer::urUSMSharedAlloc;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Device table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetDeviceProcAddrTable(
+    ur_api_version_t version,                       ///< [in] API version requested
+    ur_device_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
+    )
+{
+    auto& dditable = validation_layer::context.urDdiTable.Device;
+
+    if( nullptr == pDdiTable )
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version))
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnGet                                      = pDdiTable->pfnGet;
+    pDdiTable->pfnGet                                    = validation_layer::urDeviceGet;
+
+    dditable.pfnGetInfo                                  = pDdiTable->pfnGetInfo;
+    pDdiTable->pfnGetInfo                                = validation_layer::urDeviceGetInfo;
+
+    dditable.pfnRetain                                   = pDdiTable->pfnRetain;
+    pDdiTable->pfnRetain                                 = validation_layer::urDeviceRetain;
+
+    dditable.pfnRelease                                  = pDdiTable->pfnRelease;
+    pDdiTable->pfnRelease                                = validation_layer::urDeviceRelease;
+
+    dditable.pfnPartition                                = pDdiTable->pfnPartition;
+    pDdiTable->pfnPartition                              = validation_layer::urDevicePartition;
+
+    dditable.pfnSelectBinary                             = pDdiTable->pfnSelectBinary;
+    pDdiTable->pfnSelectBinary                           = validation_layer::urDeviceSelectBinary;
+
+    dditable.pfnGetNativeHandle                          = pDdiTable->pfnGetNativeHandle;
+    pDdiTable->pfnGetNativeHandle                        = validation_layer::urDeviceGetNativeHandle;
+
+    dditable.pfnCreateWithNativeHandle                   = pDdiTable->pfnCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle                 = validation_layer::urDeviceCreateWithNativeHandle;
+
+    dditable.pfnGetGlobalTimestamps                      = pDdiTable->pfnGetGlobalTimestamps;
+    pDdiTable->pfnGetGlobalTimestamps                    = validation_layer::urDeviceGetGlobalTimestamps;
+
+    return result;
+}
+
+#if defined(__cplusplus)
+};
+#endif

--- a/source/layers/validation/ur_validation_layer.cpp
+++ b/source/layers/validation/ur_validation_layer.cpp
@@ -1,0 +1,26 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ur_validation_layer.cpp
+ *
+ */
+#include "ur_validation_layer.h"
+
+namespace validation_layer
+{
+    context_t context;
+
+    ///////////////////////////////////////////////////////////////////////////////
+    context_t::context_t()
+    {
+        enableParameterValidation = getenv_tobool( "UR_ENABLE_PARAMETER_VALIDATION" );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    context_t::~context_t()
+    {
+    }
+} // namespace validation_layer

--- a/source/layers/validation/ur_validation_layer.h
+++ b/source/layers/validation/ur_validation_layer.h
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright (C) 2023 Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file ur_layer.h
+ *
+ */
+#pragma once
+#include "ur_ddi.h"
+#include "ur_util.h"
+
+#define VALIDATION_COMP_NAME "validation layer"
+
+namespace validation_layer
+{
+    ///////////////////////////////////////////////////////////////////////////////
+    class __urdlllocal context_t
+    {
+    public:
+        ur_api_version_t version = UR_API_VERSION_0_9;
+
+        bool enableParameterValidation = false;
+
+        ur_dditable_t   urDdiTable = {};
+
+        context_t();
+        ~context_t();
+    };
+
+    extern context_t context;
+} // namespace validation_layer

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4433,10 +4433,10 @@ urGetGlobalProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetGlobalProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetGlobalProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Global);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4461,6 +4461,16 @@ urGetGlobalProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Global;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetGlobalProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetGlobalProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -4500,10 +4510,10 @@ urGetContextProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetContextProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetContextProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Context);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4532,6 +4542,16 @@ urGetContextProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Context;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetContextProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetContextProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -4571,10 +4591,10 @@ urGetEnqueueProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetEnqueueProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetEnqueueProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Enqueue);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4622,6 +4642,16 @@ urGetEnqueueProcAddrTable(
         }
     }
 
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetEnqueueProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetEnqueueProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
+    }
+
     return result;
 }
 
@@ -4659,10 +4689,10 @@ urGetEventProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetEventProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetEventProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Event);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4692,6 +4722,16 @@ urGetEventProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Event;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetEventProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetEventProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -4731,10 +4771,10 @@ urGetKernelProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetKernelProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetKernelProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Kernel);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4770,6 +4810,16 @@ urGetKernelProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Kernel;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetKernelProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetKernelProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -4809,10 +4859,10 @@ urGetMemProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetMemProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetMemProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Mem);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4845,6 +4895,16 @@ urGetMemProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Mem;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetMemProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetMemProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -4884,10 +4944,10 @@ urGetModuleProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetModuleProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetModuleProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Module);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4914,6 +4974,16 @@ urGetModuleProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Module;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetModuleProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetModuleProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -4953,10 +5023,10 @@ urGetPlatformProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetPlatformProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetPlatformProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Platform);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -4983,6 +5053,16 @@ urGetPlatformProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Platform;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetPlatformProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetPlatformProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -5022,10 +5102,10 @@ urGetProgramProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetProgramProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetProgramProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Program);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -5057,6 +5137,16 @@ urGetProgramProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Program;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetProgramProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetProgramProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -5096,10 +5186,10 @@ urGetQueueProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetQueueProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetQueueProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Queue);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -5129,6 +5219,16 @@ urGetQueueProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Queue;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetQueueProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetQueueProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -5168,10 +5268,10 @@ urGetSamplerProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetSamplerProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetSamplerProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Sampler);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -5199,6 +5299,16 @@ urGetSamplerProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Sampler;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetSamplerProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetSamplerProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -5238,10 +5348,10 @@ urGetUSMProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetUSMProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetUSMProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.USM);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -5266,6 +5376,16 @@ urGetUSMProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.USM;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetUSMProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetUSMProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;
@@ -5305,10 +5425,10 @@ urGetDeviceProcAddrTable(
             continue;
         auto getTable = reinterpret_cast<ur_pfnGetDeviceProcAddrTable_t>(
             GET_FUNCTION_PTR( platform.handle, "urGetDeviceProcAddrTable") );
-        if(!getTable) 
-            continue; 
+        if(!getTable)
+            continue;
         auto getTableResult = getTable( version, &platform.dditable.ur.Device);
-        if(getTableResult == UR_RESULT_SUCCESS) 
+        if(getTableResult == UR_RESULT_SUCCESS)
             atLeastOneplatformValid = true;
         else
             platform.initStatus = getTableResult;
@@ -5339,6 +5459,16 @@ urGetDeviceProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Device;
         }
+    }
+
+    // If the validation layer is enabled, then intercept the loader's DDIs
+    if(( UR_RESULT_SUCCESS == result ) && ( nullptr != loader::context->validationLayer ))
+    {
+        auto getTable = reinterpret_cast<ur_pfnGetDeviceProcAddrTable_t>(
+            GET_FUNCTION_PTR(loader::context->validationLayer, "urGetDeviceProcAddrTable") );
+        if(!getTable)
+            return UR_RESULT_ERROR_UNINITIALIZED;
+        result = getTable( version, pDdiTable );
     }
 
     return result;

--- a/source/loader/ur_loader.cpp
+++ b/source/loader/ur_loader.cpp
@@ -8,6 +8,8 @@
 #include "ur_loader.h"
 #include "platform_discovery.h"
 
+#include <iostream>
+
 namespace loader
 {
     ///////////////////////////////////////////////////////////////////////////////
@@ -30,7 +32,15 @@ namespace loader
 
         if(platforms.size()==0)
             return UR_RESULT_ERROR_UNINITIALIZED;
-    
+
+        if( getenv_tobool( "UR_ENABLE_VALIDATION_LAYER" ) )
+        {
+            auto valLibName = MAKE_LIBRARY_NAME("ur_validation_layer", UR_VERSION);
+            validationLayer = LOAD_DRIVER_LIBRARY( valLibName );
+            if ( validationLayer == NULL )
+                std::cout << "VALIDATION LAYER NULL\n";
+        }
+
         forceIntercept = getenv_tobool( "UR_ENABLE_LOADER_INTERCEPT" );
 
         if(forceIntercept || platforms.size() > 1)
@@ -42,6 +52,8 @@ namespace loader
     ///////////////////////////////////////////////////////////////////////////////
     context_t::~context_t()
     {
+        FREE_DRIVER_LIBRARY( validationLayer );
+
         for( auto& drv : platforms )
         {
             FREE_DRIVER_LIBRARY( drv.handle );
@@ -50,7 +62,7 @@ namespace loader
 
 }
 
-ur_result_t 
+ur_result_t
 urLoaderInit()
 {
     return loader::context->init();

--- a/source/loader/ur_loader.h
+++ b/source/loader/ur_loader.h
@@ -39,6 +39,8 @@ namespace loader
 
         platform_vector_t platforms;
 
+        HMODULE validationLayer = nullptr;
+
         bool forceIntercept = false;
 
         ur_result_t init();
@@ -48,7 +50,7 @@ namespace loader
 
     extern context_t *context;
     extern ur_event_factory_t ur_event_factory;
-    
+
 }
 
 #endif /* UR_LOADER_H */


### PR DESCRIPTION
This PR adds an initial validation layer to build infrastructure and parameter validation functionality.
The validation layer can be controlled through the following environmental variables:
- UR_ENABLE_VALIDATION_LAYER
- UR_ENABLE_PARAMETER_VALIDATION

Related issue: https://github.com/oneapi-src/unified-runtime/issues/144.

Templates and the solution comes from: https://github.com/oneapi-src/level-zero.