### PR TITLE
[ur] Correct name for urEnqueueUSMMemAdvise

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1783,11 +1783,11 @@ else:
     _urEnqueueUSMPrefetch_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_migration_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 
 ###############################################################################
-## @brief Function-pointer for urEnqueueUSMMemAdvice
+## @brief Function-pointer for urEnqueueUSMMemAdvise
 if __use_win_types:
-    _urEnqueueUSMMemAdvice_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_mem_advice_t, POINTER(ur_event_handle_t) )
+    _urEnqueueUSMMemAdvise_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_mem_advice_t, POINTER(ur_event_handle_t) )
 else:
-    _urEnqueueUSMMemAdvice_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_mem_advice_t, POINTER(ur_event_handle_t) )
+    _urEnqueueUSMMemAdvise_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_mem_advice_t, POINTER(ur_event_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urEnqueueUSMFill2D
@@ -1847,7 +1847,7 @@ class ur_enqueue_dditable_t(Structure):
         ("pfnUSMMemset", c_void_p),                                     ## _urEnqueueUSMMemset_t
         ("pfnUSMMemcpy", c_void_p),                                     ## _urEnqueueUSMMemcpy_t
         ("pfnUSMPrefetch", c_void_p),                                   ## _urEnqueueUSMPrefetch_t
-        ("pfnUSMMemAdvice", c_void_p),                                  ## _urEnqueueUSMMemAdvice_t
+        ("pfnUSMMemAdvise", c_void_p),                                  ## _urEnqueueUSMMemAdvise_t
         ("pfnUSMFill2D", c_void_p),                                     ## _urEnqueueUSMFill2D_t
         ("pfnUSMMemset2D", c_void_p),                                   ## _urEnqueueUSMMemset2D_t
         ("pfnUSMMemcpy2D", c_void_p),                                   ## _urEnqueueUSMMemcpy2D_t
@@ -2265,7 +2265,7 @@ class UR_DDI:
         self.urEnqueueUSMMemset = _urEnqueueUSMMemset_t(self.__dditable.Enqueue.pfnUSMMemset)
         self.urEnqueueUSMMemcpy = _urEnqueueUSMMemcpy_t(self.__dditable.Enqueue.pfnUSMMemcpy)
         self.urEnqueueUSMPrefetch = _urEnqueueUSMPrefetch_t(self.__dditable.Enqueue.pfnUSMPrefetch)
-        self.urEnqueueUSMMemAdvice = _urEnqueueUSMMemAdvice_t(self.__dditable.Enqueue.pfnUSMMemAdvice)
+        self.urEnqueueUSMMemAdvise = _urEnqueueUSMMemAdvise_t(self.__dditable.Enqueue.pfnUSMMemAdvise)
         self.urEnqueueUSMFill2D = _urEnqueueUSMFill2D_t(self.__dditable.Enqueue.pfnUSMFill2D)
         self.urEnqueueUSMMemset2D = _urEnqueueUSMMemset2D_t(self.__dditable.Enqueue.pfnUSMMemset2D)
         self.urEnqueueUSMMemcpy2D = _urEnqueueUSMMemcpy2D_t(self.__dditable.Enqueue.pfnUSMMemcpy2D)

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1293,10 +1293,10 @@ typedef enum ur_mem_advice_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueUSMMemAdvice(
+urEnqueueUSMMemAdvise(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     const void* pMem,                               ///< [in] pointer to the USM memory object
-    size_t size,                                    ///< [in] size in bytes to be adviced
+    size_t size,                                    ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,                         ///< [in] USM memory advice
     ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
                                                     ///< particular command instance.
@@ -6763,26 +6763,26 @@ typedef void (UR_APICALL *ur_pfnEnqueueUSMPrefetchCb_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMMemAdvice 
+/// @brief Callback function parameters for urEnqueueUSMMemAdvise 
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_mem_advice_params_t
+typedef struct ur_enqueue_usm_mem_advise_params_t
 {
     ur_queue_handle_t* phQueue;
     const void** ppMem;
     size_t* psize;
     ur_mem_advice_t* padvice;
     ur_event_handle_t** pphEvent;
-} ur_enqueue_usm_mem_advice_params_t;
+} ur_enqueue_usm_mem_advise_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMMemAdvice 
+/// @brief Callback function-pointer for urEnqueueUSMMemAdvise 
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMMemAdviceCb_t)(
-    ur_enqueue_usm_mem_advice_params_t* params,
+typedef void (UR_APICALL *ur_pfnEnqueueUSMMemAdviseCb_t)(
+    ur_enqueue_usm_mem_advise_params_t* params,
     ur_result_t result,
     void* pTracerUserData,
     void** ppTracerInstanceUserData
@@ -6965,7 +6965,7 @@ typedef struct ur_enqueue_callbacks_t
     ur_pfnEnqueueUSMMemsetCb_t                                      pfnUSMMemsetCb;
     ur_pfnEnqueueUSMMemcpyCb_t                                      pfnUSMMemcpyCb;
     ur_pfnEnqueueUSMPrefetchCb_t                                    pfnUSMPrefetchCb;
-    ur_pfnEnqueueUSMMemAdviceCb_t                                   pfnUSMMemAdviceCb;
+    ur_pfnEnqueueUSMMemAdviseCb_t                                   pfnUSMMemAdviseCb;
     ur_pfnEnqueueUSMFill2DCb_t                                      pfnUSMFill2DCb;
     ur_pfnEnqueueUSMMemset2DCb_t                                    pfnUSMMemset2DCb;
     ur_pfnEnqueueUSMMemcpy2DCb_t                                    pfnUSMMemcpy2DCb;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1101,8 +1101,8 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMPrefetch_t)(
     );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMMemAdvice 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemAdvice_t)(
+/// @brief Function-pointer for urEnqueueUSMMemAdvise 
+typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemAdvise_t)(
     ur_queue_handle_t,
     const void*,
     size_t,
@@ -1207,7 +1207,7 @@ typedef struct ur_enqueue_dditable_t
     ur_pfnEnqueueUSMMemset_t                                    pfnUSMMemset;
     ur_pfnEnqueueUSMMemcpy_t                                    pfnUSMMemcpy;
     ur_pfnEnqueueUSMPrefetch_t                                  pfnUSMPrefetch;
-    ur_pfnEnqueueUSMMemAdvice_t                                 pfnUSMMemAdvice;
+    ur_pfnEnqueueUSMMemAdvise_t                                 pfnUSMMemAdvise;
     ur_pfnEnqueueUSMFill2D_t                                    pfnUSMFill2D;
     ur_pfnEnqueueUSMMemset2D_t                                  pfnUSMMemset2D;
     ur_pfnEnqueueUSMMemcpy2D_t                                  pfnUSMMemcpy2D;

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -988,7 +988,7 @@ etors:
 type: function
 desc: "Enqueue a command to set USM memory advice" 
 class: $xEnqueue
-name: USMMemAdvice
+name: USMMemAdvise
 ordinal: "0"
 params:
     - type: $x_queue_handle_t
@@ -999,7 +999,7 @@ params:
       desc: "[in] pointer to the USM memory object"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to be adviced"
+      desc: "[in] size in bytes to be advised"
     - type: $x_mem_advice_t
       name: advice
       desc: "[in] USM memory advice"

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -881,12 +881,12 @@ namespace driver
     }
 
     ///////////////////////////////////////////////////////////////////////////////
-    /// @brief Intercept function for urEnqueueUSMMemAdvice
+    /// @brief Intercept function for urEnqueueUSMMemAdvise
     __urdlllocal ur_result_t UR_APICALL
-    urEnqueueUSMMemAdvice(
+    urEnqueueUSMMemAdvise(
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
         const void* pMem,                               ///< [in] pointer to the USM memory object
-        size_t size,                                    ///< [in] size in bytes to be adviced
+        size_t size,                                    ///< [in] size in bytes to be advised
         ur_mem_advice_t advice,                         ///< [in] USM memory advice
         ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
                                                         ///< particular command instance.
@@ -895,10 +895,10 @@ namespace driver
         ur_result_t result = UR_RESULT_SUCCESS;
 
         // if the driver has created a custom function, then call it instead of using the generic path
-        auto pfnUSMMemAdvice = d_context.urDdiTable.Enqueue.pfnUSMMemAdvice;
-        if( nullptr != pfnUSMMemAdvice )
+        auto pfnUSMMemAdvise = d_context.urDdiTable.Enqueue.pfnUSMMemAdvise;
+        if( nullptr != pfnUSMMemAdvise )
         {
-            result = pfnUSMMemAdvice( hQueue, pMem, size, advice, phEvent );
+            result = pfnUSMMemAdvise( hQueue, pMem, size, advice, phEvent );
         }
         else
         {
@@ -3424,7 +3424,7 @@ urGetEnqueueProcAddrTable(
 
     pDdiTable->pfnUSMPrefetch                            = driver::urEnqueueUSMPrefetch;
 
-    pDdiTable->pfnUSMMemAdvice                           = driver::urEnqueueUSMMemAdvice;
+    pDdiTable->pfnUSMMemAdvise                           = driver::urEnqueueUSMMemAdvise;
 
     pDdiTable->pfnUSMFill2D                              = driver::urEnqueueUSMFill2D;
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1348,12 +1348,12 @@ namespace loader
     }
 
     ///////////////////////////////////////////////////////////////////////////////
-    /// @brief Intercept function for urEnqueueUSMMemAdvice
+    /// @brief Intercept function for urEnqueueUSMMemAdvise
     __urdlllocal ur_result_t UR_APICALL
-    urEnqueueUSMMemAdvice(
+    urEnqueueUSMMemAdvise(
         ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
         const void* pMem,                               ///< [in] pointer to the USM memory object
-        size_t size,                                    ///< [in] size in bytes to be adviced
+        size_t size,                                    ///< [in] size in bytes to be advised
         ur_mem_advice_t advice,                         ///< [in] USM memory advice
         ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
                                                         ///< particular command instance.
@@ -1363,15 +1363,15 @@ namespace loader
 
         // extract platform's function pointer table
         auto dditable = reinterpret_cast<ur_queue_object_t*>( hQueue )->dditable;
-        auto pfnUSMMemAdvice = dditable->ur.Enqueue.pfnUSMMemAdvice;
-        if( nullptr == pfnUSMMemAdvice )
+        auto pfnUSMMemAdvise = dditable->ur.Enqueue.pfnUSMMemAdvise;
+        if( nullptr == pfnUSMMemAdvise )
             return UR_RESULT_ERROR_UNINITIALIZED;
 
         // convert loader handle to platform handle
         hQueue = reinterpret_cast<ur_queue_object_t*>( hQueue )->handle;
 
         // forward to device-platform
-        result = pfnUSMMemAdvice( hQueue, pMem, size, advice, phEvent );
+        result = pfnUSMMemAdvise( hQueue, pMem, size, advice, phEvent );
 
         if( UR_RESULT_SUCCESS != result )
             return result;
@@ -4608,7 +4608,7 @@ urGetEnqueueProcAddrTable(
             pDdiTable->pfnUSMMemset                                = loader::urEnqueueUSMMemset;
             pDdiTable->pfnUSMMemcpy                                = loader::urEnqueueUSMMemcpy;
             pDdiTable->pfnUSMPrefetch                              = loader::urEnqueueUSMPrefetch;
-            pDdiTable->pfnUSMMemAdvice                             = loader::urEnqueueUSMMemAdvice;
+            pDdiTable->pfnUSMMemAdvise                             = loader::urEnqueueUSMMemAdvise;
             pDdiTable->pfnUSMFill2D                                = loader::urEnqueueUSMFill2D;
             pDdiTable->pfnUSMMemset2D                              = loader::urEnqueueUSMMemset2D;
             pDdiTable->pfnUSMMemcpy2D                              = loader::urEnqueueUSMMemcpy2D;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1147,20 +1147,20 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
-urEnqueueUSMMemAdvice(
+urEnqueueUSMMemAdvise(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     const void* pMem,                               ///< [in] pointer to the USM memory object
-    size_t size,                                    ///< [in] size in bytes to be adviced
+    size_t size,                                    ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,                         ///< [in] USM memory advice
     ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
                                                     ///< particular command instance.
     )
 {
-    auto pfnUSMMemAdvice = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvice;
-    if( nullptr == pfnUSMMemAdvice )
+    auto pfnUSMMemAdvise = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvise;
+    if( nullptr == pfnUSMMemAdvise )
         return UR_RESULT_ERROR_UNINITIALIZED;
 
-    return pfnUSMMemAdvice( hQueue, pMem, size, advice, phEvent );
+    return pfnUSMMemAdvise( hQueue, pMem, size, advice, phEvent );
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1069,10 +1069,10 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
-urEnqueueUSMMemAdvice(
+urEnqueueUSMMemAdvise(
     ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
     const void* pMem,                               ///< [in] pointer to the USM memory object
-    size_t size,                                    ///< [in] size in bytes to be adviced
+    size_t size,                                    ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,                         ///< [in] USM memory advice
     ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
                                                     ///< particular command instance.


### PR DESCRIPTION
Renames `urEnqueueUSMMemAdvice` to `urEnqeueuUSMMemAdvise`

Closes #187 