### PR TITLE
[ur] remove platform init flags for urInit

### DIFF
--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
     ur_device_handle_t pDevice = nullptr;
 
     // Initialize the platform
-    status = urInit(0, 0);
+    status = urInit(0);
     if (status != UR_RESULT_SUCCESS) {
         std::cout << "urInit failed with return code: " << status << std::endl;
         return 1;

--- a/include/ur.py
+++ b/include/ur.py
@@ -1051,16 +1051,6 @@ class ur_program_build_info_t(c_int):
 
 
 ###############################################################################
-## @brief Supported platform initialization flags
-class ur_platform_init_flags_v(IntEnum):
-    LEVEL_ZERO = UR_BIT(0)                          ## initialize Unified Runtime platform drivers
-
-class ur_platform_init_flags_t(c_int):
-    def __str__(self):
-        return hex(self.value)
-
-
-###############################################################################
 ## @brief Supported device initialization flags
 class ur_device_init_flags_v(IntEnum):
     GPU = UR_BIT(0)                                 ## initialize GPU device drivers
@@ -1904,9 +1894,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urInit
 if __use_win_types:
-    _urInit_t = WINFUNCTYPE( ur_result_t, ur_platform_init_flags_t, ur_device_init_flags_t )
+    _urInit_t = WINFUNCTYPE( ur_result_t, ur_device_init_flags_t )
 else:
-    _urInit_t = CFUNCTYPE( ur_result_t, ur_platform_init_flags_t, ur_device_init_flags_t )
+    _urInit_t = CFUNCTYPE( ur_result_t, ur_device_init_flags_t )
 
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4455,16 +4455,6 @@ urProgramCreateWithNativeHandle(
 #pragma region runtime
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Supported platform initialization flags
-typedef uint32_t ur_platform_init_flags_t;
-typedef enum ur_platform_init_flag_t
-{
-    UR_PLATFORM_INIT_FLAG_LEVEL_ZERO = UR_BIT(0),   ///< initialize Unified Runtime platform drivers
-    UR_PLATFORM_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
-
-} ur_platform_init_flag_t;
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device initialization flags
 typedef uint32_t ur_device_init_flags_t;
 typedef enum ur_device_init_flag_t
@@ -4496,13 +4486,10 @@ typedef enum ur_device_init_flag_t
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < platform_flags`
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urInit(
-    ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
-                                                    ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
     ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
                                                     ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
     );
@@ -7114,7 +7101,6 @@ typedef void (UR_APICALL *ur_pfnGetLastResultCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_init_params_t
 {
-    ur_platform_init_flags_t* pplatform_flags;
     ur_device_init_flags_t* pdevice_flags;
 } ur_init_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1316,7 +1316,6 @@ typedef ur_result_t (UR_APICALL *ur_pfnGetLastResult_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urInit 
 typedef ur_result_t (UR_APICALL *ur_pfnInit_t)(
-    ur_platform_init_flags_t,
     ur_device_init_flags_t
     );
 

--- a/scripts/core/runtime.yml
+++ b/scripts/core/runtime.yml
@@ -11,14 +11,6 @@ desc: "Intel $OneApi Level-Zero Runtime APIs for Runtime"
 ordinal: "2"
 --- #--------------------------------------------------------------------------
 type: enum
-desc: "Supported platform initialization flags"
-class: $x
-name: $x_platform_init_flags_t
-etors:
-    - name: LEVEL_ZERO
-      desc: "initialize Unified Runtime platform drivers"
---- #--------------------------------------------------------------------------
-type: enum
 desc: "Supported device initialization flags"
 class: $x
 name: $x_device_init_flags_t
@@ -41,12 +33,6 @@ details:
     - "The application may call this function from simultaneous threads."
     - "The implementation of this function must be thread-safe for scenarios where multiple libraries may initialize the driver(s) simultaneously."
 params:
-    - type: $x_platform_init_flags_t
-      name: platform_flags
-      desc: |
-            [in] platform initialization flags.
-            must be 0 (default) or a combination of $x_platform_init_flag_t.
-      init: "0"
     - type: $x_device_init_flags_t
       name: device_flags
       desc: |

--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -56,8 +56,8 @@ ${th.make_func_name(n, tags, obj)}(
 {
 %if re.match("Init", obj['name']):
     static ${x}_result_t result = ${X}_RESULT_SUCCESS;
-    std::call_once(${x}_lib::context->initOnce, [platform_flags, device_flags]() {
-        result = ${x}_lib::context->Init(platform_flags, device_flags);
+    std::call_once(${x}_lib::context->initOnce, [device_flags]() {
+        result = ${x}_lib::context->Init(device_flags);
     });
 
     if( ${X}_RESULT_SUCCESS != result )

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -3268,8 +3268,6 @@ namespace driver
     /// @brief Intercept function for urInit
     __urdlllocal ur_result_t UR_APICALL
     urInit(
-        ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
-                                                        ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
         ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
                                                         ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
         )
@@ -3280,7 +3278,7 @@ namespace driver
         auto pfnInit = d_context.urDdiTable.Global.pfnInit;
         if( nullptr != pfnInit )
         {
-            result = pfnInit( platform_flags, device_flags );
+            result = pfnInit( device_flags );
         }
         else
         {

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4369,8 +4369,6 @@ namespace loader
     /// @brief Intercept function for urInit
     __urdlllocal ur_result_t UR_APICALL
     urInit(
-        ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
-                                                        ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
         ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
                                                         ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
         )
@@ -4382,7 +4380,7 @@ namespace loader
         {
             if(platform.initStatus != UR_RESULT_SUCCESS)
                 continue;
-            platform.initStatus = platform.dditable.ur.Global.pfnInit( platform_flags, device_flags );
+            platform.initStatus = platform.dditable.ur.Global.pfnInit( device_flags );
             if(platform.initStatus == UR_RESULT_SUCCESS)
                 atLeastOneplatformValid = true;
         }

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -21,9 +21,7 @@ context_t::context_t(){};
 context_t::~context_t(){};
 
 //////////////////////////////////////////////////////////////////////////
-__urdlllocal ur_result_t
-context_t::Init(ur_platform_init_flags_t platform_flags,
-                ur_device_init_flags_t device_flags) {
+__urdlllocal ur_result_t context_t::Init(ur_device_init_flags_t device_flags) {
     ur_result_t result;
     result = loader::context->init();
 

--- a/source/loader/ur_lib.h
+++ b/source/loader/ur_lib.h
@@ -30,8 +30,7 @@ class context_t {
 
     std::once_flag initOnce;
 
-    ur_result_t Init(ur_platform_init_flags_t pflags,
-                     ur_device_init_flags_t dflags);
+    ur_result_t Init(ur_device_init_flags_t dflags);
 
     ur_result_t urInit();
     ur_dditable_t urDdiTable = {};

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -4130,20 +4130,17 @@ urProgramCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < platform_flags`
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL
 urInit(
-    ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
-                                                    ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
     ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
                                                     ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
     )
 {
     static ur_result_t result = UR_RESULT_SUCCESS;
-    std::call_once(ur_lib::context->initOnce, [platform_flags, device_flags]() {
-        result = ur_lib::context->Init(platform_flags, device_flags);
+    std::call_once(ur_lib::context->initOnce, [device_flags]() {
+        result = ur_lib::context->Init(device_flags);
     });
 
     if( UR_RESULT_SUCCESS != result )
@@ -4153,7 +4150,7 @@ urInit(
     if( nullptr == pfnInit )
         return UR_RESULT_ERROR_UNINITIALIZED;
 
-    return pfnInit( platform_flags, device_flags );
+    return pfnInit( device_flags );
 }
 
 } // extern "C"

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3791,13 +3791,10 @@ urProgramCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < platform_flags`
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL
 urInit(
-    ur_platform_init_flags_t platform_flags,        ///< [in] platform initialization flags.
-                                                    ///< must be 0 (default) or a combination of ::ur_platform_init_flag_t.
     ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
                                                     ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
     )

--- a/test/conformance/platform/fixtures.h
+++ b/test/conformance/platform/fixtures.h
@@ -11,9 +11,8 @@ namespace platform {
 struct urTest : ::testing::Test {
 
     void SetUp() override {
-        ur_platform_init_flags_t platform_flags = 0;
         ur_device_init_flags_t device_flags = 0;
-        ASSERT_SUCCESS(urInit(platform_flags, device_flags));
+        ASSERT_SUCCESS(urInit(device_flags));
     }
 
     void TearDown() override {

--- a/test/conformance/platform/urInit.cpp
+++ b/test/conformance/platform/urInit.cpp
@@ -3,26 +3,15 @@
 #include <uur/checks.h>
 
 TEST(urInitTest, Success) {
-    ur_platform_init_flags_t platform_flags = 0;
     ur_device_init_flags_t device_flags = 0;
-    ASSERT_SUCCESS(urInit(platform_flags, device_flags));
+    ASSERT_SUCCESS(urInit(device_flags));
 
     ur_tear_down_params_t tear_down_params{};
     ASSERT_SUCCESS(urTearDown(&tear_down_params));
 }
 
-TEST(urInitTest, ErrorInvalidEnumerationPlatformFlags) {
-    const ur_platform_init_flags_t platform_flags =
-        UR_PLATFORM_INIT_FLAG_FORCE_UINT32;
-    const ur_device_init_flags_t device_flags = 0;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urInit(platform_flags, device_flags));
-}
-
 TEST(urInitTest, ErrorInvalidEnumerationDeviceFlags) {
-    const ur_platform_init_flags_t platform_flags = 0;
     const ur_device_init_flags_t device_flags =
-        UR_PLATFORM_INIT_FLAG_FORCE_UINT32;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urInit(platform_flags, device_flags));
+        UR_DEVICE_INIT_FLAG_FORCE_UINT32;
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urInit(device_flags));
 }

--- a/test/conformance/platform/urTearDown.cpp
+++ b/test/conformance/platform/urTearDown.cpp
@@ -4,9 +4,8 @@
 
 struct urTearDownTest : testing::Test {
     void SetUp() override {
-        ur_platform_init_flags_t platform_flags = 0;
         ur_device_init_flags_t device_flags = 0;
-        ASSERT_SUCCESS(urInit(platform_flags, device_flags));
+        ASSERT_SUCCESS(urInit(device_flags));
     }
 };
 

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -31,9 +31,8 @@ std::ostream &operator<<(std::ostream &out,
 uur::PlatformEnvironment::PlatformEnvironment(int argc, char **argv)
     : platform_options{parsePlatformOptions(argc, argv)} {
     instance = this;
-    ur_platform_init_flags_t platform_flags = 0;
     ur_device_init_flags_t device_flags = 0;
-    if (urInit(platform_flags, device_flags)) {
+    if (urInit(device_flags)) {
         error = "urInit() failed";
         return;
     }


### PR DESCRIPTION
`ur_platform_init_flags` are now removed. Originally (I believe - we have little documentation of the ur spec before we got it) this was a flag to select the desired backend. However, this is now handled with the loader and the backend is selected through an environment variable. Moreover, the loader actually does nothing with these parameters [here](https://github.com/oneapi-src/unified-runtime/blob/main/source/loader/ur_lib.cpp#L25). This then also raises the question if we need `ur_device_init_flags_t`....

Closes #21 