### PR TITLE
[ur] Add return code for nullptr function pointers

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -481,12 +481,12 @@ typedef void (ur_context_extended_deleter_t)(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pUserData`
+///         + `NULL == pfnDeleter`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextSetExtendedDeleter(
     ur_context_handle_t hContext,                   ///< [in] handle of the context.
     ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
-    void* pUserData                                 ///< [in][out] pointer to data to be passed to callback.
+    void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
     );
 
 #if !defined(__GNUC__)
@@ -1757,6 +1757,8 @@ typedef void (ur_event_callback_t)(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnNotify`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventSetCallback(
     ur_event_handle_t hEvent,                       ///< [in] handle of the event object

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -203,4 +203,4 @@ params:
             [in] Function pointer to extended deleter.
     - type: void*
       name: pUserData
-      desc: "[in][out] pointer to data to be passed to callback."
+      desc: "[in][out][optional] pointer to data to be passed to callback."

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -666,6 +666,9 @@ def _generate_returns(obj, meta):
                 if type_traits.is_pointer(item['type']):
                     _append(rets, "$X_RESULT_ERROR_INVALID_NULL_POINTER", "`NULL == %s`"%item['name'])
 
+                elif type_traits.is_funcptr(item['type'], meta):
+                    _append(rets, "$X_RESULT_ERROR_INVALID_NULL_POINTER", "`NULL == %s`"%item['name'])
+
                 elif type_traits.is_handle(item['type']) and not type_traits.is_ipc_handle(item['type']):
                     _append(rets, "$X_RESULT_ERROR_INVALID_NULL_HANDLE", "`NULL == %s`"%item['name'])
 

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -160,6 +160,10 @@ class type_traits:
             return False
         except:
             return False
+    
+    @staticmethod
+    def is_funcptr(name, meta):
+        return name in meta['fptr_typedef']
 
     @staticmethod
     def is_struct(name, meta):

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -173,7 +173,7 @@ namespace driver
     urContextSetExtendedDeleter(
         ur_context_handle_t hContext,                   ///< [in] handle of the context.
         ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
-        void* pUserData                                 ///< [in][out] pointer to data to be passed to callback.
+        void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -231,7 +231,7 @@ namespace loader
     urContextSetExtendedDeleter(
         ur_context_handle_t hContext,                   ///< [in] handle of the context.
         ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
-        void* pUserData                                 ///< [in][out] pointer to data to be passed to callback.
+        void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
         )
     {
         ur_result_t result = UR_RESULT_SUCCESS;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -239,12 +239,12 @@ urContextCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pUserData`
+///         + `NULL == pfnDeleter`
 ur_result_t UR_APICALL
 urContextSetExtendedDeleter(
     ur_context_handle_t hContext,                   ///< [in] handle of the context.
     ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
-    void* pUserData                                 ///< [in][out] pointer to data to be passed to callback.
+    void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
     )
 {
     auto pfnSetExtendedDeleter = ur_lib::context->urDdiTable.Context.pfnSetExtendedDeleter;
@@ -1601,6 +1601,8 @@ urEventCreateWithNativeHandle(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnNotify`
 ur_result_t UR_APICALL
 urEventSetCallback(
     ur_event_handle_t hEvent,                       ///< [in] handle of the event object

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -218,12 +218,12 @@ urContextCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pUserData`
+///         + `NULL == pfnDeleter`
 ur_result_t UR_APICALL
 urContextSetExtendedDeleter(
     ur_context_handle_t hContext,                   ///< [in] handle of the context.
     ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
-    void* pUserData                                 ///< [in][out] pointer to data to be passed to callback.
+    void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
     )
 {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1484,6 +1484,8 @@ urEventCreateWithNativeHandle(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnNotify`
 ur_result_t UR_APICALL
 urEventSetCallback(
     ur_event_handle_t hEvent,                       ///< [in] handle of the event object


### PR DESCRIPTION
For entry points `urContextSetExtendedDeleter` and `urEventSetCallback` they accept a function pointer. We should clarify that the spec expects these values to not be null and if so return the appropriate error code.

Additionally the userdata parameter should be optional in `urContextSetExtendedDeleter` - this was already the case is `urEventSetCallback`.