### PR TITLE
[ur] Clarify some device return codes

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -140,56 +140,58 @@ class ur_result_v(IntEnum):
     ERROR_DEVICE_LOST = 21                          ## Device hung, reset, was removed, or driver update occurred
     ERROR_DEVICE_REQUIRES_RESET = 22                ## Device requires a reset
     ERROR_DEVICE_IN_LOW_POWER_STATE = 23            ## Device currently in low power state
-    ERROR_INVALID_WORK_ITEM_SIZE = 24               ## Invalid work item size
-    ERROR_INVALID_WORK_DIMENSION = 25               ## Invalid work dimension
-    ERROR_INVALID_KERNEL_ARGS = 26                  ## Invalid kernel args
-    ERROR_INVALID_KERNEL = 27                       ## Invalid kernel
-    ERROR_INVALID_KERNEL_NAME = 28                  ## [Validation] kernel name is not found in the module
-    ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 29        ## [Validation] kernel argument index is not valid for kernel
-    ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 30         ## [Validation] kernel argument size does not match kernel
-    ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 31       ## [Validation] value of kernel attribute is not valid for the kernel or
+    ERROR_DEVICE_PARTITION_FAILED = 24              ## Device paritioning failed
+    ERROR_INVALID_DEVICE_PARTITION_COUNT = 25       ## Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
+    ERROR_INVALID_WORK_ITEM_SIZE = 26               ## Invalid work item size
+    ERROR_INVALID_WORK_DIMENSION = 27               ## Invalid work dimension
+    ERROR_INVALID_KERNEL_ARGS = 28                  ## Invalid kernel args
+    ERROR_INVALID_KERNEL = 29                       ## Invalid kernel
+    ERROR_INVALID_KERNEL_NAME = 30                  ## [Validation] kernel name is not found in the module
+    ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 31        ## [Validation] kernel argument index is not valid for kernel
+    ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 32         ## [Validation] kernel argument size does not match kernel
+    ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 33       ## [Validation] value of kernel attribute is not valid for the kernel or
                                                     ## device
-    ERROR_INVALID_IMAGE_SIZE = 32                   ## Invalid image size
-    ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 33      ## Invalid image format descriptor
-    ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 34           ## Image format not supported
-    ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 35        ## Memory object allocation failure
-    ERROR_INVALID_PROGRAM_EXECUTABLE = 36           ## Program object parameter is invalid.
-    ERROR_UNINITIALIZED = 37                        ## [Validation] driver is not initialized
-    ERROR_OUT_OF_HOST_MEMORY = 38                   ## Insufficient host memory to satisfy call
-    ERROR_OUT_OF_DEVICE_MEMORY = 39                 ## Insufficient device memory to satisfy call
-    ERROR_OUT_OF_RESOURCES = 40                     ## Out of resources
-    ERROR_MODULE_BUILD_FAILURE = 41                 ## Error occurred when building module, see build log for details
-    ERROR_MODULE_LINK_FAILURE = 42                  ## Error occurred when linking modules, see build log for details
-    ERROR_UNSUPPORTED_VERSION = 43                  ## [Validation] generic error code for unsupported versions
-    ERROR_UNSUPPORTED_FEATURE = 44                  ## [Validation] generic error code for unsupported features
-    ERROR_INVALID_ARGUMENT = 45                     ## [Validation] generic error code for invalid arguments
-    ERROR_INVALID_NULL_HANDLE = 46                  ## [Validation] handle argument is not valid
-    ERROR_HANDLE_OBJECT_IN_USE = 47                 ## [Validation] object pointed to by handle still in-use by device
-    ERROR_INVALID_NULL_POINTER = 48                 ## [Validation] pointer argument may not be nullptr
-    ERROR_INVALID_SIZE = 49                         ## [Validation] size argument is invalid (e.g., must not be zero)
-    ERROR_UNSUPPORTED_SIZE = 50                     ## [Validation] size argument is not supported by the device (e.g., too
+    ERROR_INVALID_IMAGE_SIZE = 34                   ## Invalid image size
+    ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 35      ## Invalid image format descriptor
+    ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 36           ## Image format not supported
+    ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 37        ## Memory object allocation failure
+    ERROR_INVALID_PROGRAM_EXECUTABLE = 38           ## Program object parameter is invalid.
+    ERROR_UNINITIALIZED = 39                        ## [Validation] driver is not initialized
+    ERROR_OUT_OF_HOST_MEMORY = 40                   ## Insufficient host memory to satisfy call
+    ERROR_OUT_OF_DEVICE_MEMORY = 41                 ## Insufficient device memory to satisfy call
+    ERROR_OUT_OF_RESOURCES = 42                     ## Out of resources
+    ERROR_MODULE_BUILD_FAILURE = 43                 ## Error occurred when building module, see build log for details
+    ERROR_MODULE_LINK_FAILURE = 44                  ## Error occurred when linking modules, see build log for details
+    ERROR_UNSUPPORTED_VERSION = 45                  ## [Validation] generic error code for unsupported versions
+    ERROR_UNSUPPORTED_FEATURE = 46                  ## [Validation] generic error code for unsupported features
+    ERROR_INVALID_ARGUMENT = 47                     ## [Validation] generic error code for invalid arguments
+    ERROR_INVALID_NULL_HANDLE = 48                  ## [Validation] handle argument is not valid
+    ERROR_HANDLE_OBJECT_IN_USE = 49                 ## [Validation] object pointed to by handle still in-use by device
+    ERROR_INVALID_NULL_POINTER = 50                 ## [Validation] pointer argument may not be nullptr
+    ERROR_INVALID_SIZE = 51                         ## [Validation] size argument is invalid (e.g., must not be zero)
+    ERROR_UNSUPPORTED_SIZE = 52                     ## [Validation] size argument is not supported by the device (e.g., too
                                                     ## large)
-    ERROR_UNSUPPORTED_ALIGNMENT = 51                ## [Validation] alignment argument is not supported by the device (e.g.,
+    ERROR_UNSUPPORTED_ALIGNMENT = 53                ## [Validation] alignment argument is not supported by the device (e.g.,
                                                     ## too small)
-    ERROR_INVALID_SYNCHRONIZATION_OBJECT = 52       ## [Validation] synchronization object in invalid state
-    ERROR_INVALID_ENUMERATION = 53                  ## [Validation] enumerator argument is not valid
-    ERROR_UNSUPPORTED_ENUMERATION = 54              ## [Validation] enumerator argument is not supported by the device
-    ERROR_UNSUPPORTED_IMAGE_FORMAT = 55             ## [Validation] image format is not supported by the device
-    ERROR_INVALID_NATIVE_BINARY = 56                ## [Validation] native binary is not supported by the device
-    ERROR_INVALID_GLOBAL_NAME = 57                  ## [Validation] global variable is not found in the module
-    ERROR_INVALID_FUNCTION_NAME = 58                ## [Validation] function name is not found in the module
-    ERROR_INVALID_GROUP_SIZE_DIMENSION = 59         ## [Validation] group size dimension is not valid for the kernel or
+    ERROR_INVALID_SYNCHRONIZATION_OBJECT = 54       ## [Validation] synchronization object in invalid state
+    ERROR_INVALID_ENUMERATION = 55                  ## [Validation] enumerator argument is not valid
+    ERROR_UNSUPPORTED_ENUMERATION = 56              ## [Validation] enumerator argument is not supported by the device
+    ERROR_UNSUPPORTED_IMAGE_FORMAT = 57             ## [Validation] image format is not supported by the device
+    ERROR_INVALID_NATIVE_BINARY = 58                ## [Validation] native binary is not supported by the device
+    ERROR_INVALID_GLOBAL_NAME = 59                  ## [Validation] global variable is not found in the module
+    ERROR_INVALID_FUNCTION_NAME = 60                ## [Validation] function name is not found in the module
+    ERROR_INVALID_GROUP_SIZE_DIMENSION = 61         ## [Validation] group size dimension is not valid for the kernel or
                                                     ## device
-    ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 60       ## [Validation] global width dimension is not valid for the kernel or
+    ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 62       ## [Validation] global width dimension is not valid for the kernel or
                                                     ## device
-    ERROR_MODULE_UNLINKED = 61                      ## [Validation] module with imports needs to be linked before kernels can
+    ERROR_MODULE_UNLINKED = 63                      ## [Validation] module with imports needs to be linked before kernels can
                                                     ## be created from it.
-    ERROR_OVERLAPPING_REGIONS = 62                  ## [Validation] copy operations do not support overlapping regions of
+    ERROR_OVERLAPPING_REGIONS = 64                  ## [Validation] copy operations do not support overlapping regions of
                                                     ## memory
-    ERROR_INVALID_HOST_PTR = 63                     ## Invalid host pointer
-    ERROR_INVALID_USM_SIZE = 64                     ## Invalid USM size
-    ERROR_OBJECT_ALLOCATION_FAILURE = 65            ## Objection allocation failure
-    ERROR_ADAPTER_SPECIFIC = 66                     ## An adapter specific warning/error has been reported and can be
+    ERROR_INVALID_HOST_PTR = 65                     ## Invalid host pointer
+    ERROR_INVALID_USM_SIZE = 66                     ## Invalid USM size
+    ERROR_OBJECT_ALLOCATION_FAILURE = 67            ## Objection allocation failure
+    ERROR_ADAPTER_SPECIFIC = 68                     ## An adapter specific warning/error has been reported and can be
                                                     ## retrieved via the urGetLastResult entry point.
     ERROR_UNKNOWN = 0x7ffffffe                      ## Unknown or internal error
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -164,56 +164,58 @@ typedef enum ur_result_t
     UR_RESULT_ERROR_DEVICE_LOST = 21,               ///< Device hung, reset, was removed, or driver update occurred
     UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 22,     ///< Device requires a reset
     UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 23, ///< Device currently in low power state
-    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 24,    ///< Invalid work item size
-    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 25,    ///< Invalid work dimension
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 26,       ///< Invalid kernel args
-    UR_RESULT_ERROR_INVALID_KERNEL = 27,            ///< Invalid kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 28,       ///< [Validation] kernel name is not found in the module
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 29, ///< [Validation] kernel argument index is not valid for kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 30,  ///< [Validation] kernel argument size does not match kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 31,///< [Validation] value of kernel attribute is not valid for the kernel or
+    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 24,   ///< Device paritioning failed
+    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 25,///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
+    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 26,    ///< Invalid work item size
+    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 27,    ///< Invalid work dimension
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 28,       ///< Invalid kernel args
+    UR_RESULT_ERROR_INVALID_KERNEL = 29,            ///< Invalid kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 30,       ///< [Validation] kernel name is not found in the module
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 31, ///< [Validation] kernel argument index is not valid for kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 32,  ///< [Validation] kernel argument size does not match kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 33,///< [Validation] value of kernel attribute is not valid for the kernel or
                                                     ///< device
-    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 32,        ///< Invalid image size
-    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 33,   ///< Invalid image format descriptor
-    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 34,///< Image format not supported
-    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 35, ///< Memory object allocation failure
-    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 36,///< Program object parameter is invalid.
-    UR_RESULT_ERROR_UNINITIALIZED = 37,             ///< [Validation] driver is not initialized
-    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 38,        ///< Insufficient host memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 39,      ///< Insufficient device memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_RESOURCES = 40,          ///< Out of resources
-    UR_RESULT_ERROR_MODULE_BUILD_FAILURE = 41,      ///< Error occurred when building module, see build log for details
-    UR_RESULT_ERROR_MODULE_LINK_FAILURE = 42,       ///< Error occurred when linking modules, see build log for details
-    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 43,       ///< [Validation] generic error code for unsupported versions
-    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 44,       ///< [Validation] generic error code for unsupported features
-    UR_RESULT_ERROR_INVALID_ARGUMENT = 45,          ///< [Validation] generic error code for invalid arguments
-    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 46,       ///< [Validation] handle argument is not valid
-    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 47,      ///< [Validation] object pointed to by handle still in-use by device
-    UR_RESULT_ERROR_INVALID_NULL_POINTER = 48,      ///< [Validation] pointer argument may not be nullptr
-    UR_RESULT_ERROR_INVALID_SIZE = 49,              ///< [Validation] size argument is invalid (e.g., must not be zero)
-    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 50,          ///< [Validation] size argument is not supported by the device (e.g., too
+    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 34,        ///< Invalid image size
+    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 35,   ///< Invalid image format descriptor
+    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 36,///< Image format not supported
+    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 37, ///< Memory object allocation failure
+    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 38,///< Program object parameter is invalid.
+    UR_RESULT_ERROR_UNINITIALIZED = 39,             ///< [Validation] driver is not initialized
+    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 40,        ///< Insufficient host memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 41,      ///< Insufficient device memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_RESOURCES = 42,          ///< Out of resources
+    UR_RESULT_ERROR_MODULE_BUILD_FAILURE = 43,      ///< Error occurred when building module, see build log for details
+    UR_RESULT_ERROR_MODULE_LINK_FAILURE = 44,       ///< Error occurred when linking modules, see build log for details
+    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 45,       ///< [Validation] generic error code for unsupported versions
+    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 46,       ///< [Validation] generic error code for unsupported features
+    UR_RESULT_ERROR_INVALID_ARGUMENT = 47,          ///< [Validation] generic error code for invalid arguments
+    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 48,       ///< [Validation] handle argument is not valid
+    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 49,      ///< [Validation] object pointed to by handle still in-use by device
+    UR_RESULT_ERROR_INVALID_NULL_POINTER = 50,      ///< [Validation] pointer argument may not be nullptr
+    UR_RESULT_ERROR_INVALID_SIZE = 51,              ///< [Validation] size argument is invalid (e.g., must not be zero)
+    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 52,          ///< [Validation] size argument is not supported by the device (e.g., too
                                                     ///< large)
-    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 51,     ///< [Validation] alignment argument is not supported by the device (e.g.,
+    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 53,     ///< [Validation] alignment argument is not supported by the device (e.g.,
                                                     ///< too small)
-    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 52,///< [Validation] synchronization object in invalid state
-    UR_RESULT_ERROR_INVALID_ENUMERATION = 53,       ///< [Validation] enumerator argument is not valid
-    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 54,   ///< [Validation] enumerator argument is not supported by the device
-    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 55,  ///< [Validation] image format is not supported by the device
-    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 56,     ///< [Validation] native binary is not supported by the device
-    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 57,       ///< [Validation] global variable is not found in the module
-    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 58,     ///< [Validation] function name is not found in the module
-    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 59,  ///< [Validation] group size dimension is not valid for the kernel or
+    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 54,///< [Validation] synchronization object in invalid state
+    UR_RESULT_ERROR_INVALID_ENUMERATION = 55,       ///< [Validation] enumerator argument is not valid
+    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 56,   ///< [Validation] enumerator argument is not supported by the device
+    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 57,  ///< [Validation] image format is not supported by the device
+    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 58,     ///< [Validation] native binary is not supported by the device
+    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 59,       ///< [Validation] global variable is not found in the module
+    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 60,     ///< [Validation] function name is not found in the module
+    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 61,  ///< [Validation] group size dimension is not valid for the kernel or
                                                     ///< device
-    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 60,///< [Validation] global width dimension is not valid for the kernel or
+    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 62,///< [Validation] global width dimension is not valid for the kernel or
                                                     ///< device
-    UR_RESULT_ERROR_MODULE_UNLINKED = 61,           ///< [Validation] module with imports needs to be linked before kernels can
+    UR_RESULT_ERROR_MODULE_UNLINKED = 63,           ///< [Validation] module with imports needs to be linked before kernels can
                                                     ///< be created from it.
-    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 62,       ///< [Validation] copy operations do not support overlapping regions of
+    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 64,       ///< [Validation] copy operations do not support overlapping regions of
                                                     ///< memory
-    UR_RESULT_ERROR_INVALID_HOST_PTR = 63,          ///< Invalid host pointer
-    UR_RESULT_ERROR_INVALID_USM_SIZE = 64,          ///< Invalid USM size
-    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 65, ///< Objection allocation failure
-    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 66,          ///< An adapter specific warning/error has been reported and can be
+    UR_RESULT_ERROR_INVALID_HOST_PTR = 65,          ///< Invalid host pointer
+    UR_RESULT_ERROR_INVALID_USM_SIZE = 66,          ///< Invalid USM size
+    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 67, ///< Objection allocation failure
+    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 68,          ///< An adapter specific warning/error has been reported and can be
                                                     ///< retrieved via the urGetLastResult entry point.
     UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,           ///< Unknown or internal error
     UR_RESULT_FORCE_UINT32 = 0x7fffffff
@@ -2913,14 +2915,14 @@ typedef enum ur_device_type_t
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGet(
     ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
     uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
                                                     ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
                                                     ///< will be returned.
     ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
                                                     ///< If NumEntries is less than the number of devices available, then
@@ -3074,6 +3076,7 @@ typedef enum ur_device_info_t
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES < infoType`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetInfo(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
@@ -3082,7 +3085,7 @@ urDeviceGetInfo(
     void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
                                                     ///< If propSize is not equal to or greater than the real number of bytes
                                                     ///< needed to return the info
-                                                    ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
                                                     ///< pDeviceInfo is not used.
     size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
     );
@@ -3177,6 +3180,8 @@ typedef enum ur_device_partition_t
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pProperties`
+///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 UR_APIEXPORT ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
@@ -3212,12 +3217,14 @@ urDevicePartition(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceSelectBinary(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
     const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
-                                                    ///< equal to zero.
+    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. 
+                                                    ///< Must greater than or equal to zero otherwise
+                                                    ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
                                                     ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
     );

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -170,6 +170,10 @@ etors:
       desc: "Device requires a reset"
     - name: ERROR_DEVICE_IN_LOW_POWER_STATE
       desc: "Device currently in low power state"
+    - name: ERROR_DEVICE_PARTITION_FAILED
+      desc: "Device paritioning failed"
+    - name: ERROR_INVALID_DEVICE_PARTITION_COUNT
+      desc: "Invalid counts provided with $X_DEVICE_PARTITION_BY_COUNTS"
     - name: ERROR_INVALID_WORK_ITEM_SIZE
       desc: "Invalid work item size"
     - name: ERROR_INVALID_WORK_DIMENSION

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -57,7 +57,7 @@ params:
       name: NumEntries
       desc: |
             [in] the number of devices to be added to phDevices.
-            If phDevices in not NULL then NumEntries should be greater than zero, otherwise $X_RESULT_ERROR_INVALID_SIZE,
+            If phDevices in not NULL then NumEntries should be greater than zero, otherwise $X_RESULT_ERROR_INVALID_VALUE,
             will be returned.
     - type: "$x_device_handle_t*"
       name: phDevices
@@ -70,7 +70,7 @@ params:
             [out][optional] pointer to the number of devices.
             pNumDevices will be updated with the total number of devices available.
 returns:
-    - $X_RESULT_ERROR_INVALID_SIZE
+    - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Supported device info"
@@ -310,11 +310,13 @@ params:
       desc: |
             [out][optional] array of bytes holding the info.
             If propSize is not equal to or greater than the real number of bytes needed to return the info
-            then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pDeviceInfo is not used.
+            then the $X_RESULT_ERROR_INVALID_VALUE error is returned and pDeviceInfo is not used.
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
             [out][optional] pointer to the actual size in bytes of the queried infoType.
+returns:
+    - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Makes a reference of the device handle indicating it's in use until paired $xDeviceRelease is called"
@@ -412,6 +414,9 @@ params:
       name: pNumDevicesRet
       desc: |
             [out][optional] pointer to the number of sub-devices the device can be partitioned into according to the partitioning property.
+returns:
+    - $X_RESULT_ERROR_DEVICE_PARTITION_FAILED
+    - $X_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Selects the most appropriate device binary based on runtime information and the IR characteristics."
@@ -437,12 +442,15 @@ params:
     - type: "uint32_t"
       name: NumBinaries
       desc: |
-            [in] the number of binaries passed in ppBinaries. Must greater than or equal to zero.
+            [in] the number of binaries passed in ppBinaries. 
+            Must greater than or equal to zero otherwise $X_RESULT_ERROR_INVALID_VALUE is returned.
     - type: "uint32_t*"
       name: pSelectedBinary
       desc: |
             [out] the index of the selected binary in the input array of binaries.
             If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+returns:
+    - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "FP capabilities"

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2076,7 +2076,7 @@ namespace driver
         ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
         uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
                                                         ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                                        ///< otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                        ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
                                                         ///< will be returned.
         ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
                                                         ///< If NumEntries is less than the number of devices available, then
@@ -2114,7 +2114,7 @@ namespace driver
         void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
                                                         ///< If propSize is not equal to or greater than the real number of bytes
                                                         ///< needed to return the info
-                                                        ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
                                                         ///< pDeviceInfo is not used.
         size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
         )
@@ -2220,8 +2220,9 @@ namespace driver
     urDeviceSelectBinary(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
         const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
-        uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
-                                                        ///< equal to zero.
+        uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. 
+                                                        ///< Must greater than or equal to zero otherwise
+                                                        ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
         uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
                                                         ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
         )

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2874,7 +2874,7 @@ namespace loader
         ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
         uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
                                                         ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                                        ///< otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                        ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
                                                         ///< will be returned.
         ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
                                                         ///< If NumEntries is less than the number of devices available, then
@@ -2925,7 +2925,7 @@ namespace loader
         void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
                                                         ///< If propSize is not equal to or greater than the real number of bytes
                                                         ///< needed to return the info
-                                                        ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                        ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
                                                         ///< pDeviceInfo is not used.
         size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
         )
@@ -3047,8 +3047,9 @@ namespace loader
     urDeviceSelectBinary(
         ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
         const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
-        uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
-                                                        ///< equal to zero.
+        uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. 
+                                                        ///< Must greater than or equal to zero otherwise
+                                                        ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
         uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
                                                         ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
         )

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2641,14 +2641,14 @@ urUSMGetMemAllocInfo(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL
 urDeviceGet(
     ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
     uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
                                                     ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
                                                     ///< will be returned.
     ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
                                                     ///< If NumEntries is less than the number of devices available, then
@@ -2683,6 +2683,7 @@ urDeviceGet(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES < infoType`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL
 urDeviceGetInfo(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
@@ -2691,7 +2692,7 @@ urDeviceGetInfo(
     void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
                                                     ///< If propSize is not equal to or greater than the real number of bytes
                                                     ///< needed to return the info
-                                                    ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
                                                     ///< pDeviceInfo is not used.
     size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
     )
@@ -2790,6 +2791,8 @@ urDeviceRelease(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pProperties`
+///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
@@ -2832,12 +2835,14 @@ urDevicePartition(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL
 urDeviceSelectBinary(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
     const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
-                                                    ///< equal to zero.
+    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. 
+                                                    ///< Must greater than or equal to zero otherwise
+                                                    ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
                                                     ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
     )

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2434,14 +2434,14 @@ urUSMGetMemAllocInfo(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL
 urDeviceGet(
     ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
     uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
                                                     ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
                                                     ///< will be returned.
     ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
                                                     ///< If NumEntries is less than the number of devices available, then
@@ -2473,6 +2473,7 @@ urDeviceGet(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES < infoType`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL
 urDeviceGetInfo(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
@@ -2481,7 +2482,7 @@ urDeviceGetInfo(
     void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
                                                     ///< If propSize is not equal to or greater than the real number of bytes
                                                     ///< needed to return the info
-                                                    ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                                    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
                                                     ///< pDeviceInfo is not used.
     size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
     )
@@ -2571,6 +2572,8 @@ urDeviceRelease(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pProperties`
+///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 ur_result_t UR_APICALL
 urDevicePartition(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
@@ -2610,12 +2613,14 @@ urDevicePartition(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL
 urDeviceSelectBinary(
     ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
     const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. Must greater than or
-                                                    ///< equal to zero.
+    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. 
+                                                    ///< Must greater than or equal to zero otherwise
+                                                    ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
                                                     ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
     )


### PR DESCRIPTION
This PR clarifies some device entry-points and what error codes they should return.

* I added `UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT` to be returned from `urDeviceParition` when by-counts paritioning is used and invalid counts are provided. (to match OpenCL)
* I added `UR_RESULT_ERROR_DEVICE_PARTITION_FAILED` to be returned from `urDeviceParition` when the paritioning scheme is supported but the device could not be futher paritioned. (to march OpenCL)
* Adds `UR_RESULT_ERROR_INVALID_VALUE` error code to `urDeviceGetInfo` & `urDeviceSelectBinary`