### PR TITLE
[ur] Remove prop-value structs

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -577,6 +577,11 @@ class ur_queue_flags_t(c_int):
 
 
 ###############################################################################
+## @brief Queue property type
+class ur_queue_property_t(c_intptr_t):
+    pass
+
+###############################################################################
 ## @brief Queue Properties
 class ur_queue_properties_v(IntEnum):
     FLAGS = -1                                      ## [::ur_queue_flags_t]: the bitfield of queue flags
@@ -586,14 +591,6 @@ class ur_queue_properties_t(c_int):
     def __str__(self):
         return str(ur_queue_properties_v(self.value))
 
-
-###############################################################################
-## @brief Queue property value
-class ur_queue_property_value_t(Structure):
-    _fields_ = [
-        ("propertyType", ur_queue_properties_t),                        ## [in] queue property
-        ("propertyValue", c_ulong)                                      ## [in] queue property value
-    ]
 
 ###############################################################################
 ## @brief Get sample object information
@@ -625,6 +622,11 @@ class ur_sampler_properties_t(c_int):
 
 
 ###############################################################################
+## @brief Sampler Properties type
+class ur_sampler_property_t(c_intptr_t):
+    pass
+
+###############################################################################
 ## @brief Sampler addressing mode
 class ur_sampler_addressing_mode_v(IntEnum):
     MIRRORED_REPEAT = 0                             ## Mirrored Repeat
@@ -637,14 +639,6 @@ class ur_sampler_addressing_mode_t(c_int):
     def __str__(self):
         return str(ur_sampler_addressing_mode_v(self.value))
 
-
-###############################################################################
-## @brief Sampler properties <name, value> pair
-class ur_sampler_property_value_t(Structure):
-    _fields_ = [
-        ("propName", ur_sampler_properties_t),                          ## [in] Sampler property
-        ("propValue", c_ulong)                                          ## [in] Sampler property value
-    ]
 
 ###############################################################################
 ## @brief USM memory property flags
@@ -1509,9 +1503,9 @@ class ur_kernel_dditable_t(Structure):
 ###############################################################################
 ## @brief Function-pointer for urSamplerCreate
 if __use_win_types:
-    _urSamplerCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_value_t), POINTER(ur_sampler_handle_t) )
+    _urSamplerCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_t), POINTER(ur_sampler_handle_t) )
 else:
-    _urSamplerCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_value_t), POINTER(ur_sampler_handle_t) )
+    _urSamplerCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_t), POINTER(ur_sampler_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urSamplerRetain
@@ -1927,9 +1921,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urQueueCreate
 if __use_win_types:
-    _urQueueCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_property_value_t), POINTER(ur_queue_handle_t) )
+    _urQueueCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_property_t), POINTER(ur_queue_handle_t) )
 else:
-    _urQueueCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_property_value_t), POINTER(ur_queue_handle_t) )
+    _urQueueCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_property_t), POINTER(ur_queue_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urQueueRetain

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2244,6 +2244,10 @@ typedef enum ur_queue_flag_t
 } ur_queue_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Queue property type
+typedef intptr_t ur_queue_property_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue Properties
 typedef enum ur_queue_properties_t
 {
@@ -2252,15 +2256,6 @@ typedef enum ur_queue_properties_t
     UR_QUEUE_PROPERTIES_FORCE_UINT32 = 0x7fffffff
 
 } ur_queue_properties_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Queue property value
-typedef struct ur_queue_property_value_t
-{
-    ur_queue_properties_t propertyType;             ///< [in] queue property
-    uint32_t propertyValue;                         ///< [in] queue property value
-
-} ur_queue_property_value_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
@@ -2320,7 +2315,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urQueueCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
     ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-    ur_queue_property_value_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
+    const ur_queue_property_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
                                                     ///< Each property name is immediately followed by the corresponding
                                                     ///< desired value.
                                                     ///< The list is terminated with a 0. 
@@ -2523,6 +2518,10 @@ typedef enum ur_sampler_properties_t
 } ur_sampler_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler Properties type
+typedef intptr_t ur_sampler_property_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler addressing mode
 typedef enum ur_sampler_addressing_mode_t
 {
@@ -2534,15 +2533,6 @@ typedef enum ur_sampler_addressing_mode_t
     UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32 = 0x7fffffff
 
 } ur_sampler_addressing_mode_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Sampler properties <name, value> pair
-typedef struct ur_sampler_property_value_t
-{
-    ur_sampler_properties_t propName;               ///< [in] Sampler property
-    uint32_t propValue;                             ///< [in] Sampler property value
-
-} ur_sampler_property_value_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sampler object in a context
@@ -2574,7 +2564,7 @@ typedef struct ur_sampler_property_value_t
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+    const ur_sampler_property_t* pProps,            ///< [in] specifies a list of sampler property names and their
                                                     ///< corresponding values.
     ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
     );
@@ -5786,7 +5776,7 @@ typedef struct ur_kernel_callbacks_t
 typedef struct ur_sampler_create_params_t
 {
     ur_context_handle_t* phContext;
-    const ur_sampler_property_value_t** ppProps;
+    const ur_sampler_property_t** ppProps;
     ur_sampler_handle_t** pphSampler;
 } ur_sampler_create_params_t;
 
@@ -7173,7 +7163,7 @@ typedef struct ur_queue_create_params_t
 {
     ur_context_handle_t* phContext;
     ur_device_handle_t* phDevice;
-    ur_queue_property_value_t** ppProps;
+    const ur_queue_property_t** ppProps;
     ur_queue_handle_t** pphQueue;
 } ur_queue_create_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -637,7 +637,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnGetKernelProcAddrTable_t)(
 /// @brief Function-pointer for urSamplerCreate 
 typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreate_t)(
     ur_context_handle_t,
-    const ur_sampler_property_value_t*,
+    const ur_sampler_property_t*,
     ur_sampler_handle_t*
     );
 
@@ -1366,7 +1366,7 @@ typedef ur_result_t (UR_APICALL *ur_pfnQueueGetInfo_t)(
 typedef ur_result_t (UR_APICALL *ur_pfnQueueCreate_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_queue_property_value_t*,
+    const ur_queue_property_t*,
     ur_queue_handle_t*
     );
 

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -55,6 +55,11 @@ etors:
       value: "$X_BIT(6)"
       desc: "High priority queue"
 --- #--------------------------------------------------------------------------
+type: typedef
+desc: "Queue property type"
+name: $x_queue_property_t
+value: intptr_t
+--- #--------------------------------------------------------------------------
 type: enum
 desc: "Queue Properties"
 class: $xQueue
@@ -66,18 +71,6 @@ etors:
     - name: COMPUTE_INDEX
       value: "-2"
       desc: "[uint32_t]: the queue index"
---- #--------------------------------------------------------------------------
-type: struct
-desc: "Queue property value"
-class: $xQueue
-name: $x_queue_property_value_t
-members:
-    - type: $x_queue_properties_t
-      name: propertyType
-      desc: "[in] queue property"
-    - type: uint32_t
-      name: propertyValue
-      desc: "[in] queue property value"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Query information about a command queue"
@@ -123,7 +116,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_queue_property_value_t*
+    - type: const $x_queue_property_t*
       name: pProps
       desc: |
             [in] specifies a list of queue properties and their corresponding values.

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -44,6 +44,11 @@ etors:
     - name: FILTER_MODE
       desc: "Sampler filter mode"
 --- #--------------------------------------------------------------------------
+type: typedef
+desc: "Sampler Properties type"
+name: $x_sampler_property_t
+value: intptr_t
+--- #--------------------------------------------------------------------------
 type: enum
 desc: "Sampler addressing mode"
 class: $xSampler
@@ -60,18 +65,6 @@ etors:
     - name: NONE
       desc: "None"
 --- #--------------------------------------------------------------------------
-type: struct
-desc: "Sampler properties <name, value> pair"
-class: $xSampler
-name: $x_sampler_property_value_t
-members:
-    - type: $x_sampler_properties_t
-      name: propName
-      desc: "[in] Sampler property"
-    - type: uint32_t
-      name: propValue
-      desc: "[in] Sampler property value"
---- #--------------------------------------------------------------------------
 type: function
 desc: "Create a sampler object in a context"
 class: $xSampler
@@ -86,7 +79,7 @@ params:
     - type: $x_context_handle_t
       name: hContext
       desc: "[in] handle of the context object"
-    - type: "const $x_sampler_property_value_t*"
+    - type: "const $x_sampler_property_t*"
       name: pProps
       desc: |
             [in] specifies a list of sampler property names and their corresponding values.

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -1608,7 +1608,7 @@ namespace driver
     urQueueCreate(
         ur_context_handle_t hContext,                   ///< [in] handle of the context object
         ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-        ur_queue_property_value_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
+        const ur_queue_property_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
                                                         ///< Each property name is immediately followed by the corresponding
                                                         ///< desired value.
                                                         ///< The list is terminated with a 0. 
@@ -1784,7 +1784,7 @@ namespace driver
     __urdlllocal ur_result_t UR_APICALL
     urSamplerCreate(
         ur_context_handle_t hContext,                   ///< [in] handle of the context object
-        const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+        const ur_sampler_property_t* pProps,            ///< [in] specifies a list of sampler property names and their
                                                         ///< corresponding values.
         ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
         )

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2301,7 +2301,7 @@ namespace loader
     urQueueCreate(
         ur_context_handle_t hContext,                   ///< [in] handle of the context object
         ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-        ur_queue_property_value_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
+        const ur_queue_property_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
                                                         ///< Each property name is immediately followed by the corresponding
                                                         ///< desired value.
                                                         ///< The list is terminated with a 0. 
@@ -2526,7 +2526,7 @@ namespace loader
     __urdlllocal ur_result_t UR_APICALL
     urSamplerCreate(
         ur_context_handle_t hContext,                   ///< [in] handle of the context object
-        const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+        const ur_sampler_property_t* pProps,            ///< [in] specifies a list of sampler property names and their
                                                         ///< corresponding values.
         ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
         )

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2031,7 +2031,7 @@ ur_result_t UR_APICALL
 urQueueCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
     ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-    ur_queue_property_value_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
+    const ur_queue_property_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
                                                     ///< Each property name is immediately followed by the corresponding
                                                     ///< desired value.
                                                     ///< The list is terminated with a 0. 
@@ -2278,7 +2278,7 @@ urQueueFlush(
 ur_result_t UR_APICALL
 urSamplerCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+    const ur_sampler_property_t* pProps,            ///< [in] specifies a list of sampler property names and their
                                                     ///< corresponding values.
     ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
     )

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1878,7 +1878,7 @@ ur_result_t UR_APICALL
 urQueueCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
     ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-    ur_queue_property_value_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
+    const ur_queue_property_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
                                                     ///< Each property name is immediately followed by the corresponding
                                                     ///< desired value.
                                                     ///< The list is terminated with a 0. 
@@ -2104,7 +2104,7 @@ urQueueFlush(
 ur_result_t UR_APICALL
 urSamplerCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    const ur_sampler_property_value_t* pProps,      ///< [in] specifies a list of sampler property names and their
+    const ur_sampler_property_t* pProps,            ///< [in] specifies a list of sampler property names and their
                                                     ///< corresponding values.
     ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
     )


### PR DESCRIPTION
PR #189 fixed how we specify properties for entry-points and we moved away from using the prop-value struct so it makes sense to make this consistent with the other 2 remaining entry-points that used this style `urQueueCreate` and `urSamplerCreate`