### PR TITLE
[ur] Clarify device partition properties

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -772,8 +772,8 @@ class ur_device_info_v(IntEnum):
     PRINTF_BUFFER_SIZE = 73                         ## size_t: Maximum size in bytes of internal printf buffer
     PREFERRED_INTEROP_USER_SYNC = 74                ## bool: prefer user synchronization when sharing object with other API
     PARENT_DEVICE = 75                              ## ::ur_device_handle_t: return parent device handle
-    PARTITION_PROPERTIES = 76                       ## uint32_t: return a bit-field of partition properties
-                                                    ## ::ur_device_partition_property_flags_t
+    PARTITION_PROPERTIES = 76                       ## ::ur_device_partition_property_t[]: Returns the list of partition
+                                                    ## types supported by the device
     PARTITION_MAX_SUB_DEVICES = 77                  ## uint32_t: maximum number of sub-devices when the device is partitioned
     PARTITION_AFFINITY_DOMAIN = 78                  ## uint32_t: return a bit-field of affinity domain
                                                     ## ::ur_device_affinity_domain_flags_t
@@ -809,24 +809,23 @@ class ur_device_info_t(c_int):
 
 
 ###############################################################################
-## @brief Device partition property
-class ur_device_partition_property_flags_v(IntEnum):
-    EQUALLY = UR_BIT(0)                             ## Support equal partition
-    BY_COUNTS = UR_BIT(1)                           ## Support partition by count
-    BY_AFFINITY_DOMAIN = UR_BIT(2)                  ## Support partition by affinity domain
-
-class ur_device_partition_property_flags_t(c_int):
-    def __str__(self):
-        return hex(self.value)
-
+## @brief Device partition property type
+class ur_device_partition_property_t(c_intptr_t):
+    pass
 
 ###############################################################################
-## @brief Partition property value
-class ur_device_partition_property_value_t(Structure):
-    _fields_ = [
-        ("property", ur_device_partition_property_flags_t),             ## [in] device partition property flags
-        ("value", c_ulong)                                              ## [in] partition value
-    ]
+## @brief Partition Properties
+class ur_device_partition_v(IntEnum):
+    EQUALLY = 0x1086                                ## Partition Equally
+    BY_COUNTS = 0x1087                              ## Partition by counts
+    BY_COUNTS_LIST_END = 0x0                        ## End of by counts list
+    BY_AFFINITY_DOMAIN = 0x1088                     ## Partition by affinity domain
+    BY_CSLICE = 0x1089                              ## Partition by c-slice
+
+class ur_device_partition_t(c_int):
+    def __str__(self):
+        return str(ur_device_partition_v(self.value))
+
 
 ###############################################################################
 ## @brief FP capabilities
@@ -2020,9 +2019,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urDevicePartition
 if __use_win_types:
-    _urDevicePartition_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_partition_property_value_t), c_ulong, POINTER(ur_device_handle_t), POINTER(c_ulong) )
+    _urDevicePartition_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_partition_property_t), c_ulong, POINTER(ur_device_handle_t), POINTER(c_ulong) )
 else:
-    _urDevicePartition_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_partition_property_value_t), c_ulong, POINTER(ur_device_handle_t), POINTER(c_ulong) )
+    _urDevicePartition_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_partition_property_t), c_ulong, POINTER(ur_device_handle_t), POINTER(c_ulong) )
 
 ###############################################################################
 ## @brief Function-pointer for urDeviceSelectBinary

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3016,8 +3016,8 @@ typedef enum ur_device_info_t
     UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,         ///< size_t: Maximum size in bytes of internal printf buffer
     UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,///< bool: prefer user synchronization when sharing object with other API
     UR_DEVICE_INFO_PARENT_DEVICE = 75,              ///< ::ur_device_handle_t: return parent device handle
-    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,       ///< uint32_t: return a bit-field of partition properties
-                                                    ///< ::ur_device_partition_property_flags_t
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,       ///< ::ur_device_partition_property_t[]: Returns the list of partition
+                                                    ///< types supported by the device
     UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,  ///< uint32_t: maximum number of sub-devices when the device is partitioned
     UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,  ///< uint32_t: return a bit-field of affinity domain
                                                     ///< ::ur_device_affinity_domain_flags_t
@@ -3132,25 +3132,21 @@ urDeviceRelease(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Device partition property
-typedef uint32_t ur_device_partition_property_flags_t;
-typedef enum ur_device_partition_property_flag_t
-{
-    UR_DEVICE_PARTITION_PROPERTY_FLAG_EQUALLY = UR_BIT(0),  ///< Support equal partition
-    UR_DEVICE_PARTITION_PROPERTY_FLAG_BY_COUNTS = UR_BIT(1),///< Support partition by count
-    UR_DEVICE_PARTITION_PROPERTY_FLAG_BY_AFFINITY_DOMAIN = UR_BIT(2),   ///< Support partition by affinity domain
-    UR_DEVICE_PARTITION_PROPERTY_FLAG_FORCE_UINT32 = 0x7fffffff
-
-} ur_device_partition_property_flag_t;
+/// @brief Device partition property type
+typedef intptr_t ur_device_partition_property_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Partition property value
-typedef struct ur_device_partition_property_value_t
+/// @brief Partition Properties
+typedef enum ur_device_partition_t
 {
-    ur_device_partition_property_flags_t property;  ///< [in] device partition property flags
-    uint32_t value;                                 ///< [in] partition value
+    UR_DEVICE_PARTITION_EQUALLY = 0x1086,           ///< Partition Equally
+    UR_DEVICE_PARTITION_BY_COUNTS = 0x1087,         ///< Partition by counts
+    UR_DEVICE_PARTITION_BY_COUNTS_LIST_END = 0x0,   ///< End of by counts list
+    UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN = 0x1088,///< Partition by affinity domain
+    UR_DEVICE_PARTITION_BY_CSLICE = 0x1089,         ///< Partition by c-slice
+    UR_DEVICE_PARTITION_FORCE_UINT32 = 0x7fffffff
 
-} ur_device_partition_property_value_t;
+} ur_device_partition_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition the device into sub-devices
@@ -3179,7 +3175,7 @@ typedef struct ur_device_partition_property_value_t
 UR_APIEXPORT ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+    const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
     uint32_t NumDevices,                            ///< [in] the number of sub-devices.
     ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                     ///< If NumDevices is less than the number of sub-devices available, then
@@ -7446,7 +7442,7 @@ typedef void (UR_APICALL *ur_pfnDeviceReleaseCb_t)(
 typedef struct ur_device_partition_params_t
 {
     ur_device_handle_t* phDevice;
-    ur_device_partition_property_value_t** pProperties;
+    const ur_device_partition_property_t** pProperties;
     uint32_t* pNumDevices;
     ur_device_handle_t** pphSubDevices;
     uint32_t** ppNumDevicesRet;

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3171,11 +3171,11 @@ typedef enum ur_device_partition_t
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == Properties`
+///         + `NULL == pProperties`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
+    const ur_device_partition_property_t* pProperties,  ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices,                            ///< [in] the number of sub-devices.
     ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                     ///< If NumDevices is less than the number of sub-devices available, then
@@ -7442,7 +7442,7 @@ typedef void (UR_APICALL *ur_pfnDeviceReleaseCb_t)(
 typedef struct ur_device_partition_params_t
 {
     ur_device_handle_t* phDevice;
-    const ur_device_partition_property_t** pProperties;
+    const ur_device_partition_property_t** ppProperties;
     uint32_t* pNumDevices;
     ur_device_handle_t** pphSubDevices;
     uint32_t** ppNumDevicesRet;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1481,7 +1481,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnDeviceRelease_t)(
 /// @brief Function-pointer for urDevicePartition 
 typedef ur_result_t (UR_APICALL *ur_pfnDevicePartition_t)(
     ur_device_handle_t,
-    ur_device_partition_property_value_t*,
+    const ur_device_partition_property_t*,
     uint32_t,
     ur_device_handle_t*,
     uint32_t*

--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -117,9 +117,10 @@ fixed part of the parent device, which can explicitly be programmed individually
 .. parsed-literal::
 
     ${x}_device_handle_t hDevice;
-    ${x}_device_partition_property_value_t properties = { 
-               ${X}_DEVICE_PARTITION_PROPERTY_FLAG_BY_AFFINITY_DOMAIN,
-               ${X}_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE };
+    ${x}_device_partition_property_t properties[] = { 
+               ${X}_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
+               ${X}_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE,
+               0};
 
     uint32_t count = 0;
     std::vector<${x}_device_handle_t> subDevices;

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -230,7 +230,7 @@ etors:
     - name: PARENT_DEVICE
       desc: "$x_device_handle_t: return parent device handle"
     - name: PARTITION_PROPERTIES
-      desc: "uint32_t: return a bit-field of partition properties $x_device_partition_property_flags_t"
+      desc: "$x_device_partition_property_t[]: Returns the list of partition types supported by the device"
     - name: PARTITION_MAX_SUB_DEVICES
       desc: "uint32_t: maximum number of sub-devices when the device is partitioned"
     - name: PARTITION_AFFINITY_DOMAIN
@@ -350,32 +350,30 @@ params:
       desc: |
             [in] handle of the device to release.
 --- #--------------------------------------------------------------------------
+type: typedef
+desc: "Device partition property type"
+name: $x_device_partition_property_t
+value: intptr_t
+--- #--------------------------------------------------------------------------
 type: enum
-desc: "Device partition property"
-class: $xDevice
-name: $x_device_partition_property_flags_t
+desc: "Partition Properties"
+name: $x_device_partition_t
 etors:
     - name: EQUALLY
-      desc: "Support equal partition"
-      value: "$X_BIT(0)"
-    - name: BY_COUNTS      
-      desc: "Support partition by count"
-      value: "$X_BIT(1)"
+      desc: "Partition Equally"
+      value: "0x1086"
+    - name: BY_COUNTS
+      desc: "Partition by counts"
+      value: "0x1087"
+    - name: BY_COUNTS_LIST_END
+      desc: "End of by counts list"
+      value: "0x0"
     - name: BY_AFFINITY_DOMAIN
-      desc: "Support partition by affinity domain"
-      value: "$X_BIT(2)"
---- #--------------------------------------------------------------------------
-type: struct
-desc: "Partition property value"
-class: $xDevice
-name: $x_device_partition_property_value_t
-members:
-    - type: $x_device_partition_property_flags_t
-      name: property
-      desc: "[in] device partition property flags"
-    - type: uint32_t
-      name: value
-      desc: "[in] partition value"
+      desc: "Partition by affinity domain"
+      value: "0x1088"
+    - name: BY_CSLICE
+      desc: "Partition by c-slice"
+      value: "0x1089"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Partition the device into sub-devices"
@@ -395,10 +393,10 @@ params:
       name: hDevice
       desc: |
             [in] handle of the device to partition.
-    - type: "$x_device_partition_property_value_t*"
+    - type: const $x_device_partition_property_t*
       name: Properties
       desc: |
-            [in] null-terminated array of <property, value> pair of the requested partitioning.
+            [in] null-terminated array of <property, value> pairs.
     - type: "uint32_t"
       name: NumDevices
       desc: |

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -394,9 +394,9 @@ params:
       desc: |
             [in] handle of the device to partition.
     - type: const $x_device_partition_property_t*
-      name: Properties
+      name: pProperties
       desc: |
-            [in] null-terminated array of <property, value> pairs.
+            [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     - type: "uint32_t"
       name: NumDevices
       desc: |

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2186,7 +2186,7 @@ namespace driver
     __urdlllocal ur_result_t UR_APICALL
     urDevicePartition(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-        const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
+        const ur_device_partition_property_t* pProperties,  ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
         uint32_t NumDevices,                            ///< [in] the number of sub-devices.
         ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                         ///< If NumDevices is less than the number of sub-devices available, then
@@ -2201,7 +2201,7 @@ namespace driver
         auto pfnPartition = d_context.urDdiTable.Device.pfnPartition;
         if( nullptr != pfnPartition )
         {
-            result = pfnPartition( hDevice, Properties, NumDevices, phSubDevices, pNumDevicesRet );
+            result = pfnPartition( hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet );
         }
         else
         {

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2186,7 +2186,7 @@ namespace driver
     __urdlllocal ur_result_t UR_APICALL
     urDevicePartition(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-        ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+        const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
         uint32_t NumDevices,                            ///< [in] the number of sub-devices.
         ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                         ///< If NumDevices is less than the number of sub-devices available, then

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3000,7 +3000,7 @@ namespace loader
     __urdlllocal ur_result_t UR_APICALL
     urDevicePartition(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-        ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+        const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
         uint32_t NumDevices,                            ///< [in] the number of sub-devices.
         ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                         ///< If NumDevices is less than the number of sub-devices available, then

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3000,7 +3000,7 @@ namespace loader
     __urdlllocal ur_result_t UR_APICALL
     urDevicePartition(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-        const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
+        const ur_device_partition_property_t* pProperties,  ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
         uint32_t NumDevices,                            ///< [in] the number of sub-devices.
         ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                         ///< If NumDevices is less than the number of sub-devices available, then
@@ -3021,7 +3021,7 @@ namespace loader
         hDevice = reinterpret_cast<ur_device_object_t*>( hDevice )->handle;
 
         // forward to device-platform
-        result = pfnPartition( hDevice, Properties, NumDevices, phSubDevices, pNumDevicesRet );
+        result = pfnPartition( hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet );
 
         if( UR_RESULT_SUCCESS != result )
             return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2790,11 +2790,11 @@ urDeviceRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == Properties`
+///         + `NULL == pProperties`
 ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
+    const ur_device_partition_property_t* pProperties,  ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices,                            ///< [in] the number of sub-devices.
     ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                     ///< If NumDevices is less than the number of sub-devices available, then
@@ -2807,7 +2807,7 @@ urDevicePartition(
     if( nullptr == pfnPartition )
         return UR_RESULT_ERROR_UNINITIALIZED;
 
-    return pfnPartition( hDevice, Properties, NumDevices, phSubDevices, pNumDevicesRet );
+    return pfnPartition( hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet );
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2794,7 +2794,7 @@ urDeviceRelease(
 ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+    const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
     uint32_t NumDevices,                            ///< [in] the number of sub-devices.
     ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                     ///< If NumDevices is less than the number of sub-devices available, then

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2575,7 +2575,7 @@ urDeviceRelease(
 ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    ur_device_partition_property_value_t* Properties,   ///< [in] null-terminated array of <property, value> pair of the requested partitioning.
+    const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
     uint32_t NumDevices,                            ///< [in] the number of sub-devices.
     ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                     ///< If NumDevices is less than the number of sub-devices available, then

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2571,11 +2571,11 @@ urDeviceRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == Properties`
+///         + `NULL == pProperties`
 ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t* Properties,   ///< [in] null-terminated array of <property, value> pairs.
+    const ur_device_partition_property_t* pProperties,  ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices,                            ///< [in] the number of sub-devices.
     ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
                                                     ///< If NumDevices is less than the number of sub-devices available, then

--- a/test/conformance/device/urDevicePartition.cpp
+++ b/test/conformance/device/urDevicePartition.cpp
@@ -7,8 +7,7 @@ using urDevicePartitionTest = uur::urAllDevicesTest;
 TEST_F(urDevicePartitionTest, PartitionEquallySuccess) {
   for (auto device : devices) {
 
-    if (!uur::hasDevicePartitionSupport(
-            device, UR_DEVICE_PARTITION_PROPERTY_FLAG_EQUALLY)) {
+    if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_EQUALLY)) {
       GTEST_SKIP();
     }
 
@@ -20,14 +19,8 @@ TEST_F(urDevicePartitionTest, PartitionEquallySuccess) {
     ASSERT_NE(n_compute_units, 0);
 
     for (uint32_t i = 1; i < n_compute_units; ++i) {
-      // TODO - I don't think the API is clear here as to how we should
-      // terminate the array of property values. The spec says "null
-      // terminated", which doesn't mean much for array of structs???
-      // Additionally - if we want to use BY_COUNTS we need to supply an array
-      // of counts of Compute Units to partition. This is not really possible
-      // with the property_value struct here.
-      ur_device_partition_property_value_t properties[] = {
-          {UR_DEVICE_PARTITION_PROPERTY_FLAG_EQUALLY, i}, {}};
+      ur_device_partition_property_t properties[] = {
+          UR_DEVICE_PARTITION_EQUALLY, i, 0};
 
       // Get the number of devices that will be created
       uint32_t n_devices;


### PR DESCRIPTION
Open to suggestions on this one. 

On the WG call we decided that we should just revert how we specify device properties to be just an `intptr_t` - so i've created a typedef for `ur_device_partition_property_t` to `intptr_t`. However I have added an additional enum to specify the partitioning options `ur_device_partition_t` - which maybe isn't ideal. We could specify the values with macros but I'm not sure what I prefer.

Closes #183 & #119 