### PR TITLE
Add missing enums for atomic memory capability device queries

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -751,9 +751,12 @@ class ur_device_info_v(IntEnum):
     MAX_MEMORY_BANDWIDTH = 94                       ## uint32_t: return max memory bandwidth in Mb/s
     IMAGE_SRGB = 95                                 ## bool: image is SRGB
     ATOMIC_64 = 96                                  ## bool: support 64 bit atomics
-    ATOMIC_MEMORY_ORDER_CAPABILITIES = 97           ## uint32_t: atomics memory order capabilities
-    BFLOAT16 = 98                                   ## bool: support for bfloat16
-    MAX_COMPUTE_QUEUE_INDICES = 99                  ## uint32_t: Returns 1 if the device doesn't have a notion of a 
+    ATOMIC_MEMORY_ORDER_CAPABILITIES = 97           ## ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+                                                    ## memory order capabilities
+    ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98           ## ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+                                                    ## memory scope capabilities
+    BFLOAT16 = 99                                   ## bool: support for bfloat16
+    MAX_COMPUTE_QUEUE_INDICES = 100                 ## uint32_t: Returns 1 if the device doesn't have a notion of a 
                                                     ## queue index. Otherwise, returns the number of queue indices that are
                                                     ## available for this device.
 
@@ -839,6 +842,34 @@ class ur_device_affinity_domain_flags_v(IntEnum):
     NEXT_PARTITIONABLE = UR_BIT(1)                  ## BY next partitionable
 
 class ur_device_affinity_domain_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Memory order capabilities
+class ur_memory_order_capability_flags_v(IntEnum):
+    RELAXED = UR_BIT(0)                             ## Relaxed memory ordering
+    ACQUIRE = UR_BIT(1)                             ## Acquire memory ordering
+    RELEASE = UR_BIT(2)                             ## Release memory ordering
+    ACQ_REL = UR_BIT(3)                             ## Acquire/release memory ordering
+    SEQ_CST = UR_BIT(4)                             ## Sequentially consistent memory ordering
+
+class ur_memory_order_capability_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Memory scope capabilities
+class ur_memory_scope_capability_flags_v(IntEnum):
+    WORK_ITEM = UR_BIT(0)                           ## Work item scope
+    SUB_GROUP = UR_BIT(1)                           ## Sub group scope
+    WORK_GROUP = UR_BIT(2)                          ## Work group scope
+    DEVICE = UR_BIT(3)                              ## Device scope
+    SYSTEM = UR_BIT(4)                              ## System scope
+
+class ur_memory_scope_capability_flags_t(c_int):
     def __str__(self):
         return hex(self.value)
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2997,9 +2997,12 @@ typedef enum ur_device_info_t
     UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 94,       ///< uint32_t: return max memory bandwidth in Mb/s
     UR_DEVICE_INFO_IMAGE_SRGB = 95,                 ///< bool: image is SRGB
     UR_DEVICE_INFO_ATOMIC_64 = 96,                  ///< bool: support 64 bit atomics
-    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 97,   ///< uint32_t: atomics memory order capabilities
-    UR_DEVICE_INFO_BFLOAT16 = 98,                   ///< bool: support for bfloat16
-    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 99,  ///< uint32_t: Returns 1 if the device doesn't have a notion of a 
+    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 97,   ///< ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+                                                    ///< memory order capabilities
+    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98,   ///< ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+                                                    ///< memory scope capabilities
+    UR_DEVICE_INFO_BFLOAT16 = 99,                   ///< bool: support for bfloat16
+    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 100, ///< uint32_t: Returns 1 if the device doesn't have a notion of a 
                                                     ///< queue index. Otherwise, returns the number of queue indices that are
                                                     ///< available for this device.
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
@@ -3313,6 +3316,34 @@ urDeviceGetGlobalTimestamps(
     uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
                                                     ///< correlates with the Device's global timestamp value
     );
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory order capabilities
+typedef uint32_t ur_memory_order_capability_flags_t;
+typedef enum ur_memory_order_capability_flag_t
+{
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_RELAXED = UR_BIT(0),///< Relaxed memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQUIRE = UR_BIT(1),///< Acquire memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_RELEASE = UR_BIT(2),///< Release memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQ_REL = UR_BIT(3),///< Acquire/release memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_SEQ_CST = UR_BIT(4),///< Sequentially consistent memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ur_memory_order_capability_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Memory scope capabilities
+typedef uint32_t ur_memory_scope_capability_flags_t;
+typedef enum ur_memory_scope_capability_flag_t
+{
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_ITEM = UR_BIT(0),  ///< Work item scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_SUB_GROUP = UR_BIT(1),  ///< Sub group scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_GROUP = UR_BIT(2), ///< Work group scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_DEVICE = UR_BIT(3), ///< Device scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_SYSTEM = UR_BIT(4), ///< System scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ur_memory_scope_capability_flag_t;
 
 #if !defined(__GNUC__)
 #pragma endregion

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -272,7 +272,9 @@ etors:
     - name: ATOMIC_64
       desc: "bool: support 64 bit atomics"
     - name: ATOMIC_MEMORY_ORDER_CAPABILITIES
-      desc: "uint32_t: atomics memory order capabilities"
+      desc: "$x_memory_order_capability_flags_t: return a bit-field of atomic memory order capabilities"
+    - name: ATOMIC_MEMORY_SCOPE_CAPABILITIES
+      desc: "$x_memory_scope_capability_flags_t: return a bit-field of atomic memory scope capabilities"
     - name: BFLOAT16
       desc: "bool: support for bfloat16"
     - name: MAX_COMPUTE_QUEUE_INDICES
@@ -599,3 +601,45 @@ params:
       desc: |
             [out][optional] pointer to the Host's global timestamp that 
             correlates with the Device's global timestamp value
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Memory order capabilities"
+class: $xDevice
+name: $x_memory_order_capability_flags_t
+etors:
+    - name: RELAXED
+      desc: "Relaxed memory ordering"
+      value: "$X_BIT(0)"
+    - name: ACQUIRE
+      desc: "Acquire memory ordering"
+      value: "$X_BIT(1)"
+    - name: RELEASE
+      desc: "Release memory ordering"
+      value: "$X_BIT(2)"
+    - name: ACQ_REL
+      desc: "Acquire/release memory ordering"
+      value: "$X_BIT(3)"
+    - name: SEQ_CST
+      desc: "Sequentially consistent memory ordering"
+      value: "$X_BIT(4)"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Memory scope capabilities"
+class: $xDevice
+name: $x_memory_scope_capability_flags_t
+etors:
+    - name: WORK_ITEM
+      desc: "Work item scope"
+      value: "$X_BIT(0)"
+    - name: SUB_GROUP
+      desc: "Sub group scope"
+      value: "$X_BIT(1)"
+    - name: WORK_GROUP
+      desc: "Work group scope"
+      value: "$X_BIT(2)"
+    - name: DEVICE
+      desc: "Device scope"
+      value: "$X_BIT(3)"
+    - name: SYSTEM
+      desc: "System scope"
+      value: "$X_BIT(4)"


### PR DESCRIPTION
- Add missing `ATOMIC_MEMORY_SCOPE_CAPABILITIES` device query - this is needed for parity with PI to implement the matching SYCL device information descriptor
- Add `ur_memory_order_capability_flags` and `ur_memory_scopes_capability_flags` bit-fields so the results of these queries are well defined

Fixes #109 and #110 