### PR TITLE
[uma] Extend umaPoolGetLastResult description

### DIFF
--- a/source/common/unified_memory_allocation/include/uma/memory_pool.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool.h
@@ -90,7 +90,8 @@ void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr);
 ///
 /// \brief Retrieve string representation of the underlying pool specific
 ///        result reported by the last API that returned
-///        UMA_RESULT_ERROR_POOL_SPECIFIC. Allows for a pool independent way to
+///        UMA_RESULT_ERROR_POOL_SPECIFIC or NULL ptr (in case of allocation
+///        functions). Allows for a pool independent way to
 ///        return a pool specific result.
 ///
 /// \details


### PR DESCRIPTION
for pool. This function can also be used if an allocation function returns NULL.