### PR TITLE
enable all warnings and add developer mode

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,6 @@
 name: CMake
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 
 env:
   BUILD_TYPE: Release
@@ -26,7 +22,7 @@ jobs:
       run: pip install -r third_party/requirements.txt
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUR_ENABLE_TESTS=ON
+      run: cmake -B ${{github.workspace}}/build -DDEVELOPER_MODE=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON
 
     - name: Generate source from spec, check for uncommitted diff
       run: cmake --build ${{github.workspace}}/build --target check-generated
@@ -49,7 +45,7 @@ jobs:
         run: python3 -m pip install -r third_party/requirements.txt
 
       - name: Configure CMake
-        run: cmake -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DUR_ENABLE_TESTS=ON -B ${{github.workspace}}/build
+        run: cmake -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DDEVELOPER_MODE=ON -DBUILD_TESTS=ON -B ${{github.workspace}}/build
 
       - name: Generate source from spec, check for uncommitted diff
         run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@ include(helpers)
 
 find_package(Python3 COMPONENTS Interpreter)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Build Options
+option(DEVELOPER_MODE "enable developer checks, treats warnings as errors" OFF)
+option(BUILD_TESTS "Build unit tests." ON)
+option(FORMAT_CPP_STYLE "format code style of C++ sources" OFF)
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -30,43 +38,28 @@ if(MSVC)
     set(CUSTOM_COMMAND_BINARY_DIR ${CUSTOM_COMMAND_BINARY_DIR}/$<CONFIG>)
 endif()
 
-# CXX compiler support
+# CXX flags setup
 if(NOT MSVC)
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-    CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-    if(COMPILER_SUPPORTS_CXX14)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    elseif(COMPILER_SUPPORTS_CXX0X)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-    else()
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support.  Please use a different C++ compiler.")
+    add_compile_options(-fPIC -Wall)
+    if(DEVELOPER_MODE)
+        add_compile_options(-Werror)
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -fPIC")
-endif()
-
-# MSVC compile flags
-if(MSVC)
+elseif(MSVC)
     string(REPLACE "/MDd" "/MTd" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
     string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
-    # Treat warnings as errors
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX /W3 /wd4996")
-
-    # Enable multi-process compilation
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    add_compile_options(/MP /W3)
+
+    if(DEVELOPER_MODE)
+        add_compile_options(/WX)
+    endif()
 endif()
 
 # Allow custom third_party folder
 if(NOT DEFINED THIRD_PARTY_DIR)
     set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
 endif()
-
-# Option to disable tests
-option(${PROJECT_NAME}_BUILD_TESTS "Build unit tests." ON)
-
-# Option to run a code formatter
-option(${PROJECT_NAME}_FORMAT_CPP_STYLE "format code style of C++ sources" OFF)
 
 find_program(CLANG_FORMAT NAMES clang-format-10 clang-format-10.0 clang-format)
 
@@ -125,7 +118,7 @@ install(
 
 add_subdirectory(source)
 add_subdirectory(examples)
-if(UR_ENABLE_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(test)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of options provided by CMake:
 | - | - | - | - |
 | BUILD_TESTS | Build the tests | ON/OFF | ON |
 | FORMAT_CPP_STYLE | Format code style | ON/OFF | OFF |
+| DEVELOPER_MODE | Treats warnings as errors and enables additional checks | ON/OFF | OFF |
 
 **General**:
 

--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -16,9 +16,6 @@
 int main(int argc, char *argv[]) {
     ur_result_t status;
 
-    ur_platform_handle_t platform = nullptr;
-    ur_device_handle_t pDevice = nullptr;
-
     // Initialize the platform
     status = urInit(0);
     if (status != UR_RESULT_SUCCESS) {
@@ -47,7 +44,7 @@ int main(int argc, char *argv[]) {
 
     for (auto p : platforms) {
         ur_api_version_t api_version = {};
-        status = urPlatformGetApiVersion(platform, &api_version);
+        status = urPlatformGetApiVersion(p, &api_version);
         if (status != UR_RESULT_SUCCESS) {
             std::cout << "urPlatformGetApiVersion failed with return code: "
                       << status << std::endl;

--- a/source/loader/ur_loader.cpp
+++ b/source/loader/ur_loader.cpp
@@ -43,5 +43,3 @@ context_t::~context_t() {
 };
 
 } // namespace loader
-
-ur_result_t urLoaderInit() { return loader::context->init(); }

--- a/source/loader/windows/platform_discovery_win.cpp
+++ b/source/loader/windows/platform_discovery_win.cpp
@@ -29,7 +29,8 @@ std::vector<PlatformLibraryPath> discoverEnabledPlatforms() {
     std::vector<PlatformLibraryPath> enabledPlatforms;
 
     // UR_ADAPTERS_FORCE_LOAD  is for development/debug only
-    const char *altPlatforms = getenv("UR_ADAPTERS_FORCE_LOAD");
+    char* altPlatforms = nullptr;
+    _dupenv_s(&altPlatforms, NULL, "UR_ADAPTERS_FORCE_LOAD");
 
     if (altPlatforms == nullptr) {
         for (auto libName : knownAdaptersNames) {
@@ -42,6 +43,7 @@ std::vector<PlatformLibraryPath> discoverEnabledPlatforms() {
             getline(ss, substr, ',');
             enabledPlatforms.emplace_back(substr);
         }
+        free(altPlatforms);
     }
     return enabledPlatforms;
 }

--- a/test/unified_memory_allocation/common/pool.c
+++ b/test/unified_memory_allocation/common/pool.c
@@ -72,7 +72,8 @@ uma_memory_pool_handle_t nullPoolCreate() {
     uma_memory_pool_handle_t hPool;
     enum uma_result_t ret = umaPoolCreate(&ops, NULL,
                                      &hPool);
-    
+
+    (void) ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);
     return hPool;
 }
@@ -133,7 +134,7 @@ void traceFree(void *pool, void *ptr) {
     struct traceParams* tracePool = (struct traceParams*) pool;
 
     tracePool->trace("free");
-    return umaPoolFree(tracePool->hUpstreamPool, ptr);
+    umaPoolFree(tracePool->hUpstreamPool, ptr);
 }
 
 uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,  void (*trace)(const char*)) {
@@ -157,7 +158,8 @@ uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,
     uma_memory_pool_handle_t hPool;
     enum uma_result_t ret = umaPoolCreate(&ops, &params,
                                      &hPool);
-    
+
+    (void) ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);
     return hPool;
 }

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -45,7 +45,8 @@ uma_memory_provider_handle_t nullProviderCreate() {
     uma_memory_provider_handle_t hProvider;
     enum uma_result_t ret = umaMemoryProviderCreate(&ops, NULL,
                                      &hProvider);
-    
+
+    (void) ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);
     return hProvider;
 }
@@ -98,7 +99,8 @@ uma_memory_provider_handle_t traceProviderCreate(uma_memory_provider_handle_t hU
     uma_memory_provider_handle_t hProvider;
     enum uma_result_t ret = umaMemoryProviderCreate(&ops, &params,
                                      &hProvider);
-    
+
+    (void) ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);
     return hProvider;
 }


### PR DESCRIPTION
For now, the developer mode only turns warnings into errors, but over time it will also encompass other various checks that we don't want to happen in
normal builds.

I also did a small cleanup of the main cmake.
The UR_ENABLE_TESTS option is now BUILD_TESTS.