### PR TITLE
[ur] Implement UMA memory pool: usmPool

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -12,9 +12,8 @@ target_include_directories(ur_common INTERFACE
 )
 
 add_subdirectory(unified_memory_allocation)
-target_link_libraries(ur_common INTERFACE unified_memory_allocation ${CMAKE_DL_LIBS} ${PROJECT_NAME}::headers)
-
-target_sources(ur_common INTERFACE uma_helpers.hpp)
+add_subdirectory(uma_pools)
+target_link_libraries(ur_common INTERFACE unified_memory_allocation disjoint_pool ${CMAKE_DL_LIBS} ${PROJECT_NAME}::headers)
 
 if(WIN32)
     target_sources(ur_common

--- a/source/common/uma_pools/CMakeLists.txt
+++ b/source/common/uma_pools/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(disjoint_pool STATIC
     disjoint_pool.cpp
+    disjoint_pool_config.cpp
 )
 
 add_library(${PROJECT_NAME}::disjoint_pool ALIAS disjoint_pool)

--- a/source/common/uma_pools/CMakeLists.txt
+++ b/source/common/uma_pools/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (C) 2022-2023 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_library(disjoint_pool STATIC
+    disjoint_pool.cpp
+)
+
+add_library(${PROJECT_NAME}::disjoint_pool ALIAS disjoint_pool)
+
+target_link_libraries(disjoint_pool PRIVATE
+    unified_memory_allocation
+    ${PROJECT_NAME}::headers)
+
+target_include_directories(disjoint_pool PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/source/common/uma_pools/disjoint_pool.cpp
+++ b/source/common/uma_pools/disjoint_pool.cpp
@@ -67,13 +67,6 @@ static void *AlignPtrUp(void *Ptr, const size_t Alignment) {
     return static_cast<char *>(AlignedPtr) + Alignment;
 }
 
-// Aligns the value up to the specified alignment
-// (e.g. returns 16 for Size = 13, Alignment = 8)
-static size_t AlignUp(size_t Val, size_t Alignment) {
-    assert(Alignment > 0);
-    return (Val + Alignment - 1) & (~(Alignment - 1));
-}
-
 DisjointPoolConfig::DisjointPoolConfig()
     : limits(std::make_shared<DisjointPoolConfig::SharedLimits>()) {}
 
@@ -745,7 +738,9 @@ void *DisjointPool::AllocImpl::allocate(size_t Size, size_t Alignment,
         return allocate(Size, FromPool);
     }
 
-    size_t AlignedSize = (Size > 1) ? AlignUp(Size, Alignment) : Alignment;
+    // TODO: we potentially waste some space here, calulate it based on minBucketSize and Slab alignemnt
+    // (using umaMemoryProviderGetMinPageSize)?
+    size_t AlignedSize = (Size > 1) ? (Size + Alignment - 1) : Alignment;
 
     // Check if requested allocation size is within pooling limit.
     // If not, just request aligned pointer from the system.

--- a/source/common/uma_pools/disjoint_pool.cpp
+++ b/source/common/uma_pools/disjoint_pool.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <cctype>
 #include <iomanip>
+#include <limits>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -21,348 +22,375 @@
 #include <utility>
 #include <vector>
 
-#include "ur.hpp"
+// TODO: replace with logger?
+#include <iostream>
+
 #include "disjoint_pool.hpp"
 
-// USM allocations are a minimum of 4KB/64KB/2MB even when a smaller size is
+namespace usm {
+
+// Allocations are a minimum of 4KB/64KB/2MB even when a smaller size is
 // requested. The implementation distinguishes between allocations of size
 // ChunkCutOff = (minimum-alloc-size / 2) and those that are larger.
 // Allocation requests smaller than ChunkCutoff use chunks taken from a single
-// USM allocation. Thus, for example, for a 64KB minimum allocation size,
-// and 8-byte allocations, only 1 in ~8000 requests results in a new
-// USM allocation. Freeing results only in a chunk of a larger allocation
-// to be marked as available and no real return to the system.
-// An allocation is returned to the system only when all
-// chunks in the larger allocation are freed by the program.
-// Allocations larger than ChunkCutOff use a separate USM allocation for each
-// request. These are subject to "pooling". That is, when such an allocation is
-// freed by the program it is retained in a pool. The pool is available for
-// future allocations, which means there are fewer actual USM
-// allocations/deallocations.
+// coarse-grain allocation. Thus, for example, for a 64KB minimum allocation
+// size, and 8-byte allocations, only 1 in ~8000 requests results in a new
+// coarse-grain allocation. Freeing results only in a chunk of a larger
+// allocation to be marked as available and no real return to the system. An
+// allocation is returned to the system only when all chunks in the larger
+// allocation are freed by the program. Allocations larger than ChunkCutOff use
+// a separate coarse-grain allocation for each request. These are subject to
+// "pooling". That is, when such an allocation is freed by the program it is
+// retained in a pool. The pool is available for future allocations, which means
+// there are fewer actual coarse-grain allocations/deallocations.
 
 // The largest size which is allocated via the allocator.
-// Allocations with size > CutOff bypass the USM allocator and
-// go directly to the runtime.
+// Allocations with size > CutOff bypass the pool and
+// go directly to the provider.
 static constexpr size_t CutOff = (size_t)1 << 31; // 2GB
 
 // Aligns the pointer down to the specified alignment
 // (e.g. returns 8 for Size = 13, Alignment = 8)
 static void *AlignPtrDown(void *Ptr, const size_t Alignment) {
-  return reinterpret_cast<void *>((reinterpret_cast<size_t>(Ptr)) &
-                                  (~(Alignment - 1)));
+    return reinterpret_cast<void *>((reinterpret_cast<size_t>(Ptr)) &
+                                    (~(Alignment - 1)));
 }
 
 // Aligns the pointer up to the specified alignment
 // (e.g. returns 16 for Size = 13, Alignment = 8)
 static void *AlignPtrUp(void *Ptr, const size_t Alignment) {
-  void *AlignedPtr = AlignPtrDown(Ptr, Alignment);
-  // Special case when the pointer is already aligned
-  if (Ptr == AlignedPtr) {
-    return Ptr;
-  }
-  return static_cast<char *>(AlignedPtr) + Alignment;
+    void *AlignedPtr = AlignPtrDown(Ptr, Alignment);
+    // Special case when the pointer is already aligned
+    if (Ptr == AlignedPtr) {
+        return Ptr;
+    }
+    return static_cast<char *>(AlignedPtr) + Alignment;
 }
 
 // Aligns the value up to the specified alignment
 // (e.g. returns 16 for Size = 13, Alignment = 8)
 static size_t AlignUp(size_t Val, size_t Alignment) {
-  assert(Alignment > 0);
-  return (Val + Alignment - 1) & (~(Alignment - 1));
+    assert(Alignment > 0);
+    return (Val + Alignment - 1) & (~(Alignment - 1));
 }
+
+DisjointPoolConfig::DisjointPoolConfig()
+    : limits(std::make_shared<DisjointPoolConfig::SharedLimits>()) {}
 
 class Bucket;
 
 // Represents the allocated memory block of size 'SlabMinSize'
 // Internally, it splits the memory block into chunks. The number of
 // chunks depends of the size of a Bucket which created the Slab.
-// The chunks
-// Note: Bucket's method are responsible for thread safety of Slab access,
+// Note: Bucket's methods are responsible for thread safety of Slab access,
 // so no locking happens here.
 class Slab {
 
-  // Pointer to the allocated memory of SlabMinSize bytes
-  void *MemPtr;
+    // Pointer to the allocated memory of SlabMinSize bytes
+    void *MemPtr;
 
-  // Represents the current state of each chunk:
-  // if the bit is set then the chunk is allocated
-  // the chunk is free for allocation otherwise
-  std::vector<bool> Chunks;
+    // Represents the current state of each chunk:
+    // if the bit is set then the chunk is allocated
+    // the chunk is free for allocation otherwise
+    std::vector<bool> Chunks;
 
-  // Total number of allocated chunks at the moment.
-  size_t NumAllocated = 0;
+    // Total number of allocated chunks at the moment.
+    size_t NumAllocated = 0;
 
-  // The bucket which the slab belongs to
-  Bucket &bucket;
+    // The bucket which the slab belongs to
+    Bucket &bucket;
 
-  using ListIter = std::list<std::unique_ptr<Slab>>::iterator;
+    using ListIter = std::list<std::unique_ptr<Slab>>::iterator;
 
-  // Store iterator to the corresponding node in avail/unavail list
-  // to achieve O(1) removal
-  ListIter SlabListIter;
+    // Store iterator to the corresponding node in avail/unavail list
+    // to achieve O(1) removal
+    ListIter SlabListIter;
 
-  // Hints where to start search for free chunk in a slab
-  size_t FirstFreeChunkIdx = 0;
+    // Hints where to start search for free chunk in a slab
+    size_t FirstFreeChunkIdx = 0;
 
-  // Return the index of the first available chunk, -1 otherwize
-  size_t FindFirstAvailableChunkIdx() const;
+    // Return the index of the first available chunk, SIZE_MAX otherwize
+    size_t FindFirstAvailableChunkIdx() const;
 
-  // Register/Unregister the slab in the global slab address map.
-  void regSlab(Slab &);
-  void unregSlab(Slab &);
-  static void regSlabByAddr(void *, Slab &);
-  static void unregSlabByAddr(void *, Slab &);
+    // Register/Unregister the slab in the global slab address map.
+    void regSlab(Slab &);
+    void unregSlab(Slab &);
+    static void regSlabByAddr(void *, Slab &);
+    static void unregSlabByAddr(void *, Slab &);
 
-public:
-  Slab(Bucket &);
-  ~Slab();
+  public:
+    Slab(Bucket &);
+    ~Slab();
 
-  void setIterator(ListIter It) { SlabListIter = It; }
-  ListIter getIterator() const { return SlabListIter; }
+    void setIterator(ListIter It) { SlabListIter = It; }
+    ListIter getIterator() const { return SlabListIter; }
 
-  size_t getNumAllocated() const { return NumAllocated; }
+    size_t getNumAllocated() const { return NumAllocated; }
 
-  // Get pointer to allocation that is one piece of this slab.
-  void *getChunk();
+    // Get pointer to allocation that is one piece of this slab.
+    void *getChunk();
 
-  // Get pointer to allocation that is this entire slab.
-  void *getSlab();
+    // Get pointer to allocation that is this entire slab.
+    void *getSlab();
 
-  void *getPtr() const { return MemPtr; }
-  void *getEnd() const;
+    void *getPtr() const { return MemPtr; }
+    void *getEnd() const;
 
-  size_t getChunkSize() const;
-  size_t getNumChunks() const { return Chunks.size(); }
+    size_t getChunkSize() const;
+    size_t getNumChunks() const { return Chunks.size(); }
 
-  bool hasAvail();
+    bool hasAvail();
 
-  Bucket &getBucket();
-  const Bucket &getBucket() const;
+    Bucket &getBucket();
+    const Bucket &getBucket() const;
 
-  void freeChunk(void *Ptr);
+    void freeChunk(void *Ptr);
 };
 
 class Bucket {
-  const size_t Size;
+    const size_t Size;
 
-  // List of slabs which have at least 1 available chunk.
-  std::list<std::unique_ptr<Slab>> AvailableSlabs;
+    // List of slabs which have at least 1 available chunk.
+    std::list<std::unique_ptr<Slab>> AvailableSlabs;
 
-  // List of slabs with 0 available chunk.
-  std::list<std::unique_ptr<Slab>> UnavailableSlabs;
+    // List of slabs with 0 available chunk.
+    std::list<std::unique_ptr<Slab>> UnavailableSlabs;
 
-  // Protects the bucket and all the corresponding slabs
-  std::mutex BucketLock;
+    // Protects the bucket and all the corresponding slabs
+    std::mutex BucketLock;
 
-  // Reference to the allocator context, used access memory allocation
-  // routines, slab map and etc.
-  USMAllocContext::USMAllocImpl &OwnAllocCtx;
+    // Reference to the allocator context, used access memory allocation
+    // routines, slab map and etc.
+    DisjointPool::AllocImpl &OwnAllocCtx;
 
-  // For buckets used in chunked mode, a counter of slabs in the pool.
-  // For allocations that use an entire slab each, the entries in the Available
-  // list are entries in the pool.Each slab is available for a new
-  // allocation.The size of the Available list is the size of the pool.
-  // For allocations that use slabs in chunked mode, slabs will be in the
-  // Available list if any one or more of their chunks is free.The entire slab
-  // is not necessarily free, just some chunks in the slab are free. To
-  // implement pooling we will allow one slab in the Available list to be
-  // entirely empty. Normally such a slab would have been freed from USM. But
-  // now we don't, and treat this slab as "in the pool".
-  // When a slab becomes entirely free we have to decide whether to return it to
-  // USM or keep it allocated. A simple check for size of the Available list is
-  // not sufficient to check whether any slab has been pooled yet.We would have
-  // to traverse the entire Available listand check if any of them is entirely
-  // free. Instead we keep a counter of entirely empty slabs within the
-  // Available list to speed up the process of checking if a slab in this bucket
-  // is already pooled.
-  size_t chunkedSlabsInPool;
+    // For buckets used in chunked mode, a counter of slabs in the pool.
+    // For allocations that use an entire slab each, the entries in the Available
+    // list are entries in the pool.Each slab is available for a new
+    // allocation.The size of the Available list is the size of the pool.
+    // For allocations that use slabs in chunked mode, slabs will be in the
+    // Available list if any one or more of their chunks is free.The entire slab
+    // is not necessarily free, just some chunks in the slab are free. To
+    // implement pooling we will allow one slab in the Available list to be
+    // entirely empty. Normally such a slab would have been freed. But
+    // now we don't, and treat this slab as "in the pool".
+    // When a slab becomes entirely free we have to decide whether to return it
+    // to the provider or keep it allocated. A simple check for size of the
+    // Available list is not sufficient to check whether any slab has been
+    // pooled yet.We would have to traverse the entire Available listand check
+    // if any of them is entirely free. Instead we keep a counter of entirely
+    // empty slabs within the Available list to speed up the process of checking
+    // if a slab in this bucket is already pooled.
+    size_t chunkedSlabsInPool;
 
-  // Statistics
-  size_t allocPoolCount;
-  size_t freeCount;
-  size_t currSlabsInUse;
-  size_t currSlabsInPool;
-  size_t maxSlabsInPool;
+    // Statistics
+    size_t allocPoolCount;
+    size_t freeCount;
+    size_t currSlabsInUse;
+    size_t currSlabsInPool;
+    size_t maxSlabsInPool;
 
-public:
-  // Statistics
-  size_t allocCount;
-  size_t maxSlabsInUse;
+  public:
+    // Statistics
+    size_t allocCount;
+    size_t maxSlabsInUse;
 
-  Bucket(size_t Sz, USMAllocContext::USMAllocImpl &AllocCtx)
-      : Size{Sz}, OwnAllocCtx{AllocCtx}, chunkedSlabsInPool(0),
-        allocPoolCount(0), freeCount(0), currSlabsInUse(0), currSlabsInPool(0),
-        maxSlabsInPool(0), allocCount(0), maxSlabsInUse(0) {}
+    Bucket(size_t Sz, DisjointPool::AllocImpl &AllocCtx)
+        : Size{Sz}, OwnAllocCtx{AllocCtx}, chunkedSlabsInPool(0),
+          allocPoolCount(0), freeCount(0), currSlabsInUse(0),
+          currSlabsInPool(0), maxSlabsInPool(0), allocCount(0),
+          maxSlabsInUse(0) {}
 
-  // Get pointer to allocation that is one piece of an available slab in this
-  // bucket.
-  void *getChunk(bool &FromPool);
+    // Get pointer to allocation that is one piece of an available slab in this
+    // bucket.
+    void *getChunk(bool &FromPool);
 
-  // Get pointer to allocation that is a full slab in this bucket.
-  void *getSlab(bool &FromPool);
+    // Get pointer to allocation that is a full slab in this bucket.
+    void *getSlab(bool &FromPool);
 
-  // Return the allocation size of this bucket.
-  size_t getSize() const { return Size; }
+    // Return the allocation size of this bucket.
+    size_t getSize() const { return Size; }
 
-  // Free an allocation that is one piece of a slab in this bucket.
-  void freeChunk(void *Ptr, Slab &Slab, bool &ToPool);
+    // Free an allocation that is one piece of a slab in this bucket.
+    void freeChunk(void *Ptr, Slab &Slab, bool &ToPool);
 
-  // Free an allocation that is a full slab in this bucket.
-  void freeSlab(Slab &Slab, bool &ToPool);
+    // Free an allocation that is a full slab in this bucket.
+    void freeSlab(Slab &Slab, bool &ToPool);
 
-  SystemMemory &getMemHandle();
+    uma_memory_provider_handle_t getMemHandle();
 
-  USMAllocContext::USMAllocImpl &getUsmAllocCtx() { return OwnAllocCtx; }
+    DisjointPool::AllocImpl &getAllocCtx() { return OwnAllocCtx; }
 
-  // Check whether an allocation to be freed can be placed in the pool.
-  bool CanPool(bool &ToPool);
+    // Check whether an allocation to be freed can be placed in the pool.
+    bool CanPool(bool &ToPool);
 
-  // The minimum allocation size for any slab.
-  size_t SlabMinSize();
+    // The minimum allocation size for any slab.
+    size_t SlabMinSize();
 
-  // The allocation size for a slab in this bucket.
-  size_t SlabAllocSize();
+    // The allocation size for a slab in this bucket.
+    size_t SlabAllocSize();
 
-  // The minimum size of a chunk from this bucket's slabs.
-  size_t ChunkCutOff();
+    // The minimum size of a chunk from this bucket's slabs.
+    size_t ChunkCutOff();
 
-  // The number of slabs in this bucket that can be in the pool.
-  size_t Capacity();
+    // The number of slabs in this bucket that can be in the pool.
+    size_t Capacity();
 
-  // The maximum allocation size subject to pooling.
-  size_t MaxPoolableSize();
+    // The maximum allocation size subject to pooling.
+    size_t MaxPoolableSize();
 
-  // Update allocation count
-  void countAlloc(bool FromPool);
+    // Update allocation count
+    void countAlloc(bool FromPool);
 
-  // Update free count
-  void countFree();
+    // Update free count
+    void countFree();
 
-  // Update statistics of Available/Unavailable
-  void updateStats(int InUse, int InPool);
+    // Update statistics of Available/Unavailable
+    void updateStats(int InUse, int InPool);
 
-  // Print bucket statistics
-  void printStats(bool &TitlePrinted, const std::string &Label);
+    // Print bucket statistics
+    void printStats(bool &TitlePrinted, const std::string &Label);
 
-private:
-  void onFreeChunk(Slab &, bool &ToPool);
+  private:
+    void onFreeChunk(Slab &, bool &ToPool);
 
-  // Update statistics of pool usage, and indicate that an allocation was made
-  // from the pool.
-  void decrementPool(bool &FromPool);
+    // Update statistics of pool usage, and indicate that an allocation was made
+    // from the pool.
+    void decrementPool(bool &FromPool);
 
-  // Get a slab to be used for chunked allocations.
-  decltype(AvailableSlabs.begin()) getAvailSlab(bool &FromPool);
+    // Get a slab to be used for chunked allocations.
+    decltype(AvailableSlabs.begin()) getAvailSlab(bool &FromPool);
 
-  // Get a slab that will be used as a whole for a single allocation.
-  decltype(AvailableSlabs.begin()) getAvailFullSlab(bool &FromPool);
+    // Get a slab that will be used as a whole for a single allocation.
+    decltype(AvailableSlabs.begin()) getAvailFullSlab(bool &FromPool);
 };
 
-class USMAllocContext::USMAllocImpl {
-  // It's important for the map to be destroyed last after buckets and their
-  // slabs This is because slab's destructor removes the object from the map.
-  std::unordered_multimap<void *, Slab &> KnownSlabs;
-  std::shared_timed_mutex KnownSlabsMapLock;
+class DisjointPool::AllocImpl {
+    // It's important for the map to be destroyed last after buckets and their
+    // slabs This is because slab's destructor removes the object from the map.
+    std::unordered_multimap<void *, Slab &> KnownSlabs;
+    std::shared_timed_mutex KnownSlabsMapLock;
 
-  // Handle to the memory allocation routine
-  std::unique_ptr<SystemMemory> MemHandle;
+    // Handle to the memory provider
+    uma_memory_provider_handle_t MemHandle;
 
-  // Store as unique_ptrs since Bucket is not Movable(because of std::mutex)
-  std::vector<std::unique_ptr<Bucket>> Buckets;
+    // Store as unique_ptrs since Bucket is not Movable(because of std::mutex)
+    std::vector<std::unique_ptr<Bucket>> Buckets;
 
-  // Configuration for this instance
-  USMAllocatorParameters params;
+    // Configuration for this instance
+    DisjointPoolConfig params;
 
-public:
-  USMAllocImpl(std::unique_ptr<SystemMemory> SystemMemHandle,
-               USMAllocatorParameters params)
-      : MemHandle{std::move(SystemMemHandle)}, params(params) {
+  public:
+    AllocImpl(uma_memory_provider_handle_t hProvider, DisjointPoolConfig params)
+        : MemHandle{hProvider}, params(params) {
 
-    // Generate buckets sized such as: 64, 96, 128, 192, ..., CutOff.
-    // Powers of 2 and the value halfway between the powers of 2.
-    auto Size1 = params.MinBucketSize;
-    auto Size2 = Size1 + Size1 / 2;
-    for (; Size2 < CutOff; Size1 *= 2, Size2 *= 2) {
-      Buckets.push_back(std::make_unique<Bucket>(Size1, *this));
-      Buckets.push_back(std::make_unique<Bucket>(Size2, *this));
+        // Generate buckets sized such as: 64, 96, 128, 192, ..., CutOff.
+        // Powers of 2 and the value halfway between the powers of 2.
+        auto Size1 = params.MinBucketSize;
+        auto Size2 = Size1 + Size1 / 2;
+        for (; Size2 < CutOff; Size1 *= 2, Size2 *= 2) {
+            Buckets.push_back(std::make_unique<Bucket>(Size1, *this));
+            Buckets.push_back(std::make_unique<Bucket>(Size2, *this));
+        }
+        Buckets.push_back(std::make_unique<Bucket>(CutOff, *this));
     }
-    Buckets.push_back(std::make_unique<Bucket>(CutOff, *this));
-  }
 
-  void *allocate(size_t Size, size_t Alignment, bool &FromPool);
-  void *allocate(size_t Size, bool &FromPool);
-  void deallocate(void *Ptr, bool &ToPool);
+    void *allocate(size_t Size, size_t Alignment, bool &FromPool);
+    void *allocate(size_t Size, bool &FromPool);
+    void deallocate(void *Ptr, bool &ToPool);
 
-  SystemMemory &getMemHandle() { return *MemHandle; }
+    uma_memory_provider_handle_t getMemHandle() { return MemHandle; }
 
-  std::shared_timed_mutex &getKnownSlabsMapLock() { return KnownSlabsMapLock; }
-  std::unordered_multimap<void *, Slab &> &getKnownSlabs() {
-    return KnownSlabs;
-  }
+    std::shared_timed_mutex &getKnownSlabsMapLock() {
+        return KnownSlabsMapLock;
+    }
+    std::unordered_multimap<void *, Slab &> &getKnownSlabs() {
+        return KnownSlabs;
+    }
 
-  size_t SlabMinSize() { return params.SlabMinSize; };
+    size_t SlabMinSize() { return params.SlabMinSize; };
 
-  USMAllocatorParameters &getParams() { return params; }
+    DisjointPoolConfig &getParams() { return params; }
 
-  void printStats(bool &TitlePrinted, size_t &HighBucketSize,
-                  size_t &HighPeakSlabsInUse, const std::string &Label);
+    void printStats(bool &TitlePrinted, size_t &HighBucketSize,
+                    size_t &HighPeakSlabsInUse, const std::string &Label);
 
-private:
-  Bucket &findBucket(size_t Size);
+  private:
+    Bucket &findBucket(size_t Size);
 };
+
+static void *memoryProviderAlloc(uma_memory_provider_handle_t hProvider,
+                                 size_t size, size_t alignment = 0) {
+    void *ptr;
+    auto ret = umaMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+    if (ret != UMA_RESULT_SUCCESS) {
+        // TODO: Set last error appropriately
+        throw std::runtime_error("umaMemoryProviderAlloc");
+    }
+    return ptr;
+}
+
+static void memoryProviderFree(uma_memory_provider_handle_t hProvider,
+                               void *ptr) {
+    auto ret = umaMemoryProviderFree(hProvider, ptr, 0);
+    if (ret != UMA_RESULT_SUCCESS) {
+        // TODO: introduce custom exceptions? PI L0 relies on those
+        throw std::runtime_error("memoryProviderFree");
+    }
+}
 
 bool operator==(const Slab &Lhs, const Slab &Rhs) {
-  return Lhs.getPtr() == Rhs.getPtr();
+    return Lhs.getPtr() == Rhs.getPtr();
 }
 
 std::ostream &operator<<(std::ostream &Os, const Slab &Slab) {
-  Os << "Slab<" << Slab.getPtr() << ", " << Slab.getEnd() << ", "
-     << Slab.getBucket().getSize() << ">";
-  return Os;
+    Os << "Slab<" << Slab.getPtr() << ", " << Slab.getEnd() << ", "
+       << Slab.getBucket().getSize() << ">";
+    return Os;
 }
 
 Slab::Slab(Bucket &Bkt)
     : // In case bucket size is not a multiple of SlabMinSize, we would have
       // some padding at the end of the slab.
-      Chunks(Bkt.SlabMinSize() / Bkt.getSize()), NumAllocated{0}, bucket(Bkt),
-      SlabListIter{}, FirstFreeChunkIdx{0} {
-  auto SlabSize = Bkt.SlabAllocSize();
-  MemPtr = Bkt.getMemHandle().allocate(SlabSize);
-  regSlab(*this);
+      Chunks(Bkt.SlabMinSize() / Bkt.getSize()), NumAllocated{0},
+      bucket(Bkt), SlabListIter{}, FirstFreeChunkIdx{0} {
+    auto SlabSize = Bkt.SlabAllocSize();
+    MemPtr = memoryProviderAlloc(Bkt.getMemHandle(), SlabSize);
+    regSlab(*this);
 }
 
 Slab::~Slab() {
-  unregSlab(*this);
-  bucket.getMemHandle().deallocate(MemPtr);
+    unregSlab(*this);
+    memoryProviderFree(bucket.getMemHandle(), MemPtr);
 }
 
-// Return the index of the first available chunk, -1 otherwize
+// Return the index of the first available chunk, SIZE_MAX otherwise
 size_t Slab::FindFirstAvailableChunkIdx() const {
-  // Use the first free chunk index as a hint for the search.
-  auto It = std::find_if(Chunks.begin() + FirstFreeChunkIdx, Chunks.end(),
-                         [](auto x) { return !x; });
-  if (It != Chunks.end()) {
-    return It - Chunks.begin();
-  }
+    // Use the first free chunk index as a hint for the search.
+    auto It = std::find_if(Chunks.begin() + FirstFreeChunkIdx, Chunks.end(),
+                           [](auto x) { return !x; });
+    if (It != Chunks.end()) {
+        return It - Chunks.begin();
+    }
 
-  return static_cast<size_t>(-1);
+    return std::numeric_limits<size_t>::max();
 }
 
 void *Slab::getChunk() {
-  // assert(NumAllocated != Chunks.size());
+    // assert(NumAllocated != Chunks.size());
 
-  const size_t ChunkIdx = FindFirstAvailableChunkIdx();
-  // Free chunk must exist, otherwise we would have allocated another slab
-  assert(ChunkIdx != (static_cast<size_t>(-1)));
+    const size_t ChunkIdx = FindFirstAvailableChunkIdx();
+    // Free chunk must exist, otherwise we would have allocated another slab
+    assert(ChunkIdx != (std::numeric_limits<size_t>::max()));
 
-  void *const FreeChunk =
-      (static_cast<uint8_t *>(getPtr())) + ChunkIdx * getChunkSize();
-  Chunks[ChunkIdx] = true;
-  NumAllocated += 1;
+    void *const FreeChunk =
+        (static_cast<uint8_t *>(getPtr())) + ChunkIdx * getChunkSize();
+    Chunks[ChunkIdx] = true;
+    NumAllocated += 1;
 
-  // Use the found index as the next hint
-  FirstFreeChunkIdx = ChunkIdx;
+    // Use the found index as the next hint
+    FirstFreeChunkIdx = ChunkIdx;
 
-  return FreeChunk;
+    return FreeChunk;
 }
 
 void *Slab::getSlab() { return getPtr(); }
@@ -373,73 +401,74 @@ const Bucket &Slab::getBucket() const { return bucket; }
 size_t Slab::getChunkSize() const { return bucket.getSize(); }
 
 void Slab::regSlabByAddr(void *Addr, Slab &Slab) {
-  auto &Lock = Slab.getBucket().getUsmAllocCtx().getKnownSlabsMapLock();
-  auto &Map = Slab.getBucket().getUsmAllocCtx().getKnownSlabs();
+    auto &Lock = Slab.getBucket().getAllocCtx().getKnownSlabsMapLock();
+    auto &Map = Slab.getBucket().getAllocCtx().getKnownSlabs();
 
-  std::lock_guard<std::shared_timed_mutex> Lg(Lock);
-  Map.insert({Addr, Slab});
+    std::lock_guard<std::shared_timed_mutex> Lg(Lock);
+    Map.insert({Addr, Slab});
 }
 
 void Slab::unregSlabByAddr(void *Addr, Slab &Slab) {
-  auto &Lock = Slab.getBucket().getUsmAllocCtx().getKnownSlabsMapLock();
-  auto &Map = Slab.getBucket().getUsmAllocCtx().getKnownSlabs();
+    auto &Lock = Slab.getBucket().getAllocCtx().getKnownSlabsMapLock();
+    auto &Map = Slab.getBucket().getAllocCtx().getKnownSlabs();
 
-  std::lock_guard<std::shared_timed_mutex> Lg(Lock);
+    std::lock_guard<std::shared_timed_mutex> Lg(Lock);
 
-  auto Slabs = Map.equal_range(Addr);
-  // At least the must get the current slab from the map.
-  assert(Slabs.first != Slabs.second && "Slab is not found");
+    auto Slabs = Map.equal_range(Addr);
+    // At least the must get the current slab from the map.
+    assert(Slabs.first != Slabs.second && "Slab is not found");
 
-  for (auto It = Slabs.first; It != Slabs.second; ++It) {
-    if (It->second == Slab) {
-      Map.erase(It);
-      return;
+    for (auto It = Slabs.first; It != Slabs.second; ++It) {
+        if (It->second == Slab) {
+            Map.erase(It);
+            return;
+        }
     }
-  }
 
-  assert(false && "Slab is not found");
+    assert(false && "Slab is not found");
 }
 
 void Slab::regSlab(Slab &Slab) {
-  void *StartAddr = AlignPtrDown(Slab.getPtr(), bucket.SlabMinSize());
-  void *EndAddr = static_cast<char *>(StartAddr) + bucket.SlabMinSize();
+    void *StartAddr = AlignPtrDown(Slab.getPtr(), bucket.SlabMinSize());
+    void *EndAddr = static_cast<char *>(StartAddr) + bucket.SlabMinSize();
 
-  regSlabByAddr(StartAddr, Slab);
-  regSlabByAddr(EndAddr, Slab);
+    regSlabByAddr(StartAddr, Slab);
+    regSlabByAddr(EndAddr, Slab);
 }
 
 void Slab::unregSlab(Slab &Slab) {
-  void *StartAddr = AlignPtrDown(Slab.getPtr(), bucket.SlabMinSize());
-  void *EndAddr = static_cast<char *>(StartAddr) + bucket.SlabMinSize();
+    void *StartAddr = AlignPtrDown(Slab.getPtr(), bucket.SlabMinSize());
+    void *EndAddr = static_cast<char *>(StartAddr) + bucket.SlabMinSize();
 
-  unregSlabByAddr(StartAddr, Slab);
-  unregSlabByAddr(EndAddr, Slab);
+    unregSlabByAddr(StartAddr, Slab);
+    unregSlabByAddr(EndAddr, Slab);
 }
 
 void Slab::freeChunk(void *Ptr) {
-  // This method should be called through bucket(since we might remove the slab
-  // as a result), therefore all locks are done on that level.
+    // This method should be called through bucket(since we might remove the slab
+    // as a result), therefore all locks are done on that level.
 
-  // Make sure that we're in the right slab
-  assert(Ptr >= getPtr() && Ptr < getEnd());
+    // Make sure that we're in the right slab
+    assert(Ptr >= getPtr() && Ptr < getEnd());
 
-  // Even if the pointer p was previously aligned, it's still inside the
-  // corresponding chunk, so we get the correct index here.
-  auto ChunkIdx =
-      (static_cast<char *>(Ptr) - static_cast<char *>(MemPtr)) / getChunkSize();
+    // Even if the pointer p was previously aligned, it's still inside the
+    // corresponding chunk, so we get the correct index here.
+    auto ChunkIdx = (static_cast<char *>(Ptr) - static_cast<char *>(MemPtr)) /
+                    getChunkSize();
 
-  // Make sure that the chunk was allocated
-  assert(Chunks[ChunkIdx] && "double free detected");
+    // Make sure that the chunk was allocated
+    assert(Chunks[ChunkIdx] && "double free detected");
 
-  Chunks[ChunkIdx] = false;
-  NumAllocated -= 1;
+    Chunks[ChunkIdx] = false;
+    NumAllocated -= 1;
 
-  if (ChunkIdx < FirstFreeChunkIdx)
-    FirstFreeChunkIdx = ChunkIdx;
+    if (ChunkIdx < FirstFreeChunkIdx) {
+        FirstFreeChunkIdx = ChunkIdx;
+    }
 }
 
 void *Slab::getEnd() const {
-  return static_cast<char *>(getPtr()) + bucket.SlabMinSize();
+    return static_cast<char *>(getPtr()) + bucket.SlabMinSize();
 }
 
 bool Slab::hasAvail() { return NumAllocated != getNumChunks(); }
@@ -447,419 +476,478 @@ bool Slab::hasAvail() { return NumAllocated != getNumChunks(); }
 // If a slab was available in the pool then note that the current pooled
 // size has reduced by the size of a slab in this bucket.
 void Bucket::decrementPool(bool &FromPool) {
-  FromPool = true;
-  updateStats(1, -1);
-  OwnAllocCtx.getParams().limits->TotalSize -= SlabAllocSize();
+    FromPool = true;
+    updateStats(1, -1);
+    OwnAllocCtx.getParams().limits->TotalSize -= SlabAllocSize();
 }
 
 auto Bucket::getAvailFullSlab(bool &FromPool)
     -> decltype(AvailableSlabs.begin()) {
-  // Return a slab that will be used for a single allocation.
-  if (AvailableSlabs.size() == 0) {
-    auto It = AvailableSlabs.insert(AvailableSlabs.begin(),
-                                    std::make_unique<Slab>(*this));
-    (*It)->setIterator(It);
-    FromPool = false;
-    updateStats(1, 0);
-  } else {
-    decrementPool(FromPool);
-  }
+    // Return a slab that will be used for a single allocation.
+    if (AvailableSlabs.size() == 0) {
+        auto It = AvailableSlabs.insert(AvailableSlabs.begin(),
+                                        std::make_unique<Slab>(*this));
+        (*It)->setIterator(It);
+        FromPool = false;
+        updateStats(1, 0);
+    } else {
+        decrementPool(FromPool);
+    }
 
-  return AvailableSlabs.begin();
+    return AvailableSlabs.begin();
 }
 
 void *Bucket::getSlab(bool &FromPool) {
-  std::lock_guard<std::mutex> Lg(BucketLock);
+    std::lock_guard<std::mutex> Lg(BucketLock);
 
-  auto SlabIt = getAvailFullSlab(FromPool);
-  auto *FreeSlab = (*SlabIt)->getSlab();
-  auto It =
-      UnavailableSlabs.insert(UnavailableSlabs.begin(), std::move(*SlabIt));
-  AvailableSlabs.erase(SlabIt);
-  (*It)->setIterator(It);
-  return FreeSlab;
-}
-
-void Bucket::freeSlab(Slab &Slab, bool &ToPool) {
-  std::lock_guard<std::mutex> Lg(BucketLock);
-  auto SlabIter = Slab.getIterator();
-  assert(SlabIter != UnavailableSlabs.end());
-  if (CanPool(ToPool)) {
-    auto It =
-        AvailableSlabs.insert(AvailableSlabs.begin(), std::move(*SlabIter));
-    UnavailableSlabs.erase(SlabIter);
-    (*It)->setIterator(It);
-  } else {
-    UnavailableSlabs.erase(SlabIter);
-  }
-}
-
-auto Bucket::getAvailSlab(bool &FromPool) -> decltype(AvailableSlabs.begin()) {
-
-  if (AvailableSlabs.size() == 0) {
-    auto It = AvailableSlabs.insert(AvailableSlabs.begin(),
-                                    std::make_unique<Slab>(*this));
-    (*It)->setIterator(It);
-
-    updateStats(1, 0);
-    FromPool = false;
-  } else {
-    if ((*(AvailableSlabs.begin()))->getNumAllocated() == 0) {
-      // If this was an empty slab, it was in the pool.
-      // Now it is no longer in the pool, so update count.
-      --chunkedSlabsInPool;
-      decrementPool(FromPool);
-    } else {
-      // Allocation from existing slab is treated as from pool for statistics.
-      FromPool = true;
-    }
-  }
-
-  return AvailableSlabs.begin();
-}
-
-void *Bucket::getChunk(bool &FromPool) {
-  std::lock_guard<std::mutex> Lg(BucketLock);
-
-  auto SlabIt = getAvailSlab(FromPool);
-  auto *FreeChunk = (*SlabIt)->getChunk();
-
-  // If the slab is full, move it to unavailable slabs and update its iterator
-  if (!((*SlabIt)->hasAvail())) {
+    auto SlabIt = getAvailFullSlab(FromPool);
+    auto *FreeSlab = (*SlabIt)->getSlab();
     auto It =
         UnavailableSlabs.insert(UnavailableSlabs.begin(), std::move(*SlabIt));
     AvailableSlabs.erase(SlabIt);
     (*It)->setIterator(It);
-  }
+    return FreeSlab;
+}
 
-  return FreeChunk;
+void Bucket::freeSlab(Slab &Slab, bool &ToPool) {
+    std::lock_guard<std::mutex> Lg(BucketLock);
+    auto SlabIter = Slab.getIterator();
+    assert(SlabIter != UnavailableSlabs.end());
+    if (CanPool(ToPool)) {
+        auto It =
+            AvailableSlabs.insert(AvailableSlabs.begin(), std::move(*SlabIter));
+        UnavailableSlabs.erase(SlabIter);
+        (*It)->setIterator(It);
+    } else {
+        UnavailableSlabs.erase(SlabIter);
+    }
+}
+
+auto Bucket::getAvailSlab(bool &FromPool) -> decltype(AvailableSlabs.begin()) {
+
+    if (AvailableSlabs.size() == 0) {
+        auto It = AvailableSlabs.insert(AvailableSlabs.begin(),
+                                        std::make_unique<Slab>(*this));
+        (*It)->setIterator(It);
+
+        updateStats(1, 0);
+        FromPool = false;
+    } else {
+        if ((*(AvailableSlabs.begin()))->getNumAllocated() == 0) {
+            // If this was an empty slab, it was in the pool.
+            // Now it is no longer in the pool, so update count.
+            --chunkedSlabsInPool;
+            decrementPool(FromPool);
+        } else {
+            // Allocation from existing slab is treated as from pool for statistics.
+            FromPool = true;
+        }
+    }
+
+    return AvailableSlabs.begin();
+}
+
+void *Bucket::getChunk(bool &FromPool) {
+    std::lock_guard<std::mutex> Lg(BucketLock);
+
+    auto SlabIt = getAvailSlab(FromPool);
+    auto *FreeChunk = (*SlabIt)->getChunk();
+
+    // If the slab is full, move it to unavailable slabs and update its iterator
+    if (!((*SlabIt)->hasAvail())) {
+        auto It = UnavailableSlabs.insert(UnavailableSlabs.begin(),
+                                          std::move(*SlabIt));
+        AvailableSlabs.erase(SlabIt);
+        (*It)->setIterator(It);
+    }
+
+    return FreeChunk;
 }
 
 void Bucket::freeChunk(void *Ptr, Slab &Slab, bool &ToPool) {
-  std::lock_guard<std::mutex> Lg(BucketLock);
+    std::lock_guard<std::mutex> Lg(BucketLock);
 
-  Slab.freeChunk(Ptr);
+    Slab.freeChunk(Ptr);
 
-  onFreeChunk(Slab, ToPool);
+    onFreeChunk(Slab, ToPool);
 }
 
 // The lock must be acquired before calling this method
 void Bucket::onFreeChunk(Slab &Slab, bool &ToPool) {
-  ToPool = true;
+    ToPool = true;
 
-  // In case if the slab was previously full and now has 1 available
-  // chunk, it should be moved to the list of available slabs
-  if (Slab.getNumAllocated() == (Slab.getNumChunks() - 1)) {
-    auto SlabIter = Slab.getIterator();
-    assert(SlabIter != UnavailableSlabs.end());
+    // In case if the slab was previously full and now has 1 available
+    // chunk, it should be moved to the list of available slabs
+    if (Slab.getNumAllocated() == (Slab.getNumChunks() - 1)) {
+        auto SlabIter = Slab.getIterator();
+        assert(SlabIter != UnavailableSlabs.end());
 
-    auto It =
-        AvailableSlabs.insert(AvailableSlabs.begin(), std::move(*SlabIter));
-    UnavailableSlabs.erase(SlabIter);
+        auto It =
+            AvailableSlabs.insert(AvailableSlabs.begin(), std::move(*SlabIter));
+        UnavailableSlabs.erase(SlabIter);
 
-    (*It)->setIterator(It);
-  }
-
-  // Check if slab is empty, and pool it if we can.
-  if (Slab.getNumAllocated() == 0) {
-    // The slab is now empty.
-    // If pool has capacity then put the slab in the pool.
-    // The ToPool parameter indicates whether the Slab will be put in the pool
-    // or freed from USM.
-    if (!CanPool(ToPool)) {
-      // Note: since the slab is stored as unique_ptr, just remove it from
-      // the list to destroy the object.
-      auto It = Slab.getIterator();
-      assert(It != AvailableSlabs.end());
-      AvailableSlabs.erase(It);
+        (*It)->setIterator(It);
     }
-  }
+
+    // Check if slab is empty, and pool it if we can.
+    if (Slab.getNumAllocated() == 0) {
+        // The slab is now empty.
+        // If pool has capacity then put the slab in the pool.
+        // The ToPool parameter indicates whether the Slab will be put in the
+        // pool or freed.
+        if (!CanPool(ToPool)) {
+            // Note: since the slab is stored as unique_ptr, just remove it from
+            // the list to destroy the object.
+            auto It = Slab.getIterator();
+            assert(It != AvailableSlabs.end());
+            AvailableSlabs.erase(It);
+        }
+    }
 }
 
 bool Bucket::CanPool(bool &ToPool) {
-  size_t NewFreeSlabsInBucket;
-  // Check if this bucket is used in chunked form or as full slabs.
-  bool chunkedBucket = getSize() <= ChunkCutOff();
-  if (chunkedBucket)
-    NewFreeSlabsInBucket = chunkedSlabsInPool + 1;
-  else
-    NewFreeSlabsInBucket = AvailableSlabs.size() + 1;
-  if (Capacity() >= NewFreeSlabsInBucket) {
-    size_t PoolSize = OwnAllocCtx.getParams().limits->TotalSize;
-    while (true) {
-      size_t NewPoolSize = PoolSize + SlabAllocSize();
-
-      if (OwnAllocCtx.getParams().limits->MaxSize < NewPoolSize) {
-        break;
-      }
-
-      if (OwnAllocCtx.getParams().limits->TotalSize.compare_exchange_strong(
-              PoolSize, NewPoolSize)) {
-        if (chunkedBucket)
-          ++chunkedSlabsInPool;
-
-        updateStats(-1, 1);
-        ToPool = true;
-        return true;
-      }
+    size_t NewFreeSlabsInBucket;
+    // Check if this bucket is used in chunked form or as full slabs.
+    bool chunkedBucket = getSize() <= ChunkCutOff();
+    if (chunkedBucket) {
+        NewFreeSlabsInBucket = chunkedSlabsInPool + 1;
+    } else {
+        NewFreeSlabsInBucket = AvailableSlabs.size() + 1;
     }
-  }
+    if (Capacity() >= NewFreeSlabsInBucket) {
+        size_t PoolSize = OwnAllocCtx.getParams().limits->TotalSize;
+        while (true) {
+            size_t NewPoolSize = PoolSize + SlabAllocSize();
 
-  updateStats(-1, 0);
-  ToPool = false;
-  return false;
+            if (OwnAllocCtx.getParams().limits->MaxSize < NewPoolSize) {
+                break;
+            }
+
+            if (OwnAllocCtx.getParams()
+                    .limits->TotalSize.compare_exchange_strong(PoolSize,
+                                                               NewPoolSize)) {
+                if (chunkedBucket) {
+                    ++chunkedSlabsInPool;
+                }
+
+                updateStats(-1, 1);
+                ToPool = true;
+                return true;
+            }
+        }
+    }
+
+    updateStats(-1, 0);
+    ToPool = false;
+    return false;
 }
 
-SystemMemory &Bucket::getMemHandle() { return OwnAllocCtx.getMemHandle(); }
+uma_memory_provider_handle_t Bucket::getMemHandle() {
+    return OwnAllocCtx.getMemHandle();
+}
 
 size_t Bucket::SlabMinSize() { return OwnAllocCtx.getParams().SlabMinSize; }
 
 size_t Bucket::SlabAllocSize() { return std::max(getSize(), SlabMinSize()); }
 
 size_t Bucket::Capacity() {
-  // For buckets used in chunked mode, just one slab in pool is sufficient.
-  // For larger buckets, the capacity could be more and is adjustable.
-  if (getSize() <= ChunkCutOff())
-    return 1;
-  else
-    return OwnAllocCtx.getParams().Capacity;
+    // For buckets used in chunked mode, just one slab in pool is sufficient.
+    // For larger buckets, the capacity could be more and is adjustable.
+    if (getSize() <= ChunkCutOff()) {
+        return 1;
+    } else {
+        return OwnAllocCtx.getParams().Capacity;
+    }
 }
 
 size_t Bucket::MaxPoolableSize() {
-  return OwnAllocCtx.getParams().MaxPoolableSize;
+    return OwnAllocCtx.getParams().MaxPoolableSize;
 }
 
 size_t Bucket::ChunkCutOff() { return SlabMinSize() / 2; }
 
 void Bucket::countAlloc(bool FromPool) {
-  ++allocCount;
-  if (FromPool)
-    ++allocPoolCount;
+    ++allocCount;
+    if (FromPool) {
+        ++allocPoolCount;
+    }
 }
 
 void Bucket::countFree() { ++freeCount; }
 
 void Bucket::updateStats(int InUse, int InPool) {
-  if (OwnAllocCtx.getParams().PoolTrace == 0)
-    return;
-  currSlabsInUse += InUse;
-  maxSlabsInUse = std::max(currSlabsInUse, maxSlabsInUse);
-  currSlabsInPool += InPool;
-  maxSlabsInPool = std::max(currSlabsInPool, maxSlabsInPool);
-  // Increment or decrement current pool sizes based on whether
-  // slab was added to or removed from pool.
-  OwnAllocCtx.getParams().CurPoolSize += InPool * SlabAllocSize();
+    if (OwnAllocCtx.getParams().PoolTrace == 0) {
+        return;
+    }
+    currSlabsInUse += InUse;
+    maxSlabsInUse = std::max(currSlabsInUse, maxSlabsInUse);
+    currSlabsInPool += InPool;
+    maxSlabsInPool = std::max(currSlabsInPool, maxSlabsInPool);
+    // Increment or decrement current pool sizes based on whether
+    // slab was added to or removed from pool.
+    OwnAllocCtx.getParams().CurPoolSize += InPool * SlabAllocSize();
 }
 
 void Bucket::printStats(bool &TitlePrinted, const std::string &Label) {
-  if (allocCount) {
-    if (!TitlePrinted) {
-      std::cout << Label << " memory statistics\n";
-      std::cout << std::setw(14) << "Bucket Size" << std::setw(12) << "Allocs"
-                << std::setw(12) << "Frees" << std::setw(18)
-                << "Allocs from Pool" << std::setw(20) << "Peak Slabs in Use"
-                << std::setw(21) << "Peak Slabs in Pool" << std::endl;
-      TitlePrinted = true;
+    if (allocCount) {
+        if (!TitlePrinted) {
+            std::cout << Label << " memory statistics\n";
+            std::cout << std::setw(14) << "Bucket Size" << std::setw(12)
+                      << "Allocs" << std::setw(12) << "Frees" << std::setw(18)
+                      << "Allocs from Pool" << std::setw(20)
+                      << "Peak Slabs in Use" << std::setw(21)
+                      << "Peak Slabs in Pool" << std::endl;
+            TitlePrinted = true;
+        }
+        std::cout << std::setw(14) << getSize() << std::setw(12) << allocCount
+                  << std::setw(12) << freeCount << std::setw(18)
+                  << allocPoolCount << std::setw(20) << maxSlabsInUse
+                  << std::setw(21) << maxSlabsInPool << std::endl;
     }
-    std::cout << std::setw(14) << getSize() << std::setw(12) << allocCount
-              << std::setw(12) << freeCount << std::setw(18) << allocPoolCount
-              << std::setw(20) << maxSlabsInUse << std::setw(21)
-              << maxSlabsInPool << std::endl;
-  }
 }
 
-void *USMAllocContext::USMAllocImpl::allocate(size_t Size, bool &FromPool) {
-  void *Ptr;
+void *DisjointPool::AllocImpl::allocate(size_t Size, bool &FromPool) {
+    void *Ptr;
 
-  if (Size == 0)
-    return nullptr;
+    if (Size == 0) {
+        return nullptr;
+    }
 
-  FromPool = false;
-  if (Size > getParams().MaxPoolableSize) {
-    return getMemHandle().allocate(Size);
-  }
+    FromPool = false;
+    if (Size > getParams().MaxPoolableSize) {
+        return memoryProviderAlloc(getMemHandle(), Size);
+    }
 
-  auto &Bucket = findBucket(Size);
+    auto &Bucket = findBucket(Size);
 
-  if (Size > Bucket.ChunkCutOff())
-    Ptr = Bucket.getSlab(FromPool);
-  else
-    Ptr = Bucket.getChunk(FromPool);
+    if (Size > Bucket.ChunkCutOff()) {
+        Ptr = Bucket.getSlab(FromPool);
+    } else {
+        Ptr = Bucket.getChunk(FromPool);
+    }
 
-  if (getParams().PoolTrace > 1)
-    Bucket.countAlloc(FromPool);
+    if (getParams().PoolTrace > 1) {
+        Bucket.countAlloc(FromPool);
+    }
 
-  return Ptr;
+    return Ptr;
 }
 
-void *USMAllocContext::USMAllocImpl::allocate(size_t Size, size_t Alignment,
-                                              bool &FromPool) {
-  void *Ptr;
+void *DisjointPool::AllocImpl::allocate(size_t Size, size_t Alignment,
+                                        bool &FromPool) {
+    void *Ptr;
 
-  if (Size == 0)
-    return nullptr;
+    if (Size == 0) {
+        return nullptr;
+    }
 
-  if (Alignment <= 1)
-    return allocate(Size, FromPool);
+    if (Alignment <= 1) {
+        return allocate(Size, FromPool);
+    }
 
-  size_t AlignedSize = (Size > 1) ? AlignUp(Size, Alignment) : Alignment;
+    size_t AlignedSize = (Size > 1) ? AlignUp(Size, Alignment) : Alignment;
 
-  // Check if requested allocation size is within pooling limit.
-  // If not, just request aligned pointer from the system.
-  FromPool = false;
-  if (AlignedSize > getParams().MaxPoolableSize) {
-    return getMemHandle().allocate(Size, Alignment);
-  }
+    // Check if requested allocation size is within pooling limit.
+    // If not, just request aligned pointer from the system.
+    FromPool = false;
+    if (AlignedSize > getParams().MaxPoolableSize) {
+        return memoryProviderAlloc(getMemHandle(), Size, Alignment);
+    }
 
-  auto &Bucket = findBucket(AlignedSize);
+    auto &Bucket = findBucket(AlignedSize);
 
-  if (AlignedSize > Bucket.ChunkCutOff()) {
-    Ptr = Bucket.getSlab(FromPool);
-  } else {
-    Ptr = Bucket.getChunk(FromPool);
-  }
+    if (AlignedSize > Bucket.ChunkCutOff()) {
+        Ptr = Bucket.getSlab(FromPool);
+    } else {
+        Ptr = Bucket.getChunk(FromPool);
+    }
 
-  if (getParams().PoolTrace > 1)
-    Bucket.countAlloc(FromPool);
+    if (getParams().PoolTrace > 1) {
+        Bucket.countAlloc(FromPool);
+    }
 
-  return AlignPtrUp(Ptr, Alignment);
+    return AlignPtrUp(Ptr, Alignment);
 }
 
-Bucket &USMAllocContext::USMAllocImpl::findBucket(size_t Size) {
-  assert(Size <= CutOff && "Unexpected size");
+Bucket &DisjointPool::AllocImpl::findBucket(size_t Size) {
+    assert(Size <= CutOff && "Unexpected size");
 
-  auto It = std::find_if(
-      Buckets.begin(), Buckets.end(),
-      [Size](const auto &BucketPtr) { return BucketPtr->getSize() >= Size; });
+    auto It = std::find_if(
+        Buckets.begin(), Buckets.end(),
+        [Size](const auto &BucketPtr) { return BucketPtr->getSize() >= Size; });
 
-  assert((It != Buckets.end()) && "Bucket should always exist");
+    assert((It != Buckets.end()) && "Bucket should always exist");
 
-  return *(*It);
+    return *(*It);
 }
 
-void USMAllocContext::USMAllocImpl::deallocate(void *Ptr, bool &ToPool) {
-  auto *SlabPtr = AlignPtrDown(Ptr, SlabMinSize());
+void DisjointPool::AllocImpl::deallocate(void *Ptr, bool &ToPool) {
+    auto *SlabPtr = AlignPtrDown(Ptr, SlabMinSize());
 
-  // Lock the map on read
-  std::shared_lock<std::shared_timed_mutex> Lk(getKnownSlabsMapLock());
+    // Lock the map on read
+    std::shared_lock<std::shared_timed_mutex> Lk(getKnownSlabsMapLock());
 
-  ToPool = false;
-  auto Slabs = getKnownSlabs().equal_range(SlabPtr);
-  if (Slabs.first == Slabs.second) {
+    ToPool = false;
+    auto Slabs = getKnownSlabs().equal_range(SlabPtr);
+    if (Slabs.first == Slabs.second) {
+        Lk.unlock();
+        memoryProviderFree(getMemHandle(), Ptr);
+        return;
+    }
+
+    for (auto It = Slabs.first; It != Slabs.second; ++It) {
+        // The slab object won't be deleted until it's removed from the map which is
+        // protected by the lock, so it's safe to access it here.
+        auto &Slab = It->second;
+        if (Ptr >= Slab.getPtr() && Ptr < Slab.getEnd()) {
+            // Unlock the map before freeing the chunk, it may be locked on write
+            // there
+            Lk.unlock();
+            auto &Bucket = Slab.getBucket();
+
+            if (getParams().PoolTrace > 1) {
+                Bucket.countFree();
+            }
+
+            if (Bucket.getSize() <= Bucket.ChunkCutOff()) {
+                Bucket.freeChunk(Ptr, Slab, ToPool);
+            } else {
+                Bucket.freeSlab(Slab, ToPool);
+            }
+
+            return;
+        }
+    }
+
     Lk.unlock();
-    getMemHandle().deallocate(Ptr);
-    return;
-  }
+    // There is a rare case when we have a pointer from system allocation next
+    // to some slab with an entry in the map. So we find a slab
+    // but the range checks fail.
+    memoryProviderFree(getMemHandle(), Ptr);
+}
 
-  for (auto It = Slabs.first; It != Slabs.second; ++It) {
-    // The slab object won't be deleted until it's removed from the map which is
-    // protected by the lock, so it's safe to access it here.
-    auto &Slab = It->second;
-    if (Ptr >= Slab.getPtr() && Ptr < Slab.getEnd()) {
-      // Unlock the map before freeing the chunk, it may be locked on write
-      // there
-      Lk.unlock();
-      auto &Bucket = Slab.getBucket();
-
-      if (getParams().PoolTrace > 1)
-        Bucket.countFree();
-
-      if (Bucket.getSize() <= Bucket.ChunkCutOff()) {
-        Bucket.freeChunk(Ptr, Slab, ToPool);
-      } else {
-        Bucket.freeSlab(Slab, ToPool);
-      }
-
-      return;
+void DisjointPool::AllocImpl::printStats(bool &TitlePrinted,
+                                         size_t &HighBucketSize,
+                                         size_t &HighPeakSlabsInUse,
+                                         const std::string &MTName) {
+    HighBucketSize = 0;
+    HighPeakSlabsInUse = 0;
+    for (auto &B : Buckets) {
+        (*B).printStats(TitlePrinted, MTName);
+        HighPeakSlabsInUse = std::max((*B).maxSlabsInUse, HighPeakSlabsInUse);
+        if ((*B).allocCount) {
+            HighBucketSize = std::max((*B).SlabAllocSize(), HighBucketSize);
+        }
     }
-  }
-
-  Lk.unlock();
-  // There is a rare case when we have a pointer from system allocation next
-  // to some slab with an entry in the map. So we find a slab
-  // but the range checks fail.
-  getMemHandle().deallocate(Ptr);
 }
 
-USMAllocContext::USMAllocContext(std::unique_ptr<SystemMemory> MemHandle,
-                                 USMAllocatorParameters params)
-    : pImpl(std::make_unique<USMAllocImpl>(std::move(MemHandle), params)) {}
+uma_result_t DisjointPool::initialize(uma_memory_provider_handle_t *providers,
+                                      size_t numProviders,
+                                      DisjointPoolConfig parameters) noexcept {
+    if (numProviders != 1 || !providers[0]) {
+        return UMA_RESULT_ERROR_INVALID_ARGUMENT;
+    }
 
-void *USMAllocContext::allocate(size_t size) {
-  // For full-slab allocations indicates whether slab is from Pool.
-  bool FromPool;
-  auto Ptr = pImpl->allocate(size, FromPool);
-
-  if (pImpl->getParams().PoolTrace > 2) {
-    auto MT = pImpl->getParams().memoryTypeName;
-    std::cout << "Allocated " << std::setw(8) << size << " " << MT
-              << " USM bytes from " << (FromPool ? "Pool" : "USM") << " ->"
-              << Ptr << std::endl;
-  }
-  return Ptr;
+    impl = std::make_unique<AllocImpl>(providers[0], parameters);
+    return UMA_RESULT_SUCCESS;
 }
 
-void *USMAllocContext::allocate(size_t size, size_t alignment) {
-  bool FromPool;
-  auto Ptr = pImpl->allocate(size, alignment, FromPool);
+void *DisjointPool::malloc(
+    size_t size) noexcept { // For full-slab allocations indicates
+                            // whether slab is from Pool.
+    bool FromPool;
+    auto Ptr = impl->allocate(size, FromPool);
 
-  if (pImpl->getParams().PoolTrace > 2) {
-    auto MT = pImpl->getParams().memoryTypeName;
-    std::cout << "Allocated " << std::setw(8) << size << " " << MT
-              << " USM bytes aligned at " << alignment << " from "
-              << (FromPool ? "Pool" : "USM") << " ->" << Ptr << std::endl;
-  }
-  return Ptr;
+    if (impl->getParams().PoolTrace > 2) {
+        auto MT = impl->getParams().name;
+        std::cout << "Allocated " << std::setw(8) << size << " " << MT
+                  << " bytes from " << (FromPool ? "Pool" : "Provider") << " ->"
+                  << Ptr << std::endl;
+    }
+    return Ptr;
 }
 
-void USMAllocContext::deallocate(void *ptr) {
-  bool ToPool;
-  pImpl->deallocate(ptr, ToPool);
-
-  if (pImpl->getParams().PoolTrace > 2) {
-    auto MT = pImpl->getParams().memoryTypeName;
-    std::cout << "Freed " << MT << " USM " << ptr << " to "
-              << (ToPool ? "Pool" : "USM") << ", Current total pool size "
-              << pImpl->getParams().limits->TotalSize.load()
-              << ", Current pool size for " << MT << " "
-              << pImpl->getParams().CurPoolSize << "\n";
-  }
-  return;
+void *DisjointPool::calloc(size_t, size_t) noexcept {
+    // Not supported
+    assert(false);
+    return NULL;
 }
+
+void *DisjointPool::realloc(void *, size_t) noexcept {
+    // Not supported
+    assert(false);
+    return NULL;
+}
+
+void *DisjointPool::aligned_malloc(size_t size, size_t alignment) noexcept {
+    bool FromPool;
+    auto Ptr = impl->allocate(size, alignment, FromPool);
+
+    if (impl->getParams().PoolTrace > 2) {
+        auto MT = impl->getParams().name;
+        std::cout << "Allocated " << std::setw(8) << size << " " << MT
+                  << " bytes aligned at " << alignment << " from "
+                  << (FromPool ? "Pool" : "Provider") << " ->" << Ptr
+                  << std::endl;
+    }
+    return Ptr;
+}
+
+size_t DisjointPool::malloc_usable_size(void *) noexcept {
+    // Not supported
+    assert(false);
+
+    return 0;
+}
+
+void DisjointPool::free(void *ptr) noexcept {
+    bool ToPool;
+    impl->deallocate(ptr, ToPool);
+
+    if (impl->getParams().PoolTrace > 2) {
+        auto MT = impl->getParams().name;
+        std::cout << "Freed " << MT << " " << ptr << " to "
+                  << (ToPool ? "Pool" : "Provider")
+                  << ", Current total pool size "
+                  << impl->getParams().limits->TotalSize.load()
+                  << ", Current pool size for " << MT << " "
+                  << impl->getParams().CurPoolSize << "\n";
+    }
+    return;
+}
+
+enum uma_result_t
+DisjointPool::get_last_result(const char **ppMessage) noexcept {
+    // TODO: implement and return last error, we probably need something like
+    // https://github.com/oneapi-src/unified-runtime/issues/500 in UMA
+    return UMA_RESULT_ERROR_UNKNOWN;
+}
+
+DisjointPool::DisjointPool() {}
 
 // Define destructor for use with unique_ptr
-USMAllocContext::~USMAllocContext() {
-  bool TitlePrinted = false;
-  size_t HighBucketSize;
-  size_t HighPeakSlabsInUse;
-  if (pImpl->getParams().PoolTrace > 1) {
-    auto MT = pImpl->getParams().memoryTypeName;
-    pImpl->printStats(TitlePrinted, HighBucketSize, HighPeakSlabsInUse, MT);
-    if (TitlePrinted) {
-      try { // cannot throw in destructor
-        std::cout << "Current Pool Size "
-                  << pImpl->getParams().limits->TotalSize.load() << std::endl;
-        const char *Label = MT;
-        std::cout << "Suggested Setting: SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=;"
-                  << std::string(1, tolower(*Label)) << std::string(Label + 1)
-                  << ":" << HighBucketSize << "," << HighPeakSlabsInUse
-                  << ",64K" << std::endl;
-      } catch (...) { // ignore exceptions
-      }
+DisjointPool::~DisjointPool() {
+    bool TitlePrinted = false;
+    size_t HighBucketSize;
+    size_t HighPeakSlabsInUse;
+    if (impl->getParams().PoolTrace > 1) {
+        auto name = impl->getParams().name;
+        impl->printStats(TitlePrinted, HighBucketSize, HighPeakSlabsInUse,
+                         name.c_str());
+        if (TitlePrinted) {
+            try { // cannot throw in destructor
+                std::cout << "Current Pool Size "
+                          << impl->getParams().limits->TotalSize.load()
+                          << std::endl;
+                std::cout << "Suggested Setting=;"
+                          << std::string(1, tolower(name[0]))
+                          << std::string(name.c_str() + 1) << ":"
+                          << HighBucketSize << "," << HighPeakSlabsInUse
+                          << ",64K" << std::endl;
+            } catch (...) { // ignore exceptions
+            }
+        }
     }
-  }
 }
 
-void USMAllocContext::USMAllocImpl::printStats(bool &TitlePrinted,
-                                               size_t &HighBucketSize,
-                                               size_t &HighPeakSlabsInUse,
-                                               const std::string &MTName) {
-  HighBucketSize = 0;
-  HighPeakSlabsInUse = 0;
-  for (auto &B : Buckets) {
-    (*B).printStats(TitlePrinted, MTName);
-    HighPeakSlabsInUse = std::max((*B).maxSlabsInUse, HighPeakSlabsInUse);
-    if ((*B).allocCount)
-      HighBucketSize = std::max((*B).SlabAllocSize(), HighBucketSize);
-  }
-}
+} // namespace usm

--- a/source/common/uma_pools/disjoint_pool.cpp
+++ b/source/common/uma_pools/disjoint_pool.cpp
@@ -1,0 +1,865 @@
+//===---------- disjoint_pool.cpp - Allocator for USM memory --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <cassert>
+#include <cctype>
+#include <iomanip>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "ur.hpp"
+#include "disjoint_pool.hpp"
+
+// USM allocations are a minimum of 4KB/64KB/2MB even when a smaller size is
+// requested. The implementation distinguishes between allocations of size
+// ChunkCutOff = (minimum-alloc-size / 2) and those that are larger.
+// Allocation requests smaller than ChunkCutoff use chunks taken from a single
+// USM allocation. Thus, for example, for a 64KB minimum allocation size,
+// and 8-byte allocations, only 1 in ~8000 requests results in a new
+// USM allocation. Freeing results only in a chunk of a larger allocation
+// to be marked as available and no real return to the system.
+// An allocation is returned to the system only when all
+// chunks in the larger allocation are freed by the program.
+// Allocations larger than ChunkCutOff use a separate USM allocation for each
+// request. These are subject to "pooling". That is, when such an allocation is
+// freed by the program it is retained in a pool. The pool is available for
+// future allocations, which means there are fewer actual USM
+// allocations/deallocations.
+
+// The largest size which is allocated via the allocator.
+// Allocations with size > CutOff bypass the USM allocator and
+// go directly to the runtime.
+static constexpr size_t CutOff = (size_t)1 << 31; // 2GB
+
+// Aligns the pointer down to the specified alignment
+// (e.g. returns 8 for Size = 13, Alignment = 8)
+static void *AlignPtrDown(void *Ptr, const size_t Alignment) {
+  return reinterpret_cast<void *>((reinterpret_cast<size_t>(Ptr)) &
+                                  (~(Alignment - 1)));
+}
+
+// Aligns the pointer up to the specified alignment
+// (e.g. returns 16 for Size = 13, Alignment = 8)
+static void *AlignPtrUp(void *Ptr, const size_t Alignment) {
+  void *AlignedPtr = AlignPtrDown(Ptr, Alignment);
+  // Special case when the pointer is already aligned
+  if (Ptr == AlignedPtr) {
+    return Ptr;
+  }
+  return static_cast<char *>(AlignedPtr) + Alignment;
+}
+
+// Aligns the value up to the specified alignment
+// (e.g. returns 16 for Size = 13, Alignment = 8)
+static size_t AlignUp(size_t Val, size_t Alignment) {
+  assert(Alignment > 0);
+  return (Val + Alignment - 1) & (~(Alignment - 1));
+}
+
+class Bucket;
+
+// Represents the allocated memory block of size 'SlabMinSize'
+// Internally, it splits the memory block into chunks. The number of
+// chunks depends of the size of a Bucket which created the Slab.
+// The chunks
+// Note: Bucket's method are responsible for thread safety of Slab access,
+// so no locking happens here.
+class Slab {
+
+  // Pointer to the allocated memory of SlabMinSize bytes
+  void *MemPtr;
+
+  // Represents the current state of each chunk:
+  // if the bit is set then the chunk is allocated
+  // the chunk is free for allocation otherwise
+  std::vector<bool> Chunks;
+
+  // Total number of allocated chunks at the moment.
+  size_t NumAllocated = 0;
+
+  // The bucket which the slab belongs to
+  Bucket &bucket;
+
+  using ListIter = std::list<std::unique_ptr<Slab>>::iterator;
+
+  // Store iterator to the corresponding node in avail/unavail list
+  // to achieve O(1) removal
+  ListIter SlabListIter;
+
+  // Hints where to start search for free chunk in a slab
+  size_t FirstFreeChunkIdx = 0;
+
+  // Return the index of the first available chunk, -1 otherwize
+  size_t FindFirstAvailableChunkIdx() const;
+
+  // Register/Unregister the slab in the global slab address map.
+  void regSlab(Slab &);
+  void unregSlab(Slab &);
+  static void regSlabByAddr(void *, Slab &);
+  static void unregSlabByAddr(void *, Slab &);
+
+public:
+  Slab(Bucket &);
+  ~Slab();
+
+  void setIterator(ListIter It) { SlabListIter = It; }
+  ListIter getIterator() const { return SlabListIter; }
+
+  size_t getNumAllocated() const { return NumAllocated; }
+
+  // Get pointer to allocation that is one piece of this slab.
+  void *getChunk();
+
+  // Get pointer to allocation that is this entire slab.
+  void *getSlab();
+
+  void *getPtr() const { return MemPtr; }
+  void *getEnd() const;
+
+  size_t getChunkSize() const;
+  size_t getNumChunks() const { return Chunks.size(); }
+
+  bool hasAvail();
+
+  Bucket &getBucket();
+  const Bucket &getBucket() const;
+
+  void freeChunk(void *Ptr);
+};
+
+class Bucket {
+  const size_t Size;
+
+  // List of slabs which have at least 1 available chunk.
+  std::list<std::unique_ptr<Slab>> AvailableSlabs;
+
+  // List of slabs with 0 available chunk.
+  std::list<std::unique_ptr<Slab>> UnavailableSlabs;
+
+  // Protects the bucket and all the corresponding slabs
+  std::mutex BucketLock;
+
+  // Reference to the allocator context, used access memory allocation
+  // routines, slab map and etc.
+  USMAllocContext::USMAllocImpl &OwnAllocCtx;
+
+  // For buckets used in chunked mode, a counter of slabs in the pool.
+  // For allocations that use an entire slab each, the entries in the Available
+  // list are entries in the pool.Each slab is available for a new
+  // allocation.The size of the Available list is the size of the pool.
+  // For allocations that use slabs in chunked mode, slabs will be in the
+  // Available list if any one or more of their chunks is free.The entire slab
+  // is not necessarily free, just some chunks in the slab are free. To
+  // implement pooling we will allow one slab in the Available list to be
+  // entirely empty. Normally such a slab would have been freed from USM. But
+  // now we don't, and treat this slab as "in the pool".
+  // When a slab becomes entirely free we have to decide whether to return it to
+  // USM or keep it allocated. A simple check for size of the Available list is
+  // not sufficient to check whether any slab has been pooled yet.We would have
+  // to traverse the entire Available listand check if any of them is entirely
+  // free. Instead we keep a counter of entirely empty slabs within the
+  // Available list to speed up the process of checking if a slab in this bucket
+  // is already pooled.
+  size_t chunkedSlabsInPool;
+
+  // Statistics
+  size_t allocPoolCount;
+  size_t freeCount;
+  size_t currSlabsInUse;
+  size_t currSlabsInPool;
+  size_t maxSlabsInPool;
+
+public:
+  // Statistics
+  size_t allocCount;
+  size_t maxSlabsInUse;
+
+  Bucket(size_t Sz, USMAllocContext::USMAllocImpl &AllocCtx)
+      : Size{Sz}, OwnAllocCtx{AllocCtx}, chunkedSlabsInPool(0),
+        allocPoolCount(0), freeCount(0), currSlabsInUse(0), currSlabsInPool(0),
+        maxSlabsInPool(0), allocCount(0), maxSlabsInUse(0) {}
+
+  // Get pointer to allocation that is one piece of an available slab in this
+  // bucket.
+  void *getChunk(bool &FromPool);
+
+  // Get pointer to allocation that is a full slab in this bucket.
+  void *getSlab(bool &FromPool);
+
+  // Return the allocation size of this bucket.
+  size_t getSize() const { return Size; }
+
+  // Free an allocation that is one piece of a slab in this bucket.
+  void freeChunk(void *Ptr, Slab &Slab, bool &ToPool);
+
+  // Free an allocation that is a full slab in this bucket.
+  void freeSlab(Slab &Slab, bool &ToPool);
+
+  SystemMemory &getMemHandle();
+
+  USMAllocContext::USMAllocImpl &getUsmAllocCtx() { return OwnAllocCtx; }
+
+  // Check whether an allocation to be freed can be placed in the pool.
+  bool CanPool(bool &ToPool);
+
+  // The minimum allocation size for any slab.
+  size_t SlabMinSize();
+
+  // The allocation size for a slab in this bucket.
+  size_t SlabAllocSize();
+
+  // The minimum size of a chunk from this bucket's slabs.
+  size_t ChunkCutOff();
+
+  // The number of slabs in this bucket that can be in the pool.
+  size_t Capacity();
+
+  // The maximum allocation size subject to pooling.
+  size_t MaxPoolableSize();
+
+  // Update allocation count
+  void countAlloc(bool FromPool);
+
+  // Update free count
+  void countFree();
+
+  // Update statistics of Available/Unavailable
+  void updateStats(int InUse, int InPool);
+
+  // Print bucket statistics
+  void printStats(bool &TitlePrinted, const std::string &Label);
+
+private:
+  void onFreeChunk(Slab &, bool &ToPool);
+
+  // Update statistics of pool usage, and indicate that an allocation was made
+  // from the pool.
+  void decrementPool(bool &FromPool);
+
+  // Get a slab to be used for chunked allocations.
+  decltype(AvailableSlabs.begin()) getAvailSlab(bool &FromPool);
+
+  // Get a slab that will be used as a whole for a single allocation.
+  decltype(AvailableSlabs.begin()) getAvailFullSlab(bool &FromPool);
+};
+
+class USMAllocContext::USMAllocImpl {
+  // It's important for the map to be destroyed last after buckets and their
+  // slabs This is because slab's destructor removes the object from the map.
+  std::unordered_multimap<void *, Slab &> KnownSlabs;
+  std::shared_timed_mutex KnownSlabsMapLock;
+
+  // Handle to the memory allocation routine
+  std::unique_ptr<SystemMemory> MemHandle;
+
+  // Store as unique_ptrs since Bucket is not Movable(because of std::mutex)
+  std::vector<std::unique_ptr<Bucket>> Buckets;
+
+  // Configuration for this instance
+  USMAllocatorParameters params;
+
+public:
+  USMAllocImpl(std::unique_ptr<SystemMemory> SystemMemHandle,
+               USMAllocatorParameters params)
+      : MemHandle{std::move(SystemMemHandle)}, params(params) {
+
+    // Generate buckets sized such as: 64, 96, 128, 192, ..., CutOff.
+    // Powers of 2 and the value halfway between the powers of 2.
+    auto Size1 = params.MinBucketSize;
+    auto Size2 = Size1 + Size1 / 2;
+    for (; Size2 < CutOff; Size1 *= 2, Size2 *= 2) {
+      Buckets.push_back(std::make_unique<Bucket>(Size1, *this));
+      Buckets.push_back(std::make_unique<Bucket>(Size2, *this));
+    }
+    Buckets.push_back(std::make_unique<Bucket>(CutOff, *this));
+  }
+
+  void *allocate(size_t Size, size_t Alignment, bool &FromPool);
+  void *allocate(size_t Size, bool &FromPool);
+  void deallocate(void *Ptr, bool &ToPool);
+
+  SystemMemory &getMemHandle() { return *MemHandle; }
+
+  std::shared_timed_mutex &getKnownSlabsMapLock() { return KnownSlabsMapLock; }
+  std::unordered_multimap<void *, Slab &> &getKnownSlabs() {
+    return KnownSlabs;
+  }
+
+  size_t SlabMinSize() { return params.SlabMinSize; };
+
+  USMAllocatorParameters &getParams() { return params; }
+
+  void printStats(bool &TitlePrinted, size_t &HighBucketSize,
+                  size_t &HighPeakSlabsInUse, const std::string &Label);
+
+private:
+  Bucket &findBucket(size_t Size);
+};
+
+bool operator==(const Slab &Lhs, const Slab &Rhs) {
+  return Lhs.getPtr() == Rhs.getPtr();
+}
+
+std::ostream &operator<<(std::ostream &Os, const Slab &Slab) {
+  Os << "Slab<" << Slab.getPtr() << ", " << Slab.getEnd() << ", "
+     << Slab.getBucket().getSize() << ">";
+  return Os;
+}
+
+Slab::Slab(Bucket &Bkt)
+    : // In case bucket size is not a multiple of SlabMinSize, we would have
+      // some padding at the end of the slab.
+      Chunks(Bkt.SlabMinSize() / Bkt.getSize()), NumAllocated{0}, bucket(Bkt),
+      SlabListIter{}, FirstFreeChunkIdx{0} {
+  auto SlabSize = Bkt.SlabAllocSize();
+  MemPtr = Bkt.getMemHandle().allocate(SlabSize);
+  regSlab(*this);
+}
+
+Slab::~Slab() {
+  unregSlab(*this);
+  bucket.getMemHandle().deallocate(MemPtr);
+}
+
+// Return the index of the first available chunk, -1 otherwize
+size_t Slab::FindFirstAvailableChunkIdx() const {
+  // Use the first free chunk index as a hint for the search.
+  auto It = std::find_if(Chunks.begin() + FirstFreeChunkIdx, Chunks.end(),
+                         [](auto x) { return !x; });
+  if (It != Chunks.end()) {
+    return It - Chunks.begin();
+  }
+
+  return static_cast<size_t>(-1);
+}
+
+void *Slab::getChunk() {
+  // assert(NumAllocated != Chunks.size());
+
+  const size_t ChunkIdx = FindFirstAvailableChunkIdx();
+  // Free chunk must exist, otherwise we would have allocated another slab
+  assert(ChunkIdx != (static_cast<size_t>(-1)));
+
+  void *const FreeChunk =
+      (static_cast<uint8_t *>(getPtr())) + ChunkIdx * getChunkSize();
+  Chunks[ChunkIdx] = true;
+  NumAllocated += 1;
+
+  // Use the found index as the next hint
+  FirstFreeChunkIdx = ChunkIdx;
+
+  return FreeChunk;
+}
+
+void *Slab::getSlab() { return getPtr(); }
+
+Bucket &Slab::getBucket() { return bucket; }
+const Bucket &Slab::getBucket() const { return bucket; }
+
+size_t Slab::getChunkSize() const { return bucket.getSize(); }
+
+void Slab::regSlabByAddr(void *Addr, Slab &Slab) {
+  auto &Lock = Slab.getBucket().getUsmAllocCtx().getKnownSlabsMapLock();
+  auto &Map = Slab.getBucket().getUsmAllocCtx().getKnownSlabs();
+
+  std::lock_guard<std::shared_timed_mutex> Lg(Lock);
+  Map.insert({Addr, Slab});
+}
+
+void Slab::unregSlabByAddr(void *Addr, Slab &Slab) {
+  auto &Lock = Slab.getBucket().getUsmAllocCtx().getKnownSlabsMapLock();
+  auto &Map = Slab.getBucket().getUsmAllocCtx().getKnownSlabs();
+
+  std::lock_guard<std::shared_timed_mutex> Lg(Lock);
+
+  auto Slabs = Map.equal_range(Addr);
+  // At least the must get the current slab from the map.
+  assert(Slabs.first != Slabs.second && "Slab is not found");
+
+  for (auto It = Slabs.first; It != Slabs.second; ++It) {
+    if (It->second == Slab) {
+      Map.erase(It);
+      return;
+    }
+  }
+
+  assert(false && "Slab is not found");
+}
+
+void Slab::regSlab(Slab &Slab) {
+  void *StartAddr = AlignPtrDown(Slab.getPtr(), bucket.SlabMinSize());
+  void *EndAddr = static_cast<char *>(StartAddr) + bucket.SlabMinSize();
+
+  regSlabByAddr(StartAddr, Slab);
+  regSlabByAddr(EndAddr, Slab);
+}
+
+void Slab::unregSlab(Slab &Slab) {
+  void *StartAddr = AlignPtrDown(Slab.getPtr(), bucket.SlabMinSize());
+  void *EndAddr = static_cast<char *>(StartAddr) + bucket.SlabMinSize();
+
+  unregSlabByAddr(StartAddr, Slab);
+  unregSlabByAddr(EndAddr, Slab);
+}
+
+void Slab::freeChunk(void *Ptr) {
+  // This method should be called through bucket(since we might remove the slab
+  // as a result), therefore all locks are done on that level.
+
+  // Make sure that we're in the right slab
+  assert(Ptr >= getPtr() && Ptr < getEnd());
+
+  // Even if the pointer p was previously aligned, it's still inside the
+  // corresponding chunk, so we get the correct index here.
+  auto ChunkIdx =
+      (static_cast<char *>(Ptr) - static_cast<char *>(MemPtr)) / getChunkSize();
+
+  // Make sure that the chunk was allocated
+  assert(Chunks[ChunkIdx] && "double free detected");
+
+  Chunks[ChunkIdx] = false;
+  NumAllocated -= 1;
+
+  if (ChunkIdx < FirstFreeChunkIdx)
+    FirstFreeChunkIdx = ChunkIdx;
+}
+
+void *Slab::getEnd() const {
+  return static_cast<char *>(getPtr()) + bucket.SlabMinSize();
+}
+
+bool Slab::hasAvail() { return NumAllocated != getNumChunks(); }
+
+// If a slab was available in the pool then note that the current pooled
+// size has reduced by the size of a slab in this bucket.
+void Bucket::decrementPool(bool &FromPool) {
+  FromPool = true;
+  updateStats(1, -1);
+  OwnAllocCtx.getParams().limits->TotalSize -= SlabAllocSize();
+}
+
+auto Bucket::getAvailFullSlab(bool &FromPool)
+    -> decltype(AvailableSlabs.begin()) {
+  // Return a slab that will be used for a single allocation.
+  if (AvailableSlabs.size() == 0) {
+    auto It = AvailableSlabs.insert(AvailableSlabs.begin(),
+                                    std::make_unique<Slab>(*this));
+    (*It)->setIterator(It);
+    FromPool = false;
+    updateStats(1, 0);
+  } else {
+    decrementPool(FromPool);
+  }
+
+  return AvailableSlabs.begin();
+}
+
+void *Bucket::getSlab(bool &FromPool) {
+  std::lock_guard<std::mutex> Lg(BucketLock);
+
+  auto SlabIt = getAvailFullSlab(FromPool);
+  auto *FreeSlab = (*SlabIt)->getSlab();
+  auto It =
+      UnavailableSlabs.insert(UnavailableSlabs.begin(), std::move(*SlabIt));
+  AvailableSlabs.erase(SlabIt);
+  (*It)->setIterator(It);
+  return FreeSlab;
+}
+
+void Bucket::freeSlab(Slab &Slab, bool &ToPool) {
+  std::lock_guard<std::mutex> Lg(BucketLock);
+  auto SlabIter = Slab.getIterator();
+  assert(SlabIter != UnavailableSlabs.end());
+  if (CanPool(ToPool)) {
+    auto It =
+        AvailableSlabs.insert(AvailableSlabs.begin(), std::move(*SlabIter));
+    UnavailableSlabs.erase(SlabIter);
+    (*It)->setIterator(It);
+  } else {
+    UnavailableSlabs.erase(SlabIter);
+  }
+}
+
+auto Bucket::getAvailSlab(bool &FromPool) -> decltype(AvailableSlabs.begin()) {
+
+  if (AvailableSlabs.size() == 0) {
+    auto It = AvailableSlabs.insert(AvailableSlabs.begin(),
+                                    std::make_unique<Slab>(*this));
+    (*It)->setIterator(It);
+
+    updateStats(1, 0);
+    FromPool = false;
+  } else {
+    if ((*(AvailableSlabs.begin()))->getNumAllocated() == 0) {
+      // If this was an empty slab, it was in the pool.
+      // Now it is no longer in the pool, so update count.
+      --chunkedSlabsInPool;
+      decrementPool(FromPool);
+    } else {
+      // Allocation from existing slab is treated as from pool for statistics.
+      FromPool = true;
+    }
+  }
+
+  return AvailableSlabs.begin();
+}
+
+void *Bucket::getChunk(bool &FromPool) {
+  std::lock_guard<std::mutex> Lg(BucketLock);
+
+  auto SlabIt = getAvailSlab(FromPool);
+  auto *FreeChunk = (*SlabIt)->getChunk();
+
+  // If the slab is full, move it to unavailable slabs and update its iterator
+  if (!((*SlabIt)->hasAvail())) {
+    auto It =
+        UnavailableSlabs.insert(UnavailableSlabs.begin(), std::move(*SlabIt));
+    AvailableSlabs.erase(SlabIt);
+    (*It)->setIterator(It);
+  }
+
+  return FreeChunk;
+}
+
+void Bucket::freeChunk(void *Ptr, Slab &Slab, bool &ToPool) {
+  std::lock_guard<std::mutex> Lg(BucketLock);
+
+  Slab.freeChunk(Ptr);
+
+  onFreeChunk(Slab, ToPool);
+}
+
+// The lock must be acquired before calling this method
+void Bucket::onFreeChunk(Slab &Slab, bool &ToPool) {
+  ToPool = true;
+
+  // In case if the slab was previously full and now has 1 available
+  // chunk, it should be moved to the list of available slabs
+  if (Slab.getNumAllocated() == (Slab.getNumChunks() - 1)) {
+    auto SlabIter = Slab.getIterator();
+    assert(SlabIter != UnavailableSlabs.end());
+
+    auto It =
+        AvailableSlabs.insert(AvailableSlabs.begin(), std::move(*SlabIter));
+    UnavailableSlabs.erase(SlabIter);
+
+    (*It)->setIterator(It);
+  }
+
+  // Check if slab is empty, and pool it if we can.
+  if (Slab.getNumAllocated() == 0) {
+    // The slab is now empty.
+    // If pool has capacity then put the slab in the pool.
+    // The ToPool parameter indicates whether the Slab will be put in the pool
+    // or freed from USM.
+    if (!CanPool(ToPool)) {
+      // Note: since the slab is stored as unique_ptr, just remove it from
+      // the list to destroy the object.
+      auto It = Slab.getIterator();
+      assert(It != AvailableSlabs.end());
+      AvailableSlabs.erase(It);
+    }
+  }
+}
+
+bool Bucket::CanPool(bool &ToPool) {
+  size_t NewFreeSlabsInBucket;
+  // Check if this bucket is used in chunked form or as full slabs.
+  bool chunkedBucket = getSize() <= ChunkCutOff();
+  if (chunkedBucket)
+    NewFreeSlabsInBucket = chunkedSlabsInPool + 1;
+  else
+    NewFreeSlabsInBucket = AvailableSlabs.size() + 1;
+  if (Capacity() >= NewFreeSlabsInBucket) {
+    size_t PoolSize = OwnAllocCtx.getParams().limits->TotalSize;
+    while (true) {
+      size_t NewPoolSize = PoolSize + SlabAllocSize();
+
+      if (OwnAllocCtx.getParams().limits->MaxSize < NewPoolSize) {
+        break;
+      }
+
+      if (OwnAllocCtx.getParams().limits->TotalSize.compare_exchange_strong(
+              PoolSize, NewPoolSize)) {
+        if (chunkedBucket)
+          ++chunkedSlabsInPool;
+
+        updateStats(-1, 1);
+        ToPool = true;
+        return true;
+      }
+    }
+  }
+
+  updateStats(-1, 0);
+  ToPool = false;
+  return false;
+}
+
+SystemMemory &Bucket::getMemHandle() { return OwnAllocCtx.getMemHandle(); }
+
+size_t Bucket::SlabMinSize() { return OwnAllocCtx.getParams().SlabMinSize; }
+
+size_t Bucket::SlabAllocSize() { return std::max(getSize(), SlabMinSize()); }
+
+size_t Bucket::Capacity() {
+  // For buckets used in chunked mode, just one slab in pool is sufficient.
+  // For larger buckets, the capacity could be more and is adjustable.
+  if (getSize() <= ChunkCutOff())
+    return 1;
+  else
+    return OwnAllocCtx.getParams().Capacity;
+}
+
+size_t Bucket::MaxPoolableSize() {
+  return OwnAllocCtx.getParams().MaxPoolableSize;
+}
+
+size_t Bucket::ChunkCutOff() { return SlabMinSize() / 2; }
+
+void Bucket::countAlloc(bool FromPool) {
+  ++allocCount;
+  if (FromPool)
+    ++allocPoolCount;
+}
+
+void Bucket::countFree() { ++freeCount; }
+
+void Bucket::updateStats(int InUse, int InPool) {
+  if (OwnAllocCtx.getParams().PoolTrace == 0)
+    return;
+  currSlabsInUse += InUse;
+  maxSlabsInUse = std::max(currSlabsInUse, maxSlabsInUse);
+  currSlabsInPool += InPool;
+  maxSlabsInPool = std::max(currSlabsInPool, maxSlabsInPool);
+  // Increment or decrement current pool sizes based on whether
+  // slab was added to or removed from pool.
+  OwnAllocCtx.getParams().CurPoolSize += InPool * SlabAllocSize();
+}
+
+void Bucket::printStats(bool &TitlePrinted, const std::string &Label) {
+  if (allocCount) {
+    if (!TitlePrinted) {
+      std::cout << Label << " memory statistics\n";
+      std::cout << std::setw(14) << "Bucket Size" << std::setw(12) << "Allocs"
+                << std::setw(12) << "Frees" << std::setw(18)
+                << "Allocs from Pool" << std::setw(20) << "Peak Slabs in Use"
+                << std::setw(21) << "Peak Slabs in Pool" << std::endl;
+      TitlePrinted = true;
+    }
+    std::cout << std::setw(14) << getSize() << std::setw(12) << allocCount
+              << std::setw(12) << freeCount << std::setw(18) << allocPoolCount
+              << std::setw(20) << maxSlabsInUse << std::setw(21)
+              << maxSlabsInPool << std::endl;
+  }
+}
+
+void *USMAllocContext::USMAllocImpl::allocate(size_t Size, bool &FromPool) {
+  void *Ptr;
+
+  if (Size == 0)
+    return nullptr;
+
+  FromPool = false;
+  if (Size > getParams().MaxPoolableSize) {
+    return getMemHandle().allocate(Size);
+  }
+
+  auto &Bucket = findBucket(Size);
+
+  if (Size > Bucket.ChunkCutOff())
+    Ptr = Bucket.getSlab(FromPool);
+  else
+    Ptr = Bucket.getChunk(FromPool);
+
+  if (getParams().PoolTrace > 1)
+    Bucket.countAlloc(FromPool);
+
+  return Ptr;
+}
+
+void *USMAllocContext::USMAllocImpl::allocate(size_t Size, size_t Alignment,
+                                              bool &FromPool) {
+  void *Ptr;
+
+  if (Size == 0)
+    return nullptr;
+
+  if (Alignment <= 1)
+    return allocate(Size, FromPool);
+
+  size_t AlignedSize = (Size > 1) ? AlignUp(Size, Alignment) : Alignment;
+
+  // Check if requested allocation size is within pooling limit.
+  // If not, just request aligned pointer from the system.
+  FromPool = false;
+  if (AlignedSize > getParams().MaxPoolableSize) {
+    return getMemHandle().allocate(Size, Alignment);
+  }
+
+  auto &Bucket = findBucket(AlignedSize);
+
+  if (AlignedSize > Bucket.ChunkCutOff()) {
+    Ptr = Bucket.getSlab(FromPool);
+  } else {
+    Ptr = Bucket.getChunk(FromPool);
+  }
+
+  if (getParams().PoolTrace > 1)
+    Bucket.countAlloc(FromPool);
+
+  return AlignPtrUp(Ptr, Alignment);
+}
+
+Bucket &USMAllocContext::USMAllocImpl::findBucket(size_t Size) {
+  assert(Size <= CutOff && "Unexpected size");
+
+  auto It = std::find_if(
+      Buckets.begin(), Buckets.end(),
+      [Size](const auto &BucketPtr) { return BucketPtr->getSize() >= Size; });
+
+  assert((It != Buckets.end()) && "Bucket should always exist");
+
+  return *(*It);
+}
+
+void USMAllocContext::USMAllocImpl::deallocate(void *Ptr, bool &ToPool) {
+  auto *SlabPtr = AlignPtrDown(Ptr, SlabMinSize());
+
+  // Lock the map on read
+  std::shared_lock<std::shared_timed_mutex> Lk(getKnownSlabsMapLock());
+
+  ToPool = false;
+  auto Slabs = getKnownSlabs().equal_range(SlabPtr);
+  if (Slabs.first == Slabs.second) {
+    Lk.unlock();
+    getMemHandle().deallocate(Ptr);
+    return;
+  }
+
+  for (auto It = Slabs.first; It != Slabs.second; ++It) {
+    // The slab object won't be deleted until it's removed from the map which is
+    // protected by the lock, so it's safe to access it here.
+    auto &Slab = It->second;
+    if (Ptr >= Slab.getPtr() && Ptr < Slab.getEnd()) {
+      // Unlock the map before freeing the chunk, it may be locked on write
+      // there
+      Lk.unlock();
+      auto &Bucket = Slab.getBucket();
+
+      if (getParams().PoolTrace > 1)
+        Bucket.countFree();
+
+      if (Bucket.getSize() <= Bucket.ChunkCutOff()) {
+        Bucket.freeChunk(Ptr, Slab, ToPool);
+      } else {
+        Bucket.freeSlab(Slab, ToPool);
+      }
+
+      return;
+    }
+  }
+
+  Lk.unlock();
+  // There is a rare case when we have a pointer from system allocation next
+  // to some slab with an entry in the map. So we find a slab
+  // but the range checks fail.
+  getMemHandle().deallocate(Ptr);
+}
+
+USMAllocContext::USMAllocContext(std::unique_ptr<SystemMemory> MemHandle,
+                                 USMAllocatorParameters params)
+    : pImpl(std::make_unique<USMAllocImpl>(std::move(MemHandle), params)) {}
+
+void *USMAllocContext::allocate(size_t size) {
+  // For full-slab allocations indicates whether slab is from Pool.
+  bool FromPool;
+  auto Ptr = pImpl->allocate(size, FromPool);
+
+  if (pImpl->getParams().PoolTrace > 2) {
+    auto MT = pImpl->getParams().memoryTypeName;
+    std::cout << "Allocated " << std::setw(8) << size << " " << MT
+              << " USM bytes from " << (FromPool ? "Pool" : "USM") << " ->"
+              << Ptr << std::endl;
+  }
+  return Ptr;
+}
+
+void *USMAllocContext::allocate(size_t size, size_t alignment) {
+  bool FromPool;
+  auto Ptr = pImpl->allocate(size, alignment, FromPool);
+
+  if (pImpl->getParams().PoolTrace > 2) {
+    auto MT = pImpl->getParams().memoryTypeName;
+    std::cout << "Allocated " << std::setw(8) << size << " " << MT
+              << " USM bytes aligned at " << alignment << " from "
+              << (FromPool ? "Pool" : "USM") << " ->" << Ptr << std::endl;
+  }
+  return Ptr;
+}
+
+void USMAllocContext::deallocate(void *ptr) {
+  bool ToPool;
+  pImpl->deallocate(ptr, ToPool);
+
+  if (pImpl->getParams().PoolTrace > 2) {
+    auto MT = pImpl->getParams().memoryTypeName;
+    std::cout << "Freed " << MT << " USM " << ptr << " to "
+              << (ToPool ? "Pool" : "USM") << ", Current total pool size "
+              << pImpl->getParams().limits->TotalSize.load()
+              << ", Current pool size for " << MT << " "
+              << pImpl->getParams().CurPoolSize << "\n";
+  }
+  return;
+}
+
+// Define destructor for use with unique_ptr
+USMAllocContext::~USMAllocContext() {
+  bool TitlePrinted = false;
+  size_t HighBucketSize;
+  size_t HighPeakSlabsInUse;
+  if (pImpl->getParams().PoolTrace > 1) {
+    auto MT = pImpl->getParams().memoryTypeName;
+    pImpl->printStats(TitlePrinted, HighBucketSize, HighPeakSlabsInUse, MT);
+    if (TitlePrinted) {
+      try { // cannot throw in destructor
+        std::cout << "Current Pool Size "
+                  << pImpl->getParams().limits->TotalSize.load() << std::endl;
+        const char *Label = MT;
+        std::cout << "Suggested Setting: SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=;"
+                  << std::string(1, tolower(*Label)) << std::string(Label + 1)
+                  << ":" << HighBucketSize << "," << HighPeakSlabsInUse
+                  << ",64K" << std::endl;
+      } catch (...) { // ignore exceptions
+      }
+    }
+  }
+}
+
+void USMAllocContext::USMAllocImpl::printStats(bool &TitlePrinted,
+                                               size_t &HighBucketSize,
+                                               size_t &HighPeakSlabsInUse,
+                                               const std::string &MTName) {
+  HighBucketSize = 0;
+  HighPeakSlabsInUse = 0;
+  for (auto &B : Buckets) {
+    (*B).printStats(TitlePrinted, MTName);
+    HighPeakSlabsInUse = std::max((*B).maxSlabsInUse, HighPeakSlabsInUse);
+    if ((*B).allocCount)
+      HighBucketSize = std::max((*B).SlabAllocSize(), HighBucketSize);
+  }
+}

--- a/source/common/uma_pools/disjoint_pool.hpp
+++ b/source/common/uma_pools/disjoint_pool.hpp
@@ -12,66 +12,72 @@
 #include <atomic>
 #include <memory>
 
-// USM system memory allocation/deallocation interface.
-class SystemMemory {
-public:
-  virtual void *allocate(size_t size) = 0;
-  virtual void *allocate(size_t size, size_t aligned) = 0;
-  virtual void deallocate(void *ptr) = 0;
-  virtual ~SystemMemory() = default;
-};
+#include "../uma_helpers.hpp"
 
-class USMLimits {
-public:
-  // Maximum memory left unfreed
-  size_t MaxSize = 16 * 1024 * 1024;
-
-  // Total size of pooled memory
-  std::atomic<size_t> TotalSize = 0;
-};
+namespace usm {
 
 // Configuration for specific USM allocator instance
-class USMAllocatorParameters {
-public:
-  const char *memoryTypeName = "";
+class DisjointPoolConfig {
+  public:
+    DisjointPoolConfig();
 
-  // Minimum allocation size that will be requested from the system.
-  // By default this is the minimum allocation size of each memory type.
-  size_t SlabMinSize = 0;
+    std::string name = "";
 
-  // Allocations up to this limit will be subject to chunking/pooling
-  size_t MaxPoolableSize = 0;
+    struct SharedLimits {
+        SharedLimits() : TotalSize(0) {}
 
-  // When pooling, each bucket will hold a max of 4 unfreed slabs
-  size_t Capacity = 0;
+        // Maximum memory left unfreed
+        size_t MaxSize = 16 * 1024 * 1024;
 
-  // Holds the minimum bucket size valid for allocation of a memory type.
-  size_t MinBucketSize = 0;
+        // Total size of pooled memory
+        std::atomic<size_t> TotalSize;
+    };
 
-  // Holds size of the pool managed by the allocator.
-  size_t CurPoolSize = 0;
+    // Minimum allocation size that will be requested from the system.
+    // By default this is the minimum allocation size of each memory type.
+    size_t SlabMinSize = 0;
 
-  // Whether to print pool usage statistics
-  int PoolTrace = 0;
+    // Allocations up to this limit will be subject to chunking/pooling
+    size_t MaxPoolableSize = 0;
 
-  std::shared_ptr<USMLimits> limits;
+    // When pooling, each bucket will hold a max of 4 unfreed slabs
+    size_t Capacity = 0;
+
+    // Holds the minimum bucket size valid for allocation of a memory type.
+    size_t MinBucketSize = 0;
+
+    // Holds size of the pool managed by the allocator.
+    size_t CurPoolSize = 0;
+
+    // Whether to print pool usage statistics
+    int PoolTrace = 0;
+
+    std::shared_ptr<SharedLimits> limits;
 };
 
-class USMAllocContext {
-public:
-  // Keep it public since it needs to be accessed by the lower layer(Buckets)
-  class USMAllocImpl;
+class DisjointPool {
+  public:
+    class AllocImpl;
+    using Config = DisjointPoolConfig;
 
-  USMAllocContext(std::unique_ptr<SystemMemory> memHandle,
-                  USMAllocatorParameters params);
-  ~USMAllocContext();
+    uma_result_t initialize(uma_memory_provider_handle_t *providers,
+                            size_t numProviders,
+                            DisjointPoolConfig parameters) noexcept;
+    void *malloc(size_t size) noexcept;
+    void *calloc(size_t, size_t) noexcept;
+    void *realloc(void *, size_t) noexcept;
+    void *aligned_malloc(size_t size, size_t alignment) noexcept;
+    size_t malloc_usable_size(void *) noexcept;
+    void free(void *ptr) noexcept;
+    enum uma_result_t get_last_result(const char **ppMessage) noexcept;
 
-  void *allocate(size_t size);
-  void *allocate(size_t size, size_t alignment);
-  void deallocate(void *ptr);
+    DisjointPool();
+    ~DisjointPool();
 
-private:
-  std::unique_ptr<USMAllocImpl> pImpl;
+  private:
+    std::unique_ptr<AllocImpl> impl;
 };
+
+} // namespace usm
 
 #endif

--- a/source/common/uma_pools/disjoint_pool.hpp
+++ b/source/common/uma_pools/disjoint_pool.hpp
@@ -1,0 +1,77 @@
+//===---------- disjoint_pool.hpp - Allocator for USM memory --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef USM_ALLOCATOR
+#define USM_ALLOCATOR
+
+#include <atomic>
+#include <memory>
+
+// USM system memory allocation/deallocation interface.
+class SystemMemory {
+public:
+  virtual void *allocate(size_t size) = 0;
+  virtual void *allocate(size_t size, size_t aligned) = 0;
+  virtual void deallocate(void *ptr) = 0;
+  virtual ~SystemMemory() = default;
+};
+
+class USMLimits {
+public:
+  // Maximum memory left unfreed
+  size_t MaxSize = 16 * 1024 * 1024;
+
+  // Total size of pooled memory
+  std::atomic<size_t> TotalSize = 0;
+};
+
+// Configuration for specific USM allocator instance
+class USMAllocatorParameters {
+public:
+  const char *memoryTypeName = "";
+
+  // Minimum allocation size that will be requested from the system.
+  // By default this is the minimum allocation size of each memory type.
+  size_t SlabMinSize = 0;
+
+  // Allocations up to this limit will be subject to chunking/pooling
+  size_t MaxPoolableSize = 0;
+
+  // When pooling, each bucket will hold a max of 4 unfreed slabs
+  size_t Capacity = 0;
+
+  // Holds the minimum bucket size valid for allocation of a memory type.
+  size_t MinBucketSize = 0;
+
+  // Holds size of the pool managed by the allocator.
+  size_t CurPoolSize = 0;
+
+  // Whether to print pool usage statistics
+  int PoolTrace = 0;
+
+  std::shared_ptr<USMLimits> limits;
+};
+
+class USMAllocContext {
+public:
+  // Keep it public since it needs to be accessed by the lower layer(Buckets)
+  class USMAllocImpl;
+
+  USMAllocContext(std::unique_ptr<SystemMemory> memHandle,
+                  USMAllocatorParameters params);
+  ~USMAllocContext();
+
+  void *allocate(size_t size);
+  void *allocate(size_t size, size_t alignment);
+  void deallocate(void *ptr);
+
+private:
+  std::unique_ptr<USMAllocImpl> pImpl;
+};
+
+#endif

--- a/source/common/uma_pools/disjoint_pool_config.cpp
+++ b/source/common/uma_pools/disjoint_pool_config.cpp
@@ -1,4 +1,4 @@
-//===--- disjoint_pool_config.cpp -configuration for USM memory allocator---==//
+//===--- disjoint_pool_config.cpp -configuration for USM memory pool---------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,254 +12,259 @@
 #include <iostream>
 #include <string>
 
-namespace usm_settings {
-
+namespace usm {
 constexpr auto operator""_B(unsigned long long x) -> size_t { return x; }
 constexpr auto operator""_KB(unsigned long long x) -> size_t {
-  return x * 1024;
+    return x * 1024;
 }
 constexpr auto operator""_MB(unsigned long long x) -> size_t {
-  return x * 1024 * 1024;
+    return x * 1024 * 1024;
 }
 constexpr auto operator""_GB(unsigned long long x) -> size_t {
-  return x * 1024 * 1024 * 1024;
+    return x * 1024 * 1024 * 1024;
 }
 
-USMAllocatorConfig::USMAllocatorConfig() {
-  size_t i = 0;
-  for (auto &memoryTypeName : MemTypeNames) {
-    Configs[i++].memoryTypeName = memoryTypeName;
-  }
+DisjointPoolAllConfigs::DisjointPoolAllConfigs() {
+    Configs[DisjointPoolMemType::Host].name = "Host";
+    Configs[DisjointPoolMemType::Device].name = "Device";
+    Configs[DisjointPoolMemType::Shared].name = "Shared";
+    Configs[DisjointPoolMemType::SharedReadOnly].name = "SharedReadOnly";
 
-  // Buckets for Host use a minimum of the cache line size of 64 bytes.
-  // This prevents two separate allocations residing in the same cache line.
-  // Buckets for Device and Shared allocations will use starting size of 512.
-  // This is because memory compression on newer GPUs makes the
-  // minimum granularity 512 bytes instead of 64.
-  Configs[MemType::Host].MinBucketSize = 64;
-  Configs[MemType::Device].MinBucketSize = 512;
-  Configs[MemType::Shared].MinBucketSize = 512;
-  Configs[MemType::SharedReadOnly].MinBucketSize = 512;
+    // Buckets for Host use a minimum of the cache line size of 64 bytes.
+    // This prevents two separate allocations residing in the same cache line.
+    // Buckets for Device and Shared allocations will use starting size of 512.
+    // This is because memory compression on newer GPUs makes the
+    // minimum granularity 512 bytes instead of 64.
+    Configs[DisjointPoolMemType::Host].MinBucketSize = 64;
+    Configs[DisjointPoolMemType::Device].MinBucketSize = 512;
+    Configs[DisjointPoolMemType::Shared].MinBucketSize = 512;
+    Configs[DisjointPoolMemType::SharedReadOnly].MinBucketSize = 512;
 
-  // Initialize default pool settings.
-  Configs[MemType::Host].MaxPoolableSize = 2_MB;
-  Configs[MemType::Host].Capacity = 4;
-  Configs[MemType::Host].SlabMinSize = 64_KB;
+    // Initialize default pool settings.
+    Configs[DisjointPoolMemType::Host].MaxPoolableSize = 2_MB;
+    Configs[DisjointPoolMemType::Host].Capacity = 4;
+    Configs[DisjointPoolMemType::Host].SlabMinSize = 64_KB;
 
-  Configs[MemType::Device].MaxPoolableSize = 4_MB;
-  Configs[MemType::Device].Capacity = 4;
-  Configs[MemType::Device].SlabMinSize = 64_KB;
+    Configs[DisjointPoolMemType::Device].MaxPoolableSize = 4_MB;
+    Configs[DisjointPoolMemType::Device].Capacity = 4;
+    Configs[DisjointPoolMemType::Device].SlabMinSize = 64_KB;
 
-  // Disable pooling of shared USM allocations.
-  Configs[MemType::Shared].MaxPoolableSize = 0;
-  Configs[MemType::Shared].Capacity = 0;
-  Configs[MemType::Shared].SlabMinSize = 2_MB;
+    // Disable pooling of shared USM allocations.
+    Configs[DisjointPoolMemType::Shared].MaxPoolableSize = 0;
+    Configs[DisjointPoolMemType::Shared].Capacity = 0;
+    Configs[DisjointPoolMemType::Shared].SlabMinSize = 2_MB;
 
-  // Allow pooling of shared allocations that are only modified on host.
-  Configs[MemType::SharedReadOnly].MaxPoolableSize = 4_MB;
-  Configs[MemType::SharedReadOnly].Capacity = 4;
-  Configs[MemType::SharedReadOnly].SlabMinSize = 2_MB;
+    // Allow pooling of shared allocations that are only modified on host.
+    Configs[DisjointPoolMemType::SharedReadOnly].MaxPoolableSize = 4_MB;
+    Configs[DisjointPoolMemType::SharedReadOnly].Capacity = 4;
+    Configs[DisjointPoolMemType::SharedReadOnly].SlabMinSize = 2_MB;
+};
 
-  // Parse optional parameters of this form:
-  // SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=[EnableBuffers][;[MaxPoolSize][;memtypelimits]...]
-  //  memtypelimits: [<memtype>:]<limits>
-  //  memtype: host|device|shared
-  //  limits:  [MaxPoolableSize][,[Capacity][,SlabMinSize]]
-  //
-  // Without a memory type, the limits are applied to each memory type.
-  // Parameters are for each context, except MaxPoolSize, which is overall
-  // pool size for all contexts.
-  // Duplicate specifications will result in the right-most taking effect.
-  //
-  // EnableBuffers:   Apply chunking/pooling to SYCL buffers.
-  //                  Default 1.
-  // MaxPoolSize:     Limit on overall unfreed memory.
-  //                  Default 16MB.
-  // MaxPoolableSize: Maximum allocation size subject to chunking/pooling.
-  //                  Default 2MB host, 4MB device and 0 shared.
-  // Capacity:        Maximum number of unfreed allocations in each bucket.
-  //                  Default 4.
-  // SlabMinSize:     Minimum allocation size requested from USM.
-  //                  Default 64KB host and device, 2MB shared.
-  //
-  // Example of usage:
-  // SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=1;32M;host:1M,4,64K;device:1M,4,64K;shared:0,0,2M
+DisjointPoolAllConfigs parseDisjointPoolConfig(const std::string &config,
+                                               bool trace) {
+    DisjointPoolAllConfigs AllConfigs;
 
-  auto GetValue = [=](std::string &Param, size_t Length, size_t &Setting) {
-    size_t Multiplier = 1;
-    if (tolower(Param[Length - 1]) == 'k') {
-      Length--;
-      Multiplier = 1_KB;
-    }
-    if (tolower(Param[Length - 1]) == 'm') {
-      Length--;
-      Multiplier = 1_MB;
-    }
-    if (tolower(Param[Length - 1]) == 'g') {
-      Length--;
-      Multiplier = 1_GB;
-    }
-    std::string TheNumber = Param.substr(0, Length);
-    if (TheNumber.find_first_not_of("0123456789") == std::string::npos)
-      Setting = std::stoi(TheNumber) * Multiplier;
-  };
-
-  auto ParamParser = [=](std::string &Params, size_t &Setting,
-                         bool &ParamWasSet) {
-    bool More;
-    if (Params.size() == 0) {
-      ParamWasSet = false;
-      return false;
-    }
-    size_t Pos = Params.find(',');
-    if (Pos != std::string::npos) {
-      if (Pos > 0) {
-        GetValue(Params, Pos, Setting);
-        ParamWasSet = true;
-      }
-      Params.erase(0, Pos + 1);
-      More = true;
-    } else {
-      GetValue(Params, Params.size(), Setting);
-      ParamWasSet = true;
-      More = false;
-    }
-    return More;
-  };
-
-  auto MemParser = [=](std::string &Params, MemType M) {
-    bool ParamWasSet;
-    MemType LM = M;
-    if (M == MemType::All)
-      LM = MemType::Host;
-
-    bool More = ParamParser(Params, Configs[LM].MaxPoolableSize, ParamWasSet);
-    if (ParamWasSet && M == MemType::All) {
-      for (auto &Config : Configs) {
-        Config.MaxPoolableSize = Configs[LM].MaxPoolableSize;
-      }
-    }
-    if (More) {
-      More = ParamParser(Params, Configs[LM].Capacity, ParamWasSet);
-      if (ParamWasSet && M == MemType::All) {
-        for (auto &Config : Configs) {
-          Config.Capacity = Configs[LM].Capacity;
+    // TODO: replace with UR ENV var parser and avoid creating a copy of 'config'
+    auto GetValue = [](std::string &Param, size_t Length, size_t &Setting) {
+        size_t Multiplier = 1;
+        if (tolower(Param[Length - 1]) == 'k') {
+            Length--;
+            Multiplier = 1_KB;
         }
-      }
-    }
-    if (More) {
-      ParamParser(Params, Configs[LM].SlabMinSize, ParamWasSet);
-      if (ParamWasSet && M == MemType::All) {
-        for (auto &Config : Configs) {
-          Config.SlabMinSize = Configs[LM].SlabMinSize;
+        if (tolower(Param[Length - 1]) == 'm') {
+            Length--;
+            Multiplier = 1_MB;
         }
-      }
-    }
-  };
-
-  auto MemTypeParser = [=](std::string &Params) {
-    int Pos = 0;
-    MemType M = MemType::All;
-    if (Params.compare(0, 5, "host:") == 0) {
-      Pos = 5;
-      M = MemType::Host;
-    } else if (Params.compare(0, 7, "device:") == 0) {
-      Pos = 7;
-      M = MemType::Device;
-    } else if (Params.compare(0, 7, "shared:") == 0) {
-      Pos = 7;
-      M = MemType::Shared;
-    } else if (Params.compare(0, 17, "read_only_shared:") == 0) {
-      Pos = 17;
-      M = MemType::SharedReadOnly;
-    }
-    if (Pos > 0)
-      Params.erase(0, Pos);
-    MemParser(Params, M);
-  };
-
-  auto limits = std::make_shared<USMLimits>();
-
-  // Update pool settings if specified in environment.
-  char *PoolParams = getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR");
-  if (PoolParams != nullptr) {
-    std::string Params(PoolParams);
-    size_t Pos = Params.find(';');
-    if (Pos != std::string::npos) {
-      if (Pos > 0) {
-        GetValue(Params, Pos, EnableBuffers);
-      }
-      Params.erase(0, Pos + 1);
-      size_t Pos = Params.find(';');
-      if (Pos != std::string::npos) {
-        if (Pos > 0) {
-          GetValue(Params, Pos, limits->MaxSize);
+        if (tolower(Param[Length - 1]) == 'g') {
+            Length--;
+            Multiplier = 1_GB;
         }
-        Params.erase(0, Pos + 1);
-        do {
-          size_t Pos = Params.find(';');
-          if (Pos != std::string::npos) {
+        std::string TheNumber = Param.substr(0, Length);
+        if (TheNumber.find_first_not_of("0123456789") == std::string::npos) {
+            Setting = std::stoi(TheNumber) * Multiplier;
+        }
+    };
+
+    auto ParamParser = [GetValue](std::string &Params, size_t &Setting,
+                                  bool &ParamWasSet) {
+        bool More;
+        if (Params.size() == 0) {
+            ParamWasSet = false;
+            return false;
+        }
+        size_t Pos = Params.find(',');
+        if (Pos != std::string::npos) {
             if (Pos > 0) {
-              std::string MemParams = Params.substr(0, Pos);
-              MemTypeParser(MemParams);
+                GetValue(Params, Pos, Setting);
+                ParamWasSet = true;
             }
             Params.erase(0, Pos + 1);
-            if (Params.size() == 0)
-              break;
-          } else {
-            MemTypeParser(Params);
-            break;
-          }
-        } while (true);
-      } else {
-        // set MaxPoolSize for all configs
-        GetValue(Params, Params.size(), limits->MaxSize);
-      }
-    } else {
-      GetValue(Params, Params.size(), EnableBuffers);
+            More = true;
+        } else {
+            GetValue(Params, Params.size(), Setting);
+            ParamWasSet = true;
+            More = false;
+        }
+        return More;
+    };
+
+    auto MemParser = [&AllConfigs, ParamParser](std::string &Params,
+                                                DisjointPoolMemType memType =
+                                                    DisjointPoolMemType::All) {
+        bool ParamWasSet;
+        DisjointPoolMemType LM = memType;
+        if (memType == DisjointPoolMemType::All) {
+            LM = DisjointPoolMemType::Host;
+        }
+
+        bool More = ParamParser(Params, AllConfigs.Configs[LM].MaxPoolableSize,
+                                ParamWasSet);
+        if (ParamWasSet && memType == DisjointPoolMemType::All) {
+            for (auto &Config : AllConfigs.Configs) {
+                Config.MaxPoolableSize = AllConfigs.Configs[LM].MaxPoolableSize;
+            }
+        }
+        if (More) {
+            More = ParamParser(Params, AllConfigs.Configs[LM].Capacity,
+                               ParamWasSet);
+            if (ParamWasSet && memType == DisjointPoolMemType::All) {
+                for (auto &Config : AllConfigs.Configs) {
+                    Config.Capacity = AllConfigs.Configs[LM].Capacity;
+                }
+            }
+        }
+        if (More) {
+            ParamParser(Params, AllConfigs.Configs[LM].SlabMinSize,
+                        ParamWasSet);
+            if (ParamWasSet && memType == DisjointPoolMemType::All) {
+                for (auto &Config : AllConfigs.Configs) {
+                    Config.SlabMinSize = AllConfigs.Configs[LM].SlabMinSize;
+                }
+            }
+        }
+    };
+
+    auto MemTypeParser = [MemParser](std::string &Params) {
+        int Pos = 0;
+        DisjointPoolMemType M(DisjointPoolMemType::All);
+        if (Params.compare(0, 5, "host:") == 0) {
+            Pos = 5;
+            M = DisjointPoolMemType::Host;
+        } else if (Params.compare(0, 7, "device:") == 0) {
+            Pos = 7;
+            M = DisjointPoolMemType::Device;
+        } else if (Params.compare(0, 7, "shared:") == 0) {
+            Pos = 7;
+            M = DisjointPoolMemType::Shared;
+        } else if (Params.compare(0, 17, "read_only_shared:") == 0) {
+            Pos = 17;
+            M = DisjointPoolMemType::SharedReadOnly;
+        }
+        if (Pos > 0) {
+            Params.erase(0, Pos);
+        }
+        MemParser(Params, M);
+    };
+
+    auto limits = std::make_shared<DisjointPoolConfig::SharedLimits>();
+
+    // Update pool settings if specified in environment.
+    size_t EnableBuffers = 1;
+    if (config != "") {
+        std::string Params = config;
+        size_t Pos = Params.find(';');
+        if (Pos != std::string::npos) {
+            if (Pos > 0) {
+                GetValue(Params, Pos, EnableBuffers);
+            }
+            Params.erase(0, Pos + 1);
+            size_t Pos = Params.find(';');
+            if (Pos != std::string::npos) {
+                if (Pos > 0) {
+                    GetValue(Params, Pos, limits->MaxSize);
+                }
+                Params.erase(0, Pos + 1);
+                do {
+                    size_t Pos = Params.find(';');
+                    if (Pos != std::string::npos) {
+                        if (Pos > 0) {
+                            std::string MemParams = Params.substr(0, Pos);
+                            MemTypeParser(MemParams);
+                        }
+                        Params.erase(0, Pos + 1);
+                        if (Params.size() == 0) {
+                            break;
+                        }
+                    } else {
+                        MemTypeParser(Params);
+                        break;
+                    }
+                } while (true);
+            } else {
+                // set MaxPoolSize for all configs
+                GetValue(Params, Params.size(), limits->MaxSize);
+            }
+        } else {
+            GetValue(Params, Params.size(), EnableBuffers);
+        }
     }
-  }
 
-  char *PoolTraceVal = getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR_TRACE");
-  int PoolTrace = 0;
-  if (PoolTraceVal != nullptr) {
-    PoolTrace = std::atoi(PoolTraceVal);
-  }
+    for (auto &Config : AllConfigs.Configs) {
+        Config.limits = limits;
+        Config.PoolTrace = trace;
+    }
 
-  for (auto &Config : Configs) {
-    Config.limits = limits;
-    Config.PoolTrace = PoolTrace;
-  }
+    if (!EnableBuffers) {
+        return {};
+    }
 
-  if (PoolTrace < 1)
-    return;
+    if (!trace) {
+        return AllConfigs;
+    }
 
-  std::cout << "USM Pool Settings (Built-in or Adjusted by Environment "
-               "Variable)"
-            << std::endl;
+    std::cout << "USM Pool Settings (Built-in or Adjusted by Environment "
+                 "Variable)"
+              << std::endl;
 
-  std::cout << std::setw(15) << "Parameter" << std::setw(12) << "Host"
-            << std::setw(12) << "Device" << std::setw(12) << "Shared RW"
-            << std::setw(12) << "Shared RO" << std::endl;
-  std::cout << std::setw(15) << "SlabMinSize" << std::setw(12)
-            << Configs[MemType::Host].SlabMinSize << std::setw(12)
-            << Configs[MemType::Device].SlabMinSize << std::setw(12)
-            << Configs[MemType::Shared].SlabMinSize << std::setw(12)
-            << Configs[MemType::SharedReadOnly].SlabMinSize << std::endl;
-  std::cout << std::setw(15) << "MaxPoolableSize" << std::setw(12)
-            << Configs[MemType::Host].MaxPoolableSize << std::setw(12)
-            << Configs[MemType::Device].MaxPoolableSize << std::setw(12)
-            << Configs[MemType::Shared].MaxPoolableSize << std::setw(12)
-            << Configs[MemType::SharedReadOnly].MaxPoolableSize << std::endl;
-  std::cout << std::setw(15) << "Capacity" << std::setw(12)
-            << Configs[MemType::Host].Capacity << std::setw(12)
-            << Configs[MemType::Device].Capacity << std::setw(12)
-            << Configs[MemType::Shared].Capacity << std::setw(12)
-            << Configs[MemType::SharedReadOnly].Capacity << std::endl;
-  std::cout << std::setw(15) << "MaxPoolSize" << std::setw(12)
-            << limits->MaxSize << std::endl;
-  std::cout << std::setw(15) << "EnableBuffers" << std::setw(12)
-            << EnableBuffers << std::endl
-            << std::endl;
+    std::cout << std::setw(15) << "Parameter" << std::setw(12) << "Host"
+              << std::setw(12) << "Device" << std::setw(12) << "Shared RW"
+              << std::setw(12) << "Shared RO" << std::endl;
+    std::cout
+        << std::setw(15) << "SlabMinSize" << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::Host].SlabMinSize
+        << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::Device].SlabMinSize
+        << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::Shared].SlabMinSize
+        << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::SharedReadOnly].SlabMinSize
+        << std::endl;
+    std::cout << std::setw(15) << "MaxPoolableSize" << std::setw(12)
+              << AllConfigs.Configs[DisjointPoolMemType::Host].MaxPoolableSize
+              << std::setw(12)
+              << AllConfigs.Configs[DisjointPoolMemType::Device].MaxPoolableSize
+              << std::setw(12)
+              << AllConfigs.Configs[DisjointPoolMemType::Shared].MaxPoolableSize
+              << std::setw(12)
+              << AllConfigs.Configs[DisjointPoolMemType::SharedReadOnly]
+                     .MaxPoolableSize
+              << std::endl;
+    std::cout
+        << std::setw(15) << "Capacity" << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::Host].Capacity
+        << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::Device].Capacity
+        << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::Shared].Capacity
+        << std::setw(12)
+        << AllConfigs.Configs[DisjointPoolMemType::SharedReadOnly].Capacity
+        << std::endl;
+    std::cout << std::setw(15) << "MaxPoolSize" << std::setw(12)
+              << limits->MaxSize << std::endl;
+    std::cout << std::setw(15) << "EnableBuffers" << std::setw(12)
+              << EnableBuffers << std::endl
+              << std::endl;
+
+    return AllConfigs;
 }
-} // namespace usm_settings
+} // namespace usm

--- a/source/common/uma_pools/disjoint_pool_config.cpp
+++ b/source/common/uma_pools/disjoint_pool_config.cpp
@@ -1,0 +1,265 @@
+//===--- disjoint_pool_config.cpp -configuration for USM memory allocator---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "disjoint_pool_config.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+namespace usm_settings {
+
+constexpr auto operator""_B(unsigned long long x) -> size_t { return x; }
+constexpr auto operator""_KB(unsigned long long x) -> size_t {
+  return x * 1024;
+}
+constexpr auto operator""_MB(unsigned long long x) -> size_t {
+  return x * 1024 * 1024;
+}
+constexpr auto operator""_GB(unsigned long long x) -> size_t {
+  return x * 1024 * 1024 * 1024;
+}
+
+USMAllocatorConfig::USMAllocatorConfig() {
+  size_t i = 0;
+  for (auto &memoryTypeName : MemTypeNames) {
+    Configs[i++].memoryTypeName = memoryTypeName;
+  }
+
+  // Buckets for Host use a minimum of the cache line size of 64 bytes.
+  // This prevents two separate allocations residing in the same cache line.
+  // Buckets for Device and Shared allocations will use starting size of 512.
+  // This is because memory compression on newer GPUs makes the
+  // minimum granularity 512 bytes instead of 64.
+  Configs[MemType::Host].MinBucketSize = 64;
+  Configs[MemType::Device].MinBucketSize = 512;
+  Configs[MemType::Shared].MinBucketSize = 512;
+  Configs[MemType::SharedReadOnly].MinBucketSize = 512;
+
+  // Initialize default pool settings.
+  Configs[MemType::Host].MaxPoolableSize = 2_MB;
+  Configs[MemType::Host].Capacity = 4;
+  Configs[MemType::Host].SlabMinSize = 64_KB;
+
+  Configs[MemType::Device].MaxPoolableSize = 4_MB;
+  Configs[MemType::Device].Capacity = 4;
+  Configs[MemType::Device].SlabMinSize = 64_KB;
+
+  // Disable pooling of shared USM allocations.
+  Configs[MemType::Shared].MaxPoolableSize = 0;
+  Configs[MemType::Shared].Capacity = 0;
+  Configs[MemType::Shared].SlabMinSize = 2_MB;
+
+  // Allow pooling of shared allocations that are only modified on host.
+  Configs[MemType::SharedReadOnly].MaxPoolableSize = 4_MB;
+  Configs[MemType::SharedReadOnly].Capacity = 4;
+  Configs[MemType::SharedReadOnly].SlabMinSize = 2_MB;
+
+  // Parse optional parameters of this form:
+  // SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=[EnableBuffers][;[MaxPoolSize][;memtypelimits]...]
+  //  memtypelimits: [<memtype>:]<limits>
+  //  memtype: host|device|shared
+  //  limits:  [MaxPoolableSize][,[Capacity][,SlabMinSize]]
+  //
+  // Without a memory type, the limits are applied to each memory type.
+  // Parameters are for each context, except MaxPoolSize, which is overall
+  // pool size for all contexts.
+  // Duplicate specifications will result in the right-most taking effect.
+  //
+  // EnableBuffers:   Apply chunking/pooling to SYCL buffers.
+  //                  Default 1.
+  // MaxPoolSize:     Limit on overall unfreed memory.
+  //                  Default 16MB.
+  // MaxPoolableSize: Maximum allocation size subject to chunking/pooling.
+  //                  Default 2MB host, 4MB device and 0 shared.
+  // Capacity:        Maximum number of unfreed allocations in each bucket.
+  //                  Default 4.
+  // SlabMinSize:     Minimum allocation size requested from USM.
+  //                  Default 64KB host and device, 2MB shared.
+  //
+  // Example of usage:
+  // SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=1;32M;host:1M,4,64K;device:1M,4,64K;shared:0,0,2M
+
+  auto GetValue = [=](std::string &Param, size_t Length, size_t &Setting) {
+    size_t Multiplier = 1;
+    if (tolower(Param[Length - 1]) == 'k') {
+      Length--;
+      Multiplier = 1_KB;
+    }
+    if (tolower(Param[Length - 1]) == 'm') {
+      Length--;
+      Multiplier = 1_MB;
+    }
+    if (tolower(Param[Length - 1]) == 'g') {
+      Length--;
+      Multiplier = 1_GB;
+    }
+    std::string TheNumber = Param.substr(0, Length);
+    if (TheNumber.find_first_not_of("0123456789") == std::string::npos)
+      Setting = std::stoi(TheNumber) * Multiplier;
+  };
+
+  auto ParamParser = [=](std::string &Params, size_t &Setting,
+                         bool &ParamWasSet) {
+    bool More;
+    if (Params.size() == 0) {
+      ParamWasSet = false;
+      return false;
+    }
+    size_t Pos = Params.find(',');
+    if (Pos != std::string::npos) {
+      if (Pos > 0) {
+        GetValue(Params, Pos, Setting);
+        ParamWasSet = true;
+      }
+      Params.erase(0, Pos + 1);
+      More = true;
+    } else {
+      GetValue(Params, Params.size(), Setting);
+      ParamWasSet = true;
+      More = false;
+    }
+    return More;
+  };
+
+  auto MemParser = [=](std::string &Params, MemType M) {
+    bool ParamWasSet;
+    MemType LM = M;
+    if (M == MemType::All)
+      LM = MemType::Host;
+
+    bool More = ParamParser(Params, Configs[LM].MaxPoolableSize, ParamWasSet);
+    if (ParamWasSet && M == MemType::All) {
+      for (auto &Config : Configs) {
+        Config.MaxPoolableSize = Configs[LM].MaxPoolableSize;
+      }
+    }
+    if (More) {
+      More = ParamParser(Params, Configs[LM].Capacity, ParamWasSet);
+      if (ParamWasSet && M == MemType::All) {
+        for (auto &Config : Configs) {
+          Config.Capacity = Configs[LM].Capacity;
+        }
+      }
+    }
+    if (More) {
+      ParamParser(Params, Configs[LM].SlabMinSize, ParamWasSet);
+      if (ParamWasSet && M == MemType::All) {
+        for (auto &Config : Configs) {
+          Config.SlabMinSize = Configs[LM].SlabMinSize;
+        }
+      }
+    }
+  };
+
+  auto MemTypeParser = [=](std::string &Params) {
+    int Pos = 0;
+    MemType M = MemType::All;
+    if (Params.compare(0, 5, "host:") == 0) {
+      Pos = 5;
+      M = MemType::Host;
+    } else if (Params.compare(0, 7, "device:") == 0) {
+      Pos = 7;
+      M = MemType::Device;
+    } else if (Params.compare(0, 7, "shared:") == 0) {
+      Pos = 7;
+      M = MemType::Shared;
+    } else if (Params.compare(0, 17, "read_only_shared:") == 0) {
+      Pos = 17;
+      M = MemType::SharedReadOnly;
+    }
+    if (Pos > 0)
+      Params.erase(0, Pos);
+    MemParser(Params, M);
+  };
+
+  auto limits = std::make_shared<USMLimits>();
+
+  // Update pool settings if specified in environment.
+  char *PoolParams = getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR");
+  if (PoolParams != nullptr) {
+    std::string Params(PoolParams);
+    size_t Pos = Params.find(';');
+    if (Pos != std::string::npos) {
+      if (Pos > 0) {
+        GetValue(Params, Pos, EnableBuffers);
+      }
+      Params.erase(0, Pos + 1);
+      size_t Pos = Params.find(';');
+      if (Pos != std::string::npos) {
+        if (Pos > 0) {
+          GetValue(Params, Pos, limits->MaxSize);
+        }
+        Params.erase(0, Pos + 1);
+        do {
+          size_t Pos = Params.find(';');
+          if (Pos != std::string::npos) {
+            if (Pos > 0) {
+              std::string MemParams = Params.substr(0, Pos);
+              MemTypeParser(MemParams);
+            }
+            Params.erase(0, Pos + 1);
+            if (Params.size() == 0)
+              break;
+          } else {
+            MemTypeParser(Params);
+            break;
+          }
+        } while (true);
+      } else {
+        // set MaxPoolSize for all configs
+        GetValue(Params, Params.size(), limits->MaxSize);
+      }
+    } else {
+      GetValue(Params, Params.size(), EnableBuffers);
+    }
+  }
+
+  char *PoolTraceVal = getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR_TRACE");
+  int PoolTrace = 0;
+  if (PoolTraceVal != nullptr) {
+    PoolTrace = std::atoi(PoolTraceVal);
+  }
+
+  for (auto &Config : Configs) {
+    Config.limits = limits;
+    Config.PoolTrace = PoolTrace;
+  }
+
+  if (PoolTrace < 1)
+    return;
+
+  std::cout << "USM Pool Settings (Built-in or Adjusted by Environment "
+               "Variable)"
+            << std::endl;
+
+  std::cout << std::setw(15) << "Parameter" << std::setw(12) << "Host"
+            << std::setw(12) << "Device" << std::setw(12) << "Shared RW"
+            << std::setw(12) << "Shared RO" << std::endl;
+  std::cout << std::setw(15) << "SlabMinSize" << std::setw(12)
+            << Configs[MemType::Host].SlabMinSize << std::setw(12)
+            << Configs[MemType::Device].SlabMinSize << std::setw(12)
+            << Configs[MemType::Shared].SlabMinSize << std::setw(12)
+            << Configs[MemType::SharedReadOnly].SlabMinSize << std::endl;
+  std::cout << std::setw(15) << "MaxPoolableSize" << std::setw(12)
+            << Configs[MemType::Host].MaxPoolableSize << std::setw(12)
+            << Configs[MemType::Device].MaxPoolableSize << std::setw(12)
+            << Configs[MemType::Shared].MaxPoolableSize << std::setw(12)
+            << Configs[MemType::SharedReadOnly].MaxPoolableSize << std::endl;
+  std::cout << std::setw(15) << "Capacity" << std::setw(12)
+            << Configs[MemType::Host].Capacity << std::setw(12)
+            << Configs[MemType::Device].Capacity << std::setw(12)
+            << Configs[MemType::Shared].Capacity << std::setw(12)
+            << Configs[MemType::SharedReadOnly].Capacity << std::endl;
+  std::cout << std::setw(15) << "MaxPoolSize" << std::setw(12)
+            << limits->MaxSize << std::endl;
+  std::cout << std::setw(15) << "EnableBuffers" << std::setw(12)
+            << EnableBuffers << std::endl
+            << std::endl;
+}
+} // namespace usm_settings

--- a/source/common/uma_pools/disjoint_pool_config.hpp
+++ b/source/common/uma_pools/disjoint_pool_config.hpp
@@ -1,0 +1,35 @@
+//===--- disjoint_pool_config.hpp -configuration for USM memory allocator---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef USM_ALLOCATOR_CONFIG
+#define USM_ALLOCATOR_CONFIG
+
+#include "disjoint_pool.hpp"
+
+#include <string>
+
+namespace usm_settings {
+
+enum MemType { Host, Device, Shared, SharedReadOnly, All };
+
+// Reads and stores configuration for all instances of USM allocator
+class USMAllocatorConfig {
+public:
+  size_t EnableBuffers = 1;
+
+  USMAllocatorParameters Configs[MemType::All];
+
+  // String names of memory types for printing in limits traces.
+  static constexpr const char *MemTypeNames[MemType::All] = {
+      "Host", "Device", "Shared", "SharedReadOnly"};
+
+  USMAllocatorConfig();
+};
+} // namespace usm_settings
+
+#endif

--- a/test/unified_memory_allocation/CMakeLists.txt
+++ b/test/unified_memory_allocation/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(uma_test_helpers STATIC
     ${UR_UMA_TEST_DIR}/common/provider.c
 )
 
-target_link_libraries(uma_test_helpers PRIVATE ${PROJECT_NAME}::unified_memory_allocation)
+target_link_libraries(uma_test_helpers PRIVATE ${PROJECT_NAME}::common)
 
 function(add_uma_test name)
     set(TEST_TARGET_NAME uma_test-${name})
@@ -29,6 +29,8 @@ function(add_uma_test name)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(uma-${name} PROPERTIES LABELS "uma")
 endfunction()
+
+add_subdirectory(uma_pools)
 
 add_uma_test(memoryProvider memoryProviderAPI.cpp)
 add_uma_test(memoryPool memoryPoolAPI.cpp)

--- a/test/unified_memory_allocation/common/pool.hpp
+++ b/test/unified_memory_allocation/common/pool.hpp
@@ -52,7 +52,7 @@ struct malloc_pool : public pool_base {
     }
     void *aligned_malloc(size_t size, size_t alignment) noexcept {
 #ifdef _WIN32
-        // we could use _aligned_alloc but it requires using _aligned_free...
+        // we could use _aligned_malloc but it requires using _aligned_free...
         return nullptr;
 #else
         return ::aligned_alloc(alignment, size);

--- a/test/unified_memory_allocation/common/provider.h
+++ b/test/unified_memory_allocation/common/provider.h
@@ -16,6 +16,7 @@ uma_memory_provider_handle_t nullProviderCreate(void);
 uma_memory_provider_handle_t
 traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
                     void (*trace)(const char *));
+uma_memory_provider_handle_t mallocProviderCreate(void);
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -60,16 +60,20 @@ struct provider_malloc : public provider_base {
         }
 
 #ifdef _WIN32
-        // we could use _aligned_alloc but it requires using _aligned_free...
-        return UMA_RESULT_ERROR_INVALID_ARGUMENT;
+        *ptr = _aligned_malloc(size, align);
 #else
         *ptr = ::aligned_alloc(align, size);
+#endif
+
         return (*ptr) ? UMA_RESULT_SUCCESS
                       : UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-#endif
     }
     enum uma_result_t free(void *ptr, size_t) noexcept {
+#ifdef _WIN32
+        _aligned_free(ptr);
+#else
         ::free(ptr);
+#endif
         return UMA_RESULT_SUCCESS;
     }
 };

--- a/test/unified_memory_allocation/memoryPool.hpp
+++ b/test/unified_memory_allocation/memoryPool.hpp
@@ -64,14 +64,23 @@ TEST_P(umaPoolTest, pow2AlignedAlloc) {
 #endif
 
     static constexpr size_t maxAlignment = (1u << 22);
+    static constexpr size_t numAllocs = 4;
 
     for (size_t alignment = 1; alignment <= maxAlignment; alignment <<= 1) {
         std::cout << alignment << std::endl;
-        auto *ptr = umaPoolAlignedMalloc(pool.get(), alignment, alignment);
-        ASSERT_NE(ptr, nullptr);
-        ASSERT_TRUE(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
-        std::memset(ptr, 0, alignment);
-        umaPoolFree(pool.get(), ptr);
+        std::vector<void *> allocs;
+
+        for (size_t alloc = 0; alloc < numAllocs; alloc++) {
+            auto *ptr = umaPoolAlignedMalloc(pool.get(), alignment, alignment);
+            ASSERT_NE(ptr, nullptr);
+            ASSERT_TRUE(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
+            std::memset(ptr, 0, alignment);
+            allocs.push_back(ptr);
+        }
+
+        for (auto &ptr : allocs) {
+            umaPoolFree(pool.get(), ptr);
+        }
     }
 }
 

--- a/test/unified_memory_allocation/uma_pools/CMakeLists.txt
+++ b/test/unified_memory_allocation/uma_pools/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (C) 2022-2023 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_uma_test(disjointPool disjoint_pool.cpp)
+target_include_directories(uma_test-disjointPool PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(uma_test-disjointPool PRIVATE ${PROJECT_NAME}::common)

--- a/test/unified_memory_allocation/uma_pools/disjoint_pool.cpp
+++ b/test/unified_memory_allocation/uma_pools/disjoint_pool.cpp
@@ -14,8 +14,8 @@
 #include "provider.h"
 #include "provider.hpp"
 
-static DisjointPool::Config poolConfig() {
-    DisjointPool::Config config{};
+static usm::DisjointPool::Config poolConfig() {
+    usm::DisjointPool::Config config{};
     config.SlabMinSize = 4096;
     config.MaxPoolableSize = 4096;
     config.Capacity = 4;
@@ -28,7 +28,8 @@ static auto makePool() {
         uma::memoryProviderMakeUnique<uma_test::provider_malloc>().second;
     auto provider = providerUnique.release();
     auto pool =
-        uma::poolMakeUnique<DisjointPool>(&provider, 1, poolConfig()).second;
+        uma::poolMakeUnique<usm::DisjointPool>(&provider, 1, poolConfig())
+            .second;
     auto dtor = [provider = provider](uma_memory_pool_handle_t hPool) {
         umaPoolDestroy(hPool);
         umaMemoryProviderDestroy(provider);

--- a/test/unified_memory_allocation/uma_pools/disjoint_pool.cpp
+++ b/test/unified_memory_allocation/uma_pools/disjoint_pool.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include "disjoint_pool.hpp"
+
+#include "memoryPool.hpp"
+#include "provider.h"
+#include "provider.hpp"
+
+static DisjointPool::Config poolConfig() {
+    DisjointPool::Config config{};
+    config.SlabMinSize = 4096;
+    config.MaxPoolableSize = 4096;
+    config.Capacity = 4;
+    config.MinBucketSize = 64;
+    return config;
+}
+
+static auto makePool() {
+    auto providerUnique =
+        uma::memoryProviderMakeUnique<uma_test::provider_malloc>().second;
+    auto provider = providerUnique.release();
+    auto pool =
+        uma::poolMakeUnique<DisjointPool>(&provider, 1, poolConfig()).second;
+    auto dtor = [provider = provider](uma_memory_pool_handle_t hPool) {
+        umaPoolDestroy(hPool);
+        umaMemoryProviderDestroy(provider);
+    };
+    return uma::pool_unique_handle_t(pool.release(), std::move(dtor));
+}
+
+INSTANTIATE_TEST_SUITE_P(disjointPoolTests, umaPoolTest,
+                         ::testing::Values(makePool));
+
+INSTANTIATE_TEST_SUITE_P(disjointMultiPoolTests, umaMultiPoolTest,
+                         ::testing::Values(makePool));

--- a/test/usm/CMakeLists.txt
+++ b/test/usm/CMakeLists.txt
@@ -25,3 +25,4 @@ function(add_usm_test name)
 endfunction()
 
 add_usm_test(usmPoolManager usmPoolManager.cpp)
+add_usm_test(disjointPoolConfig disjoint_pool_config.cpp)

--- a/test/usm/disjoint_pool_config.cpp
+++ b/test/usm/disjoint_pool_config.cpp
@@ -1,0 +1,314 @@
+// Copyright (C) 2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <uur/fixtures.h>
+
+#include "disjoint_pool_config.hpp"
+
+class disjointPoolConfigTests : public testing::TestWithParam<std::string> {
+  protected:
+    const int hostMaxPoolableSizeDefault = 2 * 1024 * 1024;
+    const int hostCapacityDefault = 4;
+    const int hostSlabMinSizeDefault = 64 * 1024;
+
+    const int deviceMaxPoolableSizeDefault = 4 * 1024 * 1024;
+    const int deviceCapacityDefault = 4;
+    const int deviceSlabMinSizeDefault = 64 * 1024;
+
+    const int sharedMaxPoolableSizeDefault = 0;
+    const int sharedCapacityDefault = 0;
+    const int sharedSlabMinSizeDefault = 2 * 1024 * 1024;
+
+    const int readOnlySharedMaxPoolableSizeDefault = 4 * 1024 * 1024;
+    const int readOnlySharedCapacityDefault = 4;
+    const int readOnlySharedSlabMinSizeDefault = 2 * 1024 * 1024;
+
+    const int maxSizeDefault = 16 * 1024 * 1024;
+};
+
+// invalid configs for which descriptors' parameters should be set to default values
+INSTANTIATE_TEST_SUITE_P(
+    configsForDefaultValues, disjointPoolConfigTests,
+    testing::Values("", "ab12cdefghi34jk56lmn78opr910",
+                    "1;32M;foo:0,3,2m;device:1M,4,64k",
+                    "132M;host:4m,3,2m,4m;device:1M,4,64k",
+                    "1;32M;abdc123;;;device:1M,4,64k",
+                    "1;32M;host:0,3,2m,4;device:1M,4,64k,5;host:1,8,4m,100",
+                    "32M;1;host:1M,4,64k;device:1m,4,64K;shared:0,3,1M"));
+
+TEST_F(disjointPoolConfigTests, disjointPoolConfigStringEnabledBuffersTest) {
+    // test for valid string with enabled buffers-- (values to configs should be
+    // parsed from string)
+    std::string config = "1;32M;host:1M,3,32k;device:1m,2,32m;shared:2m,3,1M;"
+                         "read_only_shared:0,0,3M";
+    auto allConfigs = usm::parseDisjointPoolConfig(config);
+
+    // test for host
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].MaxPoolableSize,
+        1 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].Capacity, 3);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].SlabMinSize,
+              32 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for device
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].MaxPoolableSize,
+        1 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].Capacity, 2);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].SlabMinSize,
+              32 * 1024 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for shared
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].MaxPoolableSize,
+        2 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].Capacity, 3);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].SlabMinSize,
+              1 * 1024 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for read-only shared
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .MaxPoolableSize,
+              0);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly].Capacity,
+        0);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .SlabMinSize,
+              3 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .limits->MaxSize,
+              32 * 1024 * 1024);
+}
+
+TEST_F(disjointPoolConfigTests,
+       disjointPoolConfigStringImpartialEnabledBuffersTest) {
+    // test for valid impartial string with enabled buffers-- (values to configs should be
+    // parsed from string if present, the rest should be default
+    // set by getConfigurationsFor)
+    std::string config = "1;32M;host:1M,2,16k;shared:64k,3,1M;";
+    auto allConfigs = usm::parseDisjointPoolConfig(config);
+
+    // test for host
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].MaxPoolableSize,
+        1 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].Capacity, 2);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].SlabMinSize,
+              16 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for device
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].MaxPoolableSize,
+        deviceMaxPoolableSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].Capacity,
+              deviceCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].SlabMinSize,
+              deviceSlabMinSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for shared
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].MaxPoolableSize,
+        64 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].Capacity, 3);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].SlabMinSize,
+              1 * 1024 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for read-only shared
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .MaxPoolableSize,
+              readOnlySharedMaxPoolableSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly].Capacity,
+        readOnlySharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .SlabMinSize,
+              readOnlySharedSlabMinSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .limits->MaxSize,
+              32 * 1024 * 1024);
+}
+
+TEST_P(disjointPoolConfigTests, disjointPoolConfigInvalid) {
+    std::string config = GetParam();
+    auto allConfigs = usm::parseDisjointPoolConfig(config);
+
+    // test for host
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].MaxPoolableSize,
+        hostMaxPoolableSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].Capacity,
+              hostCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].SlabMinSize,
+              hostSlabMinSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].limits->MaxSize,
+        maxSizeDefault);
+
+    // test for device
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].MaxPoolableSize,
+        deviceMaxPoolableSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].Capacity,
+              deviceCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].SlabMinSize,
+              deviceSlabMinSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].limits->MaxSize,
+        maxSizeDefault);
+
+    // test for shared
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].MaxPoolableSize,
+        sharedMaxPoolableSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].Capacity,
+              sharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].SlabMinSize,
+              sharedSlabMinSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].limits->MaxSize,
+        maxSizeDefault);
+
+    // test for read-only shared
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .MaxPoolableSize,
+              readOnlySharedMaxPoolableSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly].Capacity,
+        readOnlySharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .SlabMinSize,
+              readOnlySharedSlabMinSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .limits->MaxSize,
+              maxSizeDefault);
+}
+
+TEST_F(disjointPoolConfigTests, disjointPoolConfigStringInvalidEnabledBuffers) {
+    // test for a string with invalid parameter for EnabledBuffers--
+    // (it should be set to a default)
+    std::string config = "-5;32M;host:0,3,32k,4m;device:1M,2,32m";
+    auto allConfigs = usm::parseDisjointPoolConfig(config);
+
+    // test for host
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].MaxPoolableSize, 0);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].Capacity, 3);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].SlabMinSize,
+              32 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for device
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].MaxPoolableSize,
+        1 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].Capacity, 2);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].SlabMinSize,
+              32 * 1024 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for shared
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].MaxPoolableSize,
+        sharedMaxPoolableSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].Capacity,
+              sharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].SlabMinSize,
+              sharedSlabMinSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for read-only shared
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .MaxPoolableSize,
+              readOnlySharedMaxPoolableSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly].Capacity,
+        readOnlySharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .SlabMinSize,
+              readOnlySharedSlabMinSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .limits->MaxSize,
+              32 * 1024 * 1024);
+}
+
+TEST_F(disjointPoolConfigTests, disjointPoolConfigStringTooManyParameters) {
+    // test for when too many parameters are passed-- (the extra parameters
+    // should be ignored)
+    std::string config = "1;32M;host:0,3,2m,4;device:1M,5,32k,5";
+    auto allConfigs = usm::parseDisjointPoolConfig(config);
+
+    // test for host
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].MaxPoolableSize, 0);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].Capacity, 3);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Host].SlabMinSize,
+              2 * 1024 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Host].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for device
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].MaxPoolableSize,
+        1 * 1024 * 1024);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].Capacity, 5);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Device].SlabMinSize,
+              32 * 1024);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Device].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for shared
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].MaxPoolableSize,
+        sharedMaxPoolableSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].Capacity,
+              sharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::Shared].SlabMinSize,
+              sharedSlabMinSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::Shared].limits->MaxSize,
+        32 * 1024 * 1024);
+
+    // test for read-only shared
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .MaxPoolableSize,
+              readOnlySharedMaxPoolableSizeDefault);
+    ASSERT_EQ(
+        allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly].Capacity,
+        readOnlySharedCapacityDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .SlabMinSize,
+              readOnlySharedSlabMinSizeDefault);
+    ASSERT_EQ(allConfigs.Configs[usm::DisjointPoolMemType::SharedReadOnly]
+                  .limits->MaxSize,
+              32 * 1024 * 1024);
+}


### PR DESCRIPTION
This PR moves usm_allocator implementation from intel/llvm repo.
"[ur] Remove OwnZeMemHandle from USMAllocator]" is cherry-picked from: https://github.com/intel/llvm/pull/7853

Remaining commits implement the UMA memory pool.

I wasn't sure what to do with the licence. I left the original one for usm_allocator for now. LLVM files are under Apache license and the UR code is under MIT. @kbenzie @pbalcer should we keep the original license and just remove the mention that those file are part of llvm project?