### PR TITLE
[ur] HostPtr should be optional in urMemBufferCreate

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1956,7 +1956,6 @@ urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3f < flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pHost`
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -1969,7 +1968,7 @@ urMemBufferCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
     ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
     size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
-    void* pHost,                                    ///< [in] pointer to the buffer data
+    void* pHost,                                    ///< [in][optional] pointer to the buffer data
     ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
     );
 

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -255,7 +255,7 @@ params:
       desc: "[in] size in bytes of the memory object to be allocated"
     - type: "void*"
       name: pHost
-      desc: "[in] pointer to the buffer data"
+      desc: "[in][optional] pointer to the buffer data"
     - type: $x_mem_handle_t*
       name: phBuffer     
       desc: "[out] pointer to handle of the memory buffer created"

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -1342,7 +1342,7 @@ namespace driver
         ur_context_handle_t hContext,                   ///< [in] handle of the context object
         ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
         size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
-        void* pHost,                                    ///< [in] pointer to the buffer data
+        void* pHost,                                    ///< [in][optional] pointer to the buffer data
         ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
         )
     {

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1980,7 +1980,7 @@ namespace loader
         ur_context_handle_t hContext,                   ///< [in] handle of the context object
         ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
         size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
-        void* pHost,                                    ///< [in] pointer to the buffer data
+        void* pHost,                                    ///< [in][optional] pointer to the buffer data
         ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
         )
     {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1678,7 +1678,6 @@ urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3f < flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pHost`
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -1691,7 +1690,7 @@ urMemBufferCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
     ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
     size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
-    void* pHost,                                    ///< [in] pointer to the buffer data
+    void* pHost,                                    ///< [in][optional] pointer to the buffer data
     ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
     )
 {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1555,7 +1555,6 @@ urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x3f < flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pHost`
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -1568,7 +1567,7 @@ urMemBufferCreate(
     ur_context_handle_t hContext,                   ///< [in] handle of the context object
     ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
     size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
-    void* pHost,                                    ///< [in] pointer to the buffer data
+    void* pHost,                                    ///< [in][optional] pointer to the buffer data
     ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
     )
 {


### PR DESCRIPTION
`hostPtr` argument in urMemBufferCreate is not required for all uses of this entry-point and is only required when specific flags are set such as `UR_MEM_FLAGS_USE_HOST_POINTER`.
This also clarifies the spec that `UR_RESULT_ERROR_INVALID_HOST_PTR` should be returned instead of `UR_RESULT_ERROR_INVALID_NULL_POINTER`