### PR TITLE
Add urEventRetain and urEventRelease tests

### DIFF
--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -1,0 +1,50 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// SPDX-License-Identifier: MIT
+
+#ifndef UR_CONFORMANCE_EVENT_FIXTURES_H_INCLUDED
+#define UR_CONFORMANCE_EVENT_FIXTURES_H_INCLUDED
+
+#include <uur/fixtures.h>
+
+namespace uur {
+namespace event {
+
+/**
+ * Test fixture that is intended to be used when testing reference count APIs
+ * (i.e. urEventRelease and urEventRetain). Does not handle destruction of the
+ * event.
+ */
+struct urEventReferenceTest : uur::urQueueTest {
+
+    void CreateEvent() {
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &buffer));
+
+        input.assign(count, 42);
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(
+            queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
+    }
+
+    void checkEventReferenceCount(uint32_t expected_value) {
+        uint32_t reference_count{};
+        urEventGetInfo(event, ur_event_info_t::UR_EVENT_INFO_REFERENCE_COUNT,
+                       sizeof(uint32_t), &reference_count, nullptr);
+        ASSERT_EQ(reference_count, expected_value);
+    }
+
+    void Cleanup() {
+        if (buffer) {
+            EXPECT_SUCCESS(urMemRelease(buffer));
+        }
+    }
+
+    const size_t count = 1024;
+    const size_t size = sizeof(uint32_t) * count;
+    ur_mem_handle_t buffer = nullptr;
+    ur_event_handle_t event = nullptr;
+    std::vector<uint32_t> input;
+};
+} // namespace event
+} // namespace uur
+
+#endif // UR_CONFORMANCE_EVENT_FIXTURES_H_INCLUDED

--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -16,7 +16,8 @@ namespace event {
  */
 struct urEventReferenceTest : uur::urQueueTest {
 
-    void CreateEvent() {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
                                          nullptr, &buffer));
 
@@ -25,17 +26,18 @@ struct urEventReferenceTest : uur::urQueueTest {
             queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
     }
 
-    void checkEventReferenceCount(uint32_t expected_value) {
-        uint32_t reference_count{};
-        urEventGetInfo(event, ur_event_info_t::UR_EVENT_INFO_REFERENCE_COUNT,
-                       sizeof(uint32_t), &reference_count, nullptr);
-        ASSERT_EQ(reference_count, expected_value);
-    }
-
-    void Cleanup() {
+    void TearDown() override {
         if (buffer) {
             EXPECT_SUCCESS(urMemRelease(buffer));
         }
+        urQueueTest::TearDown();
+    }
+
+    bool checkEventReferenceCount(uint32_t expected_value) {
+        uint32_t reference_count{};
+        urEventGetInfo(event, ur_event_info_t::UR_EVENT_INFO_REFERENCE_COUNT,
+                       sizeof(uint32_t), &reference_count, nullptr);
+        return reference_count == expected_value;
     }
 
     const size_t count = 1024;

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -1,2 +1,35 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: MIT
+
+#include "fixtures.h"
+
+using urEventReleaseTest = uur::event::urEventReferenceTest;
+
+/* Check that urEventRelease returns Success */
+TEST_P(urEventReleaseTest, Success) {
+    ASSERT_NO_FATAL_FAILURE(CreateEvent());
+    ASSERT_SUCCESS(urEventRelease(event));
+    EXPECT_NO_FATAL_FAILURE(Cleanup());
+}
+
+/* Check that urEventRelease decrements the reference count*/
+TEST_P(urEventReleaseTest, CheckReferenceCount) {
+    ASSERT_NO_FATAL_FAILURE(CreateEvent());
+    ASSERT_SUCCESS(urEventRetain(event));
+    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(2));
+    ASSERT_SUCCESS(urEventRelease(event));
+    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(1));
+    ASSERT_SUCCESS(urEventRelease(event));
+    EXPECT_NO_FATAL_FAILURE(Cleanup());
+}
+
+TEST_P(urEventReleaseTest, InvalidNullHandle) {
+    ASSERT_EQ(urEventRelease(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urEventReleaseTest, InvalidEvent) {
+    ur_event_handle_t event{};
+    ASSERT_EQ(urEventRelease(event), UR_RESULT_ERROR_INVALID_EVENT);
+}
+
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseTest);

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -6,30 +6,22 @@
 using urEventReleaseTest = uur::event::urEventReferenceTest;
 
 /* Check that urEventRelease returns Success */
-TEST_P(urEventReleaseTest, Success) {
-    ASSERT_NO_FATAL_FAILURE(CreateEvent());
-    ASSERT_SUCCESS(urEventRelease(event));
-    EXPECT_NO_FATAL_FAILURE(Cleanup());
-}
+TEST_P(urEventReleaseTest, Success) { ASSERT_SUCCESS(urEventRelease(event)); }
 
 /* Check that urEventRelease decrements the reference count*/
 TEST_P(urEventReleaseTest, CheckReferenceCount) {
-    ASSERT_NO_FATAL_FAILURE(CreateEvent());
     ASSERT_SUCCESS(urEventRetain(event));
-    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(2));
+    ASSERT_TRUE(checkEventReferenceCount(2));
     ASSERT_SUCCESS(urEventRelease(event));
-    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(1));
+    ASSERT_TRUE(checkEventReferenceCount(1));
     ASSERT_SUCCESS(urEventRelease(event));
-    EXPECT_NO_FATAL_FAILURE(Cleanup());
 }
 
-TEST_P(urEventReleaseTest, InvalidNullHandle) {
+using urEventReleaseNegativeTest = uur::urQueueTest;
+
+TEST_P(urEventReleaseNegativeTest, InvalidNullHandle) {
     ASSERT_EQ(urEventRelease(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
-TEST_P(urEventReleaseTest, InvalidEvent) {
-    ur_event_handle_t event{};
-    ASSERT_EQ(urEventRelease(event), UR_RESULT_ERROR_INVALID_EVENT);
-}
-
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseNegativeTest);

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -7,32 +7,25 @@ using urEventRetainTest = uur::event::urEventReferenceTest;
 
 /* Check that urEventRetain returns Success */
 TEST_P(urEventRetainTest, Success) {
-    ASSERT_NO_FATAL_FAILURE(CreateEvent());
     ASSERT_SUCCESS(urEventRetain(event));
     ASSERT_SUCCESS(urEventRelease(event));
     ASSERT_SUCCESS(urEventRelease(event));
-    EXPECT_NO_FATAL_FAILURE(Cleanup());
 }
 
 /* Check that urEventRetain increments the reference count */
 TEST_P(urEventRetainTest, CheckReferenceCount) {
-
-    ASSERT_NO_FATAL_FAILURE(CreateEvent());
-    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(1));
+    ASSERT_TRUE(checkEventReferenceCount(1));
     ASSERT_SUCCESS(urEventRetain(event));
-    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(2));
+    ASSERT_TRUE(checkEventReferenceCount(2));
     ASSERT_SUCCESS(urEventRelease(event));
     ASSERT_SUCCESS(urEventRelease(event));
-    EXPECT_NO_FATAL_FAILURE(Cleanup());
 }
 
-TEST_P(urEventRetainTest, InvalidNullHandle) {
+using urEventRetainNegativeTest = uur::urQueueTest;
+
+TEST_P(urEventRetainNegativeTest, InvalidNullHandle) {
     ASSERT_EQ(urEventRetain(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
-TEST_P(urEventRetainTest, InvalidEvent) {
-    ur_event_handle_t event{};
-    ASSERT_EQ(urEventRetain(event), UR_RESULT_ERROR_INVALID_EVENT);
-}
-
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainNegativeTest);

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -1,2 +1,38 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: MIT
+
+#include "fixtures.h"
+
+using urEventRetainTest = uur::event::urEventReferenceTest;
+
+/* Check that urEventRetain returns Success */
+TEST_P(urEventRetainTest, Success) {
+    ASSERT_NO_FATAL_FAILURE(CreateEvent());
+    ASSERT_SUCCESS(urEventRetain(event));
+    ASSERT_SUCCESS(urEventRelease(event));
+    ASSERT_SUCCESS(urEventRelease(event));
+    EXPECT_NO_FATAL_FAILURE(Cleanup());
+}
+
+/* Check that urEventRetain increments the reference count */
+TEST_P(urEventRetainTest, CheckReferenceCount) {
+
+    ASSERT_NO_FATAL_FAILURE(CreateEvent());
+    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(1));
+    ASSERT_SUCCESS(urEventRetain(event));
+    ASSERT_NO_FATAL_FAILURE(checkEventReferenceCount(2));
+    ASSERT_SUCCESS(urEventRelease(event));
+    ASSERT_SUCCESS(urEventRelease(event));
+    EXPECT_NO_FATAL_FAILURE(Cleanup());
+}
+
+TEST_P(urEventRetainTest, InvalidNullHandle) {
+    ASSERT_EQ(urEventRetain(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urEventRetainTest, InvalidEvent) {
+    ur_event_handle_t event{};
+    ASSERT_EQ(urEventRetain(event), UR_RESULT_ERROR_INVALID_EVENT);
+}
+
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainTest);

--- a/test/conformance/event/urEventWait.cpp
+++ b/test/conformance/event/urEventWait.cpp
@@ -4,7 +4,7 @@
 #include <uur/fixtures.h>
 
 struct urEventWaitTest : uur::urQueueTest {
-    void WriteSourceBuffer() {
+    void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
                                          nullptr, &src_buffer));
@@ -17,7 +17,7 @@ struct urEventWaitTest : uur::urQueueTest {
         ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
-    void Cleanup() {
+    void TearDown() override {
         if (src_buffer) {
             EXPECT_SUCCESS(urMemRelease(src_buffer));
         }
@@ -40,7 +40,6 @@ struct urEventWaitTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitTest);
 
 TEST_P(urEventWaitTest, Success) {
-    ASSERT_NO_FATAL_FAILURE(WriteSourceBuffer());
     ur_event_handle_t event1 = nullptr;
     ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
                                           size, 0, nullptr, &event1));
@@ -56,14 +55,17 @@ TEST_P(urEventWaitTest, Success) {
 
     EXPECT_SUCCESS(urEventRelease(event1));
     EXPECT_SUCCESS(urEventRelease(event2));
-    EXPECT_NO_FATAL_FAILURE(Cleanup());
 }
 
-TEST_P(urEventWaitTest, ZeroSize) {
+using urEventWaitNegativeTest = uur::urQueueTest;
+
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitNegativeTest);
+
+TEST_P(urEventWaitNegativeTest, ZeroSize) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE, urEventWait(0, nullptr));
 }
 
-TEST_P(urEventWaitTest, InvalidNullPointerEventList) {
+TEST_P(urEventWaitNegativeTest, InvalidNullPointerEventList) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                      urEventWait(1, nullptr));
 }

--- a/test/conformance/event/urEventWait.cpp
+++ b/test/conformance/event/urEventWait.cpp
@@ -4,7 +4,7 @@
 #include <uur/fixtures.h>
 
 struct urEventWaitTest : uur::urQueueTest {
-    void SetUp() override {
+    void WriteSourceBuffer() {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
                                          nullptr, &src_buffer));
@@ -17,7 +17,7 @@ struct urEventWaitTest : uur::urQueueTest {
         ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
-    void TearDown() override {
+    void Cleanup() {
         if (src_buffer) {
             EXPECT_SUCCESS(urMemRelease(src_buffer));
         }
@@ -40,6 +40,7 @@ struct urEventWaitTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitTest);
 
 TEST_P(urEventWaitTest, Success) {
+    ASSERT_NO_FATAL_FAILURE(WriteSourceBuffer());
     ur_event_handle_t event1 = nullptr;
     ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
                                           size, 0, nullptr, &event1));
@@ -55,6 +56,7 @@ TEST_P(urEventWaitTest, Success) {
 
     EXPECT_SUCCESS(urEventRelease(event1));
     EXPECT_SUCCESS(urEventRelease(event2));
+    EXPECT_NO_FATAL_FAILURE(Cleanup());
 }
 
 TEST_P(urEventWaitTest, ZeroSize) {


### PR DESCRIPTION
Add urEventRetain and urEventRelease tests 
Update urEventWait tests to avoid allocating buffer when running negative tests

Addresses issue https://github.com/oneapi-src/unified-runtime/issues/215