### PR TITLE
disable ReflowComments in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ BasedOnStyle:  LLVM
 IndentWidth:   4
 InsertBraces: true
 ReflowComments: false
+ColumnLimit: 0
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,5 @@ Language:      Cpp
 BasedOnStyle:  LLVM
 IndentWidth:   4
 InsertBraces: true
+ReflowComments: false
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,6 @@ file(GLOB_RECURSE format_src
 # Exclude files from build directory to ensure they're not passed to the formatter
 list(FILTER format_src EXCLUDE REGEX "${CMAKE_CURRENT_BINARY_DIR}.")
 
-# Exclude files we do not want to format
-list(FILTER format_src EXCLUDE REGEX "${CMAKE_PROJECT_DIR}/include/ur_api.h")
-list(FILTER format_src EXCLUDE REGEX "${CMAKE_PROJECT_DIR}/include/ur_ddi.h")
-
 # Add code formatter target
 add_custom_target(cppformat)
 

--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -29,16 +29,14 @@ int main(int argc, char *argv[]) {
 
     status = urPlatformGet(1, nullptr, &platformCount);
     if (status != UR_RESULT_SUCCESS) {
-        std::cout << "urPlatformGet failed with return code: " << status
-                  << std::endl;
+        std::cout << "urPlatformGet failed with return code: " << status << std::endl;
         goto out;
     }
 
     platforms.resize(platformCount);
     status = urPlatformGet(platformCount, platforms.data(), nullptr);
     if (status != UR_RESULT_SUCCESS) {
-        std::cout << "urPlatformGet failed with return code: " << status
-                  << std::endl;
+        std::cout << "urPlatformGet failed with return code: " << status << std::endl;
         goto out;
     }
 
@@ -46,47 +44,36 @@ int main(int argc, char *argv[]) {
         ur_api_version_t api_version = {};
         status = urPlatformGetApiVersion(p, &api_version);
         if (status != UR_RESULT_SUCCESS) {
-            std::cout << "urPlatformGetApiVersion failed with return code: "
-                      << status << std::endl;
+            std::cout << "urPlatformGetApiVersion failed with return code: " << status << std::endl;
             goto out;
         }
-        std::cout << "API version: " << UR_MAJOR_VERSION(api_version) << "."
-                  << UR_MINOR_VERSION(api_version) << std::endl;
+        std::cout << "API version: " << UR_MAJOR_VERSION(api_version) << "." << UR_MINOR_VERSION(api_version) << std::endl;
 
         uint32_t deviceCount = 0;
         status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, 0, nullptr, &deviceCount);
         if (status != UR_RESULT_SUCCESS) {
-            std::cout << "urDeviceGet failed with return code: " << status
-                      << std::endl;
+            std::cout << "urDeviceGet failed with return code: " << status << std::endl;
             goto out;
         }
 
         std::vector<ur_device_handle_t> devices(deviceCount);
-        status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, deviceCount, devices.data(),
-                             nullptr);
+        status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, deviceCount, devices.data(), nullptr);
         if (status != UR_RESULT_SUCCESS) {
-            std::cout << "urDeviceGet failed with return code: " << status
-                      << std::endl;
+            std::cout << "urDeviceGet failed with return code: " << status << std::endl;
             goto out;
         }
         for (auto d : devices) {
             ur_device_type_t device_type;
-            status = urDeviceGetInfo(
-                d, UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t),
-                static_cast<void *>(&device_type), nullptr);
+            status = urDeviceGetInfo(d, UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t), static_cast<void *>(&device_type), nullptr);
             if (status != UR_RESULT_SUCCESS) {
-                std::cout << "urDeviceGetInfo failed with return code: "
-                          << status << std::endl;
+                std::cout << "urDeviceGetInfo failed with return code: " << status << std::endl;
                 goto out;
             }
             static const size_t DEVICE_NAME_MAX_LEN = 1024;
             char device_name[DEVICE_NAME_MAX_LEN] = {0};
-            status =
-                urDeviceGetInfo(d, UR_DEVICE_INFO_NAME, DEVICE_NAME_MAX_LEN - 1,
-                                static_cast<void *>(&device_name), nullptr);
+            status = urDeviceGetInfo(d, UR_DEVICE_INFO_NAME, DEVICE_NAME_MAX_LEN - 1, static_cast<void *>(&device_name), nullptr);
             if (status != UR_RESULT_SUCCESS) {
-                std::cout << "urDeviceGetInfo failed with return code: "
-                          << status << std::endl;
+                std::cout << "urDeviceGetInfo failed with return code: " << status << std::endl;
                 goto out;
             }
             if (device_type == UR_DEVICE_TYPE_GPU) {

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -15,8 +15,8 @@
 #endif
 
 // standard headers
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -29,28 +29,28 @@ extern "C" {
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef UR_MAKE_VERSION
 /// @brief Generates generic 'oneAPI' API versions
-#define UR_MAKE_VERSION( _major, _minor )  (( _major << 16 )|( _minor & 0x0000ffff))
+#define UR_MAKE_VERSION(_major, _minor) ((_major << 16) | (_minor & 0x0000ffff))
 #endif // UR_MAKE_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef UR_MAJOR_VERSION
 /// @brief Extracts 'oneAPI' API major version
-#define UR_MAJOR_VERSION( _ver )  ( _ver >> 16 )
+#define UR_MAJOR_VERSION(_ver) (_ver >> 16)
 #endif // UR_MAJOR_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef UR_MINOR_VERSION
 /// @brief Extracts 'oneAPI' API minor version
-#define UR_MINOR_VERSION( _ver )  ( _ver & 0x0000ffff )
+#define UR_MINOR_VERSION(_ver) (_ver & 0x0000ffff)
 #endif // UR_MINOR_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef UR_APICALL
 #if defined(_WIN32)
 /// @brief Calling convention for all API functions
-#define UR_APICALL  __cdecl
+#define UR_APICALL __cdecl
 #else
-#define UR_APICALL  
+#define UR_APICALL
 #endif // defined(_WIN32)
 #endif // UR_APICALL
 
@@ -58,9 +58,9 @@ extern "C" {
 #ifndef UR_APIEXPORT
 #if defined(_WIN32)
 /// @brief Microsoft-specific dllexport storage-class attribute
-#define UR_APIEXPORT  __declspec(dllexport)
+#define UR_APIEXPORT __declspec(dllexport)
 #else
-#define UR_APIEXPORT  
+#define UR_APIEXPORT
 #endif // defined(_WIN32)
 #endif // UR_APIEXPORT
 
@@ -68,7 +68,7 @@ extern "C" {
 #ifndef UR_DLLEXPORT
 #if defined(_WIN32)
 /// @brief Microsoft-specific dllexport storage-class attribute
-#define UR_DLLEXPORT  __declspec(dllexport)
+#define UR_DLLEXPORT __declspec(dllexport)
 #endif // defined(_WIN32)
 #endif // UR_DLLEXPORT
 
@@ -76,9 +76,9 @@ extern "C" {
 #ifndef UR_DLLEXPORT
 #if __GNUC__ >= 4
 /// @brief GCC-specific dllexport storage-class attribute
-#define UR_DLLEXPORT  __attribute__ ((visibility ("default")))
+#define UR_DLLEXPORT __attribute__((visibility("default")))
 #else
-#define UR_DLLEXPORT  
+#define UR_DLLEXPORT
 #endif // __GNUC__ >= 4
 #endif // UR_DLLEXPORT
 
@@ -133,139 +133,133 @@ typedef struct ur_mem_handle_t_ *ur_mem_handle_t;
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef UR_BIT
 /// @brief Generic macro for enumerator bit masks
-#define UR_BIT( _i )  ( 1 << _i )
+#define UR_BIT(_i) (1 << _i)
 #endif // UR_BIT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines Return/Error codes
-typedef enum ur_result_t
-{
-    UR_RESULT_SUCCESS = 0,                          ///< Success
-    UR_RESULT_ERROR_INVALID_OPERATION = 1,          ///< Invalid operation
-    UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES = 2,   ///< Invalid queue properties
-    UR_RESULT_ERROR_INVALID_QUEUE = 3,              ///< Invalid queue
-    UR_RESULT_ERROR_INVALID_VALUE = 4,              ///< Invalid Value
-    UR_RESULT_ERROR_INVALID_CONTEXT = 5,            ///< Invalid context
-    UR_RESULT_ERROR_INVALID_PLATFORM = 6,           ///< Invalid platform
-    UR_RESULT_ERROR_INVALID_BINARY = 7,             ///< Invalid binary
-    UR_RESULT_ERROR_INVALID_PROGRAM = 8,            ///< Invalid program
-    UR_RESULT_ERROR_INVALID_SAMPLER = 9,            ///< Invalid sampler
-    UR_RESULT_ERROR_INVALID_BUFFER_SIZE = 10,       ///< Invalid buffer size
-    UR_RESULT_ERROR_INVALID_MEM_OBJECT = 11,        ///< Invalid memory object
-    UR_RESULT_ERROR_INVALID_EVENT = 12,             ///< Invalid event
-    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST = 13,   ///< Invalid event wait list
-    UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET = 14,  ///< Misaligned sub buffer offset
-    UR_RESULT_ERROR_BUILD_PROGRAM_FAILURE = 15,     ///< Build program failure
-    UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE = 16,   ///< Invalid work group size
-    UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE = 17,    ///< Compiler not available
-    UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE = 18,  ///< Profiling info not available
-    UR_RESULT_ERROR_DEVICE_NOT_FOUND = 19,          ///< Device not found
-    UR_RESULT_ERROR_INVALID_DEVICE = 20,            ///< Invalid device
-    UR_RESULT_ERROR_DEVICE_LOST = 21,               ///< Device hung, reset, was removed, or driver update occurred
-    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 22,     ///< Device requires a reset
-    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 23, ///< Device currently in low power state
-    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 24,   ///< Device paritioning failed
-    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 25,///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
-    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 26,    ///< Invalid work item size
-    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 27,    ///< Invalid work dimension
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 28,       ///< Invalid kernel args
-    UR_RESULT_ERROR_INVALID_KERNEL = 29,            ///< Invalid kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 30,       ///< [Validation] kernel name is not found in the module
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 31, ///< [Validation] kernel argument index is not valid for kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 32,  ///< [Validation] kernel argument size does not match kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 33,///< [Validation] value of kernel attribute is not valid for the kernel or
-                                                    ///< device
-    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 34,        ///< Invalid image size
-    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 35,   ///< Invalid image format descriptor
-    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 36,///< Image format not supported
-    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 37, ///< Memory object allocation failure
-    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 38,///< Program object parameter is invalid.
-    UR_RESULT_ERROR_UNINITIALIZED = 39,             ///< [Validation] driver is not initialized
-    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 40,        ///< Insufficient host memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 41,      ///< Insufficient device memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_RESOURCES = 42,          ///< Out of resources
-    UR_RESULT_ERROR_MODULE_BUILD_FAILURE = 43,      ///< Error occurred when building module, see build log for details
-    UR_RESULT_ERROR_MODULE_LINK_FAILURE = 44,       ///< Error occurred when linking modules, see build log for details
-    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 45,       ///< [Validation] generic error code for unsupported versions
-    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 46,       ///< [Validation] generic error code for unsupported features
-    UR_RESULT_ERROR_INVALID_ARGUMENT = 47,          ///< [Validation] generic error code for invalid arguments
-    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 48,       ///< [Validation] handle argument is not valid
-    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 49,      ///< [Validation] object pointed to by handle still in-use by device
-    UR_RESULT_ERROR_INVALID_NULL_POINTER = 50,      ///< [Validation] pointer argument may not be nullptr
-    UR_RESULT_ERROR_INVALID_SIZE = 51,              ///< [Validation] size argument is invalid (e.g., must not be zero)
-    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 52,          ///< [Validation] size argument is not supported by the device (e.g., too
-                                                    ///< large)
-    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 53,     ///< [Validation] alignment argument is not supported by the device (e.g.,
-                                                    ///< too small)
-    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 54,///< [Validation] synchronization object in invalid state
-    UR_RESULT_ERROR_INVALID_ENUMERATION = 55,       ///< [Validation] enumerator argument is not valid
-    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 56,   ///< [Validation] enumerator argument is not supported by the device
-    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 57,  ///< [Validation] image format is not supported by the device
-    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 58,     ///< [Validation] native binary is not supported by the device
-    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 59,       ///< [Validation] global variable is not found in the module
-    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 60,     ///< [Validation] function name is not found in the module
-    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 61,  ///< [Validation] group size dimension is not valid for the kernel or
-                                                    ///< device
-    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 62,///< [Validation] global width dimension is not valid for the kernel or
-                                                    ///< device
-    UR_RESULT_ERROR_MODULE_UNLINKED = 63,           ///< [Validation] module with imports needs to be linked before kernels can
-                                                    ///< be created from it.
-    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 64,       ///< [Validation] copy operations do not support overlapping regions of
-                                                    ///< memory
-    UR_RESULT_ERROR_INVALID_HOST_PTR = 65,          ///< Invalid host pointer
-    UR_RESULT_ERROR_INVALID_USM_SIZE = 66,          ///< Invalid USM size
-    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 67, ///< Objection allocation failure
-    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 68,          ///< An adapter specific warning/error has been reported and can be
-                                                    ///< retrieved via the urGetLastResult entry point.
-    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,           ///< Unknown or internal error
+typedef enum ur_result_t {
+    UR_RESULT_SUCCESS = 0,                                ///< Success
+    UR_RESULT_ERROR_INVALID_OPERATION = 1,                ///< Invalid operation
+    UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES = 2,         ///< Invalid queue properties
+    UR_RESULT_ERROR_INVALID_QUEUE = 3,                    ///< Invalid queue
+    UR_RESULT_ERROR_INVALID_VALUE = 4,                    ///< Invalid Value
+    UR_RESULT_ERROR_INVALID_CONTEXT = 5,                  ///< Invalid context
+    UR_RESULT_ERROR_INVALID_PLATFORM = 6,                 ///< Invalid platform
+    UR_RESULT_ERROR_INVALID_BINARY = 7,                   ///< Invalid binary
+    UR_RESULT_ERROR_INVALID_PROGRAM = 8,                  ///< Invalid program
+    UR_RESULT_ERROR_INVALID_SAMPLER = 9,                  ///< Invalid sampler
+    UR_RESULT_ERROR_INVALID_BUFFER_SIZE = 10,             ///< Invalid buffer size
+    UR_RESULT_ERROR_INVALID_MEM_OBJECT = 11,              ///< Invalid memory object
+    UR_RESULT_ERROR_INVALID_EVENT = 12,                   ///< Invalid event
+    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST = 13,         ///< Invalid event wait list
+    UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET = 14,    ///< Misaligned sub buffer offset
+    UR_RESULT_ERROR_BUILD_PROGRAM_FAILURE = 15,           ///< Build program failure
+    UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE = 16,         ///< Invalid work group size
+    UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE = 17,          ///< Compiler not available
+    UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE = 18,    ///< Profiling info not available
+    UR_RESULT_ERROR_DEVICE_NOT_FOUND = 19,                ///< Device not found
+    UR_RESULT_ERROR_INVALID_DEVICE = 20,                  ///< Invalid device
+    UR_RESULT_ERROR_DEVICE_LOST = 21,                     ///< Device hung, reset, was removed, or driver update occurred
+    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 22,           ///< Device requires a reset
+    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 23,       ///< Device currently in low power state
+    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 24,         ///< Device paritioning failed
+    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 25,  ///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
+    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 26,          ///< Invalid work item size
+    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 27,          ///< Invalid work dimension
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 28,             ///< Invalid kernel args
+    UR_RESULT_ERROR_INVALID_KERNEL = 29,                  ///< Invalid kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 30,             ///< [Validation] kernel name is not found in the module
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 31,   ///< [Validation] kernel argument index is not valid for kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 32,    ///< [Validation] kernel argument size does not match kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 33,  ///< [Validation] value of kernel attribute is not valid for the kernel or
+                                                          ///< device
+    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 34,              ///< Invalid image size
+    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 35, ///< Invalid image format descriptor
+    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 36,      ///< Image format not supported
+    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 37,   ///< Memory object allocation failure
+    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 38,      ///< Program object parameter is invalid.
+    UR_RESULT_ERROR_UNINITIALIZED = 39,                   ///< [Validation] driver is not initialized
+    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 40,              ///< Insufficient host memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 41,            ///< Insufficient device memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_RESOURCES = 42,                ///< Out of resources
+    UR_RESULT_ERROR_MODULE_BUILD_FAILURE = 43,            ///< Error occurred when building module, see build log for details
+    UR_RESULT_ERROR_MODULE_LINK_FAILURE = 44,             ///< Error occurred when linking modules, see build log for details
+    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 45,             ///< [Validation] generic error code for unsupported versions
+    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 46,             ///< [Validation] generic error code for unsupported features
+    UR_RESULT_ERROR_INVALID_ARGUMENT = 47,                ///< [Validation] generic error code for invalid arguments
+    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 48,             ///< [Validation] handle argument is not valid
+    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 49,            ///< [Validation] object pointed to by handle still in-use by device
+    UR_RESULT_ERROR_INVALID_NULL_POINTER = 50,            ///< [Validation] pointer argument may not be nullptr
+    UR_RESULT_ERROR_INVALID_SIZE = 51,                    ///< [Validation] size argument is invalid (e.g., must not be zero)
+    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 52,                ///< [Validation] size argument is not supported by the device (e.g., too
+                                                          ///< large)
+    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 53,           ///< [Validation] alignment argument is not supported by the device (e.g.,
+                                                          ///< too small)
+    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 54,  ///< [Validation] synchronization object in invalid state
+    UR_RESULT_ERROR_INVALID_ENUMERATION = 55,             ///< [Validation] enumerator argument is not valid
+    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 56,         ///< [Validation] enumerator argument is not supported by the device
+    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 57,        ///< [Validation] image format is not supported by the device
+    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 58,           ///< [Validation] native binary is not supported by the device
+    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 59,             ///< [Validation] global variable is not found in the module
+    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 60,           ///< [Validation] function name is not found in the module
+    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 61,    ///< [Validation] group size dimension is not valid for the kernel or
+                                                          ///< device
+    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 62,  ///< [Validation] global width dimension is not valid for the kernel or
+                                                          ///< device
+    UR_RESULT_ERROR_MODULE_UNLINKED = 63,                 ///< [Validation] module with imports needs to be linked before kernels can
+                                                          ///< be created from it.
+    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 64,             ///< [Validation] copy operations do not support overlapping regions of
+                                                          ///< memory
+    UR_RESULT_ERROR_INVALID_HOST_PTR = 65,                ///< Invalid host pointer
+    UR_RESULT_ERROR_INVALID_USM_SIZE = 66,                ///< Invalid USM size
+    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 67,       ///< Objection allocation failure
+    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 68,                ///< An adapter specific warning/error has been reported and can be
+                                                          ///< retrieved via the urGetLastResult entry point.
+    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                 ///< Unknown or internal error
     UR_RESULT_FORCE_UINT32 = 0x7fffffff
 
 } ur_result_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
-typedef enum ur_structure_type_t
-{
-    UR_STRUCTURE_TYPE_IMAGE_DESC = 0,               ///< ::ur_image_desc_t
+typedef enum ur_structure_type_t {
+    UR_STRUCTURE_TYPE_IMAGE_DESC = 0, ///< ::ur_image_desc_t
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_structure_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Base for all properties types
-typedef struct ur_base_properties_t
-{
-    ur_structure_type_t stype;                      ///< [in] type of this structure
-    void* pNext;                                    ///< [in,out][optional] pointer to extension-specific structure
+typedef struct ur_base_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
 
 } ur_base_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Base for all descriptor types
-typedef struct ur_base_desc_t
-{
-    ur_structure_type_t stype;                      ///< [in] type of this structure
-    const void* pNext;                              ///< [in][optional] pointer to extension-specific structure
+typedef struct ur_base_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_base_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief 3D offset argument passed to buffer rect operations
-typedef struct ur_rect_offset_t
-{
-    uint64_t x;                                     ///< [in] x offset (bytes)
-    uint64_t y;                                     ///< [in] y offset (scalar)
-    uint64_t z;                                     ///< [in] z offset (scalar)
+typedef struct ur_rect_offset_t {
+    uint64_t x; ///< [in] x offset (bytes)
+    uint64_t y; ///< [in] y offset (scalar)
+    uint64_t z; ///< [in] z offset (scalar)
 
 } ur_rect_offset_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief 3D region argument passed to buffer rect operations
-typedef struct ur_rect_region_t
-{
-    uint64_t width;                                 ///< [in] width (bytes)
-    uint64_t height;                                ///< [in] height (scalar)
-    uint64_t depth;                                 ///< [in] scalar (scalar)
+typedef struct ur_rect_region_t {
+    uint64_t width;  ///< [in] width (bytes)
+    uint64_t height; ///< [in] height (scalar)
+    uint64_t depth;  ///< [in] scalar (scalar)
 
 } ur_rect_region_t;
 
@@ -278,7 +272,7 @@ typedef struct ur_rect_region_t
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Creates a context with the given devices.
-/// 
+///
 /// @details
 ///     - All devices should be from the same platform.
 ///     - Context is used for resource sharing between all the devices
@@ -289,11 +283,11 @@ typedef struct ur_rect_region_t
 ///       subsequent call to ::urContextRelease.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function must be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateContext**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -305,26 +299,26 @@ typedef struct ur_rect_region_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                           ///< [in] the number of devices given in phDevices
-    ur_device_handle_t* phDevices,                  ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t* phContext                  ///< [out] pointer to handle of context object created
-    );
+    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
+    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Makes a reference of the context handle indicating it's in use until
 ///        paired ::urContextRelease is called
-/// 
+///
 /// @details
 ///     - It is not valid to use a context handle, which has all of its
 ///       references released.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainContext**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -333,38 +327,37 @@ urContextCreate(
 ///         + `NULL == hContext`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(
-    ur_context_handle_t hContext                    ///< [in] handle of the context to get a reference of.
-    );
+    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported context info
-typedef enum ur_context_info_t
-{
-    UR_CONTEXT_INFO_NUM_DEVICES = 1,                ///< [uint32_t] The number of the devices in the context
-    UR_CONTEXT_INFO_DEVICES = 2,                    ///< [::ur_context_handle_t...] The array of the device handles in the
-                                                    ///< context
-    UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT = 3,       ///< [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
-                                                    ///< supported.
-    UR_CONTEXT_INFO_USM_FILL2D_SUPPORT = 4,         ///< [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is
-                                                    ///< supported.
-    UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT = 5,       ///< [bool] to indicate if the ::urEnqueueUSMMemset2D entrypoint is
-                                                    ///< supported.
+typedef enum ur_context_info_t {
+    UR_CONTEXT_INFO_NUM_DEVICES = 1,          ///< [uint32_t] The number of the devices in the context
+    UR_CONTEXT_INFO_DEVICES = 2,              ///< [::ur_context_handle_t...] The array of the device handles in the
+                                              ///< context
+    UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT = 3, ///< [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
+                                              ///< supported.
+    UR_CONTEXT_INFO_USM_FILL2D_SUPPORT = 4,   ///< [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is
+                                              ///< supported.
+    UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT = 5, ///< [bool] to indicate if the ::urEnqueueUSMMemset2D entrypoint is
+                                              ///< supported.
     UR_CONTEXT_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_context_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Releases the context handle reference indicating end of its usage
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseContext**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -373,20 +366,20 @@ typedef enum ur_context_info_t
 ///         + `NULL == hContext`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(
-    ur_context_handle_t hContext                    ///< [in] handle of the context to release.
-    );
+    ur_context_handle_t hContext ///< [in] handle of the context to release.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about context
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetContextInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -397,20 +390,20 @@ urContextRelease(
 ///         + `::UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT < ContextInfoType`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextGetInfo(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context
-    ur_context_info_t ContextInfoType,              ///< [in] type of the info to retrieve
-    size_t propSize,                                ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void* pContextInfo,                             ///< [out][optional] array of bytes holding the info.
-                                                    ///< if propSize is not equal to or greater than the real number of bytes
-                                                    ///< needed to return 
-                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                                    ///< pContextInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
-    );
+    ur_context_handle_t hContext,      ///< [in] handle of the context
+    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
+                                       ///< if propSize is not equal to or greater than the real number of bytes
+                                       ///< needed to return
+                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                       ///< pContextInfo is not used.
+    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native context handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -419,7 +412,7 @@ urContextGetInfo(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -430,19 +423,19 @@ urContextGetInfo(
 ///         + `NULL == phNativeContext`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextGetNativeHandle(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context.
-    ur_native_handle_t* phNativeContext             ///< [out] a pointer to the native handle of the context.
-    );
+    ur_context_handle_t hContext,       ///< [in] handle of the context.
+    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime context object from native context handle.
-/// 
+///
 /// @details
 ///     - Creates runtime context handle from native driver context handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -453,19 +446,19 @@ urContextGetNativeHandle(
 ///         + `NULL == phContext`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext,              ///< [in] the native handle of the context.
-    ur_context_handle_t* phContext                  ///< [out] pointer to the handle of the context object created.
-    );
+    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Context's extended deleter callback function with user data.
-typedef void (ur_context_extended_deleter_t)(
-    void* pUserData                                 ///< [in][out] pointer to data to be passed to callback
-    );
+typedef void(ur_context_extended_deleter_t)(
+    void *pUserData ///< [in][out] pointer to data to be passed to callback
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Call extended deleter function as callback.
-/// 
+///
 /// @details
 ///     - Calls extended deleter, a user-defined callback to delete context on
 ///       some platforms.
@@ -475,7 +468,7 @@ typedef void (ur_context_extended_deleter_t)(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -486,10 +479,10 @@ typedef void (ur_context_extended_deleter_t)(
 ///         + `NULL == pfnDeleter`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter,       ///< [in] Function pointer to extended deleter.
-    void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
-    );
+    ur_context_handle_t hContext,             ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -500,11 +493,11 @@ urContextSetExtendedDeleter(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -525,42 +518,42 @@ urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    uint32_t workDim,                               ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                                    ///< work-group work-items
-    const size_t* pGlobalWorkOffset,                ///< [in] pointer to an array of workDim unsigned values that specify the
-                                                    ///< offset used to calculate the global ID of a work-item
-    const size_t* pGlobalWorkSize,                  ///< [in] pointer to an array of workDim unsigned values that specify the
-                                                    ///< number of global work-items in workDim that will execute the kernel
-                                                    ///< function
-    const size_t* pLocalWorkSize,                   ///< [in][optional] pointer to an array of workDim unsigned values that
-                                                    ///< specify the number of local work-items forming a work-group that will
-                                                    ///< execute the kernel function.
-                                                    ///< If nullptr, the runtime implementation will choose the work-group
-                                                    ///< size. 
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before the kernel execution.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                                    ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular kernel execution instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
+    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                              ///< work-group work-items
+    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< number of global work-items in workDim that will execute the kernel
+                                              ///< function
+    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
+                                              ///< specify the number of local work-items forming a work-group that will
+                                              ///< execute the kernel function.
+                                              ///< If nullptr, the runtime implementation will choose the work-group
+                                              ///< size.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command which waits a list of events to complete before it
 ///        completes
-/// 
+///
 /// @details
 ///     - If the event list is empty, it waits for all previously enqueued
 ///       commands to complete.
 ///     - It returns an event which can be waited on.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueMarkerWithWaitList**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -574,32 +567,32 @@ urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                                    ///< previously enqueued commands
-                                                    ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a barrier command which waits a list of events to complete
 ///        before it completes
-/// 
+///
 /// @details
 ///     - If the event list is empty, it waits for all previously enqueued
 ///       commands to complete.
 ///     - It blocks command execution - any following commands enqueued after it
 ///       do not execute until it completes.
 ///     - It returns an event which can be waited on.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueBarrierWithWaitList**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -613,28 +606,28 @@ urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                                    ///< previously enqueued commands
-                                                    ///< must be complete. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to read from a buffer object to host memory
-/// 
+///
 /// @details
 ///     - Input parameter blockingRead indicates if the read is blocking or
 ///       non-blocking.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueReadBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -651,32 +644,32 @@ urEnqueueEventsWaitWithBarrier(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
-    bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                                  ///< [in] offset in bytes in the buffer object
-    size_t size,                                    ///< [in] size in bytes of data being read
-    void* pDst,                                     ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being read
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to write into a buffer object from host memory
-/// 
+///
 /// @details
 ///     - Input parameter blockingWrite indicates if the write is blocking or
 ///       non-blocking.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueWriteBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -693,35 +686,35 @@ urEnqueueMemBufferRead(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
-    bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                                  ///< [in] offset in bytes in the buffer object
-    size_t size,                                    ///< [in] size in bytes of data being written
-    const void* pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being written
+    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to read a 2D or 3D rectangular region from a buffer
 ///        object to host memory
-/// 
+///
 /// @details
 ///     - Input parameter blockingRead indicates if the read is blocking or
 ///       non-blocking.
 ///     - The buffer and host 2D or 3D rectangular regions can have different
 ///       shapes.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueReadBufferRect**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -738,42 +731,42 @@ urEnqueueMemBufferWrite(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
-    bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
-                                                    ///< dst
-    size_t hostSlicePitch,                          ///< [in] length of each 2D slice in bytes in the host memory region
-                                                    ///< pointed by dst
-    void* pDst,                                     ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< dst
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by dst
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to write a 2D or 3D rectangular region in a buffer
 ///        object from host memory
-/// 
+///
 /// @details
 ///     - Input parameter blockingWrite indicates if the write is blocking or
 ///       non-blocking.
 ///     - The buffer and host 2D or 3D rectangular regions can have different
 ///       shapes.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueWriteBufferRect**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -790,36 +783,36 @@ urEnqueueMemBufferReadRect(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
-    bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,                  ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,                    ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                        ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                          ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                        ///< [in] length of each 2D slice in bytes in the buffer object being
-                                                    ///< written
-    size_t hostRowPitch,                            ///< [in] length of each row in bytes in the host memory region pointed by
-                                                    ///< src
-    size_t hostSlicePitch,                          ///< [in] length of each 2D slice in bytes in the host memory region
-                                                    ///< pointed by src
-    void* pSrc,                                     ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance. 
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
+                                              ///< written
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< src
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by src
+    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to copy from a buffer object to another
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueCopyBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -835,29 +828,29 @@ urEnqueueMemBufferWriteRect(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
-    size_t srcOffset,                               ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                               ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                                    ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance. 
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
+    size_t size,                              ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to copy a 2D or 3D rectangular region from one
 ///        buffer object to another
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueCopyBufferRect**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -873,33 +866,33 @@ urEnqueueMemBufferCopy(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,                     ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,                     ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,                     ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,                     ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,                     ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                             ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                           ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                             ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                           ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to fill a buffer object with a pattern of a given
 ///        size
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueFillBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -916,33 +909,33 @@ urEnqueueMemBufferCopyRect(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
-    const void* pPattern,                           ///< [in] pointer to the fill pattern
-    size_t patternSize,                             ///< [in] size in bytes of the pattern
-    size_t offset,                                  ///< [in] offset into the buffer
-    size_t size,                                    ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    const void *pPattern,                     ///< [in] pointer to the fill pattern
+    size_t patternSize,                       ///< [in] size in bytes of the pattern
+    size_t offset,                            ///< [in] offset into the buffer
+    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to read from an image or image array object to host
 ///        memory
-/// 
+///
 /// @details
 ///     - Input parameter blockingRead indicates if the read is blocking or
 ///       non-blocking.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueReadImage**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -959,36 +952,36 @@ urEnqueueMemBufferFill(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                         ///< [in] handle of the image object
-    bool blockingRead,                              ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                                    ///< image
-    size_t rowPitch,                                ///< [in] length of each row in bytes
-    size_t slicePitch,                              ///< [in] length of each 2D slice of the 3D image
-    void* pDst,                                     ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance. 
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
+    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to write an image or image array object from host
 ///        memory
-/// 
+///
 /// @details
 ///     - Input parameter blockingWrite indicates if the write is blocking or
 ///       non-blocking.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueWriteImage**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1005,31 +998,31 @@ urEnqueueMemImageRead(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                         ///< [in] handle of the image object
-    bool blockingWrite,                             ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                        ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                                    ///< image
-    size_t inputRowPitch,                           ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                         ///< [in] length of each 2D slice of the 3D image
-    void* pSrc,                                     ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t inputRowPitch,                     ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to copy from an image object to another
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueCopyImage**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1045,31 +1038,30 @@ urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                      ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                      ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                                    ///< image
-    ur_rect_offset_t dstOrigin,                     ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                                    ///< or 3D image
-    ur_rect_region_t region,                        ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                                    ///< image
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance. 
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                              ///< image
+    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                              ///< or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map flags
 typedef uint32_t ur_map_flags_t;
-typedef enum ur_map_flag_t
-{
-    UR_MAP_FLAG_READ = UR_BIT(0),                   ///< Map for read access
-    UR_MAP_FLAG_WRITE = UR_BIT(1),                  ///< Map for write access
+typedef enum ur_map_flag_t {
+    UR_MAP_FLAG_READ = UR_BIT(0),  ///< Map for read access
+    UR_MAP_FLAG_WRITE = UR_BIT(1), ///< Map for write access
     UR_MAP_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_map_flag_t;
@@ -1077,9 +1069,8 @@ typedef enum ur_map_flag_t
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map flags
 typedef uint32_t ur_usm_migration_flags_t;
-typedef enum ur_usm_migration_flag_t
-{
-    UR_USM_MIGRATION_FLAG_DEFAULT = UR_BIT(0),      ///< Default migration TODO: Add more enums! 
+typedef enum ur_usm_migration_flag_t {
+    UR_USM_MIGRATION_FLAG_DEFAULT = UR_BIT(0), ///< Default migration TODO: Add more enums!
     UR_USM_MIGRATION_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_usm_migration_flag_t;
@@ -1087,18 +1078,18 @@ typedef enum ur_usm_migration_flag_t
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to map a region of the buffer object into the host
 ///        address space and return a pointer to the mapped region
-/// 
+///
 /// @details
 ///     - Input parameter blockingMap indicates if the map is blocking or
 ///       non-blocking.
 ///     - Currently, no direct support in Level Zero. Implemented as a shared
 ///       allocation followed by copying on discrete GPU
 ///     - TODO: add a driver function in Level Zero?
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueMapBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1117,31 +1108,31 @@ typedef enum ur_usm_migration_flag_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object
-    bool blockingMap,                               ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                        ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                                  ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                                    ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent,                     ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    void** ppRetMap                                 ///< [in,out] return mapped pointer.  TODO: move it before
-                                                    ///< numEventsInWaitList?
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+                                              ///< numEventsInWaitList?
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to unmap a previously mapped region of a memory
 ///        object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueUnmapMemObject**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1158,21 +1149,21 @@ urEnqueueMemBufferMap(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                           ///< [in] handle of the memory (buffer or image) object
-    void* pMappedPtr,                               ///< [in] mapped host address
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr,                         ///< [in] mapped host address
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to set USM memory object value
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1188,22 +1179,22 @@ urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMMemset(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    void* ptr,                                      ///< [in] pointer to USM memory object
-    int8_t byteValue,                               ///< [in] byte value to fill
-    size_t count,                                   ///< [in] size in bytes to be set
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance. 
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    void *ptr,                                ///< [in] pointer to USM memory object
+    int8_t byteValue,                         ///< [in] byte value to fill
+    size_t count,                             ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to copy USM memory
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1220,23 +1211,23 @@ urEnqueueUSMMemset(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    bool blocking,                                  ///< [in] blocking or non-blocking copy
-    void* pDst,                                     ///< [in] pointer to the destination USM memory object
-    const void* pSrc,                               ///< [in] pointer to the source USM memory object
-    size_t size,                                    ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking copy
+    void *pDst,                               ///< [in] pointer to the destination USM memory object
+    const void *pSrc,                         ///< [in] pointer to the source USM memory object
+    size_t size,                              ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to prefetch USM memory
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1254,31 +1245,30 @@ urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    const void* pMem,                               ///< [in] pointer to the USM memory object
-    size_t size,                                    ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,                 ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before this command can be executed.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                                    ///< command does not wait on any event to complete.
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory advice
-typedef enum ur_mem_advice_t
-{
-    UR_MEM_ADVICE_DEFAULT = 0,                      ///< The USM memory advice is default
+typedef enum ur_mem_advice_t {
+    UR_MEM_ADVICE_DEFAULT = 0, ///< The USM memory advice is default
     UR_MEM_ADVICE_FORCE_UINT32 = 0x7fffffff
 
 } ur_mem_advice_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to set USM memory advice
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1296,17 +1286,17 @@ typedef enum ur_mem_advice_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    const void* pMem,                               ///< [in] pointer to the USM memory object
-    size_t size,                                    ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,                         ///< [in] USM memory advice
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular command instance.
-    );
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    const void *pMem,          ///< [in] pointer to the USM memory object
+    size_t size,               ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,    ///< [in] USM memory advice
+    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
+                               ///< particular command instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to fill 2D USM memory.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1319,25 +1309,25 @@ urEnqueueUSMMemAdvise(
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    void* pMem,                                     ///< [in] pointer to memory to be filled.
-    size_t pitch,                                   ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                             ///< [in] the size in bytes of the pattern.
-    const void* pPattern,                           ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                                   ///< [in] the width in bytes of each row to fill.
-    size_t height,                                  ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before the kernel execution.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                                    ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular kernel execution instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    size_t patternSize,                       ///< [in] the size in bytes of the pattern.
+    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
+    size_t width,                             ///< [in] the width in bytes of each row to fill.
+    size_t height,                            ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to set 2D USM memory.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1349,24 +1339,24 @@ urEnqueueUSMFill2D(
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMMemset2D(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    void* pMem,                                     ///< [in] pointer to memory to be filled.
-    size_t pitch,                                   ///< [in] the total width of the destination memory including padding.
-    int value,                                      ///< [in] the value to fill into the region in pMem.
-    size_t width,                                   ///< [in] the width in bytes of each row to set.
-    size_t height,                                  ///< [in] the height of the columns to set.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before the kernel execution.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                                    ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular kernel execution instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    int value,                                ///< [in] the value to fill into the region in pMem.
+    size_t width,                             ///< [in] the width in bytes of each row to set.
+    size_t height,                            ///< [in] the height of the columns to set.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to copy 2D USM memory.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1379,27 +1369,27 @@ urEnqueueUSMMemset2D(
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    bool blocking,                                  ///< [in] indicates if this operation should block the host.
-    void* pDst,                                     ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                                ///< [in] the total width of the source memory including padding.
-    const void* pSrc,                               ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                                ///< [in] the total width of the source memory including padding.
-    size_t width,                                   ///< [in] the width in bytes of each row to be copied.
-    size_t height,                                  ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before the kernel execution.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                                    ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular kernel execution instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    bool blocking,                            ///< [in] indicates if this operation should block the host.
+    void *pDst,                               ///< [in] pointer to memory where data will be copied.
+    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
+    const void *pSrc,                         ///< [in] pointer to memory to be copied.
+    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
+    size_t width,                             ///< [in] the width in bytes of each row to be copied.
+    size_t height,                            ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to write data from the host to device global
 ///        variable.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1412,26 +1402,26 @@ urEnqueueUSMMemcpy2D(
 ///         + `NULL == pSrc`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
-    const char* name,                               ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                             ///< [in] indicates if this operation should block.
-    size_t count,                                   ///< [in] the number of bytes to copy.
-    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
-    const void* pSrc,                               ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before the kernel execution.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                                    ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular kernel execution instance.
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                       ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to read data from a device global variable to the
 ///        host.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1444,21 +1434,21 @@ urEnqueueDeviceGlobalVariableWrite(
 ///         + `NULL == pDst`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,                   ///< [in] handle of the program containing the device global variable.
-    const char* name,                               ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                              ///< [in] indicates if this operation should block.
-    size_t count,                                   ///< [in] the number of bytes to copy.
-    size_t offset,                                  ///< [in] the byte offset into the device global variable to start copying.
-    void* pDst,                                     ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,                   ///< [in] size of the event wait list.
-    const ur_event_handle_t* phEventWaitList,       ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                    ///< events that must be complete before the kernel execution.
-                                                    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                                    ///< event. 
-    ur_event_handle_t* phEvent                      ///< [in,out][optional] return an event object that identifies this
-                                                    ///< particular kernel execution instance.    
-    );
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                        ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst,                               ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -1469,84 +1459,80 @@ urEnqueueDeviceGlobalVariableRead(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Command type
-typedef enum ur_command_t
-{
-    UR_COMMAND_KERNEL_LAUNCH = 0,                   ///< Event created by ::urEnqueueKernelLaunch
-    UR_COMMAND_EVENTS_WAIT = 1,                     ///< Event created by ::urEnqueueEventsWait
-    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,        ///< Event created by ::urEnqueueEventsWaitWithBarrier
-    UR_COMMAND_MEM_BUFFER_READ = 3,                 ///< Event created by ::urEnqueueMemBufferRead
-    UR_COMMAND_MEM_BUFFER_WRITE = 4,                ///< Event created by ::urEnqueueMemBufferWrite
-    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,            ///< Event created by ::urEnqueueMemBufferReadRect
-    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,           ///< Event created by ::urEnqueueMemBufferWriteRect
-    UR_COMMAND_MEM_BUFFER_COPY = 7,                 ///< Event created by ::urEnqueueMemBufferCopy
-    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,            ///< Event created by ::urEnqueueMemBufferCopyRect
-    UR_COMMAND_MEM_BUFFER_FILL = 9,                 ///< Event created by ::urEnqueueMemBufferFill
-    UR_COMMAND_MEM_IMAGE_READ = 10,                 ///< Event created by ::urEnqueueMemImageRead
-    UR_COMMAND_MEM_IMAGE_WRITE = 11,                ///< Event created by ::urEnqueueMemImageWrite
-    UR_COMMAND_MEM_IMAGE_COPY = 12,                 ///< Event created by ::urEnqueueMemImageCopy
-    UR_COMMAND_MEM_BUFFER_MAP = 14,                 ///< Event created by ::urEnqueueMemBufferMap
-    UR_COMMAND_MEM_UNMAP = 16,                      ///< Event created by ::urEnqueueMemUnmap
-    UR_COMMAND_USM_MEMSET = 17,                     ///< Event created by ::urEnqueueUSMMemset
-    UR_COMMAND_USM_MEMCPY = 18,                     ///< Event created by ::urEnqueueUSMMemcpy
-    UR_COMMAND_USM_PREFETCH = 19,                   ///< Event created by ::urEnqueueUSMPrefetch
-    UR_COMMAND_USM_MEM_ADVISE = 20,                 ///< Event created by ::urEnqueueUSMMemAdvise
-    UR_COMMAND_USM_FILL_2D = 21,                    ///< Event created by ::urEnqueueUSMFill2D
-    UR_COMMAND_USM_MEMSET_2D = 22,                  ///< Event created by ::urEnqueueUSMMemset2D
-    UR_COMMAND_USM_MEMCPY_2D = 23,                  ///< Event created by ::urEnqueueUSMMemcpy2D
-    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 24,   ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
-    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 25,    ///< Event created by ::urEnqueueDeviceGlobalVariableRead
+typedef enum ur_command_t {
+    UR_COMMAND_KERNEL_LAUNCH = 0,                 ///< Event created by ::urEnqueueKernelLaunch
+    UR_COMMAND_EVENTS_WAIT = 1,                   ///< Event created by ::urEnqueueEventsWait
+    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,      ///< Event created by ::urEnqueueEventsWaitWithBarrier
+    UR_COMMAND_MEM_BUFFER_READ = 3,               ///< Event created by ::urEnqueueMemBufferRead
+    UR_COMMAND_MEM_BUFFER_WRITE = 4,              ///< Event created by ::urEnqueueMemBufferWrite
+    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,          ///< Event created by ::urEnqueueMemBufferReadRect
+    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,         ///< Event created by ::urEnqueueMemBufferWriteRect
+    UR_COMMAND_MEM_BUFFER_COPY = 7,               ///< Event created by ::urEnqueueMemBufferCopy
+    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,          ///< Event created by ::urEnqueueMemBufferCopyRect
+    UR_COMMAND_MEM_BUFFER_FILL = 9,               ///< Event created by ::urEnqueueMemBufferFill
+    UR_COMMAND_MEM_IMAGE_READ = 10,               ///< Event created by ::urEnqueueMemImageRead
+    UR_COMMAND_MEM_IMAGE_WRITE = 11,              ///< Event created by ::urEnqueueMemImageWrite
+    UR_COMMAND_MEM_IMAGE_COPY = 12,               ///< Event created by ::urEnqueueMemImageCopy
+    UR_COMMAND_MEM_BUFFER_MAP = 14,               ///< Event created by ::urEnqueueMemBufferMap
+    UR_COMMAND_MEM_UNMAP = 16,                    ///< Event created by ::urEnqueueMemUnmap
+    UR_COMMAND_USM_MEMSET = 17,                   ///< Event created by ::urEnqueueUSMMemset
+    UR_COMMAND_USM_MEMCPY = 18,                   ///< Event created by ::urEnqueueUSMMemcpy
+    UR_COMMAND_USM_PREFETCH = 19,                 ///< Event created by ::urEnqueueUSMPrefetch
+    UR_COMMAND_USM_MEM_ADVISE = 20,               ///< Event created by ::urEnqueueUSMMemAdvise
+    UR_COMMAND_USM_FILL_2D = 21,                  ///< Event created by ::urEnqueueUSMFill2D
+    UR_COMMAND_USM_MEMSET_2D = 22,                ///< Event created by ::urEnqueueUSMMemset2D
+    UR_COMMAND_USM_MEMCPY_2D = 23,                ///< Event created by ::urEnqueueUSMMemcpy2D
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 24, ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 25,  ///< Event created by ::urEnqueueDeviceGlobalVariableRead
     UR_COMMAND_FORCE_UINT32 = 0x7fffffff
 
 } ur_command_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event Status
-typedef enum ur_event_status_t
-{
-    UR_EVENT_STATUS_COMPLETE = 0,                   ///< Command is complete
-    UR_EVENT_STATUS_RUNNING = 1,                    ///< Command is running
-    UR_EVENT_STATUS_SUBMITTED = 2,                  ///< Command is submitted
-    UR_EVENT_STATUS_QUEUED = 3,                     ///< Command is queued
+typedef enum ur_event_status_t {
+    UR_EVENT_STATUS_COMPLETE = 0,  ///< Command is complete
+    UR_EVENT_STATUS_RUNNING = 1,   ///< Command is running
+    UR_EVENT_STATUS_SUBMITTED = 2, ///< Command is submitted
+    UR_EVENT_STATUS_QUEUED = 3,    ///< Command is queued
     UR_EVENT_STATUS_FORCE_UINT32 = 0x7fffffff
 
 } ur_event_status_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event query information type
-typedef enum ur_event_info_t
-{
-    UR_EVENT_INFO_COMMAND_QUEUE = 0,                ///< [::ur_queue_handle_t] Command queue information of an event object
-    UR_EVENT_INFO_CONTEXT = 1,                      ///< [::ur_context_handle_t] Context information of an event object
-    UR_EVENT_INFO_COMMAND_TYPE = 2,                 ///< [::ur_command_t] Command type information of an event object
-    UR_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3,     ///< [::ur_event_status_t] Command execution status of an event object
-    UR_EVENT_INFO_REFERENCE_COUNT = 4,              ///< [uint32_t] Reference count of an event object
+typedef enum ur_event_info_t {
+    UR_EVENT_INFO_COMMAND_QUEUE = 0,            ///< [::ur_queue_handle_t] Command queue information of an event object
+    UR_EVENT_INFO_CONTEXT = 1,                  ///< [::ur_context_handle_t] Context information of an event object
+    UR_EVENT_INFO_COMMAND_TYPE = 2,             ///< [::ur_command_t] Command type information of an event object
+    UR_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3, ///< [::ur_event_status_t] Command execution status of an event object
+    UR_EVENT_INFO_REFERENCE_COUNT = 4,          ///< [uint32_t] Reference count of an event object
     UR_EVENT_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_event_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Profiling query information type
-typedef enum ur_profiling_info_t
-{
-    UR_PROFILING_INFO_COMMAND_QUEUED = 0,           ///< A 64-bit value of current device counter in nanoseconds when the event
-                                                    ///< is enqueued
-    UR_PROFILING_INFO_COMMAND_SUBMIT = 1,           ///< A 64-bit value of current device counter in nanoseconds when the event
-                                                    ///< is submitted
-    UR_PROFILING_INFO_COMMAND_START = 2,            ///< A 64-bit value of current device counter in nanoseconds when the event
-                                                    ///< starts execution
-    UR_PROFILING_INFO_COMMAND_END = 3,              ///< A 64-bit value of current device counter in nanoseconds when the event
-                                                    ///< has finished execution
+typedef enum ur_profiling_info_t {
+    UR_PROFILING_INFO_COMMAND_QUEUED = 0, ///< A 64-bit value of current device counter in nanoseconds when the event
+                                          ///< is enqueued
+    UR_PROFILING_INFO_COMMAND_SUBMIT = 1, ///< A 64-bit value of current device counter in nanoseconds when the event
+                                          ///< is submitted
+    UR_PROFILING_INFO_COMMAND_START = 2,  ///< A 64-bit value of current device counter in nanoseconds when the event
+                                          ///< starts execution
+    UR_PROFILING_INFO_COMMAND_END = 3,    ///< A 64-bit value of current device counter in nanoseconds when the event
+                                          ///< has finished execution
     UR_PROFILING_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_profiling_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetEventInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1561,21 +1547,21 @@ typedef enum ur_profiling_info_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventGetInfo(
-    ur_event_handle_t hEvent,                       ///< [in] handle of the event object
-    ur_event_info_t propName,                       ///< [in] the name of the event property to query
-    size_t propValueSize,                           ///< [in] size in bytes of the event property value
-    void* pPropValue,                               ///< [out][optional] value of the event property
-    size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in event property
-    );
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_event_info_t propName, ///< [in] the name of the event property to query
+    size_t propValueSize,     ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional] value of the event property
+    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get profiling information for the command associated with an event
 ///        object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetEventProfilingInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1590,21 +1576,21 @@ urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,                       ///< [in] handle of the event object
-    ur_profiling_info_t propName,                   ///< [in] the name of the profiling property to query
-    size_t propValueSize,                           ///< [in] size in bytes of the profiling property value
-    void* pPropValue,                               ///< [out][optional] value of the profiling property
-    size_t* pPropValueSizeRet                       ///< [out][optional] pointer to the actual size in bytes returned in
-                                                    ///< propValue
-    );
+    ur_event_handle_t hEvent,     ///< [in] handle of the event object
+    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
+    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional] value of the profiling property
+    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+                                  ///< propValue
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Wait for a list of events to finish.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clWaitForEvent**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1618,19 +1604,19 @@ urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventWait(
-    uint32_t numEvents,                             ///< [in] number of events in the event list
-    const ur_event_handle_t* phEventWaitList        ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                                    ///< completion
-    );
+    uint32_t numEvents,                      ///< [in] number of events in the event list
+    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                             ///< completion
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference to an event handle. Increment the event object's
 ///        reference count.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainEvent**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1642,17 +1628,17 @@ urEventWait(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventRetain(
-    ur_event_handle_t hEvent                        ///< [in] handle of the event object
-    );
+    ur_event_handle_t hEvent ///< [in] handle of the event object
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Decrement the event object's reference count and delete the event
 ///        object if the reference count becomes zero.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseEvent**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1664,12 +1650,12 @@ urEventRetain(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventRelease(
-    ur_event_handle_t hEvent                        ///< [in] handle of the event object
-    );
+    ur_event_handle_t hEvent ///< [in] handle of the event object
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native event handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -1678,7 +1664,7 @@ urEventRelease(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1689,19 +1675,19 @@ urEventRelease(
 ///         + `NULL == phNativeEvent`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventGetNativeHandle(
-    ur_event_handle_t hEvent,                       ///< [in] handle of the event.
-    ur_native_handle_t* phNativeEvent               ///< [out] a pointer to the native handle of the event.
-    );
+    ur_event_handle_t hEvent,         ///< [in] handle of the event.
+    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime event object from native event handle.
-/// 
+///
 /// @details
 ///     - Creates runtime event handle from native driver event handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1713,15 +1699,14 @@ urEventGetNativeHandle(
 ///         + `NULL == phEvent`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventCreateWithNativeHandle(
-    ur_native_handle_t hNativeEvent,                ///< [in] the native handle of the event.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_event_handle_t* phEvent                      ///< [out] pointer to the handle of the event object created.
-    );
+    ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
+    ur_context_handle_t hContext,    ///< [in] handle of the context object
+    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event states for all events.
-typedef enum ur_execution_info_t
-{
+typedef enum ur_execution_info_t {
     UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE = 0,  ///< Indicates that the event has completed.
     UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING = 1,   ///< Indicates that the device has started processing this event.
     UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED = 2, ///< Indicates that the event has been submitted by the host to the device.
@@ -1733,16 +1718,16 @@ typedef enum ur_execution_info_t
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event callback function that can be registered by the application.
-typedef void (ur_event_callback_t)(
-    ur_event_handle_t hEvent,                       ///< [in] handle to event
-    ur_execution_info_t execStatus,                 ///< [in] execution status of the event
-    void* pUserData                                 ///< [in][out] pointer to data to be passed to callback
-    );
+typedef void(ur_event_callback_t)(
+    ur_event_handle_t hEvent,       ///< [in] handle to event
+    ur_execution_info_t execStatus, ///< [in] execution status of the event
+    void *pUserData                 ///< [in][out] pointer to data to be passed to callback
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Register a user callback function for a specific command execution
 ///        status.
-/// 
+///
 /// @details
 ///     - The registered callback function will be called when the execution
 ///       status of command associated with event changes to an execution status
@@ -1750,7 +1735,7 @@ typedef void (ur_event_callback_t)(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1763,11 +1748,11 @@ typedef void (ur_event_callback_t)(
 ///         + `NULL == pfnNotify`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventSetCallback(
-    ur_event_handle_t hEvent,                       ///< [in] handle of the event object
-    ur_execution_info_t execStatus,                 ///< [in] execution status of the event
-    ur_event_callback_t pfnNotify,                  ///< [in] execution status of the event
-    void* pUserData                                 ///< [in][out][optional] pointer to data to be passed to callback.
-    );
+    ur_event_handle_t hEvent,       ///< [in] handle of the event object
+    ur_execution_info_t execStatus, ///< [in] execution status of the event
+    ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
+    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -1779,139 +1764,131 @@ urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory flags
 typedef uint32_t ur_mem_flags_t;
-typedef enum ur_mem_flag_t
-{
-    UR_MEM_FLAG_READ_WRITE = UR_BIT(0),             ///< The memory object will be read and written by a kernel. This is the
-                                                    ///< default
-    UR_MEM_FLAG_WRITE_ONLY = UR_BIT(1),             ///< The memory object will be written but not read by a kernel
-    UR_MEM_FLAG_READ_ONLY = UR_BIT(2),              ///< The memory object is a read-only inside a kernel
-    UR_MEM_FLAG_USE_HOST_POINTER = UR_BIT(3),       ///< Use memory pointed by a host pointer parameter as the storage bits for
-                                                    ///< the memory object
-    UR_MEM_FLAG_ALLOC_HOST_POINTER = UR_BIT(4),     ///< Allocate memory object from host accessible memory
-    UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER = UR_BIT(5),///< Allocate memory and copy the data from host pointer pointed memory
+typedef enum ur_mem_flag_t {
+    UR_MEM_FLAG_READ_WRITE = UR_BIT(0),              ///< The memory object will be read and written by a kernel. This is the
+                                                     ///< default
+    UR_MEM_FLAG_WRITE_ONLY = UR_BIT(1),              ///< The memory object will be written but not read by a kernel
+    UR_MEM_FLAG_READ_ONLY = UR_BIT(2),               ///< The memory object is a read-only inside a kernel
+    UR_MEM_FLAG_USE_HOST_POINTER = UR_BIT(3),        ///< Use memory pointed by a host pointer parameter as the storage bits for
+                                                     ///< the memory object
+    UR_MEM_FLAG_ALLOC_HOST_POINTER = UR_BIT(4),      ///< Allocate memory object from host accessible memory
+    UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER = UR_BIT(5), ///< Allocate memory and copy the data from host pointer pointed memory
     UR_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_mem_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory types
-typedef enum ur_mem_type_t
-{
-    UR_MEM_TYPE_BUFFER = 0,                         ///< Buffer object
-    UR_MEM_TYPE_IMAGE2D = 1,                        ///< 2D image object
-    UR_MEM_TYPE_IMAGE3D = 2,                        ///< 3D image object
-    UR_MEM_TYPE_IMAGE2D_ARRAY = 3,                  ///< 2D image array object
-    UR_MEM_TYPE_IMAGE1D = 4,                        ///< 1D image object
-    UR_MEM_TYPE_IMAGE1D_ARRAY = 5,                  ///< 1D image array object
-    UR_MEM_TYPE_IMAGE1D_BUFFER = 6,                 ///< 1D image buffer object
+typedef enum ur_mem_type_t {
+    UR_MEM_TYPE_BUFFER = 0,         ///< Buffer object
+    UR_MEM_TYPE_IMAGE2D = 1,        ///< 2D image object
+    UR_MEM_TYPE_IMAGE3D = 2,        ///< 3D image object
+    UR_MEM_TYPE_IMAGE2D_ARRAY = 3,  ///< 2D image array object
+    UR_MEM_TYPE_IMAGE1D = 4,        ///< 1D image object
+    UR_MEM_TYPE_IMAGE1D_ARRAY = 5,  ///< 1D image array object
+    UR_MEM_TYPE_IMAGE1D_BUFFER = 6, ///< 1D image buffer object
     UR_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_mem_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory Information type
-typedef enum ur_mem_info_t
-{
-    UR_MEM_INFO_SIZE = 0,                           ///< size_t: actual size of of memory object in bytes
-    UR_MEM_INFO_CONTEXT = 1,                        ///< ::ur_context_handle_t: context in which the memory object was created
+typedef enum ur_mem_info_t {
+    UR_MEM_INFO_SIZE = 0,    ///< size_t: actual size of of memory object in bytes
+    UR_MEM_INFO_CONTEXT = 1, ///< ::ur_context_handle_t: context in which the memory object was created
     UR_MEM_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_mem_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel order info: number of channels and the channel layout
-typedef enum ur_image_channel_order_t
-{
-    UR_IMAGE_CHANNEL_ORDER_A = 0,                   ///< channel order A
-    UR_IMAGE_CHANNEL_ORDER_R = 1,                   ///< channel order R
-    UR_IMAGE_CHANNEL_ORDER_RG = 2,                  ///< channel order RG
-    UR_IMAGE_CHANNEL_ORDER_RA = 3,                  ///< channel order RA
-    UR_IMAGE_CHANNEL_ORDER_RGB = 4,                 ///< channel order RGB
-    UR_IMAGE_CHANNEL_ORDER_RGBA = 5,                ///< channel order RGBA
-    UR_IMAGE_CHANNEL_ORDER_BGRA = 6,                ///< channel order BGRA
-    UR_IMAGE_CHANNEL_ORDER_ARGB = 7,                ///< channel order ARGB
-    UR_IMAGE_CHANNEL_ORDER_INTENSITY = 8,           ///< channel order intensity
-    UR_IMAGE_CHANNEL_ORDER_LUMINANCE = 9,           ///< channel order luminance
-    UR_IMAGE_CHANNEL_ORDER_RX = 10,                 ///< channel order Rx
-    UR_IMAGE_CHANNEL_ORDER_RGX = 11,                ///< channel order RGx
-    UR_IMAGE_CHANNEL_ORDER_RGBX = 12,               ///< channel order RGBx
-    UR_IMAGE_CHANNEL_ORDER_SRGBA = 13,              ///< channel order sRGBA
+typedef enum ur_image_channel_order_t {
+    UR_IMAGE_CHANNEL_ORDER_A = 0,         ///< channel order A
+    UR_IMAGE_CHANNEL_ORDER_R = 1,         ///< channel order R
+    UR_IMAGE_CHANNEL_ORDER_RG = 2,        ///< channel order RG
+    UR_IMAGE_CHANNEL_ORDER_RA = 3,        ///< channel order RA
+    UR_IMAGE_CHANNEL_ORDER_RGB = 4,       ///< channel order RGB
+    UR_IMAGE_CHANNEL_ORDER_RGBA = 5,      ///< channel order RGBA
+    UR_IMAGE_CHANNEL_ORDER_BGRA = 6,      ///< channel order BGRA
+    UR_IMAGE_CHANNEL_ORDER_ARGB = 7,      ///< channel order ARGB
+    UR_IMAGE_CHANNEL_ORDER_INTENSITY = 8, ///< channel order intensity
+    UR_IMAGE_CHANNEL_ORDER_LUMINANCE = 9, ///< channel order luminance
+    UR_IMAGE_CHANNEL_ORDER_RX = 10,       ///< channel order Rx
+    UR_IMAGE_CHANNEL_ORDER_RGX = 11,      ///< channel order RGx
+    UR_IMAGE_CHANNEL_ORDER_RGBX = 12,     ///< channel order RGBx
+    UR_IMAGE_CHANNEL_ORDER_SRGBA = 13,    ///< channel order sRGBA
     UR_IMAGE_CHANNEL_ORDER_FORCE_UINT32 = 0x7fffffff
 
 } ur_image_channel_order_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel type info: describe the size of the channel data type
-typedef enum ur_image_channel_type_t
-{
-    UR_IMAGE_CHANNEL_TYPE_SNORM_INT8 = 0,           ///< channel type snorm int8
-    UR_IMAGE_CHANNEL_TYPE_SNORM_INT16 = 1,          ///< channel type snorm int16
-    UR_IMAGE_CHANNEL_TYPE_UNORM_INT8 = 2,           ///< channel type unorm int8
-    UR_IMAGE_CHANNEL_TYPE_UNORM_INT16 = 3,          ///< channel type unorm int16
-    UR_IMAGE_CHANNEL_TYPE_UNORM_SHORT_565 = 4,      ///< channel type unorm short 565
-    UR_IMAGE_CHANNEL_TYPE_UNORM_SHORT_555 = 5,      ///< channel type unorm short 555
-    UR_IMAGE_CHANNEL_TYPE_INT_101010 = 6,           ///< channel type int 101010
-    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT8 = 7,          ///< channel type signed int8
-    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT16 = 8,         ///< channel type signed int16
-    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32 = 9,         ///< channel type signed int32
-    UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8 = 10,       ///< channel type unsigned int8
-    UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT16 = 11,      ///< channel type unsigned int16
-    UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32 = 12,      ///< channel type unsigned int32
-    UR_IMAGE_CHANNEL_TYPE_HALF_FLOAT = 13,          ///< channel type half float
-    UR_IMAGE_CHANNEL_TYPE_FLOAT = 14,               ///< channel type float
+typedef enum ur_image_channel_type_t {
+    UR_IMAGE_CHANNEL_TYPE_SNORM_INT8 = 0,      ///< channel type snorm int8
+    UR_IMAGE_CHANNEL_TYPE_SNORM_INT16 = 1,     ///< channel type snorm int16
+    UR_IMAGE_CHANNEL_TYPE_UNORM_INT8 = 2,      ///< channel type unorm int8
+    UR_IMAGE_CHANNEL_TYPE_UNORM_INT16 = 3,     ///< channel type unorm int16
+    UR_IMAGE_CHANNEL_TYPE_UNORM_SHORT_565 = 4, ///< channel type unorm short 565
+    UR_IMAGE_CHANNEL_TYPE_UNORM_SHORT_555 = 5, ///< channel type unorm short 555
+    UR_IMAGE_CHANNEL_TYPE_INT_101010 = 6,      ///< channel type int 101010
+    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT8 = 7,     ///< channel type signed int8
+    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT16 = 8,    ///< channel type signed int16
+    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32 = 9,    ///< channel type signed int32
+    UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8 = 10,  ///< channel type unsigned int8
+    UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT16 = 11, ///< channel type unsigned int16
+    UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32 = 12, ///< channel type unsigned int32
+    UR_IMAGE_CHANNEL_TYPE_HALF_FLOAT = 13,     ///< channel type half float
+    UR_IMAGE_CHANNEL_TYPE_FLOAT = 14,          ///< channel type float
     UR_IMAGE_CHANNEL_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_image_channel_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image information types
-typedef enum ur_image_info_t
-{
-    UR_IMAGE_INFO_FORMAT = 0,                       ///< ::ur_image_format_t: image format
-    UR_IMAGE_INFO_ELEMENT_SIZE = 1,                 ///< size_t: element size
-    UR_IMAGE_INFO_ROW_PITCH = 2,                    ///< size_t: row pitch
-    UR_IMAGE_INFO_SLICE_PITCH = 3,                  ///< size_t: slice pitch
-    UR_IMAGE_INFO_WIDTH = 4,                        ///< size_t: image width
-    UR_IMAGE_INFO_HEIGHT = 5,                       ///< size_t: image height
-    UR_IMAGE_INFO_DEPTH = 6,                        ///< size_t: image depth
+typedef enum ur_image_info_t {
+    UR_IMAGE_INFO_FORMAT = 0,       ///< ::ur_image_format_t: image format
+    UR_IMAGE_INFO_ELEMENT_SIZE = 1, ///< size_t: element size
+    UR_IMAGE_INFO_ROW_PITCH = 2,    ///< size_t: row pitch
+    UR_IMAGE_INFO_SLICE_PITCH = 3,  ///< size_t: slice pitch
+    UR_IMAGE_INFO_WIDTH = 4,        ///< size_t: image width
+    UR_IMAGE_INFO_HEIGHT = 5,       ///< size_t: image height
+    UR_IMAGE_INFO_DEPTH = 6,        ///< size_t: image depth
     UR_IMAGE_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_image_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image format including channel layout and data type
-typedef struct ur_image_format_t
-{
-    ur_image_channel_order_t channelOrder;          ///< [in] image channel order
-    ur_image_channel_type_t channelType;            ///< [in] image channel type
+typedef struct ur_image_format_t {
+    ur_image_channel_order_t channelOrder; ///< [in] image channel order
+    ur_image_channel_type_t channelType;   ///< [in] image channel type
 
 } ur_image_format_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image descriptor type.
-typedef struct ur_image_desc_t
-{
-    ur_structure_type_t stype;                      ///< [in] type of this structure
-    const void* pNext;                              ///< [in][optional] pointer to extension-specific structure
-    ur_mem_type_t type;                             ///< [in] memory object type
-    size_t width;                                   ///< [in] image width
-    size_t height;                                  ///< [in] image height
-    size_t depth;                                   ///< [in] image depth
-    size_t arraySize;                               ///< [in] image array size
-    size_t rowPitch;                                ///< [in] image row pitch
-    size_t slicePitch;                              ///< [in] image slice pitch
-    uint32_t numMipLevel;                           ///< [in] number of MIP levels
-    uint32_t numSamples;                            ///< [in] number of samples
+typedef struct ur_image_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    ur_mem_type_t type;        ///< [in] memory object type
+    size_t width;              ///< [in] image width
+    size_t height;             ///< [in] image height
+    size_t depth;              ///< [in] image depth
+    size_t arraySize;          ///< [in] image array size
+    size_t rowPitch;           ///< [in] image row pitch
+    size_t slicePitch;         ///< [in] image slice pitch
+    uint32_t numMipLevel;      ///< [in] number of MIP levels
+    uint32_t numSamples;       ///< [in] number of samples
 
 } ur_image_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create an image object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateImage**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1936,21 +1913,21 @@ typedef struct ur_image_desc_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemImageCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
-    const ur_image_format_t* pImageFormat,          ///< [in] pointer to image format specification
-    const ur_image_desc_t* pImageDesc,              ///< [in] pointer to image description
-    void* pHost,                                    ///< [in] pointer to the buffer data
-    ur_mem_handle_t* phMem                          ///< [out] pointer to handle of image object created
-    );
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    void *pHost,                           ///< [in] pointer to the buffer data
+    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a memory buffer
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1969,25 +1946,25 @@ urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemBufferCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
-    size_t size,                                    ///< [in] size in bytes of the memory object to be allocated
-    void* pHost,                                    ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t* phBuffer                       ///< [out] pointer to handle of the memory buffer created
-    );
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
+    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
+    void *pHost,                  ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference the memory object. Increment the memory object's
 ///        reference count
-/// 
+///
 /// @details
 ///     - Useful in library function to retain access to the memory object after
 ///       the caller released the object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainMemoryObject**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -1999,17 +1976,17 @@ urMemBufferCreate(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemRetain(
-    ur_mem_handle_t hMem                            ///< [in] handle of the memory object to get access
-    );
+    ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Decrement the memory object's reference count and delete the object if
 ///        the reference count becomes zero.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseMemoryObject**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2020,34 +1997,32 @@ urMemRetain(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemRelease(
-    ur_mem_handle_t hMem                            ///< [in] handle of the memory object to release
-    );
+    ur_mem_handle_t hMem ///< [in] handle of the memory object to release
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Buffer region type, used to describe a sub buffer
-typedef struct ur_buffer_region_t
-{
-    size_t origin;                                  ///< [in] buffer origin offset
-    size_t size;                                    ///< [in] size of the buffer region
+typedef struct ur_buffer_region_t {
+    size_t origin; ///< [in] buffer origin offset
+    size_t size;   ///< [in] size of the buffer region
 
 } ur_buffer_region_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Buffer creation type
-typedef enum ur_buffer_create_type_t
-{
-    UR_BUFFER_CREATE_TYPE_REGION = 0,               ///< buffer create type is region
+typedef enum ur_buffer_create_type_t {
+    UR_BUFFER_CREATE_TYPE_REGION = 0, ///< buffer create type is region
     UR_BUFFER_CREATE_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_buffer_create_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sub buffer representing a region in an existing buffer
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateSubBuffer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2069,16 +2044,16 @@ typedef enum ur_buffer_create_type_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                        ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                           ///< [in] allocation and usage information flags
-    ur_buffer_create_type_t bufferCreateType,       ///< [in] buffer creation type
-    ur_buffer_region_t* pBufferCreateInfo,          ///< [in] pointer to buffer create region information
-    ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of sub buffer created
-    );
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+    ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
+    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
+    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native mem handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -2087,7 +2062,7 @@ urMemBufferPartition(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2098,19 +2073,19 @@ urMemBufferPartition(
 ///         + `NULL == phNativeMem`
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemGetNativeHandle(
-    ur_mem_handle_t hMem,                           ///< [in] handle of the mem.
-    ur_native_handle_t* phNativeMem                 ///< [out] a pointer to the native handle of the mem.
-    );
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime mem object from native mem handle.
-/// 
+///
 /// @details
 ///     - Creates runtime mem handle from native driver mem handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2122,21 +2097,21 @@ urMemGetNativeHandle(
 ///         + `NULL == phMem`
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemCreateWithNativeHandle(
-    ur_native_handle_t hNativeMem,                  ///< [in] the native handle of the mem.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_mem_handle_t* phMem                          ///< [out] pointer to the handle of the mem object created.
-    );
+    ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieve information about a memory object.
-/// 
+///
 /// @details
 ///     - Query information that is common to all memory objects.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetMemObjectInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2147,26 +2122,26 @@ urMemCreateWithNativeHandle(
 ///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemGetInfo(
-    ur_mem_handle_t hMemory,                        ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType,                      ///< [in] type of the info to retrieve.
-    size_t propSize,                                ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void* pMemInfo,                                 ///< [out][optional] array of bytes holding the info.
-                                                    ///< If propSize is less than the real number of bytes needed to return 
-                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                                    ///< pMemInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
-    );
+    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
+                               ///< If propSize is less than the real number of bytes needed to return
+                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                               ///< pMemInfo is not used.
+    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieve information about an image object.
-/// 
+///
 /// @details
 ///     - Query information specific to an image object.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetImageInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2177,15 +2152,15 @@ urMemGetInfo(
 ///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemImageGetInfo(
-    ur_mem_handle_t hMemory,                        ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType,                    ///< [in] type of image info to retrieve.
-    size_t propSize,                                ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void* pImgInfo,                                 ///< [out][optional] array of bytes holding the info.
-                                                    ///< If propSize is less than the real number of bytes needed to return
-                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                                    ///< pImgInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
-    );
+    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
+                                 ///< If propSize is less than the real number of bytes needed to return
+                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                 ///< pImgInfo is not used.
+    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -2196,7 +2171,7 @@ urMemImageGetInfo(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Tear down L0 runtime instance and release all its resources
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2206,8 +2181,8 @@ urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urTearDown(
-    void* pParams                                   ///< [in] pointer to tear down parameters
-    );
+    void *pParams ///< [in] pointer to tear down parameters
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -2218,14 +2193,13 @@ urTearDown(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query queue info
-typedef enum ur_queue_info_t
-{
-    UR_QUEUE_INFO_CONTEXT = 0,                      ///< Queue context info
-    UR_QUEUE_INFO_DEVICE = 1,                       ///< Queue device info
-    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,               ///< Queue device default info
-    UR_QUEUE_INFO_PROPERTIES = 3,                   ///< Queue properties info
-    UR_QUEUE_INFO_REFERENCE_COUNT = 4,              ///< Queue reference count
-    UR_QUEUE_INFO_SIZE = 5,                         ///< Queue size info
+typedef enum ur_queue_info_t {
+    UR_QUEUE_INFO_CONTEXT = 0,         ///< Queue context info
+    UR_QUEUE_INFO_DEVICE = 1,          ///< Queue device info
+    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< Queue device default info
+    UR_QUEUE_INFO_PROPERTIES = 3,      ///< Queue properties info
+    UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< Queue reference count
+    UR_QUEUE_INFO_SIZE = 5,            ///< Queue size info
     UR_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_queue_info_t;
@@ -2233,15 +2207,14 @@ typedef enum ur_queue_info_t
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue property flags
 typedef uint32_t ur_queue_flags_t;
-typedef enum ur_queue_flag_t
-{
-    UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE = UR_BIT(0),///< Enable/disable out of order execution
-    UR_QUEUE_FLAG_PROFILING_ENABLE = UR_BIT(1),     ///< Enable/disable profiling
-    UR_QUEUE_FLAG_ON_DEVICE = UR_BIT(2),            ///< Is a device queue
-    UR_QUEUE_FLAG_ON_DEVICE_DEFAULT = UR_BIT(3),    ///< Is the default queue for a device
-    UR_QUEUE_FLAG_DISCARD_EVENTS = UR_BIT(4),       ///< Events will be discarded
-    UR_QUEUE_FLAG_PRIORITY_LOW = UR_BIT(5),         ///< Low priority queue
-    UR_QUEUE_FLAG_PRIORITY_HIGH = UR_BIT(6),        ///< High priority queue
+typedef enum ur_queue_flag_t {
+    UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE = UR_BIT(0), ///< Enable/disable out of order execution
+    UR_QUEUE_FLAG_PROFILING_ENABLE = UR_BIT(1),              ///< Enable/disable profiling
+    UR_QUEUE_FLAG_ON_DEVICE = UR_BIT(2),                     ///< Is a device queue
+    UR_QUEUE_FLAG_ON_DEVICE_DEFAULT = UR_BIT(3),             ///< Is the default queue for a device
+    UR_QUEUE_FLAG_DISCARD_EVENTS = UR_BIT(4),                ///< Events will be discarded
+    UR_QUEUE_FLAG_PRIORITY_LOW = UR_BIT(5),                  ///< Low priority queue
+    UR_QUEUE_FLAG_PRIORITY_HIGH = UR_BIT(6),                 ///< High priority queue
     UR_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_queue_flag_t;
@@ -2252,21 +2225,20 @@ typedef intptr_t ur_queue_property_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue Properties
-typedef enum ur_queue_properties_t
-{
-    UR_QUEUE_PROPERTIES_FLAGS = -1,                 ///< [::ur_queue_flags_t]: the bitfield of queue flags
-    UR_QUEUE_PROPERTIES_COMPUTE_INDEX = -2,         ///< [uint32_t]: the queue index
+typedef enum ur_queue_properties_t {
+    UR_QUEUE_PROPERTIES_FLAGS = -1,         ///< [::ur_queue_flags_t]: the bitfield of queue flags
+    UR_QUEUE_PROPERTIES_COMPUTE_INDEX = -2, ///< [uint32_t]: the queue index
     UR_QUEUE_PROPERTIES_FORCE_UINT32 = 0x7fffffff
 
 } ur_queue_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetCommandQueueInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2284,20 +2256,20 @@ typedef enum ur_queue_properties_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueGetInfo(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue object
-    ur_queue_info_t propName,                       ///< [in] name of the queue property to query
-    size_t propValueSize,                           ///< [in] size in bytes of the queue property value provided
-    void* pPropValue,                               ///< [out] value of the queue property
-    size_t* pPropSizeRet                            ///< [out] size in bytes returned in queue property value
-    );
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_queue_info_t propName, ///< [in] name of the queue property to query
+    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out] value of the queue property
+    size_t *pPropSizeRet      ///< [out] size in bytes returned in queue property value
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a command queue for a device in a context
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateCommandQueueWithProperties**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2316,28 +2288,28 @@ urQueueGetInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-    const ur_queue_property_t* pProps,              ///< [in] specifies a list of queue properties and their corresponding values.
-                                                    ///< Each property name is immediately followed by the corresponding
-                                                    ///< desired value.
-                                                    ///< The list is terminated with a 0. 
-                                                    ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t* phQueue                      ///< [out] pointer to handle of queue object created
-    );
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_device_handle_t hDevice,        ///< [in] handle of the device object
+    const ur_queue_property_t *pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+                                       ///< Each property name is immediately followed by the corresponding
+                                       ///< desired value.
+                                       ///< The list is terminated with a 0.
+                                       ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference to the command queue handle. Increment the command
 ///        queue's reference count
-/// 
+///
 /// @details
 ///     - Useful in library function to retain access to the command queue after
 ///       the caller released the queue.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainCommandQueue**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2349,23 +2321,23 @@ urQueueCreate(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueRetain(
-    ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to get access
-    );
+    ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Decrement the command queue's reference count and delete the command
 ///        queue if the reference count becomes zero.
-/// 
+///
 /// @details
 ///     - After the command queue reference count becomes zero and all queued
 ///       commands in the queue have finished, the queue is deleted.
 ///     - It also performs an implicit flush to issue all previously queued
 ///       commands in the queue.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseCommandQueue**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2377,12 +2349,12 @@ urQueueRetain(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueRelease(
-    ur_queue_handle_t hQueue                        ///< [in] handle of the queue object to release
-    );
+    ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return queue native queue handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -2391,7 +2363,7 @@ urQueueRelease(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2402,19 +2374,19 @@ urQueueRelease(
 ///         + `NULL == phNativeQueue`
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,                       ///< [in] handle of the queue.
-    ur_native_handle_t* phNativeQueue               ///< [out] a pointer to the native handle of the queue.
-    );
+    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime queue object from native queue handle.
-/// 
+///
 /// @details
 ///     - Creates runtime queue handle from native driver queue handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2426,26 +2398,26 @@ urQueueGetNativeHandle(
 ///         + `NULL == phQueue`
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueCreateWithNativeHandle(
-    ur_native_handle_t hNativeQueue,                ///< [in] the native handle of the queue.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_queue_handle_t* phQueue                      ///< [out] pointer to the handle of the queue object created.
-    );
+    ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
+    ur_context_handle_t hContext,    ///< [in] handle of the context object
+    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Blocks until all previously issued commands to the command queue are
 ///        finished.
-/// 
+///
 /// @details
 ///     - Blocks until all previously issued commands to the command queue are
 ///       issued and completed.
 ///     - ::urQueueFinish does not return until all enqueued commands have been
 ///       processed and finished.
 ///     - ::urQueueFinish acts as a synchronization point.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clFinish**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2456,23 +2428,23 @@ urQueueCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueFinish(
-    ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be finished.
-    );
+    ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Issues all previously enqueued commands in a command queue to the
 ///        device.
-/// 
+///
 /// @details
 ///     - Guarantees that all enqueued commands will be issued to the
 ///       appropriate device.
 ///     - There is no guarantee that they will be completed after ::urQueueFlush
 ///       returns.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clFlush**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2483,8 +2455,8 @@ urQueueFinish(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueFlush(
-    ur_queue_handle_t hQueue                        ///< [in] handle of the queue to be flushed.
-    );
+    ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -2495,27 +2467,25 @@ urQueueFlush(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get sample object information
-typedef enum ur_sampler_info_t
-{
-    UR_SAMPLER_INFO_REFERENCE_COUNT = 0,            ///< Sampler reference count info
-    UR_SAMPLER_INFO_CONTEXT = 1,                    ///< Sampler context info
-    UR_SAMPLER_INFO_NORMALIZED_COORDS = 2,          ///< Sampler normalized coordindate setting
-    UR_SAMPLER_INFO_ADDRESSING_MODE = 3,            ///< Sampler addressing mode setting
-    UR_SAMPLER_INFO_FILTER_MODE = 4,                ///< Sampler filter mode setting
-    UR_SAMPLER_INFO_MIP_FILTER_MODE = 5,            ///< Sampler MIP filter mode setting
-    UR_SAMPLER_INFO_LOD_MIN = 6,                    ///< Sampler LOD Min value
-    UR_SAMPLER_INFO_LOD_MAX = 7,                    ///< Sampler LOD Max value
+typedef enum ur_sampler_info_t {
+    UR_SAMPLER_INFO_REFERENCE_COUNT = 0,   ///< Sampler reference count info
+    UR_SAMPLER_INFO_CONTEXT = 1,           ///< Sampler context info
+    UR_SAMPLER_INFO_NORMALIZED_COORDS = 2, ///< Sampler normalized coordindate setting
+    UR_SAMPLER_INFO_ADDRESSING_MODE = 3,   ///< Sampler addressing mode setting
+    UR_SAMPLER_INFO_FILTER_MODE = 4,       ///< Sampler filter mode setting
+    UR_SAMPLER_INFO_MIP_FILTER_MODE = 5,   ///< Sampler MIP filter mode setting
+    UR_SAMPLER_INFO_LOD_MIN = 6,           ///< Sampler LOD Min value
+    UR_SAMPLER_INFO_LOD_MAX = 7,           ///< Sampler LOD Max value
     UR_SAMPLER_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_sampler_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler properties
-typedef enum ur_sampler_properties_t
-{
-    UR_SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0,    ///< Sampler normalized coordinates
-    UR_SAMPLER_PROPERTIES_ADDRESSING_MODE = 1,      ///< Sampler addressing mode
-    UR_SAMPLER_PROPERTIES_FILTER_MODE = 2,          ///< Sampler filter mode
+typedef enum ur_sampler_properties_t {
+    UR_SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0, ///< Sampler normalized coordinates
+    UR_SAMPLER_PROPERTIES_ADDRESSING_MODE = 1,   ///< Sampler addressing mode
+    UR_SAMPLER_PROPERTIES_FILTER_MODE = 2,       ///< Sampler filter mode
     UR_SAMPLER_PROPERTIES_FORCE_UINT32 = 0x7fffffff
 
 } ur_sampler_properties_t;
@@ -2526,8 +2496,7 @@ typedef intptr_t ur_sampler_property_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler addressing mode
-typedef enum ur_sampler_addressing_mode_t
-{
+typedef enum ur_sampler_addressing_mode_t {
     UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT = 0, ///< Mirrored Repeat
     UR_SAMPLER_ADDRESSING_MODE_REPEAT = 1,          ///< Repeat
     UR_SAMPLER_ADDRESSING_MODE_CLAMP = 2,           ///< Clamp
@@ -2539,17 +2508,17 @@ typedef enum ur_sampler_addressing_mode_t
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sampler object in a context
-/// 
+///
 /// @details
 ///     - The props parameter specifies a list of sampler property names and
 ///       their corresponding values.
 ///     - The list is terminated with 0. If the list is NULL, default values
 ///       will be used.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateSamplerWithProperties**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2566,20 +2535,20 @@ typedef enum ur_sampler_addressing_mode_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    const ur_sampler_property_t* pProps,            ///< [in] specifies a list of sampler property names and their
-                                                    ///< corresponding values.
-    ur_sampler_handle_t* phSampler                  ///< [out] pointer to handle of sampler object created
-    );
+    ur_context_handle_t hContext,        ///< [in] handle of the context object
+    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
+                                         ///< corresponding values.
+    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference to the sampler object handle. Increment its reference
 ///        count
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainSampler**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2591,17 +2560,17 @@ urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRetain(
-    ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to get access
-    );
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Decrement the sampler's reference count and delete the sampler if the
 ///        reference count becomes zero.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseSampler**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2613,16 +2582,16 @@ urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(
-    ur_sampler_handle_t hSampler                    ///< [in] handle of the sampler object to release
-    );
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a sampler object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetSamplerInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2640,16 +2609,16 @@ urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerGetInfo(
-    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,                     ///< [in] name of the sampler property to query
-    size_t propValueSize,                           ///< [in] size in bytes of the sampler property value provided
-    void* pPropValue,                               ///< [out] value of the sampler property
-    size_t* pPropSizeRet                            ///< [out] size in bytes returned in sampler property value
-    );
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
+    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
+    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out] value of the sampler property
+    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return sampler native sampler handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -2658,7 +2627,7 @@ urSamplerGetInfo(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2669,19 +2638,19 @@ urSamplerGetInfo(
 ///         + `NULL == phNativeSampler`
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,                   ///< [in] handle of the sampler.
-    ur_native_handle_t* phNativeSampler             ///< [out] a pointer to the native handle of the sampler.
-    );
+    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
+    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime sampler object from native sampler handle.
-/// 
+///
 /// @details
 ///     - Creates runtime sampler handle from native driver sampler handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2693,10 +2662,10 @@ urSamplerGetNativeHandle(
 ///         + `NULL == phSampler`
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler,              ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_sampler_handle_t* phSampler                  ///< [out] pointer to the handle of the sampler object created.
-    );
+    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -2708,40 +2677,37 @@ urSamplerCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory property flags
 typedef uint32_t ur_usm_mem_flags_t;
-typedef enum ur_usm_mem_flag_t
-{
-    UR_USM_MEM_FLAG_ALLOC_FLAGS_INTEL = UR_BIT(0),  ///< The USM memory allocation is from Intel USM
+typedef enum ur_usm_mem_flag_t {
+    UR_USM_MEM_FLAG_ALLOC_FLAGS_INTEL = UR_BIT(0), ///< The USM memory allocation is from Intel USM
     UR_USM_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_usm_mem_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocation type
-typedef enum ur_usm_type_t
-{
-    UR_USM_TYPE_UNKOWN = 0,                         ///< Unkown USM type
-    UR_USM_TYPE_HOST = 1,                           ///< Host USM type
-    UR_USM_TYPE_DEVICE = 2,                         ///< Device USM type
-    UR_USM_TYPE_SHARED = 3,                         ///< Shared USM type
+typedef enum ur_usm_type_t {
+    UR_USM_TYPE_UNKOWN = 0, ///< Unkown USM type
+    UR_USM_TYPE_HOST = 1,   ///< Host USM type
+    UR_USM_TYPE_DEVICE = 2, ///< Device USM type
+    UR_USM_TYPE_SHARED = 3, ///< Shared USM type
     UR_USM_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_usm_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory allocation information type
-typedef enum ur_usm_alloc_info_t
-{
-    UR_USM_ALLOC_INFO_TYPE = 0,                     ///< Memory allocation type info
-    UR_USM_ALLOC_INFO_BASE_PTR = 1,                 ///< Memory allocation base pointer info
-    UR_USM_ALLOC_INFO_SIZE = 2,                     ///< Memory allocation size info
-    UR_USM_ALLOC_INFO_DEVICE = 3,                   ///< Memory allocation device info
+typedef enum ur_usm_alloc_info_t {
+    UR_USM_ALLOC_INFO_TYPE = 0,     ///< Memory allocation type info
+    UR_USM_ALLOC_INFO_BASE_PTR = 1, ///< Memory allocation base pointer info
+    UR_USM_ALLOC_INFO_SIZE = 2,     ///< Memory allocation size info
+    UR_USM_ALLOC_INFO_DEVICE = 3,   ///< Memory allocation device info
     UR_USM_ALLOC_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_usm_alloc_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocate host memory
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2758,16 +2724,16 @@ typedef enum ur_usm_alloc_info_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMHostAlloc(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_usm_mem_flags_t* pUSMFlag,                   ///< [in] USM memory allocation flags
-    size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,                                 ///< [in] alignment of the USM memory object
-    void** ppMem                                    ///< [out] pointer to USM host memory object
-    );
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_mem_flags_t *pUSMFlag, ///< [in] USM memory allocation flags
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM host memory object
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocate device memory
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2785,17 +2751,17 @@ urUSMHostAlloc(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMDeviceAlloc(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-    ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
-    size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,                                 ///< [in] alignment of the USM memory object
-    void** ppMem                                    ///< [out] pointer to USM device memory object
-    );
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM device memory object
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocate shared memory
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2813,17 +2779,17 @@ urUSMDeviceAlloc(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMSharedAlloc(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device object
-    ur_usm_mem_flags_t* pUSMProp,                   ///< [in] USM memory properties
-    size_t size,                                    ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,                                 ///< [in] alignment of the USM memory object
-    void** ppMem                                    ///< [out] pointer to USM shared memory object
-    );
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM shared memory object
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Free the USM memory object
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2836,13 +2802,13 @@ urUSMSharedAlloc(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMFree(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    void* pMem                                      ///< [in] pointer to USM memory object
-    );
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to USM memory object
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get USM memory object allocation information
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2859,13 +2825,13 @@ urUSMFree(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMGetMemAllocInfo(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    const void* pMem,                               ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName,                   ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,                           ///< [in] size in bytes of the USM allocation property value
-    void* pPropValue,                               ///< [out][optional] value of the USM allocation property
-    size_t* pPropValueSizeRet                       ///< [out][optional] bytes returned in USM allocation property
-    );
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const void *pMem,             ///< [in] pointer to USM memory object
+    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional] value of the USM allocation property
+    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -2876,22 +2842,21 @@ urUSMGetMemAllocInfo(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device types
-typedef enum ur_device_type_t
-{
-    UR_DEVICE_TYPE_DEFAULT = 1,                     ///< The default device type as preferred by the runtime
-    UR_DEVICE_TYPE_ALL = 2,                         ///< Devices of all types
-    UR_DEVICE_TYPE_GPU = 3,                         ///< Graphics Processing Unit
-    UR_DEVICE_TYPE_CPU = 4,                         ///< Central Processing Unit
-    UR_DEVICE_TYPE_FPGA = 5,                        ///< Field Programmable Gate Array
-    UR_DEVICE_TYPE_MCA = 6,                         ///< Memory Copy Accelerator
-    UR_DEVICE_TYPE_VPU = 7,                         ///< Vision Processing Unit
+typedef enum ur_device_type_t {
+    UR_DEVICE_TYPE_DEFAULT = 1, ///< The default device type as preferred by the runtime
+    UR_DEVICE_TYPE_ALL = 2,     ///< Devices of all types
+    UR_DEVICE_TYPE_GPU = 3,     ///< Graphics Processing Unit
+    UR_DEVICE_TYPE_CPU = 4,     ///< Central Processing Unit
+    UR_DEVICE_TYPE_FPGA = 5,    ///< Field Programmable Gate Array
+    UR_DEVICE_TYPE_MCA = 6,     ///< Memory Copy Accelerator
+    UR_DEVICE_TYPE_VPU = 7,     ///< Vision Processing Unit
     UR_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves devices within a platform
-/// 
+///
 /// @details
 ///     - Multiple calls to this function will return identical device handles,
 ///       in the same order.
@@ -2902,11 +2867,11 @@ typedef enum ur_device_type_t
 ///       with a subsequent call to ::urDeviceRelease.
 ///     - The application may call this function from simultaneous threads, the
 ///       implementation must be thread-safe
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetDeviceIDs**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -2918,156 +2883,155 @@ typedef enum ur_device_type_t
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGet(
-    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
-    ur_device_type_t DeviceType,                    ///< [in] the type of the devices.
-    uint32_t NumEntries,                            ///< [in] the number of devices to be added to phDevices.
-                                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                                    ///< will be returned.
-    ur_device_handle_t* phDevices,                  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                                    ///< If NumEntries is less than the number of devices available, then
-                                                    ///< platform shall only retrieve that number of devices.
-    uint32_t* pNumDevices                           ///< [out][optional] pointer to the number of devices.
-                                                    ///< pNumDevices will be updated with the total number of devices available.
-    );
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
+    ur_device_type_t DeviceType,    ///< [in] the type of the devices.
+    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
+                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+                                    ///< will be returned.
+    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                    ///< If NumEntries is less than the number of devices available, then
+                                    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
+                                    ///< pNumDevices will be updated with the total number of devices available.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device info
-typedef enum ur_device_info_t
-{
-    UR_DEVICE_INFO_TYPE = 0,                        ///< ::ur_device_type_t: type of the device
-    UR_DEVICE_INFO_VENDOR_ID = 1,                   ///< uint32_t: vendor Id of the device
-    UR_DEVICE_INFO_DEVICE_ID = 2,                   ///< uint32_t: Id of the device
-    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,           ///< uint32_t: the number of compute units
-    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,    ///< uint32_t: max work item dimensions
-    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,         ///< size_t[]: return an array of max work item sizes
-    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,         ///< size_t: max work group size
-    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,            ///< Return a bit field of ::ur_fp_capability_flags_t: single precision
-                                                    ///< floating point capability
-    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,              ///< Return a bit field of ::ur_fp_capability_flags_t: half precision
-                                                    ///< floating point capability
-    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,            ///< Return a bit field of ::ur_fp_capability_flags_t: double precision
-                                                    ///< floating point capability
-    UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,           ///< Return a bit field of ::ur_queue_flags_t: command queue properties
-                                                    ///< supported by the device
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,///< uint32_t: preferred vector width for char
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 12,   ///< uint32_t: preferred vector width for short
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 13, ///< uint32_t: preferred vector width for int
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 14,///< uint32_t: preferred vector width for long
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 15,   ///< uint32_t: preferred vector width for float
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 16,  ///< uint32_t: preferred vector width for double
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 17,///< uint32_t: preferred vector width for half float
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 18,   ///< uint32_t: native vector width for char
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 19,  ///< uint32_t: native vector width for short
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 20,    ///< uint32_t: native vector width for int
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 21,   ///< uint32_t: native vector width for long
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 22,  ///< uint32_t: native vector width for float
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 23, ///< uint32_t: native vector width for double
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 24,   ///< uint32_t: native vector width for half float
-    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 25,        ///< uint32_t: max clock frequency in MHz
-    UR_DEVICE_INFO_MEMORY_CLOCK_RATE = 26,          ///< uint32_t: memory clock frequency in MHz
-    UR_DEVICE_INFO_ADDRESS_BITS = 27,               ///< uint32_t: address bits
-    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 28,         ///< uint64_t: max memory allocation size
-    UR_DEVICE_INFO_IMAGE_SUPPORTED = 29,            ///< bool: images are supported
-    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 30,        ///< uint32_t: max number of image objects arguments of a kernel declared
-                                                    ///< with the read_only qualifier
-    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 31,       ///< uint32_t: max number of image objects arguments of a kernel declared
-                                                    ///< with the write_only qualifier
-    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 32,  ///< uint32_t: max number of image objects arguments of a kernel declared
-                                                    ///< with the read_write qualifier
-    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 33,          ///< size_t: max width of Image2D object
-    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 34,         ///< size_t: max heigh of Image2D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 35,          ///< size_t: max width of Image3D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 36,         ///< size_t: max height of Image3D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 37,          ///< size_t: max depth of Image3D object
-    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 38,      ///< size_t: max image buffer size
-    UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE = 39,       ///< size_t: max image array size
-    UR_DEVICE_INFO_MAX_SAMPLERS = 40,               ///< uint32_t: max number of samplers that can be used in a kernel
-    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 41,         ///< size_t: max size in bytes of all arguments passed to a kernel
-    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 42,        ///< uint32_t: memory base address alignment
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 43,      ///< ::ur_device_mem_cache_type_t: global memory cache type
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 44,  ///< uint32_t: global memory cache line size in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 45,      ///< uint64_t: size of global memory cache in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 46,            ///< uint64_t: size of global memory in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_FREE = 47,            ///< uint64_t: size of global memory which is free in bytes
-    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 48,   ///< uint64_t: max constant buffer size in bytes
-    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,          ///< uint32_t: max number of __const declared arguments in a kernel
-    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,             ///< ::ur_device_local_mem_type_t: local memory type
-    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,             ///< uint64_t: local memory size in bytes
-    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,   ///< bool: support error correction to global and local memory
-    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,        ///< bool: unified host device memory
-    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54, ///< size_t: profiling timer resolution in nanoseconds
-    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,              ///< bool: little endian byte order
-    UR_DEVICE_INFO_AVAILABLE = 56,                  ///< bool: device is available
-    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,         ///< bool: device compiler is available
-    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,           ///< bool: device linker is available
-    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,     ///< ::ur_device_exec_capability_flags_t: device kernel execution
-                                                    ///< capability bit-field
-    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60, ///< ::ur_queue_flags_t: device command queue property bit-field
-    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,   ///< ::ur_queue_flags_t: host queue property bit-field
-    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,           ///< char[]: a semi-colon separated list of built-in kernels
-    UR_DEVICE_INFO_PLATFORM = 63,                   ///< ::ur_platform_handle_t: the platform associated with the device
-    UR_DEVICE_INFO_REFERENCE_COUNT = 64,            ///< uint32_t: reference count
-    UR_DEVICE_INFO_IL_VERSION = 65,                 ///< char[]: IL version
-    UR_DEVICE_INFO_NAME = 66,                       ///< char[]: Device name
-    UR_DEVICE_INFO_VENDOR = 67,                     ///< char[]: Device vendor
-    UR_DEVICE_INFO_DRIVER_VERSION = 68,             ///< char[]: Driver version
-    UR_DEVICE_INFO_PROFILE = 69,                    ///< char[]: Device profile
-    UR_DEVICE_INFO_VERSION = 70,                    ///< char[]: Device version
-    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,    ///< char[]: Version of backend runtime
-    UR_DEVICE_INFO_EXTENSIONS = 72,                 ///< char[]: Return a space separated list of extension names
-    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,         ///< size_t: Maximum size in bytes of internal printf buffer
-    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,///< bool: prefer user synchronization when sharing object with other API
-    UR_DEVICE_INFO_PARENT_DEVICE = 75,              ///< ::ur_device_handle_t: return parent device handle
-    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,       ///< ::ur_device_partition_property_t[]: Returns the list of partition
-                                                    ///< types supported by the device
-    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,  ///< uint32_t: maximum number of sub-devices when the device is partitioned
-    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,  ///< uint32_t: return a bit-field of affinity domain
-                                                    ///< ::ur_device_affinity_domain_flags_t
-    UR_DEVICE_INFO_PARTITION_TYPE = 79,             ///< ::ur_device_partition_property_t[]: return a list of
-                                                    ///< ::ur_device_partition_property_t for properties specified in
-                                                    ///< ::urDevicePartition
-    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,         ///< uint32_t: max number of sub groups
+typedef enum ur_device_info_t {
+    UR_DEVICE_INFO_TYPE = 0,                                    ///< ::ur_device_type_t: type of the device
+    UR_DEVICE_INFO_VENDOR_ID = 1,                               ///< uint32_t: vendor Id of the device
+    UR_DEVICE_INFO_DEVICE_ID = 2,                               ///< uint32_t: Id of the device
+    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,                       ///< uint32_t: the number of compute units
+    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                ///< uint32_t: max work item dimensions
+    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< size_t[]: return an array of max work item sizes
+    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                     ///< size_t: max work group size
+    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< Return a bit field of ::ur_fp_capability_flags_t: single precision
+                                                                ///< floating point capability
+    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                          ///< Return a bit field of ::ur_fp_capability_flags_t: half precision
+                                                                ///< floating point capability
+    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                        ///< Return a bit field of ::ur_fp_capability_flags_t: double precision
+                                                                ///< floating point capability
+    UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,                       ///< Return a bit field of ::ur_queue_flags_t: command queue properties
+                                                                ///< supported by the device
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,            ///< uint32_t: preferred vector width for char
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 12,           ///< uint32_t: preferred vector width for short
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 13,             ///< uint32_t: preferred vector width for int
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 14,            ///< uint32_t: preferred vector width for long
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 15,           ///< uint32_t: preferred vector width for float
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 16,          ///< uint32_t: preferred vector width for double
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 17,            ///< uint32_t: preferred vector width for half float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 18,               ///< uint32_t: native vector width for char
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 19,              ///< uint32_t: native vector width for short
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 20,                ///< uint32_t: native vector width for int
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 21,               ///< uint32_t: native vector width for long
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 22,              ///< uint32_t: native vector width for float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 23,             ///< uint32_t: native vector width for double
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 24,               ///< uint32_t: native vector width for half float
+    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 25,                    ///< uint32_t: max clock frequency in MHz
+    UR_DEVICE_INFO_MEMORY_CLOCK_RATE = 26,                      ///< uint32_t: memory clock frequency in MHz
+    UR_DEVICE_INFO_ADDRESS_BITS = 27,                           ///< uint32_t: address bits
+    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 28,                     ///< uint64_t: max memory allocation size
+    UR_DEVICE_INFO_IMAGE_SUPPORTED = 29,                        ///< bool: images are supported
+    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 30,                    ///< uint32_t: max number of image objects arguments of a kernel declared
+                                                                ///< with the read_only qualifier
+    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 31,                   ///< uint32_t: max number of image objects arguments of a kernel declared
+                                                                ///< with the write_only qualifier
+    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 32,              ///< uint32_t: max number of image objects arguments of a kernel declared
+                                                                ///< with the read_write qualifier
+    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 33,                      ///< size_t: max width of Image2D object
+    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 34,                     ///< size_t: max heigh of Image2D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 35,                      ///< size_t: max width of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 36,                     ///< size_t: max height of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 37,                      ///< size_t: max depth of Image3D object
+    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 38,                  ///< size_t: max image buffer size
+    UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE = 39,                   ///< size_t: max image array size
+    UR_DEVICE_INFO_MAX_SAMPLERS = 40,                           ///< uint32_t: max number of samplers that can be used in a kernel
+    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 41,                     ///< size_t: max size in bytes of all arguments passed to a kernel
+    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 42,                    ///< uint32_t: memory base address alignment
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 43,                  ///< ::ur_device_mem_cache_type_t: global memory cache type
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 44,              ///< uint32_t: global memory cache line size in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 45,                  ///< uint64_t: size of global memory cache in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 46,                        ///< uint64_t: size of global memory in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_FREE = 47,                        ///< uint64_t: size of global memory which is free in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 48,               ///< uint64_t: max constant buffer size in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,                      ///< uint32_t: max number of __const declared arguments in a kernel
+    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,                         ///< ::ur_device_local_mem_type_t: local memory type
+    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,                         ///< uint64_t: local memory size in bytes
+    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,               ///< bool: support error correction to global and local memory
+    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                    ///< bool: unified host device memory
+    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54,             ///< size_t: profiling timer resolution in nanoseconds
+    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                          ///< bool: little endian byte order
+    UR_DEVICE_INFO_AVAILABLE = 56,                              ///< bool: device is available
+    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                     ///< bool: device compiler is available
+    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                       ///< bool: device linker is available
+    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,                 ///< ::ur_device_exec_capability_flags_t: device kernel execution
+                                                                ///< capability bit-field
+    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,             ///< ::ur_queue_flags_t: device command queue property bit-field
+    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,               ///< ::ur_queue_flags_t: host queue property bit-field
+    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< char[]: a semi-colon separated list of built-in kernels
+    UR_DEVICE_INFO_PLATFORM = 63,                               ///< ::ur_platform_handle_t: the platform associated with the device
+    UR_DEVICE_INFO_REFERENCE_COUNT = 64,                        ///< uint32_t: reference count
+    UR_DEVICE_INFO_IL_VERSION = 65,                             ///< char[]: IL version
+    UR_DEVICE_INFO_NAME = 66,                                   ///< char[]: Device name
+    UR_DEVICE_INFO_VENDOR = 67,                                 ///< char[]: Device vendor
+    UR_DEVICE_INFO_DRIVER_VERSION = 68,                         ///< char[]: Driver version
+    UR_DEVICE_INFO_PROFILE = 69,                                ///< char[]: Device profile
+    UR_DEVICE_INFO_VERSION = 70,                                ///< char[]: Device version
+    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                ///< char[]: Version of backend runtime
+    UR_DEVICE_INFO_EXTENSIONS = 72,                             ///< char[]: Return a space separated list of extension names
+    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,                     ///< size_t: Maximum size in bytes of internal printf buffer
+    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,            ///< bool: prefer user synchronization when sharing object with other API
+    UR_DEVICE_INFO_PARENT_DEVICE = 75,                          ///< ::ur_device_handle_t: return parent device handle
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< ::ur_device_partition_property_t[]: Returns the list of partition
+                                                                ///< types supported by the device
+    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,              ///< uint32_t: maximum number of sub-devices when the device is partitioned
+    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,              ///< uint32_t: return a bit-field of affinity domain
+                                                                ///< ::ur_device_affinity_domain_flags_t
+    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< ::ur_device_partition_property_t[]: return a list of
+                                                                ///< ::ur_device_partition_property_t for properties specified in
+                                                                ///< ::urDevicePartition
+    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                     ///< uint32_t: max number of sub groups
     UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81, ///< bool: support sub group independent forward progress
-    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,      ///< uint32_t[]: return an array of sub group sizes supported on Intel
-                                                    ///< device
-    UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,           ///< bool: support USM host memory access
-    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,         ///< bool: support USM device memory access
-    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,  ///< bool: support USM single device shared memory access
-    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,   ///< bool: support USM cross device shared memory access
-    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,  ///< bool: support USM system wide shared memory access
-    UR_DEVICE_INFO_UUID = 88,                       ///< char[]: return device UUID
-    UR_DEVICE_INFO_PCI_ADDRESS = 89,                ///< char[]: return device PCI address
-    UR_DEVICE_INFO_GPU_EU_COUNT = 90,               ///< uint32_t: return Intel GPU EU count
-    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,          ///< uint32_t: return Intel GPU EU SIMD width
-    UR_DEVICE_INFO_GPU_EU_SLICES = 92,              ///< uint32_t: return Intel GPU number of slices
-    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 93,    ///< uint32_t: return Intel GPU number of subslices per slice
-    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 94,       ///< uint32_t: return max memory bandwidth in Mb/s
-    UR_DEVICE_INFO_IMAGE_SRGB = 95,                 ///< bool: image is SRGB
-    UR_DEVICE_INFO_ATOMIC_64 = 96,                  ///< bool: support 64 bit atomics
-    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 97,   ///< ::ur_memory_order_capability_flags_t: return a bit-field of atomic
-                                                    ///< memory order capabilities
-    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98,   ///< ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
-                                                    ///< memory scope capabilities
-    UR_DEVICE_INFO_BFLOAT16 = 99,                   ///< bool: support for bfloat16
-    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 100, ///< uint32_t: Returns 1 if the device doesn't have a notion of a 
-                                                    ///< queue index. Otherwise, returns the number of queue indices that are
-                                                    ///< available for this device.
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< uint32_t[]: return an array of sub group sizes supported on Intel
+                                                                ///< device
+    UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                       ///< bool: support USM host memory access
+    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                     ///< bool: support USM device memory access
+    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,              ///< bool: support USM single device shared memory access
+    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,               ///< bool: support USM cross device shared memory access
+    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,              ///< bool: support USM system wide shared memory access
+    UR_DEVICE_INFO_UUID = 88,                                   ///< char[]: return device UUID
+    UR_DEVICE_INFO_PCI_ADDRESS = 89,                            ///< char[]: return device PCI address
+    UR_DEVICE_INFO_GPU_EU_COUNT = 90,                           ///< uint32_t: return Intel GPU EU count
+    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                      ///< uint32_t: return Intel GPU EU SIMD width
+    UR_DEVICE_INFO_GPU_EU_SLICES = 92,                          ///< uint32_t: return Intel GPU number of slices
+    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 93,                ///< uint32_t: return Intel GPU number of subslices per slice
+    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 94,                   ///< uint32_t: return max memory bandwidth in Mb/s
+    UR_DEVICE_INFO_IMAGE_SRGB = 95,                             ///< bool: image is SRGB
+    UR_DEVICE_INFO_ATOMIC_64 = 96,                              ///< bool: support 64 bit atomics
+    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 97,       ///< ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+                                                                ///< memory order capabilities
+    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98,       ///< ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+                                                                ///< memory scope capabilities
+    UR_DEVICE_INFO_BFLOAT16 = 99,                               ///< bool: support for bfloat16
+    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 100,             ///< uint32_t: Returns 1 if the device doesn't have a notion of a
+                                                                ///< queue index. Otherwise, returns the number of queue indices that are
+                                                                ///< available for this device.
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about device
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetDeviceInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3079,32 +3043,32 @@ typedef enum ur_device_info_t
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetInfo(
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-    ur_device_info_t infoType,                      ///< [in] type of the info to retrieve
-    size_t propSize,                                ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void* pDeviceInfo,                              ///< [out][optional] array of bytes holding the info.
-                                                    ///< If propSize is not equal to or greater than the real number of bytes
-                                                    ///< needed to return the info
-                                                    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                                    ///< pDeviceInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
-    );
+    ur_device_handle_t hDevice, ///< [in] handle of the device instance
+    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
+    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return the info
+                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+                                ///< pDeviceInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Makes a reference of the device handle indicating it's in use until
 ///        paired ::urDeviceRelease is called
-/// 
+///
 /// @details
 ///     - It is not valid to use the device handle, which has all of its
 ///       references released.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainDevice**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3113,21 +3077,21 @@ urDeviceGetInfo(
 ///         + `NULL == hDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceRetain(
-    ur_device_handle_t hDevice                      ///< [in] handle of the device to get a reference of.
-    );
+    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Releases the device handle reference indicating end of its usage
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseDevice**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3136,8 +3100,8 @@ urDeviceRetain(
 ///         + `NULL == hDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceRelease(
-    ur_device_handle_t hDevice                      ///< [in] handle of the device to release.
-    );
+    ur_device_handle_t hDevice ///< [in] handle of the device to release.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device partition property type
@@ -3145,20 +3109,19 @@ typedef intptr_t ur_device_partition_property_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition Properties
-typedef enum ur_device_partition_t
-{
-    UR_DEVICE_PARTITION_EQUALLY = 0x1086,           ///< Partition Equally
-    UR_DEVICE_PARTITION_BY_COUNTS = 0x1087,         ///< Partition by counts
-    UR_DEVICE_PARTITION_BY_COUNTS_LIST_END = 0x0,   ///< End of by counts list
-    UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN = 0x1088,///< Partition by affinity domain
-    UR_DEVICE_PARTITION_BY_CSLICE = 0x1089,         ///< Partition by c-slice
+typedef enum ur_device_partition_t {
+    UR_DEVICE_PARTITION_EQUALLY = 0x1086,            ///< Partition Equally
+    UR_DEVICE_PARTITION_BY_COUNTS = 0x1087,          ///< Partition by counts
+    UR_DEVICE_PARTITION_BY_COUNTS_LIST_END = 0x0,    ///< End of by counts list
+    UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN = 0x1088, ///< Partition by affinity domain
+    UR_DEVICE_PARTITION_BY_CSLICE = 0x1089,          ///< Partition by c-slice
     UR_DEVICE_PARTITION_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_partition_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition the device into sub-devices
-/// 
+///
 /// @details
 ///     - Repeated calls to this function with the same inputs will produce the
 ///       same output in the same order.
@@ -3167,11 +3130,11 @@ typedef enum ur_device_partition_t
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateSubDevices**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3184,20 +3147,20 @@ typedef enum ur_device_partition_t
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 UR_APIEXPORT ur_result_t UR_APICALL
 urDevicePartition(
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t* pProperties,  ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                            ///< [in] the number of sub-devices.
-    ur_device_handle_t* phSubDevices,               ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                    ///< If NumDevices is less than the number of sub-devices available, then
-                                                    ///< the function shall only retrieve that number of sub-devices.
-    uint32_t* pNumDevicesRet                        ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                    ///< partitioned into according to the partitioning property.
-    );
+    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                       ///< If NumDevices is less than the number of sub-devices available, then
+                                                       ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                       ///< partitioned into according to the partitioning property.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Selects the most appropriate device binary based on runtime
 ///        information and the IR characteristics.
-/// 
+///
 /// @details
 ///     - The input binaries are various AOT images, and possibly a SPIR-V
 ///       binary for JIT compilation.
@@ -3207,7 +3170,7 @@ urDevicePartition(
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3220,48 +3183,45 @@ urDevicePartition(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceSelectBinary(
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device to select binary for.
-    const uint8_t** ppBinaries,                     ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,                           ///< [in] the number of binaries passed in ppBinaries. 
-                                                    ///< Must greater than or equal to zero otherwise
-                                                    ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t* pSelectedBinary                       ///< [out] the index of the selected binary in the input array of binaries.
-                                                    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
-    );
+    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
+                                ///< Must greater than or equal to zero otherwise
+                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
+                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief FP capabilities
 typedef uint32_t ur_fp_capability_flags_t;
-typedef enum ur_fp_capability_flag_t
-{
-    UR_FP_CAPABILITY_FLAG_CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0),///< Support correctly rounded divide and sqrt
-    UR_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST = UR_BIT(1), ///< Support round to nearest
-    UR_FP_CAPABILITY_FLAG_ROUND_TO_ZERO = UR_BIT(2),///< Support round to zero
-    UR_FP_CAPABILITY_FLAG_ROUND_TO_INF = UR_BIT(3), ///< Support round to infinity
-    UR_FP_CAPABILITY_FLAG_INF_NAN = UR_BIT(4),      ///< Support INF to NAN
-    UR_FP_CAPABILITY_FLAG_DENORM = UR_BIT(5),       ///< Support denorm
-    UR_FP_CAPABILITY_FLAG_FMA = UR_BIT(6),          ///< Support FMA
+typedef enum ur_fp_capability_flag_t {
+    UR_FP_CAPABILITY_FLAG_CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0), ///< Support correctly rounded divide and sqrt
+    UR_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST = UR_BIT(1),              ///< Support round to nearest
+    UR_FP_CAPABILITY_FLAG_ROUND_TO_ZERO = UR_BIT(2),                 ///< Support round to zero
+    UR_FP_CAPABILITY_FLAG_ROUND_TO_INF = UR_BIT(3),                  ///< Support round to infinity
+    UR_FP_CAPABILITY_FLAG_INF_NAN = UR_BIT(4),                       ///< Support INF to NAN
+    UR_FP_CAPABILITY_FLAG_DENORM = UR_BIT(5),                        ///< Support denorm
+    UR_FP_CAPABILITY_FLAG_FMA = UR_BIT(6),                           ///< Support FMA
     UR_FP_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_fp_capability_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device memory cache type
-typedef enum ur_device_mem_cache_type_t
-{
-    UR_DEVICE_MEM_CACHE_TYPE_NONE = 0,              ///< Has none cache
-    UR_DEVICE_MEM_CACHE_TYPE_READ_ONLY_CACHE = 1,   ///< Has read only cache
-    UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE = 2,  ///< Has read write cache
+typedef enum ur_device_mem_cache_type_t {
+    UR_DEVICE_MEM_CACHE_TYPE_NONE = 0,             ///< Has none cache
+    UR_DEVICE_MEM_CACHE_TYPE_READ_ONLY_CACHE = 1,  ///< Has read only cache
+    UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE = 2, ///< Has read write cache
     UR_DEVICE_MEM_CACHE_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_mem_cache_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device local memory type
-typedef enum ur_device_local_mem_type_t
-{
-    UR_DEVICE_LOCAL_MEM_TYPE_LOCAL = 0,             ///< Dedicated local memory
-    UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 1,            ///< Global memory
+typedef enum ur_device_local_mem_type_t {
+    UR_DEVICE_LOCAL_MEM_TYPE_LOCAL = 0,  ///< Dedicated local memory
+    UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 1, ///< Global memory
     UR_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_local_mem_type_t;
@@ -3269,10 +3229,9 @@ typedef enum ur_device_local_mem_type_t
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device kernel execution capability
 typedef uint32_t ur_device_exec_capability_flags_t;
-typedef enum ur_device_exec_capability_flag_t
-{
-    UR_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL = UR_BIT(0),  ///< Support kernel execution
-    UR_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL = UR_BIT(1),   ///< Support native kernel execution
+typedef enum ur_device_exec_capability_flag_t {
+    UR_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL = UR_BIT(0),        ///< Support kernel execution
+    UR_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL = UR_BIT(1), ///< Support native kernel execution
     UR_DEVICE_EXEC_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_exec_capability_flag_t;
@@ -3280,17 +3239,16 @@ typedef enum ur_device_exec_capability_flag_t
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device affinity domain
 typedef uint32_t ur_device_affinity_domain_flags_t;
-typedef enum ur_device_affinity_domain_flag_t
-{
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),///< By NUMA
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1),  ///< BY next partitionable
+typedef enum ur_device_affinity_domain_flag_t {
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),               ///< By NUMA
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1), ///< BY next partitionable
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_affinity_domain_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native device handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -3299,7 +3257,7 @@ typedef enum ur_device_affinity_domain_flag_t
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3310,19 +3268,19 @@ typedef enum ur_device_affinity_domain_flag_t
 ///         + `NULL == phNativeDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device.
-    ur_native_handle_t* phNativeDevice              ///< [out] a pointer to the native handle of the device.
-    );
+    ur_device_handle_t hDevice,        ///< [in] handle of the device.
+    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime device object from native device handle.
-/// 
+///
 /// @details
 ///     - Creates runtime device handle from native driver device handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3334,23 +3292,23 @@ urDeviceGetNativeHandle(
 ///         + `NULL == phDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceCreateWithNativeHandle(
-    ur_native_handle_t hNativeDevice,               ///< [in] the native handle of the device.
-    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
-    ur_device_handle_t* phDevice                    ///< [out] pointer to the handle of the device object created.
-    );
+    ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
+    ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief static
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetDeviceAndHostTimer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3359,23 +3317,22 @@ urDeviceCreateWithNativeHandle(
 ///         + `NULL == hDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetGlobalTimestamps(
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device instance
-    uint64_t* pDeviceTimestamp,                     ///< [out][optional] pointer to the Device's global timestamp that 
-                                                    ///< correlates with the Host's global timestamp value
-    uint64_t* pHostTimestamp                        ///< [out][optional] pointer to the Host's global timestamp that 
-                                                    ///< correlates with the Device's global timestamp value
-    );
+    ur_device_handle_t hDevice, ///< [in] handle of the device instance
+    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                                ///< correlates with the Host's global timestamp value
+    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
+                                ///< correlates with the Device's global timestamp value
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory order capabilities
 typedef uint32_t ur_memory_order_capability_flags_t;
-typedef enum ur_memory_order_capability_flag_t
-{
-    UR_MEMORY_ORDER_CAPABILITY_FLAG_RELAXED = UR_BIT(0),///< Relaxed memory ordering
-    UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQUIRE = UR_BIT(1),///< Acquire memory ordering
-    UR_MEMORY_ORDER_CAPABILITY_FLAG_RELEASE = UR_BIT(2),///< Release memory ordering
-    UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQ_REL = UR_BIT(3),///< Acquire/release memory ordering
-    UR_MEMORY_ORDER_CAPABILITY_FLAG_SEQ_CST = UR_BIT(4),///< Sequentially consistent memory ordering
+typedef enum ur_memory_order_capability_flag_t {
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_RELAXED = UR_BIT(0), ///< Relaxed memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQUIRE = UR_BIT(1), ///< Acquire memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_RELEASE = UR_BIT(2), ///< Release memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQ_REL = UR_BIT(3), ///< Acquire/release memory ordering
+    UR_MEMORY_ORDER_CAPABILITY_FLAG_SEQ_CST = UR_BIT(4), ///< Sequentially consistent memory ordering
     UR_MEMORY_ORDER_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_memory_order_capability_flag_t;
@@ -3383,13 +3340,12 @@ typedef enum ur_memory_order_capability_flag_t
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory scope capabilities
 typedef uint32_t ur_memory_scope_capability_flags_t;
-typedef enum ur_memory_scope_capability_flag_t
-{
+typedef enum ur_memory_scope_capability_flag_t {
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_ITEM = UR_BIT(0),  ///< Work item scope
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_SUB_GROUP = UR_BIT(1),  ///< Sub group scope
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_GROUP = UR_BIT(2), ///< Work group scope
-    UR_MEMORY_SCOPE_CAPABILITY_FLAG_DEVICE = UR_BIT(3), ///< Device scope
-    UR_MEMORY_SCOPE_CAPABILITY_FLAG_SYSTEM = UR_BIT(4), ///< System scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_DEVICE = UR_BIT(3),     ///< Device scope
+    UR_MEMORY_SCOPE_CAPABILITY_FLAG_SYSTEM = UR_BIT(4),     ///< System scope
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_memory_scope_capability_flag_t;
@@ -3403,13 +3359,13 @@ typedef enum ur_memory_scope_capability_flag_t
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create kernel object from a program.
-/// 
+///
 /// @details
 ///     - Multiple calls to this function will return identical device handles,
 ///       in the same order.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3421,19 +3377,19 @@ typedef enum ur_memory_scope_capability_flag_t
 ///         + `NULL == phKernel`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelCreate(
-    ur_program_handle_t hProgram,                   ///< [in] handle of the program instance
-    const char* pKernelName,                        ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t* phKernel                    ///< [out] pointer to handle of kernel object created.
-    );
+    ur_program_handle_t hProgram, ///< [in] handle of the program instance
+    const char *pKernelName,      ///< [in] pointer to null-terminated string.
+    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set kernel argument to a value.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads with
 ///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3446,20 +3402,20 @@ urKernelCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgValue(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,                                 ///< [in] size of argument type
-    const void* pArgValue                           ///< [in] argument value represented as matching arg type.
-    );
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set kernel argument to a local buffer.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads with
 ///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3470,73 +3426,69 @@ urKernelSetArgValue(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgLocal(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    size_t argSize                                  ///< [in] size of the local buffer to be allocated by the runtime
-    );
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel object information
-typedef enum ur_kernel_info_t
-{
-    UR_KERNEL_INFO_FUNCTION_NAME = 0,               ///< Return Kernel function name, return type char[]
-    UR_KERNEL_INFO_NUM_ARGS = 1,                    ///< Return Kernel number of arguments
-    UR_KERNEL_INFO_REFERENCE_COUNT = 2,             ///< Return Kernel reference count
-    UR_KERNEL_INFO_CONTEXT = 3,                     ///< Return Context object associated with Kernel
-    UR_KERNEL_INFO_PROGRAM = 4,                     ///< Return Program object associated with Kernel
-    UR_KERNEL_INFO_ATTRIBUTES = 5,                  ///< Return Kernel attributes, return type char[]
+typedef enum ur_kernel_info_t {
+    UR_KERNEL_INFO_FUNCTION_NAME = 0,   ///< Return Kernel function name, return type char[]
+    UR_KERNEL_INFO_NUM_ARGS = 1,        ///< Return Kernel number of arguments
+    UR_KERNEL_INFO_REFERENCE_COUNT = 2, ///< Return Kernel reference count
+    UR_KERNEL_INFO_CONTEXT = 3,         ///< Return Context object associated with Kernel
+    UR_KERNEL_INFO_PROGRAM = 4,         ///< Return Program object associated with Kernel
+    UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< Return Kernel attributes, return type char[]
     UR_KERNEL_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_kernel_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel Work Group information
-typedef enum ur_kernel_group_info_t
-{
-    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,      ///< Return Work Group maximum global size, return type size_t[3]
-    UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,       ///< Return maximum Work Group size, return type size_t
-    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,   ///< Return Work Group size required by the source code, such as
-                                                    ///< __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]
-    UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,        ///< Return local memory required by the Kernel, return type size_t
-    UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4,///< Return preferred multiple of Work Group size for launch, return type
-                                                    ///< size_t
-    UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,      ///< Return minimum amount of private memory in bytes used by each work
-                                                    ///< item in the Kernel, return type size_t
+typedef enum ur_kernel_group_info_t {
+    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,                   ///< Return Work Group maximum global size, return type size_t[3]
+    UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,                    ///< Return maximum Work Group size, return type size_t
+    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,            ///< Return Work Group size required by the source code, such as
+                                                                 ///< __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]
+    UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,                     ///< Return local memory required by the Kernel, return type size_t
+    UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4, ///< Return preferred multiple of Work Group size for launch, return type
+                                                                 ///< size_t
+    UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,                   ///< Return minimum amount of private memory in bytes used by each work
+                                                                 ///< item in the Kernel, return type size_t
     UR_KERNEL_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_kernel_group_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel SubGroup information
-typedef enum ur_kernel_sub_group_info_t
-{
-    UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE = 0,///< Return maximum SubGroup size, return type uint32_t
-    UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS = 1,///< Return maximum number of SubGroup, return type uint32_t
-    UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2,///< Return number of SubGroup required by the source code, return type
-                                                    ///< uint32_t
-    UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3,  ///< Return SubGroup size required by Intel, return type uint32_t
+typedef enum ur_kernel_sub_group_info_t {
+    UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE = 0,     ///< Return maximum SubGroup size, return type uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS = 1,     ///< Return maximum number of SubGroup, return type uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2, ///< Return number of SubGroup required by the source code, return type
+                                                         ///< uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3,   ///< Return SubGroup size required by Intel, return type uint32_t
     UR_KERNEL_SUB_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_kernel_sub_group_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set additional Kernel execution information
-typedef enum ur_kernel_exec_info_t
-{
-    UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0,    ///< Kernel might access data through USM pointer, type bool_t*
-    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,               ///< Provide an explicit list of USM pointers that the kernel will access,
-                                                    ///< type void*[].
+typedef enum ur_kernel_exec_info_t {
+    UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0, ///< Kernel might access data through USM pointer, type bool_t*
+    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,            ///< Provide an explicit list of USM pointers that the kernel will access,
+                                                 ///< type void*[].
     UR_KERNEL_EXEC_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_kernel_exec_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Kernel object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetKernelInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3547,25 +3499,25 @@ typedef enum ur_kernel_exec_info_t
 ///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelGetInfo(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
-    ur_kernel_info_t propName,                      ///< [in] name of the Kernel property to query
-    size_t propSize,                                ///< [in] the size of the Kernel property value.           
-    void* pKernelInfo,                              ///< [in,out][optional] array of bytes holding the kernel info property.
-                                                    ///< If propSize is not equal to or greater than the real number of bytes
-                                                    ///< needed to return 
-                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                                    ///< pKernelInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
-                                                    ///< queried by propName.
-    );
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
+    size_t propSize,            ///< [in] the size of the Kernel property value.
+    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return
+                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                ///< pKernelInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
+                                ///< queried by propName.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query work Group information about a Kernel object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetKernelWorkGroupInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3577,19 +3529,19 @@ urKernelGetInfo(
 ///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName,                ///< [in] name of the work Group property to query
-    size_t propSize,                                ///< [in] size of the Kernel Work Group property value
-    void* pPropValue,                               ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                                    ///< property.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
-                                                    ///< queried by propName.
-    );
+    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
+    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
+    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                     ///< property.
+    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
+                                     ///< queried by propName.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query SubGroup information about a Kernel object
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3601,29 +3553,29 @@ urKernelGetGroupInfo(
 ///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName,            ///< [in] name of the SubGroup property to query
-    size_t propSize,                                ///< [in] size of the Kernel SubGroup property value
-    void* pPropValue,                               ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                                    ///< property.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
-                                                    ///< queried by propName.
-    );
+    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
+    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
+    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                         ///< property.
+    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
+                                         ///< queried by propName.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference to the Kernel object.
-/// 
+///
 /// @details
 ///     - Get a reference to the Kernel object handle. Increment its reference
 ///       count
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainKernel**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3632,22 +3584,22 @@ urKernelGetSubGroupInfo(
 ///         + `NULL == hKernel`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRetain(
-    ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to retain
-    );
+    ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Release Kernel.
-/// 
+///
 /// @details
 ///     - Decrement reference count and destroy the Kernel if reference count
 ///       becomes zero.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseKernel**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3656,21 +3608,21 @@ urKernelRetain(
 ///         + `NULL == hKernel`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(
-    ur_kernel_handle_t hKernel                      ///< [in] handle for the Kernel to release
-    );
+    ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set a USM pointer as the argument value of a Kernel.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads with
 ///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clSetKernelArgSVMPointer**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3681,25 +3633,25 @@ urKernelRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgPointer(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,                                 ///< [in] size of argument type
-    const void* pArgValue                           ///< [in][optional] SVM pointer to memory location holding the argument
-                                                    ///< value. If null then argument value is considered null.
-    );
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
+                                ///< value. If null then argument value is considered null.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set additional Kernel execution attributes.
-/// 
+///
 /// @details
 ///     - The application must **not** call this function from simultaneous
 ///       threads with the same kernel handle.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clSetKernelExecInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3712,21 +3664,21 @@ urKernelSetArgPointer(
 ///         + `NULL == pPropValue`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetExecInfo(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    ur_kernel_exec_info_t propName,                 ///< [in] name of the execution attribute
-    size_t propSize,                                ///< [in] size in byte the attribute value
-    const void* pPropValue                          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                                    ///< property value.
-    );
+    ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
+    ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
+    size_t propSize,                ///< [in] size in byte the attribute value
+    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                    ///< property value.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set a Sampler object as the argument value of a Kernel.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads with
 ///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3737,19 +3689,19 @@ urKernelSetExecInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    ur_sampler_handle_t hArgValue                   ///< [in] handle of Sampler object.
-    );
+    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
+    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+    ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set a Memory object as the argument value of a Kernel.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads with
 ///       the same kernel handle.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3759,14 +3711,14 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgMemObj(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
-    uint32_t argIndex,                              ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue                       ///< [in][optional] handle of Memory object.
-    );
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native kernel handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -3775,7 +3727,7 @@ urKernelSetArgMemObj(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3786,19 +3738,19 @@ urKernelSetArgMemObj(
 ///         + `NULL == phNativeKernel`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,                     ///< [in] handle of the kernel.
-    ur_native_handle_t* phNativeKernel              ///< [out] a pointer to the native handle of the kernel.
-    );
+    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime kernel object from native kernel handle.
-/// 
+///
 /// @details
 ///     - Creates runtime kernel handle from native driver kernel handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3810,10 +3762,10 @@ urKernelGetNativeHandle(
 ///         + `NULL == phKernel`
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelCreateWithNativeHandle(
-    ur_native_handle_t hNativeKernel,               ///< [in] the native handle of the kernel.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context object
-    ur_kernel_handle_t* phKernel                    ///< [out] pointer to the handle of the kernel object created.
-    );
+    ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
+    ur_context_handle_t hContext,     ///< [in] handle of the context object
+    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -3824,20 +3776,20 @@ urKernelCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief callback function for urModuleCreate
-typedef void (ur_modulecreate_callback_t)(
-    ur_module_handle_t hModule,                     ///< [in] handle of Module object created.
-    void* pParams                                   ///< [in][out] pointer to user data to be passed to callback.
-    );
+typedef void(ur_modulecreate_callback_t)(
+    ur_module_handle_t hModule, ///< [in] handle of Module object created.
+    void *pParams               ///< [in][out] pointer to user data to be passed to callback.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create Module object from IL.
-/// 
+///
 /// @details
 ///     - Multiple calls to this function will return identical device handles,
 ///       in the same order.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3850,25 +3802,25 @@ typedef void (ur_modulecreate_callback_t)(
 ///         + `NULL == phModule`
 UR_APIEXPORT ur_result_t UR_APICALL
 urModuleCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context instance.
-    const void* pIL,                                ///< [in] pointer to IL string.
-    size_t length,                                  ///< [in] length of IL in bytes.
-    const char* pOptions,                           ///< [in] pointer to compiler options null-terminated string.
-    ur_modulecreate_callback_t pfnNotify,           ///< [in][optional] A function pointer to a notification routine that is
-                                                    ///< called when program compilation is complete.
-    void* pUserData,                                ///< [in][optional] Passed as an argument when pfnNotify is called.
-    ur_module_handle_t* phModule                    ///< [out] pointer to handle of Module object created.
-    );
+    ur_context_handle_t hContext,         ///< [in] handle of the context instance.
+    const void *pIL,                      ///< [in] pointer to IL string.
+    size_t length,                        ///< [in] length of IL in bytes.
+    const char *pOptions,                 ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                                          ///< called when program compilation is complete.
+    void *pUserData,                      ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t *phModule          ///< [out] pointer to handle of Module object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference to the Module object.
-/// 
+///
 /// @details
 ///     - Get a reference to the Module object handle. Increment its reference
 ///       count
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3877,18 +3829,18 @@ urModuleCreate(
 ///         + `NULL == hModule`
 UR_APIEXPORT ur_result_t UR_APICALL
 urModuleRetain(
-    ur_module_handle_t hModule                      ///< [in] handle for the Module to retain
-    );
+    ur_module_handle_t hModule ///< [in] handle for the Module to retain
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Release Module.
-/// 
+///
 /// @details
 ///     - Decrement reference count and destroy the Module if reference count
 ///       becomes zero.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3897,12 +3849,12 @@ urModuleRetain(
 ///         + `NULL == hModule`
 UR_APIEXPORT ur_result_t UR_APICALL
 urModuleRelease(
-    ur_module_handle_t hModule                      ///< [in] handle for the Module to release
-    );
+    ur_module_handle_t hModule ///< [in] handle for the Module to release
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native module handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -3911,7 +3863,7 @@ urModuleRelease(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3922,19 +3874,19 @@ urModuleRelease(
 ///         + `NULL == phNativeModule`
 UR_APIEXPORT ur_result_t UR_APICALL
 urModuleGetNativeHandle(
-    ur_module_handle_t hModule,                     ///< [in] handle of the module.
-    ur_native_handle_t* phNativeModule              ///< [out] a pointer to the native handle of the module.
-    );
+    ur_module_handle_t hModule,        ///< [in] handle of the module.
+    ur_native_handle_t *phNativeModule ///< [out] a pointer to the native handle of the module.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime module object from native module handle.
-/// 
+///
 /// @details
 ///     - Creates runtime module handle from native driver module handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3946,10 +3898,10 @@ urModuleGetNativeHandle(
 ///         + `NULL == phModule`
 UR_APIEXPORT ur_result_t UR_APICALL
 urModuleCreateWithNativeHandle(
-    ur_native_handle_t hNativeModule,               ///< [in] the native handle of the module.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context instance.
-    ur_module_handle_t* phModule                    ///< [out] pointer to the handle of the module object created.
-    );
+    ur_native_handle_t hNativeModule, ///< [in] the native handle of the module.
+    ur_context_handle_t hContext,     ///< [in] handle of the context instance.
+    ur_module_handle_t *phModule      ///< [out] pointer to the handle of the module object created.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -3960,17 +3912,17 @@ urModuleCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms
-/// 
+///
 /// @details
 ///     - Multiple calls to this function will return identical platforms
 ///       handles, in the same order.
 ///     - The application may call this function from simultaneous threads, the
 ///       implementation must be thread-safe
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetPlatformIDs**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -3978,45 +3930,44 @@ urModuleCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGet(
-    uint32_t NumEntries,                            ///< [in] the number of platforms to be added to phPlatforms. 
-                                                    ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                                    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                                    ///< will be returned.
-    ur_platform_handle_t* phPlatforms,              ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                                    ///< If NumEntries is less than the number of platforms available, then
-                                                    ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t* pNumPlatforms                         ///< [out][optional] returns the total number of platforms available. 
-    );
+    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
+                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                       ///< will be returned.
+    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                       ///< If NumEntries is less than the number of platforms available, then
+                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported platform info
-typedef enum ur_platform_info_t
-{
-    UR_PLATFORM_INFO_NAME = 1,                      ///< [char*] The string denoting name of the platform. The size of the info
-                                                    ///< needs to be dynamically queried.
-    UR_PLATFORM_INFO_VENDOR_NAME = 2,               ///< [char*] The string denoting name of the vendor of the platform. The
-                                                    ///< size of the info needs to be dynamically queried.
-    UR_PLATFORM_INFO_VERSION = 3,                   ///< [char*] The string denoting the version of the platform. The size of
-                                                    ///< the info needs to be dynamically queried.
-    UR_PLATFORM_INFO_EXTENSIONS = 4,                ///< [char*] The string denoting extensions supported by the platform. The
-                                                    ///< size of the info needs to be dynamically queried.
-    UR_PLATFORM_INFO_PROFILE = 5,                   ///< [char*] The string denoting profile of the platform. The size of the
-                                                    ///< info needs to be dynamically queried.
+typedef enum ur_platform_info_t {
+    UR_PLATFORM_INFO_NAME = 1,        ///< [char*] The string denoting name of the platform. The size of the info
+                                      ///< needs to be dynamically queried.
+    UR_PLATFORM_INFO_VENDOR_NAME = 2, ///< [char*] The string denoting name of the vendor of the platform. The
+                                      ///< size of the info needs to be dynamically queried.
+    UR_PLATFORM_INFO_VERSION = 3,     ///< [char*] The string denoting the version of the platform. The size of
+                                      ///< the info needs to be dynamically queried.
+    UR_PLATFORM_INFO_EXTENSIONS = 4,  ///< [char*] The string denoting extensions supported by the platform. The
+                                      ///< size of the info needs to be dynamically queried.
+    UR_PLATFORM_INFO_PROFILE = 5,     ///< [char*] The string denoting profile of the platform. The size of the
+                                      ///< info needs to be dynamically queried.
     UR_PLATFORM_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_platform_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about platform
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetPlatformInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4027,37 +3978,36 @@ typedef enum ur_platform_info_t
 ///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType,            ///< [in] type of the info to retrieve
-    size_t Size,                                    ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void* pPlatformInfo,                            ///< [out][optional] array of bytes holding the info.
-                                                    ///< If Size is not equal to or greater to the real number of bytes needed
-                                                    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                                    ///< returned and pPlatformInfo is not used.
-    size_t* pSizeRet                                ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
-    );
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
+    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
+    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
+                                         ///< If Size is not equal to or greater to the real number of bytes needed
+                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                         ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported API versions
-/// 
+///
 /// @details
 ///     - API versions contain major and minor attributes, use
 ///       ::UR_MAJOR_VERSION and ::UR_MINOR_VERSION
-typedef enum ur_api_version_t
-{
-    UR_API_VERSION_0_9 = UR_MAKE_VERSION( 0, 9 ),   ///< version 0.9
-    UR_API_VERSION_CURRENT = UR_MAKE_VERSION( 0, 9 ),   ///< latest known version
+typedef enum ur_api_version_t {
+    UR_API_VERSION_0_9 = UR_MAKE_VERSION(0, 9),     ///< version 0.9
+    UR_API_VERSION_CURRENT = UR_MAKE_VERSION(0, 9), ///< latest known version
     UR_API_VERSION_FORCE_UINT32 = 0x7fffffff
 
 } ur_api_version_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Returns the API version supported by the specified platform
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4068,13 +4018,13 @@ typedef enum ur_api_version_t
 ///         + `NULL == pVersion`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver,                   ///< [in] handle of the platform
-    ur_api_version_t* pVersion                      ///< [out] api version
-    );
+    ur_platform_handle_t hDriver, ///< [in] handle of the platform
+    ur_api_version_t *pVersion    ///< [out] api version
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native platform handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -4083,7 +4033,7 @@ urPlatformGetApiVersion(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4094,19 +4044,19 @@ urPlatformGetApiVersion(
 ///         + `NULL == phNativePlatform`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform.
-    ur_native_handle_t* phNativePlatform            ///< [out] a pointer to the native handle of the platform.
-    );
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
+    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime platform object from native platform handle.
-/// 
+///
 /// @details
 ///     - Creates runtime platform handle from native driver platform handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4117,16 +4067,16 @@ urPlatformGetNativeHandle(
 ///         + `NULL == phPlatform`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform,             ///< [in] the native handle of the platform.
-    ur_platform_handle_t* phPlatform                ///< [out] pointer to the handle of the platform object created.
-    );
+    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieve string representation of the underlying adapter specific
 ///        result reported by the the last API that returned
 ///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
 ///        return an adapter specific result.
-/// 
+///
 /// @details
 ///     - The string returned via the ppMessage is a NULL terminated C style
 ///       string.
@@ -4138,7 +4088,7 @@ urPlatformCreateWithNativeHandle(
 ///       adapter.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4149,10 +4099,10 @@ urPlatformCreateWithNativeHandle(
 ///         + `NULL == ppMessage`
 UR_APIEXPORT ur_result_t UR_APICALL
 urGetLastResult(
-    ur_platform_handle_t hPlatform,                 ///< [in] handle of the platform instance
-    const char** ppMessage                          ///< [out] pointer to a string containing adapter specific result in string
-                                                    ///< representation.
-    );
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
+    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
+                                    ///< representation.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -4163,14 +4113,14 @@ urGetLastResult(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create Program from input SPIR-V modules.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateProgram**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4182,23 +4132,23 @@ urGetLastResult(
 ///         + `NULL == phProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreate(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
-    uint32_t count,                                 ///< [in] number of module handles in module list.
-    const ur_module_handle_t* phModules,            ///< [in][range(0, count)] pointer to array of modules.
-    const char* pOptions,                           ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t* phProgram                  ///< [out] pointer to handle of program object created.
-    );
+    ur_context_handle_t hContext,        ///< [in] handle of the context instance
+    uint32_t count,                      ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create program object from native binary.
-/// 
+///
 /// @details
 ///     - The application may call this function from simultaneous threads.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateProgramWithBinary**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4211,26 +4161,26 @@ urProgramCreate(
 ///         + `NULL == phProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreateWithBinary(
-    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                     ///< [in] handle to device associated with binary.
-    size_t size,                                    ///< [in] size in bytes.
-    const uint8_t* pBinary,                         ///< [in] pointer to binary.
-    ur_program_handle_t* phProgram                  ///< [out] pointer to handle of Program object created.
-    );
+    ur_context_handle_t hContext,  ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
+    size_t size,                   ///< [in] size in bytes.
+    const uint8_t *pBinary,        ///< [in] pointer to binary.
+    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get a reference to the Program object.
-/// 
+///
 /// @details
 ///     - Get a reference to the Program object handle. Increment its reference
 ///       count
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clRetainProgram**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4239,22 +4189,22 @@ urProgramCreateWithBinary(
 ///         + `NULL == hProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(
-    ur_program_handle_t hProgram                    ///< [in] handle for the Program to retain
-    );
+    ur_program_handle_t hProgram ///< [in] handle for the Program to retain
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Release Program.
-/// 
+///
 /// @details
 ///     - Decrement reference count and destroy the Program if reference count
 ///       becomes zero.
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function should be lock-free.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clReleaseProgram**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4263,12 +4213,12 @@ urProgramRetain(
 ///         + `NULL == hProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(
-    ur_program_handle_t hProgram                    ///< [in] handle for the Program to release
-    );
+    ur_program_handle_t hProgram ///< [in] handle for the Program to release
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves a device function pointer to a user-defined function.
-/// 
+///
 /// @details
 ///     - Retrieves a pointer to the functions with the given name and defined
 ///       in the given program.
@@ -4277,11 +4227,11 @@ urProgramRelease(
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetDeviceFunctionPointerINTEL**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4294,41 +4244,40 @@ urProgramRelease(
 ///         + `NULL == ppFunctionPointer`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,                     ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram,                   ///< [in] handle of the program to search for function in.
-                                                    ///< The program must already be built to the specified device, or
-                                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char* pFunctionName,                      ///< [in] A null-terminates string denoting the mangled function name.
-    void** ppFunctionPointer                        ///< [out] Returns the pointer to the function if it is found in the program.
-    );
+    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
+                                  ///< The program must already be built to the specified device, or
+                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
+    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object information
-typedef enum ur_program_info_t
-{
-    UR_PROGRAM_INFO_REFERENCE_COUNT = 0,            ///< Program reference count info
-    UR_PROGRAM_INFO_CONTEXT = 1,                    ///< Program context info
-    UR_PROGRAM_INFO_NUM_DEVICES = 2,                ///< Return number of devices associated with Program
-    UR_PROGRAM_INFO_DEVICES = 3,                    ///< Return list of devices associated with Program, return type
-                                                    ///< uint32_t[].
-    UR_PROGRAM_INFO_SOURCE = 4,                     ///< Return program source associated with Program, return type char[].
-    UR_PROGRAM_INFO_BINARY_SIZES = 5,               ///< Return program binary sizes for each device, return type size_t[].
-    UR_PROGRAM_INFO_BINARIES = 6,                   ///< Return program binaries for all devices for this Program, return type
-                                                    ///< uchar[].
-    UR_PROGRAM_INFO_NUM_KERNELS = 7,                ///< Number of kernels in Program, return type size_t
-    UR_PROGRAM_INFO_KERNEL_NAMES = 8,               ///< Return a semi-colon separated list of kernel names in Program, return
-                                                    ///< type char[]
+typedef enum ur_program_info_t {
+    UR_PROGRAM_INFO_REFERENCE_COUNT = 0, ///< Program reference count info
+    UR_PROGRAM_INFO_CONTEXT = 1,         ///< Program context info
+    UR_PROGRAM_INFO_NUM_DEVICES = 2,     ///< Return number of devices associated with Program
+    UR_PROGRAM_INFO_DEVICES = 3,         ///< Return list of devices associated with Program, return type
+                                         ///< uint32_t[].
+    UR_PROGRAM_INFO_SOURCE = 4,          ///< Return program source associated with Program, return type char[].
+    UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< Return program binary sizes for each device, return type size_t[].
+    UR_PROGRAM_INFO_BINARIES = 6,        ///< Return program binaries for all devices for this Program, return type
+                                         ///< uchar[].
+    UR_PROGRAM_INFO_NUM_KERNELS = 7,     ///< Number of kernels in Program, return type size_t
+    UR_PROGRAM_INFO_KERNEL_NAMES = 8,    ///< Return a semi-colon separated list of kernel names in Program, return
+                                         ///< type char[]
     UR_PROGRAM_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_program_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Program object
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetProgramInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4339,60 +4288,57 @@ typedef enum ur_program_info_t
 ///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetInfo(
-    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
-    ur_program_info_t propName,                     ///< [in] name of the Program property to query
-    size_t propSize,                                ///< [in] the size of the Program property.
-    void* pProgramInfo,                             ///< [in,out][optional] array of bytes of holding the program info property.
-                                                    ///< If propSize is not equal to or greater than the real number of bytes
-                                                    ///< needed to return 
-                                                    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                                    ///< pProgramInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
-    );
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_program_info_t propName,   ///< [in] name of the Program property to query
+    size_t propSize,              ///< [in] the size of the Program property.
+    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+                                  ///< If propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pProgramInfo is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program object build status
-typedef enum ur_program_build_status_t
-{
-    UR_PROGRAM_BUILD_STATUS_NONE = 0,               ///< Program build status none
-    UR_PROGRAM_BUILD_STATUS_ERROR = 1,              ///< Program build error
-    UR_PROGRAM_BUILD_STATUS_SUCCESS = 2,            ///< Program build success
-    UR_PROGRAM_BUILD_STATUS_IN_PROGRESS = 3,        ///< Program build in progress
+typedef enum ur_program_build_status_t {
+    UR_PROGRAM_BUILD_STATUS_NONE = 0,        ///< Program build status none
+    UR_PROGRAM_BUILD_STATUS_ERROR = 1,       ///< Program build error
+    UR_PROGRAM_BUILD_STATUS_SUCCESS = 2,     ///< Program build success
+    UR_PROGRAM_BUILD_STATUS_IN_PROGRESS = 3, ///< Program build in progress
     UR_PROGRAM_BUILD_STATUS_FORCE_UINT32 = 0x7fffffff
 
 } ur_program_build_status_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program object binary type
-typedef enum ur_program_binary_type_t
-{
-    UR_PROGRAM_BINARY_TYPE_NONE = 0,                ///< No program binary is associated with device
-    UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT = 1,     ///< Program binary is compiled object
-    UR_PROGRAM_BINARY_TYPE_LIBRARY = 2,             ///< Program binary is library object
-    UR_PROGRAM_BINARY_TYPE_EXECUTABLE = 3,          ///< Program binary is executable
+typedef enum ur_program_binary_type_t {
+    UR_PROGRAM_BINARY_TYPE_NONE = 0,            ///< No program binary is associated with device
+    UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT = 1, ///< Program binary is compiled object
+    UR_PROGRAM_BINARY_TYPE_LIBRARY = 2,         ///< Program binary is library object
+    UR_PROGRAM_BINARY_TYPE_EXECUTABLE = 3,      ///< Program binary is executable
     UR_PROGRAM_BINARY_TYPE_FORCE_UINT32 = 0x7fffffff
 
 } ur_program_binary_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object build information
-typedef enum ur_program_build_info_t
-{
-    UR_PROGRAM_BUILD_INFO_STATUS = 0,               ///< Program build status, return type ::ur_program_build_status_t
-    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,              ///< Program build options, return type char[]
-    UR_PROGRAM_BUILD_INFO_LOG = 2,                  ///< Program build log, return type char[]
-    UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3,          ///< Program binary type, return type ::ur_program_binary_type_t
+typedef enum ur_program_build_info_t {
+    UR_PROGRAM_BUILD_INFO_STATUS = 0,      ///< Program build status, return type ::ur_program_build_status_t
+    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,     ///< Program build options, return type char[]
+    UR_PROGRAM_BUILD_INFO_LOG = 2,         ///< Program build log, return type char[]
+    UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3, ///< Program binary type, return type ::ur_program_binary_type_t
     UR_PROGRAM_BUILD_INFO_FORCE_UINT32 = 0x7fffffff
 
 } ur_program_build_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query build information about a Program object for a Device
-/// 
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clGetProgramBuildInfo**
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4404,21 +4350,21 @@ typedef enum ur_program_build_info_t
 ///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,                     ///< [in] handle of the Device object
-    ur_program_build_info_t propName,               ///< [in] name of the Program build info to query
-    size_t propSize,                                ///< [in] size of the Program build info property.
-    void* pPropValue,                               ///< [in,out][optional] value of the Program build property.
-                                                    ///< If propSize is not equal to or greater than the real number of bytes
-                                                    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                                    ///< error is returned and pKernelInfo is not used.
-    size_t* pPropSizeRet                            ///< [out][optional] pointer to the actual size in bytes of data being
-                                                    ///< queried by propName.
-    );
+    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
+    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
+    size_t propSize,                  ///< [in] size of the Program build info property.
+    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+                                      ///< If propSize is not equal to or greater than the real number of bytes
+                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                      ///< error is returned and pKernelInfo is not used.
+    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
+                                      ///< queried by propName.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set a Program object specialization constant to a specific value
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4429,15 +4375,15 @@ urProgramGetBuildInfo(
 ///         + `NULL == pSpecValue`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramSetSpecializationConstant(
-    ur_program_handle_t hProgram,                   ///< [in] handle of the Program object
-    uint32_t specId,                                ///< [in] specification constant Id
-    size_t specSize,                                ///< [in] size of the specialization constant value
-    const void* pSpecValue                          ///< [in] pointer to the specialization value bytes
-    );
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t specId,              ///< [in] specification constant Id
+    size_t specSize,              ///< [in] size of the specialization constant value
+    const void *pSpecValue        ///< [in] pointer to the specialization value bytes
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return program native program handle.
-/// 
+///
 /// @details
 ///     - Retrieved native handle can be used for direct interaction with the
 ///       native platform driver.
@@ -4446,7 +4392,7 @@ urProgramSetSpecializationConstant(
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4457,19 +4403,19 @@ urProgramSetSpecializationConstant(
 ///         + `NULL == phNativeProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,                   ///< [in] handle of the program.
-    ur_native_handle_t* phNativeProgram             ///< [out] a pointer to the native handle of the program.
-    );
+    ur_program_handle_t hProgram,       ///< [in] handle of the program.
+    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime program object from native program handle.
-/// 
+///
 /// @details
 ///     - Creates runtime program handle from native driver program handle.
 ///     - The application may call this function from simultaneous threads for
 ///       the same context.
 ///     - The implementation of this function should be thread-safe.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4481,10 +4427,10 @@ urProgramGetNativeHandle(
 ///         + `NULL == phProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram,              ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,                   ///< [in] handle of the context instance
-    ur_program_handle_t* phProgram                  ///< [out] pointer to the handle of the program object created.
-    );
+    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,      ///< [in] handle of the context instance
+    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -4496,16 +4442,15 @@ urProgramCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device initialization flags
 typedef uint32_t ur_device_init_flags_t;
-typedef enum ur_device_init_flag_t
-{
-    UR_DEVICE_INIT_FLAG_GPU = UR_BIT(0),            ///< initialize GPU device drivers
+typedef enum ur_device_init_flag_t {
+    UR_DEVICE_INIT_FLAG_GPU = UR_BIT(0), ///< initialize GPU device drivers
     UR_DEVICE_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
 
 } ur_device_init_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' driver(s)
-/// 
+///
 /// @details
 ///     - The application must call this function before calling any other
 ///       function.
@@ -4519,7 +4464,7 @@ typedef enum ur_device_init_flag_t
 ///     - The application may call this function from simultaneous threads.
 ///     - The implementation of this function must be thread-safe for scenarios
 ///       where multiple libraries may initialize the driver(s) simultaneously.
-/// 
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
@@ -4529,9 +4474,9 @@ typedef enum ur_device_init_flag_t
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urInit(
-    ur_device_init_flags_t device_flags             ///< [in] device initialization flags.
-                                                    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
-    );
+    ur_device_init_flags_t device_flags ///< [in] device initialization flags.
+                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -4541,3080 +4486,2840 @@ urInit(
 #pragma region callbacks
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urPlatformGet 
+/// @brief Callback function parameters for urPlatformGet
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_platform_get_params_t
-{
-    uint32_t* pNumEntries;
-    ur_platform_handle_t** pphPlatforms;
-    uint32_t** ppNumPlatforms;
+typedef struct ur_platform_get_params_t {
+    uint32_t *pNumEntries;
+    ur_platform_handle_t **pphPlatforms;
+    uint32_t **ppNumPlatforms;
 } ur_platform_get_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urPlatformGet 
+/// @brief Callback function-pointer for urPlatformGet
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnPlatformGetCb_t)(
-    ur_platform_get_params_t* params,
+typedef void(UR_APICALL *ur_pfnPlatformGetCb_t)(
+    ur_platform_get_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urPlatformGetInfo 
+/// @brief Callback function parameters for urPlatformGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_platform_get_info_params_t
-{
-    ur_platform_handle_t* phPlatform;
-    ur_platform_info_t* pPlatformInfoType;
-    size_t* pSize;
-    void** ppPlatformInfo;
-    size_t** ppSizeRet;
+typedef struct ur_platform_get_info_params_t {
+    ur_platform_handle_t *phPlatform;
+    ur_platform_info_t *pPlatformInfoType;
+    size_t *pSize;
+    void **ppPlatformInfo;
+    size_t **ppSizeRet;
 } ur_platform_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urPlatformGetInfo 
+/// @brief Callback function-pointer for urPlatformGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnPlatformGetInfoCb_t)(
-    ur_platform_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnPlatformGetInfoCb_t)(
+    ur_platform_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urPlatformGetNativeHandle 
+/// @brief Callback function parameters for urPlatformGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_platform_get_native_handle_params_t
-{
-    ur_platform_handle_t* phPlatform;
-    ur_native_handle_t** pphNativePlatform;
+typedef struct ur_platform_get_native_handle_params_t {
+    ur_platform_handle_t *phPlatform;
+    ur_native_handle_t **pphNativePlatform;
 } ur_platform_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urPlatformGetNativeHandle 
+/// @brief Callback function-pointer for urPlatformGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnPlatformGetNativeHandleCb_t)(
-    ur_platform_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnPlatformGetNativeHandleCb_t)(
+    ur_platform_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urPlatformCreateWithNativeHandle 
+/// @brief Callback function parameters for urPlatformCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_platform_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativePlatform;
-    ur_platform_handle_t** pphPlatform;
+typedef struct ur_platform_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativePlatform;
+    ur_platform_handle_t **pphPlatform;
 } ur_platform_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urPlatformCreateWithNativeHandle 
+/// @brief Callback function-pointer for urPlatformCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnPlatformCreateWithNativeHandleCb_t)(
-    ur_platform_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnPlatformCreateWithNativeHandleCb_t)(
+    ur_platform_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urPlatformGetApiVersion 
+/// @brief Callback function parameters for urPlatformGetApiVersion
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_platform_get_api_version_params_t
-{
-    ur_platform_handle_t* phDriver;
-    ur_api_version_t** ppVersion;
+typedef struct ur_platform_get_api_version_params_t {
+    ur_platform_handle_t *phDriver;
+    ur_api_version_t **ppVersion;
 } ur_platform_get_api_version_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urPlatformGetApiVersion 
+/// @brief Callback function-pointer for urPlatformGetApiVersion
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnPlatformGetApiVersionCb_t)(
-    ur_platform_get_api_version_params_t* params,
+typedef void(UR_APICALL *ur_pfnPlatformGetApiVersionCb_t)(
+    ur_platform_get_api_version_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Platform callback functions pointers
-typedef struct ur_platform_callbacks_t
-{
-    ur_pfnPlatformGetCb_t                                           pfnGetCb;
-    ur_pfnPlatformGetInfoCb_t                                       pfnGetInfoCb;
-    ur_pfnPlatformGetNativeHandleCb_t                               pfnGetNativeHandleCb;
-    ur_pfnPlatformCreateWithNativeHandleCb_t                        pfnCreateWithNativeHandleCb;
-    ur_pfnPlatformGetApiVersionCb_t                                 pfnGetApiVersionCb;
+typedef struct ur_platform_callbacks_t {
+    ur_pfnPlatformGetCb_t pfnGetCb;
+    ur_pfnPlatformGetInfoCb_t pfnGetInfoCb;
+    ur_pfnPlatformGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnPlatformCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnPlatformGetApiVersionCb_t pfnGetApiVersionCb;
 } ur_platform_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextCreate 
+/// @brief Callback function parameters for urContextCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_create_params_t
-{
-    uint32_t* pDeviceCount;
-    ur_device_handle_t** pphDevices;
-    ur_context_handle_t** pphContext;
+typedef struct ur_context_create_params_t {
+    uint32_t *pDeviceCount;
+    ur_device_handle_t **pphDevices;
+    ur_context_handle_t **pphContext;
 } ur_context_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextCreate 
+/// @brief Callback function-pointer for urContextCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextCreateCb_t)(
-    ur_context_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextCreateCb_t)(
+    ur_context_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextRetain 
+/// @brief Callback function parameters for urContextRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_retain_params_t
-{
-    ur_context_handle_t* phContext;
+typedef struct ur_context_retain_params_t {
+    ur_context_handle_t *phContext;
 } ur_context_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextRetain 
+/// @brief Callback function-pointer for urContextRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextRetainCb_t)(
-    ur_context_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextRetainCb_t)(
+    ur_context_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextRelease 
+/// @brief Callback function parameters for urContextRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_release_params_t
-{
-    ur_context_handle_t* phContext;
+typedef struct ur_context_release_params_t {
+    ur_context_handle_t *phContext;
 } ur_context_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextRelease 
+/// @brief Callback function-pointer for urContextRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextReleaseCb_t)(
-    ur_context_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextReleaseCb_t)(
+    ur_context_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextGetInfo 
+/// @brief Callback function parameters for urContextGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_get_info_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_context_info_t* pContextInfoType;
-    size_t* ppropSize;
-    void** ppContextInfo;
-    size_t** ppPropSizeRet;
+typedef struct ur_context_get_info_params_t {
+    ur_context_handle_t *phContext;
+    ur_context_info_t *pContextInfoType;
+    size_t *ppropSize;
+    void **ppContextInfo;
+    size_t **ppPropSizeRet;
 } ur_context_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextGetInfo 
+/// @brief Callback function-pointer for urContextGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextGetInfoCb_t)(
-    ur_context_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextGetInfoCb_t)(
+    ur_context_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextGetNativeHandle 
+/// @brief Callback function parameters for urContextGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_get_native_handle_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_native_handle_t** pphNativeContext;
+typedef struct ur_context_get_native_handle_params_t {
+    ur_context_handle_t *phContext;
+    ur_native_handle_t **pphNativeContext;
 } ur_context_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextGetNativeHandle 
+/// @brief Callback function-pointer for urContextGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextGetNativeHandleCb_t)(
-    ur_context_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextGetNativeHandleCb_t)(
+    ur_context_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextCreateWithNativeHandle 
+/// @brief Callback function parameters for urContextCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeContext;
-    ur_context_handle_t** pphContext;
+typedef struct ur_context_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeContext;
+    ur_context_handle_t **pphContext;
 } ur_context_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextCreateWithNativeHandle 
+/// @brief Callback function-pointer for urContextCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextCreateWithNativeHandleCb_t)(
-    ur_context_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextCreateWithNativeHandleCb_t)(
+    ur_context_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urContextSetExtendedDeleter 
+/// @brief Callback function parameters for urContextSetExtendedDeleter
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_context_set_extended_deleter_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_context_extended_deleter_t* ppfnDeleter;
-    void** ppUserData;
+typedef struct ur_context_set_extended_deleter_params_t {
+    ur_context_handle_t *phContext;
+    ur_context_extended_deleter_t *ppfnDeleter;
+    void **ppUserData;
 } ur_context_set_extended_deleter_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urContextSetExtendedDeleter 
+/// @brief Callback function-pointer for urContextSetExtendedDeleter
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnContextSetExtendedDeleterCb_t)(
-    ur_context_set_extended_deleter_params_t* params,
+typedef void(UR_APICALL *ur_pfnContextSetExtendedDeleterCb_t)(
+    ur_context_set_extended_deleter_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Context callback functions pointers
-typedef struct ur_context_callbacks_t
-{
-    ur_pfnContextCreateCb_t                                         pfnCreateCb;
-    ur_pfnContextRetainCb_t                                         pfnRetainCb;
-    ur_pfnContextReleaseCb_t                                        pfnReleaseCb;
-    ur_pfnContextGetInfoCb_t                                        pfnGetInfoCb;
-    ur_pfnContextGetNativeHandleCb_t                                pfnGetNativeHandleCb;
-    ur_pfnContextCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
-    ur_pfnContextSetExtendedDeleterCb_t                             pfnSetExtendedDeleterCb;
+typedef struct ur_context_callbacks_t {
+    ur_pfnContextCreateCb_t pfnCreateCb;
+    ur_pfnContextRetainCb_t pfnRetainCb;
+    ur_pfnContextReleaseCb_t pfnReleaseCb;
+    ur_pfnContextGetInfoCb_t pfnGetInfoCb;
+    ur_pfnContextGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnContextCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnContextSetExtendedDeleterCb_t pfnSetExtendedDeleterCb;
 } ur_context_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventGetInfo 
+/// @brief Callback function parameters for urEventGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_get_info_params_t
-{
-    ur_event_handle_t* phEvent;
-    ur_event_info_t* ppropName;
-    size_t* ppropValueSize;
-    void** ppPropValue;
-    size_t** ppPropValueSizeRet;
+typedef struct ur_event_get_info_params_t {
+    ur_event_handle_t *phEvent;
+    ur_event_info_t *ppropName;
+    size_t *ppropValueSize;
+    void **ppPropValue;
+    size_t **ppPropValueSizeRet;
 } ur_event_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventGetInfo 
+/// @brief Callback function-pointer for urEventGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventGetInfoCb_t)(
-    ur_event_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventGetInfoCb_t)(
+    ur_event_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventGetProfilingInfo 
+/// @brief Callback function parameters for urEventGetProfilingInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_get_profiling_info_params_t
-{
-    ur_event_handle_t* phEvent;
-    ur_profiling_info_t* ppropName;
-    size_t* ppropValueSize;
-    void** ppPropValue;
-    size_t** ppPropValueSizeRet;
+typedef struct ur_event_get_profiling_info_params_t {
+    ur_event_handle_t *phEvent;
+    ur_profiling_info_t *ppropName;
+    size_t *ppropValueSize;
+    void **ppPropValue;
+    size_t **ppPropValueSizeRet;
 } ur_event_get_profiling_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventGetProfilingInfo 
+/// @brief Callback function-pointer for urEventGetProfilingInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventGetProfilingInfoCb_t)(
-    ur_event_get_profiling_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventGetProfilingInfoCb_t)(
+    ur_event_get_profiling_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventWait 
+/// @brief Callback function parameters for urEventWait
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_wait_params_t
-{
-    uint32_t* pnumEvents;
-    const ur_event_handle_t** pphEventWaitList;
+typedef struct ur_event_wait_params_t {
+    uint32_t *pnumEvents;
+    const ur_event_handle_t **pphEventWaitList;
 } ur_event_wait_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventWait 
+/// @brief Callback function-pointer for urEventWait
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventWaitCb_t)(
-    ur_event_wait_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventWaitCb_t)(
+    ur_event_wait_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventRetain 
+/// @brief Callback function parameters for urEventRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_retain_params_t
-{
-    ur_event_handle_t* phEvent;
+typedef struct ur_event_retain_params_t {
+    ur_event_handle_t *phEvent;
 } ur_event_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventRetain 
+/// @brief Callback function-pointer for urEventRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventRetainCb_t)(
-    ur_event_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventRetainCb_t)(
+    ur_event_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventRelease 
+/// @brief Callback function parameters for urEventRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_release_params_t
-{
-    ur_event_handle_t* phEvent;
+typedef struct ur_event_release_params_t {
+    ur_event_handle_t *phEvent;
 } ur_event_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventRelease 
+/// @brief Callback function-pointer for urEventRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventReleaseCb_t)(
-    ur_event_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventReleaseCb_t)(
+    ur_event_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventGetNativeHandle 
+/// @brief Callback function parameters for urEventGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_get_native_handle_params_t
-{
-    ur_event_handle_t* phEvent;
-    ur_native_handle_t** pphNativeEvent;
+typedef struct ur_event_get_native_handle_params_t {
+    ur_event_handle_t *phEvent;
+    ur_native_handle_t **pphNativeEvent;
 } ur_event_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventGetNativeHandle 
+/// @brief Callback function-pointer for urEventGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventGetNativeHandleCb_t)(
-    ur_event_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventGetNativeHandleCb_t)(
+    ur_event_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventCreateWithNativeHandle 
+/// @brief Callback function parameters for urEventCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeEvent;
-    ur_context_handle_t* phContext;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_event_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeEvent;
+    ur_context_handle_t *phContext;
+    ur_event_handle_t **pphEvent;
 } ur_event_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventCreateWithNativeHandle 
+/// @brief Callback function-pointer for urEventCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventCreateWithNativeHandleCb_t)(
-    ur_event_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventCreateWithNativeHandleCb_t)(
+    ur_event_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEventSetCallback 
+/// @brief Callback function parameters for urEventSetCallback
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_event_set_callback_params_t
-{
-    ur_event_handle_t* phEvent;
-    ur_execution_info_t* pexecStatus;
-    ur_event_callback_t* ppfnNotify;
-    void** ppUserData;
+typedef struct ur_event_set_callback_params_t {
+    ur_event_handle_t *phEvent;
+    ur_execution_info_t *pexecStatus;
+    ur_event_callback_t *ppfnNotify;
+    void **ppUserData;
 } ur_event_set_callback_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEventSetCallback 
+/// @brief Callback function-pointer for urEventSetCallback
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEventSetCallbackCb_t)(
-    ur_event_set_callback_params_t* params,
+typedef void(UR_APICALL *ur_pfnEventSetCallbackCb_t)(
+    ur_event_set_callback_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Event callback functions pointers
-typedef struct ur_event_callbacks_t
-{
-    ur_pfnEventGetInfoCb_t                                          pfnGetInfoCb;
-    ur_pfnEventGetProfilingInfoCb_t                                 pfnGetProfilingInfoCb;
-    ur_pfnEventWaitCb_t                                             pfnWaitCb;
-    ur_pfnEventRetainCb_t                                           pfnRetainCb;
-    ur_pfnEventReleaseCb_t                                          pfnReleaseCb;
-    ur_pfnEventGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
-    ur_pfnEventCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
-    ur_pfnEventSetCallbackCb_t                                      pfnSetCallbackCb;
+typedef struct ur_event_callbacks_t {
+    ur_pfnEventGetInfoCb_t pfnGetInfoCb;
+    ur_pfnEventGetProfilingInfoCb_t pfnGetProfilingInfoCb;
+    ur_pfnEventWaitCb_t pfnWaitCb;
+    ur_pfnEventRetainCb_t pfnRetainCb;
+    ur_pfnEventReleaseCb_t pfnReleaseCb;
+    ur_pfnEventGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnEventCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnEventSetCallbackCb_t pfnSetCallbackCb;
 } ur_event_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramCreate 
+/// @brief Callback function parameters for urProgramCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_create_params_t
-{
-    ur_context_handle_t* phContext;
-    uint32_t* pcount;
-    const ur_module_handle_t** pphModules;
-    const char** ppOptions;
-    ur_program_handle_t** pphProgram;
+typedef struct ur_program_create_params_t {
+    ur_context_handle_t *phContext;
+    uint32_t *pcount;
+    const ur_module_handle_t **pphModules;
+    const char **ppOptions;
+    ur_program_handle_t **pphProgram;
 } ur_program_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramCreate 
+/// @brief Callback function-pointer for urProgramCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramCreateCb_t)(
-    ur_program_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramCreateCb_t)(
+    ur_program_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramCreateWithBinary 
+/// @brief Callback function parameters for urProgramCreateWithBinary
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_create_with_binary_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_device_handle_t* phDevice;
-    size_t* psize;
-    const uint8_t** ppBinary;
-    ur_program_handle_t** pphProgram;
+typedef struct ur_program_create_with_binary_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    size_t *psize;
+    const uint8_t **ppBinary;
+    ur_program_handle_t **pphProgram;
 } ur_program_create_with_binary_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramCreateWithBinary 
+/// @brief Callback function-pointer for urProgramCreateWithBinary
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramCreateWithBinaryCb_t)(
-    ur_program_create_with_binary_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramCreateWithBinaryCb_t)(
+    ur_program_create_with_binary_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramRetain 
+/// @brief Callback function parameters for urProgramRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_retain_params_t
-{
-    ur_program_handle_t* phProgram;
+typedef struct ur_program_retain_params_t {
+    ur_program_handle_t *phProgram;
 } ur_program_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramRetain 
+/// @brief Callback function-pointer for urProgramRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramRetainCb_t)(
-    ur_program_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramRetainCb_t)(
+    ur_program_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramRelease 
+/// @brief Callback function parameters for urProgramRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_release_params_t
-{
-    ur_program_handle_t* phProgram;
+typedef struct ur_program_release_params_t {
+    ur_program_handle_t *phProgram;
 } ur_program_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramRelease 
+/// @brief Callback function-pointer for urProgramRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramReleaseCb_t)(
-    ur_program_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramReleaseCb_t)(
+    ur_program_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramGetFunctionPointer 
+/// @brief Callback function parameters for urProgramGetFunctionPointer
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_get_function_pointer_params_t
-{
-    ur_device_handle_t* phDevice;
-    ur_program_handle_t* phProgram;
-    const char** ppFunctionName;
-    void*** pppFunctionPointer;
+typedef struct ur_program_get_function_pointer_params_t {
+    ur_device_handle_t *phDevice;
+    ur_program_handle_t *phProgram;
+    const char **ppFunctionName;
+    void ***pppFunctionPointer;
 } ur_program_get_function_pointer_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramGetFunctionPointer 
+/// @brief Callback function-pointer for urProgramGetFunctionPointer
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramGetFunctionPointerCb_t)(
-    ur_program_get_function_pointer_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramGetFunctionPointerCb_t)(
+    ur_program_get_function_pointer_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramGetInfo 
+/// @brief Callback function parameters for urProgramGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_get_info_params_t
-{
-    ur_program_handle_t* phProgram;
-    ur_program_info_t* ppropName;
-    size_t* ppropSize;
-    void** ppProgramInfo;
-    size_t** ppPropSizeRet;
+typedef struct ur_program_get_info_params_t {
+    ur_program_handle_t *phProgram;
+    ur_program_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppProgramInfo;
+    size_t **ppPropSizeRet;
 } ur_program_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramGetInfo 
+/// @brief Callback function-pointer for urProgramGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramGetInfoCb_t)(
-    ur_program_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramGetInfoCb_t)(
+    ur_program_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramGetBuildInfo 
+/// @brief Callback function parameters for urProgramGetBuildInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_get_build_info_params_t
-{
-    ur_program_handle_t* phProgram;
-    ur_device_handle_t* phDevice;
-    ur_program_build_info_t* ppropName;
-    size_t* ppropSize;
-    void** ppPropValue;
-    size_t** ppPropSizeRet;
+typedef struct ur_program_get_build_info_params_t {
+    ur_program_handle_t *phProgram;
+    ur_device_handle_t *phDevice;
+    ur_program_build_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
 } ur_program_get_build_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramGetBuildInfo 
+/// @brief Callback function-pointer for urProgramGetBuildInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramGetBuildInfoCb_t)(
-    ur_program_get_build_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramGetBuildInfoCb_t)(
+    ur_program_get_build_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramSetSpecializationConstant 
+/// @brief Callback function parameters for urProgramSetSpecializationConstant
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_set_specialization_constant_params_t
-{
-    ur_program_handle_t* phProgram;
-    uint32_t* pspecId;
-    size_t* pspecSize;
-    const void** ppSpecValue;
+typedef struct ur_program_set_specialization_constant_params_t {
+    ur_program_handle_t *phProgram;
+    uint32_t *pspecId;
+    size_t *pspecSize;
+    const void **ppSpecValue;
 } ur_program_set_specialization_constant_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramSetSpecializationConstant 
+/// @brief Callback function-pointer for urProgramSetSpecializationConstant
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramSetSpecializationConstantCb_t)(
-    ur_program_set_specialization_constant_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramSetSpecializationConstantCb_t)(
+    ur_program_set_specialization_constant_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramGetNativeHandle 
+/// @brief Callback function parameters for urProgramGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_get_native_handle_params_t
-{
-    ur_program_handle_t* phProgram;
-    ur_native_handle_t** pphNativeProgram;
+typedef struct ur_program_get_native_handle_params_t {
+    ur_program_handle_t *phProgram;
+    ur_native_handle_t **pphNativeProgram;
 } ur_program_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramGetNativeHandle 
+/// @brief Callback function-pointer for urProgramGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramGetNativeHandleCb_t)(
-    ur_program_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramGetNativeHandleCb_t)(
+    ur_program_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urProgramCreateWithNativeHandle 
+/// @brief Callback function parameters for urProgramCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_program_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeProgram;
-    ur_context_handle_t* phContext;
-    ur_program_handle_t** pphProgram;
+typedef struct ur_program_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeProgram;
+    ur_context_handle_t *phContext;
+    ur_program_handle_t **pphProgram;
 } ur_program_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urProgramCreateWithNativeHandle 
+/// @brief Callback function-pointer for urProgramCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnProgramCreateWithNativeHandleCb_t)(
-    ur_program_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnProgramCreateWithNativeHandleCb_t)(
+    ur_program_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Program callback functions pointers
-typedef struct ur_program_callbacks_t
-{
-    ur_pfnProgramCreateCb_t                                         pfnCreateCb;
-    ur_pfnProgramCreateWithBinaryCb_t                               pfnCreateWithBinaryCb;
-    ur_pfnProgramRetainCb_t                                         pfnRetainCb;
-    ur_pfnProgramReleaseCb_t                                        pfnReleaseCb;
-    ur_pfnProgramGetFunctionPointerCb_t                             pfnGetFunctionPointerCb;
-    ur_pfnProgramGetInfoCb_t                                        pfnGetInfoCb;
-    ur_pfnProgramGetBuildInfoCb_t                                   pfnGetBuildInfoCb;
-    ur_pfnProgramSetSpecializationConstantCb_t                      pfnSetSpecializationConstantCb;
-    ur_pfnProgramGetNativeHandleCb_t                                pfnGetNativeHandleCb;
-    ur_pfnProgramCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
+typedef struct ur_program_callbacks_t {
+    ur_pfnProgramCreateCb_t pfnCreateCb;
+    ur_pfnProgramCreateWithBinaryCb_t pfnCreateWithBinaryCb;
+    ur_pfnProgramRetainCb_t pfnRetainCb;
+    ur_pfnProgramReleaseCb_t pfnReleaseCb;
+    ur_pfnProgramGetFunctionPointerCb_t pfnGetFunctionPointerCb;
+    ur_pfnProgramGetInfoCb_t pfnGetInfoCb;
+    ur_pfnProgramGetBuildInfoCb_t pfnGetBuildInfoCb;
+    ur_pfnProgramSetSpecializationConstantCb_t pfnSetSpecializationConstantCb;
+    ur_pfnProgramGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnProgramCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
 } ur_program_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urModuleCreate 
+/// @brief Callback function parameters for urModuleCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_module_create_params_t
-{
-    ur_context_handle_t* phContext;
-    const void** ppIL;
-    size_t* plength;
-    const char** ppOptions;
-    ur_modulecreate_callback_t* ppfnNotify;
-    void** ppUserData;
-    ur_module_handle_t** pphModule;
+typedef struct ur_module_create_params_t {
+    ur_context_handle_t *phContext;
+    const void **ppIL;
+    size_t *plength;
+    const char **ppOptions;
+    ur_modulecreate_callback_t *ppfnNotify;
+    void **ppUserData;
+    ur_module_handle_t **pphModule;
 } ur_module_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urModuleCreate 
+/// @brief Callback function-pointer for urModuleCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnModuleCreateCb_t)(
-    ur_module_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnModuleCreateCb_t)(
+    ur_module_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urModuleRetain 
+/// @brief Callback function parameters for urModuleRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_module_retain_params_t
-{
-    ur_module_handle_t* phModule;
+typedef struct ur_module_retain_params_t {
+    ur_module_handle_t *phModule;
 } ur_module_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urModuleRetain 
+/// @brief Callback function-pointer for urModuleRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnModuleRetainCb_t)(
-    ur_module_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnModuleRetainCb_t)(
+    ur_module_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urModuleRelease 
+/// @brief Callback function parameters for urModuleRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_module_release_params_t
-{
-    ur_module_handle_t* phModule;
+typedef struct ur_module_release_params_t {
+    ur_module_handle_t *phModule;
 } ur_module_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urModuleRelease 
+/// @brief Callback function-pointer for urModuleRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnModuleReleaseCb_t)(
-    ur_module_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnModuleReleaseCb_t)(
+    ur_module_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urModuleGetNativeHandle 
+/// @brief Callback function parameters for urModuleGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_module_get_native_handle_params_t
-{
-    ur_module_handle_t* phModule;
-    ur_native_handle_t** pphNativeModule;
+typedef struct ur_module_get_native_handle_params_t {
+    ur_module_handle_t *phModule;
+    ur_native_handle_t **pphNativeModule;
 } ur_module_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urModuleGetNativeHandle 
+/// @brief Callback function-pointer for urModuleGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnModuleGetNativeHandleCb_t)(
-    ur_module_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnModuleGetNativeHandleCb_t)(
+    ur_module_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urModuleCreateWithNativeHandle 
+/// @brief Callback function parameters for urModuleCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_module_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeModule;
-    ur_context_handle_t* phContext;
-    ur_module_handle_t** pphModule;
+typedef struct ur_module_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeModule;
+    ur_context_handle_t *phContext;
+    ur_module_handle_t **pphModule;
 } ur_module_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urModuleCreateWithNativeHandle 
+/// @brief Callback function-pointer for urModuleCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnModuleCreateWithNativeHandleCb_t)(
-    ur_module_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnModuleCreateWithNativeHandleCb_t)(
+    ur_module_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Module callback functions pointers
-typedef struct ur_module_callbacks_t
-{
-    ur_pfnModuleCreateCb_t                                          pfnCreateCb;
-    ur_pfnModuleRetainCb_t                                          pfnRetainCb;
-    ur_pfnModuleReleaseCb_t                                         pfnReleaseCb;
-    ur_pfnModuleGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
-    ur_pfnModuleCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
+typedef struct ur_module_callbacks_t {
+    ur_pfnModuleCreateCb_t pfnCreateCb;
+    ur_pfnModuleRetainCb_t pfnRetainCb;
+    ur_pfnModuleReleaseCb_t pfnReleaseCb;
+    ur_pfnModuleGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnModuleCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
 } ur_module_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelCreate 
+/// @brief Callback function parameters for urKernelCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_create_params_t
-{
-    ur_program_handle_t* phProgram;
-    const char** ppKernelName;
-    ur_kernel_handle_t** pphKernel;
+typedef struct ur_kernel_create_params_t {
+    ur_program_handle_t *phProgram;
+    const char **ppKernelName;
+    ur_kernel_handle_t **pphKernel;
 } ur_kernel_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelCreate 
+/// @brief Callback function-pointer for urKernelCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelCreateCb_t)(
-    ur_kernel_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelCreateCb_t)(
+    ur_kernel_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelGetInfo 
+/// @brief Callback function parameters for urKernelGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_get_info_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    ur_kernel_info_t* ppropName;
-    size_t* ppropSize;
-    void** ppKernelInfo;
-    size_t** ppPropSizeRet;
+typedef struct ur_kernel_get_info_params_t {
+    ur_kernel_handle_t *phKernel;
+    ur_kernel_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppKernelInfo;
+    size_t **ppPropSizeRet;
 } ur_kernel_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelGetInfo 
+/// @brief Callback function-pointer for urKernelGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelGetInfoCb_t)(
-    ur_kernel_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelGetInfoCb_t)(
+    ur_kernel_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelGetGroupInfo 
+/// @brief Callback function parameters for urKernelGetGroupInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_get_group_info_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    ur_device_handle_t* phDevice;
-    ur_kernel_group_info_t* ppropName;
-    size_t* ppropSize;
-    void** ppPropValue;
-    size_t** ppPropSizeRet;
+typedef struct ur_kernel_get_group_info_params_t {
+    ur_kernel_handle_t *phKernel;
+    ur_device_handle_t *phDevice;
+    ur_kernel_group_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
 } ur_kernel_get_group_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelGetGroupInfo 
+/// @brief Callback function-pointer for urKernelGetGroupInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelGetGroupInfoCb_t)(
-    ur_kernel_get_group_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelGetGroupInfoCb_t)(
+    ur_kernel_get_group_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelGetSubGroupInfo 
+/// @brief Callback function parameters for urKernelGetSubGroupInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_get_sub_group_info_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    ur_device_handle_t* phDevice;
-    ur_kernel_sub_group_info_t* ppropName;
-    size_t* ppropSize;
-    void** ppPropValue;
-    size_t** ppPropSizeRet;
+typedef struct ur_kernel_get_sub_group_info_params_t {
+    ur_kernel_handle_t *phKernel;
+    ur_device_handle_t *phDevice;
+    ur_kernel_sub_group_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
 } ur_kernel_get_sub_group_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelGetSubGroupInfo 
+/// @brief Callback function-pointer for urKernelGetSubGroupInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelGetSubGroupInfoCb_t)(
-    ur_kernel_get_sub_group_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelGetSubGroupInfoCb_t)(
+    ur_kernel_get_sub_group_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelRetain 
+/// @brief Callback function parameters for urKernelRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_retain_params_t
-{
-    ur_kernel_handle_t* phKernel;
+typedef struct ur_kernel_retain_params_t {
+    ur_kernel_handle_t *phKernel;
 } ur_kernel_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelRetain 
+/// @brief Callback function-pointer for urKernelRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelRetainCb_t)(
-    ur_kernel_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelRetainCb_t)(
+    ur_kernel_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelRelease 
+/// @brief Callback function parameters for urKernelRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_release_params_t
-{
-    ur_kernel_handle_t* phKernel;
+typedef struct ur_kernel_release_params_t {
+    ur_kernel_handle_t *phKernel;
 } ur_kernel_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelRelease 
+/// @brief Callback function-pointer for urKernelRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelReleaseCb_t)(
-    ur_kernel_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelReleaseCb_t)(
+    ur_kernel_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelGetNativeHandle 
+/// @brief Callback function parameters for urKernelGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_get_native_handle_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    ur_native_handle_t** pphNativeKernel;
+typedef struct ur_kernel_get_native_handle_params_t {
+    ur_kernel_handle_t *phKernel;
+    ur_native_handle_t **pphNativeKernel;
 } ur_kernel_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelGetNativeHandle 
+/// @brief Callback function-pointer for urKernelGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelGetNativeHandleCb_t)(
-    ur_kernel_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelGetNativeHandleCb_t)(
+    ur_kernel_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelCreateWithNativeHandle 
+/// @brief Callback function parameters for urKernelCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeKernel;
-    ur_context_handle_t* phContext;
-    ur_kernel_handle_t** pphKernel;
+typedef struct ur_kernel_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeKernel;
+    ur_context_handle_t *phContext;
+    ur_kernel_handle_t **pphKernel;
 } ur_kernel_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelCreateWithNativeHandle 
+/// @brief Callback function-pointer for urKernelCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelCreateWithNativeHandleCb_t)(
-    ur_kernel_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelCreateWithNativeHandleCb_t)(
+    ur_kernel_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelSetArgValue 
+/// @brief Callback function parameters for urKernelSetArgValue
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_set_arg_value_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    uint32_t* pargIndex;
-    size_t* pargSize;
-    const void** ppArgValue;
+typedef struct ur_kernel_set_arg_value_params_t {
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pargIndex;
+    size_t *pargSize;
+    const void **ppArgValue;
 } ur_kernel_set_arg_value_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelSetArgValue 
+/// @brief Callback function-pointer for urKernelSetArgValue
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelSetArgValueCb_t)(
-    ur_kernel_set_arg_value_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelSetArgValueCb_t)(
+    ur_kernel_set_arg_value_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelSetArgLocal 
+/// @brief Callback function parameters for urKernelSetArgLocal
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_set_arg_local_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    uint32_t* pargIndex;
-    size_t* pargSize;
+typedef struct ur_kernel_set_arg_local_params_t {
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pargIndex;
+    size_t *pargSize;
 } ur_kernel_set_arg_local_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelSetArgLocal 
+/// @brief Callback function-pointer for urKernelSetArgLocal
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelSetArgLocalCb_t)(
-    ur_kernel_set_arg_local_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelSetArgLocalCb_t)(
+    ur_kernel_set_arg_local_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelSetArgPointer 
+/// @brief Callback function parameters for urKernelSetArgPointer
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_set_arg_pointer_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    uint32_t* pargIndex;
-    size_t* pargSize;
-    const void** ppArgValue;
+typedef struct ur_kernel_set_arg_pointer_params_t {
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pargIndex;
+    size_t *pargSize;
+    const void **ppArgValue;
 } ur_kernel_set_arg_pointer_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelSetArgPointer 
+/// @brief Callback function-pointer for urKernelSetArgPointer
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelSetArgPointerCb_t)(
-    ur_kernel_set_arg_pointer_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelSetArgPointerCb_t)(
+    ur_kernel_set_arg_pointer_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelSetExecInfo 
+/// @brief Callback function parameters for urKernelSetExecInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_set_exec_info_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    ur_kernel_exec_info_t* ppropName;
-    size_t* ppropSize;
-    const void** ppPropValue;
+typedef struct ur_kernel_set_exec_info_params_t {
+    ur_kernel_handle_t *phKernel;
+    ur_kernel_exec_info_t *ppropName;
+    size_t *ppropSize;
+    const void **ppPropValue;
 } ur_kernel_set_exec_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelSetExecInfo 
+/// @brief Callback function-pointer for urKernelSetExecInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelSetExecInfoCb_t)(
-    ur_kernel_set_exec_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelSetExecInfoCb_t)(
+    ur_kernel_set_exec_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelSetArgSampler 
+/// @brief Callback function parameters for urKernelSetArgSampler
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_set_arg_sampler_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    uint32_t* pargIndex;
-    ur_sampler_handle_t* phArgValue;
+typedef struct ur_kernel_set_arg_sampler_params_t {
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pargIndex;
+    ur_sampler_handle_t *phArgValue;
 } ur_kernel_set_arg_sampler_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelSetArgSampler 
+/// @brief Callback function-pointer for urKernelSetArgSampler
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelSetArgSamplerCb_t)(
-    ur_kernel_set_arg_sampler_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelSetArgSamplerCb_t)(
+    ur_kernel_set_arg_sampler_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urKernelSetArgMemObj 
+/// @brief Callback function parameters for urKernelSetArgMemObj
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_kernel_set_arg_mem_obj_params_t
-{
-    ur_kernel_handle_t* phKernel;
-    uint32_t* pargIndex;
-    ur_mem_handle_t* phArgValue;
+typedef struct ur_kernel_set_arg_mem_obj_params_t {
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pargIndex;
+    ur_mem_handle_t *phArgValue;
 } ur_kernel_set_arg_mem_obj_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urKernelSetArgMemObj 
+/// @brief Callback function-pointer for urKernelSetArgMemObj
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnKernelSetArgMemObjCb_t)(
-    ur_kernel_set_arg_mem_obj_params_t* params,
+typedef void(UR_APICALL *ur_pfnKernelSetArgMemObjCb_t)(
+    ur_kernel_set_arg_mem_obj_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Kernel callback functions pointers
-typedef struct ur_kernel_callbacks_t
-{
-    ur_pfnKernelCreateCb_t                                          pfnCreateCb;
-    ur_pfnKernelGetInfoCb_t                                         pfnGetInfoCb;
-    ur_pfnKernelGetGroupInfoCb_t                                    pfnGetGroupInfoCb;
-    ur_pfnKernelGetSubGroupInfoCb_t                                 pfnGetSubGroupInfoCb;
-    ur_pfnKernelRetainCb_t                                          pfnRetainCb;
-    ur_pfnKernelReleaseCb_t                                         pfnReleaseCb;
-    ur_pfnKernelGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
-    ur_pfnKernelCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
-    ur_pfnKernelSetArgValueCb_t                                     pfnSetArgValueCb;
-    ur_pfnKernelSetArgLocalCb_t                                     pfnSetArgLocalCb;
-    ur_pfnKernelSetArgPointerCb_t                                   pfnSetArgPointerCb;
-    ur_pfnKernelSetExecInfoCb_t                                     pfnSetExecInfoCb;
-    ur_pfnKernelSetArgSamplerCb_t                                   pfnSetArgSamplerCb;
-    ur_pfnKernelSetArgMemObjCb_t                                    pfnSetArgMemObjCb;
+typedef struct ur_kernel_callbacks_t {
+    ur_pfnKernelCreateCb_t pfnCreateCb;
+    ur_pfnKernelGetInfoCb_t pfnGetInfoCb;
+    ur_pfnKernelGetGroupInfoCb_t pfnGetGroupInfoCb;
+    ur_pfnKernelGetSubGroupInfoCb_t pfnGetSubGroupInfoCb;
+    ur_pfnKernelRetainCb_t pfnRetainCb;
+    ur_pfnKernelReleaseCb_t pfnReleaseCb;
+    ur_pfnKernelGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnKernelCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnKernelSetArgValueCb_t pfnSetArgValueCb;
+    ur_pfnKernelSetArgLocalCb_t pfnSetArgLocalCb;
+    ur_pfnKernelSetArgPointerCb_t pfnSetArgPointerCb;
+    ur_pfnKernelSetExecInfoCb_t pfnSetExecInfoCb;
+    ur_pfnKernelSetArgSamplerCb_t pfnSetArgSamplerCb;
+    ur_pfnKernelSetArgMemObjCb_t pfnSetArgMemObjCb;
 } ur_kernel_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerCreate 
+/// @brief Callback function parameters for urSamplerCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_sampler_create_params_t
-{
-    ur_context_handle_t* phContext;
-    const ur_sampler_property_t** ppProps;
-    ur_sampler_handle_t** pphSampler;
+typedef struct ur_sampler_create_params_t {
+    ur_context_handle_t *phContext;
+    const ur_sampler_property_t **ppProps;
+    ur_sampler_handle_t **pphSampler;
 } ur_sampler_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerCreate 
+/// @brief Callback function-pointer for urSamplerCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerCreateCb_t)(
-    ur_sampler_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnSamplerCreateCb_t)(
+    ur_sampler_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerRetain 
+/// @brief Callback function parameters for urSamplerRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_sampler_retain_params_t
-{
-    ur_sampler_handle_t* phSampler;
+typedef struct ur_sampler_retain_params_t {
+    ur_sampler_handle_t *phSampler;
 } ur_sampler_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerRetain 
+/// @brief Callback function-pointer for urSamplerRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerRetainCb_t)(
-    ur_sampler_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnSamplerRetainCb_t)(
+    ur_sampler_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerRelease 
+/// @brief Callback function parameters for urSamplerRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_sampler_release_params_t
-{
-    ur_sampler_handle_t* phSampler;
+typedef struct ur_sampler_release_params_t {
+    ur_sampler_handle_t *phSampler;
 } ur_sampler_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerRelease 
+/// @brief Callback function-pointer for urSamplerRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerReleaseCb_t)(
-    ur_sampler_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnSamplerReleaseCb_t)(
+    ur_sampler_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerGetInfo 
+/// @brief Callback function parameters for urSamplerGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_sampler_get_info_params_t
-{
-    ur_sampler_handle_t* phSampler;
-    ur_sampler_info_t* ppropName;
-    size_t* ppropValueSize;
-    void** ppPropValue;
-    size_t** ppPropSizeRet;
+typedef struct ur_sampler_get_info_params_t {
+    ur_sampler_handle_t *phSampler;
+    ur_sampler_info_t *ppropName;
+    size_t *ppropValueSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
 } ur_sampler_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerGetInfo 
+/// @brief Callback function-pointer for urSamplerGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerGetInfoCb_t)(
-    ur_sampler_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnSamplerGetInfoCb_t)(
+    ur_sampler_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerGetNativeHandle 
+/// @brief Callback function parameters for urSamplerGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_sampler_get_native_handle_params_t
-{
-    ur_sampler_handle_t* phSampler;
-    ur_native_handle_t** pphNativeSampler;
+typedef struct ur_sampler_get_native_handle_params_t {
+    ur_sampler_handle_t *phSampler;
+    ur_native_handle_t **pphNativeSampler;
 } ur_sampler_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerGetNativeHandle 
+/// @brief Callback function-pointer for urSamplerGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerGetNativeHandleCb_t)(
-    ur_sampler_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnSamplerGetNativeHandleCb_t)(
+    ur_sampler_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urSamplerCreateWithNativeHandle 
+/// @brief Callback function parameters for urSamplerCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_sampler_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeSampler;
-    ur_context_handle_t* phContext;
-    ur_sampler_handle_t** pphSampler;
+typedef struct ur_sampler_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeSampler;
+    ur_context_handle_t *phContext;
+    ur_sampler_handle_t **pphSampler;
 } ur_sampler_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urSamplerCreateWithNativeHandle 
+/// @brief Callback function-pointer for urSamplerCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnSamplerCreateWithNativeHandleCb_t)(
-    ur_sampler_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnSamplerCreateWithNativeHandleCb_t)(
+    ur_sampler_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Sampler callback functions pointers
-typedef struct ur_sampler_callbacks_t
-{
-    ur_pfnSamplerCreateCb_t                                         pfnCreateCb;
-    ur_pfnSamplerRetainCb_t                                         pfnRetainCb;
-    ur_pfnSamplerReleaseCb_t                                        pfnReleaseCb;
-    ur_pfnSamplerGetInfoCb_t                                        pfnGetInfoCb;
-    ur_pfnSamplerGetNativeHandleCb_t                                pfnGetNativeHandleCb;
-    ur_pfnSamplerCreateWithNativeHandleCb_t                         pfnCreateWithNativeHandleCb;
+typedef struct ur_sampler_callbacks_t {
+    ur_pfnSamplerCreateCb_t pfnCreateCb;
+    ur_pfnSamplerRetainCb_t pfnRetainCb;
+    ur_pfnSamplerReleaseCb_t pfnReleaseCb;
+    ur_pfnSamplerGetInfoCb_t pfnGetInfoCb;
+    ur_pfnSamplerGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnSamplerCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
 } ur_sampler_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemImageCreate 
+/// @brief Callback function parameters for urMemImageCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_image_create_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_mem_flags_t* pflags;
-    const ur_image_format_t** ppImageFormat;
-    const ur_image_desc_t** ppImageDesc;
-    void** ppHost;
-    ur_mem_handle_t** pphMem;
+typedef struct ur_mem_image_create_params_t {
+    ur_context_handle_t *phContext;
+    ur_mem_flags_t *pflags;
+    const ur_image_format_t **ppImageFormat;
+    const ur_image_desc_t **ppImageDesc;
+    void **ppHost;
+    ur_mem_handle_t **pphMem;
 } ur_mem_image_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemImageCreate 
+/// @brief Callback function-pointer for urMemImageCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemImageCreateCb_t)(
-    ur_mem_image_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemImageCreateCb_t)(
+    ur_mem_image_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemBufferCreate 
+/// @brief Callback function parameters for urMemBufferCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_buffer_create_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_mem_flags_t* pflags;
-    size_t* psize;
-    void** ppHost;
-    ur_mem_handle_t** pphBuffer;
+typedef struct ur_mem_buffer_create_params_t {
+    ur_context_handle_t *phContext;
+    ur_mem_flags_t *pflags;
+    size_t *psize;
+    void **ppHost;
+    ur_mem_handle_t **pphBuffer;
 } ur_mem_buffer_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemBufferCreate 
+/// @brief Callback function-pointer for urMemBufferCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemBufferCreateCb_t)(
-    ur_mem_buffer_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemBufferCreateCb_t)(
+    ur_mem_buffer_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemRetain 
+/// @brief Callback function parameters for urMemRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_retain_params_t
-{
-    ur_mem_handle_t* phMem;
+typedef struct ur_mem_retain_params_t {
+    ur_mem_handle_t *phMem;
 } ur_mem_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemRetain 
+/// @brief Callback function-pointer for urMemRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemRetainCb_t)(
-    ur_mem_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemRetainCb_t)(
+    ur_mem_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemRelease 
+/// @brief Callback function parameters for urMemRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_release_params_t
-{
-    ur_mem_handle_t* phMem;
+typedef struct ur_mem_release_params_t {
+    ur_mem_handle_t *phMem;
 } ur_mem_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemRelease 
+/// @brief Callback function-pointer for urMemRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemReleaseCb_t)(
-    ur_mem_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemReleaseCb_t)(
+    ur_mem_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemBufferPartition 
+/// @brief Callback function parameters for urMemBufferPartition
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_buffer_partition_params_t
-{
-    ur_mem_handle_t* phBuffer;
-    ur_mem_flags_t* pflags;
-    ur_buffer_create_type_t* pbufferCreateType;
-    ur_buffer_region_t** ppBufferCreateInfo;
-    ur_mem_handle_t** pphMem;
+typedef struct ur_mem_buffer_partition_params_t {
+    ur_mem_handle_t *phBuffer;
+    ur_mem_flags_t *pflags;
+    ur_buffer_create_type_t *pbufferCreateType;
+    ur_buffer_region_t **ppBufferCreateInfo;
+    ur_mem_handle_t **pphMem;
 } ur_mem_buffer_partition_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemBufferPartition 
+/// @brief Callback function-pointer for urMemBufferPartition
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemBufferPartitionCb_t)(
-    ur_mem_buffer_partition_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemBufferPartitionCb_t)(
+    ur_mem_buffer_partition_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemGetNativeHandle 
+/// @brief Callback function parameters for urMemGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_get_native_handle_params_t
-{
-    ur_mem_handle_t* phMem;
-    ur_native_handle_t** pphNativeMem;
+typedef struct ur_mem_get_native_handle_params_t {
+    ur_mem_handle_t *phMem;
+    ur_native_handle_t **pphNativeMem;
 } ur_mem_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemGetNativeHandle 
+/// @brief Callback function-pointer for urMemGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemGetNativeHandleCb_t)(
-    ur_mem_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemGetNativeHandleCb_t)(
+    ur_mem_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemCreateWithNativeHandle 
+/// @brief Callback function parameters for urMemCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeMem;
-    ur_context_handle_t* phContext;
-    ur_mem_handle_t** pphMem;
+typedef struct ur_mem_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeMem;
+    ur_context_handle_t *phContext;
+    ur_mem_handle_t **pphMem;
 } ur_mem_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemCreateWithNativeHandle 
+/// @brief Callback function-pointer for urMemCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemCreateWithNativeHandleCb_t)(
-    ur_mem_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemCreateWithNativeHandleCb_t)(
+    ur_mem_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemGetInfo 
+/// @brief Callback function parameters for urMemGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_get_info_params_t
-{
-    ur_mem_handle_t* phMemory;
-    ur_mem_info_t* pMemInfoType;
-    size_t* ppropSize;
-    void** ppMemInfo;
-    size_t** ppPropSizeRet;
+typedef struct ur_mem_get_info_params_t {
+    ur_mem_handle_t *phMemory;
+    ur_mem_info_t *pMemInfoType;
+    size_t *ppropSize;
+    void **ppMemInfo;
+    size_t **ppPropSizeRet;
 } ur_mem_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemGetInfo 
+/// @brief Callback function-pointer for urMemGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemGetInfoCb_t)(
-    ur_mem_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemGetInfoCb_t)(
+    ur_mem_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urMemImageGetInfo 
+/// @brief Callback function parameters for urMemImageGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_mem_image_get_info_params_t
-{
-    ur_mem_handle_t* phMemory;
-    ur_image_info_t* pImgInfoType;
-    size_t* ppropSize;
-    void** ppImgInfo;
-    size_t** ppPropSizeRet;
+typedef struct ur_mem_image_get_info_params_t {
+    ur_mem_handle_t *phMemory;
+    ur_image_info_t *pImgInfoType;
+    size_t *ppropSize;
+    void **ppImgInfo;
+    size_t **ppPropSizeRet;
 } ur_mem_image_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urMemImageGetInfo 
+/// @brief Callback function-pointer for urMemImageGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnMemImageGetInfoCb_t)(
-    ur_mem_image_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnMemImageGetInfoCb_t)(
+    ur_mem_image_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Mem callback functions pointers
-typedef struct ur_mem_callbacks_t
-{
-    ur_pfnMemImageCreateCb_t                                        pfnImageCreateCb;
-    ur_pfnMemBufferCreateCb_t                                       pfnBufferCreateCb;
-    ur_pfnMemRetainCb_t                                             pfnRetainCb;
-    ur_pfnMemReleaseCb_t                                            pfnReleaseCb;
-    ur_pfnMemBufferPartitionCb_t                                    pfnBufferPartitionCb;
-    ur_pfnMemGetNativeHandleCb_t                                    pfnGetNativeHandleCb;
-    ur_pfnMemCreateWithNativeHandleCb_t                             pfnCreateWithNativeHandleCb;
-    ur_pfnMemGetInfoCb_t                                            pfnGetInfoCb;
-    ur_pfnMemImageGetInfoCb_t                                       pfnImageGetInfoCb;
+typedef struct ur_mem_callbacks_t {
+    ur_pfnMemImageCreateCb_t pfnImageCreateCb;
+    ur_pfnMemBufferCreateCb_t pfnBufferCreateCb;
+    ur_pfnMemRetainCb_t pfnRetainCb;
+    ur_pfnMemReleaseCb_t pfnReleaseCb;
+    ur_pfnMemBufferPartitionCb_t pfnBufferPartitionCb;
+    ur_pfnMemGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnMemCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnMemGetInfoCb_t pfnGetInfoCb;
+    ur_pfnMemImageGetInfoCb_t pfnImageGetInfoCb;
 } ur_mem_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueKernelLaunch 
+/// @brief Callback function parameters for urEnqueueKernelLaunch
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_kernel_launch_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_kernel_handle_t* phKernel;
-    uint32_t* pworkDim;
-    const size_t** ppGlobalWorkOffset;
-    const size_t** ppGlobalWorkSize;
-    const size_t** ppLocalWorkSize;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_kernel_launch_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pworkDim;
+    const size_t **ppGlobalWorkOffset;
+    const size_t **ppGlobalWorkSize;
+    const size_t **ppLocalWorkSize;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_kernel_launch_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueKernelLaunch 
+/// @brief Callback function-pointer for urEnqueueKernelLaunch
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueKernelLaunchCb_t)(
-    ur_enqueue_kernel_launch_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueKernelLaunchCb_t)(
+    ur_enqueue_kernel_launch_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueEventsWait 
+/// @brief Callback function parameters for urEnqueueEventsWait
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_events_wait_params_t
-{
-    ur_queue_handle_t* phQueue;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_events_wait_params_t {
+    ur_queue_handle_t *phQueue;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_events_wait_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueEventsWait 
+/// @brief Callback function-pointer for urEnqueueEventsWait
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueEventsWaitCb_t)(
-    ur_enqueue_events_wait_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueEventsWaitCb_t)(
+    ur_enqueue_events_wait_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueEventsWaitWithBarrier 
+/// @brief Callback function parameters for urEnqueueEventsWaitWithBarrier
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_events_wait_with_barrier_params_t
-{
-    ur_queue_handle_t* phQueue;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_events_wait_with_barrier_params_t {
+    ur_queue_handle_t *phQueue;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_events_wait_with_barrier_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueEventsWaitWithBarrier 
+/// @brief Callback function-pointer for urEnqueueEventsWaitWithBarrier
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueEventsWaitWithBarrierCb_t)(
-    ur_enqueue_events_wait_with_barrier_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueEventsWaitWithBarrierCb_t)(
+    ur_enqueue_events_wait_with_barrier_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferRead 
+/// @brief Callback function parameters for urEnqueueMemBufferRead
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_read_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBuffer;
-    bool* pblockingRead;
-    size_t* poffset;
-    size_t* psize;
-    void** ppDst;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_read_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBuffer;
+    bool *pblockingRead;
+    size_t *poffset;
+    size_t *psize;
+    void **ppDst;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_read_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferRead 
+/// @brief Callback function-pointer for urEnqueueMemBufferRead
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferReadCb_t)(
-    ur_enqueue_mem_buffer_read_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferReadCb_t)(
+    ur_enqueue_mem_buffer_read_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferWrite 
+/// @brief Callback function parameters for urEnqueueMemBufferWrite
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_write_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBuffer;
-    bool* pblockingWrite;
-    size_t* poffset;
-    size_t* psize;
-    const void** ppSrc;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_write_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBuffer;
+    bool *pblockingWrite;
+    size_t *poffset;
+    size_t *psize;
+    const void **ppSrc;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_write_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferWrite 
+/// @brief Callback function-pointer for urEnqueueMemBufferWrite
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferWriteCb_t)(
-    ur_enqueue_mem_buffer_write_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferWriteCb_t)(
+    ur_enqueue_mem_buffer_write_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferReadRect 
+/// @brief Callback function parameters for urEnqueueMemBufferReadRect
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_read_rect_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBuffer;
-    bool* pblockingRead;
-    ur_rect_offset_t* pbufferOffset;
-    ur_rect_offset_t* phostOffset;
-    ur_rect_region_t* pregion;
-    size_t* pbufferRowPitch;
-    size_t* pbufferSlicePitch;
-    size_t* phostRowPitch;
-    size_t* phostSlicePitch;
-    void** ppDst;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_read_rect_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBuffer;
+    bool *pblockingRead;
+    ur_rect_offset_t *pbufferOffset;
+    ur_rect_offset_t *phostOffset;
+    ur_rect_region_t *pregion;
+    size_t *pbufferRowPitch;
+    size_t *pbufferSlicePitch;
+    size_t *phostRowPitch;
+    size_t *phostSlicePitch;
+    void **ppDst;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_read_rect_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferReadRect 
+/// @brief Callback function-pointer for urEnqueueMemBufferReadRect
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferReadRectCb_t)(
-    ur_enqueue_mem_buffer_read_rect_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferReadRectCb_t)(
+    ur_enqueue_mem_buffer_read_rect_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferWriteRect 
+/// @brief Callback function parameters for urEnqueueMemBufferWriteRect
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_write_rect_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBuffer;
-    bool* pblockingWrite;
-    ur_rect_offset_t* pbufferOffset;
-    ur_rect_offset_t* phostOffset;
-    ur_rect_region_t* pregion;
-    size_t* pbufferRowPitch;
-    size_t* pbufferSlicePitch;
-    size_t* phostRowPitch;
-    size_t* phostSlicePitch;
-    void** ppSrc;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_write_rect_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBuffer;
+    bool *pblockingWrite;
+    ur_rect_offset_t *pbufferOffset;
+    ur_rect_offset_t *phostOffset;
+    ur_rect_region_t *pregion;
+    size_t *pbufferRowPitch;
+    size_t *pbufferSlicePitch;
+    size_t *phostRowPitch;
+    size_t *phostSlicePitch;
+    void **ppSrc;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_write_rect_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferWriteRect 
+/// @brief Callback function-pointer for urEnqueueMemBufferWriteRect
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferWriteRectCb_t)(
-    ur_enqueue_mem_buffer_write_rect_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferWriteRectCb_t)(
+    ur_enqueue_mem_buffer_write_rect_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferCopy 
+/// @brief Callback function parameters for urEnqueueMemBufferCopy
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_copy_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBufferSrc;
-    ur_mem_handle_t* phBufferDst;
-    size_t* psrcOffset;
-    size_t* pdstOffset;
-    size_t* psize;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_copy_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBufferSrc;
+    ur_mem_handle_t *phBufferDst;
+    size_t *psrcOffset;
+    size_t *pdstOffset;
+    size_t *psize;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_copy_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferCopy 
+/// @brief Callback function-pointer for urEnqueueMemBufferCopy
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferCopyCb_t)(
-    ur_enqueue_mem_buffer_copy_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferCopyCb_t)(
+    ur_enqueue_mem_buffer_copy_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferCopyRect 
+/// @brief Callback function parameters for urEnqueueMemBufferCopyRect
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_copy_rect_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBufferSrc;
-    ur_mem_handle_t* phBufferDst;
-    ur_rect_offset_t* psrcOrigin;
-    ur_rect_offset_t* pdstOrigin;
-    ur_rect_region_t* psrcRegion;
-    size_t* psrcRowPitch;
-    size_t* psrcSlicePitch;
-    size_t* pdstRowPitch;
-    size_t* pdstSlicePitch;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_copy_rect_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBufferSrc;
+    ur_mem_handle_t *phBufferDst;
+    ur_rect_offset_t *psrcOrigin;
+    ur_rect_offset_t *pdstOrigin;
+    ur_rect_region_t *psrcRegion;
+    size_t *psrcRowPitch;
+    size_t *psrcSlicePitch;
+    size_t *pdstRowPitch;
+    size_t *pdstSlicePitch;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_copy_rect_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferCopyRect 
+/// @brief Callback function-pointer for urEnqueueMemBufferCopyRect
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferCopyRectCb_t)(
-    ur_enqueue_mem_buffer_copy_rect_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferCopyRectCb_t)(
+    ur_enqueue_mem_buffer_copy_rect_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferFill 
+/// @brief Callback function parameters for urEnqueueMemBufferFill
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_fill_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBuffer;
-    const void** ppPattern;
-    size_t* ppatternSize;
-    size_t* poffset;
-    size_t* psize;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_buffer_fill_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBuffer;
+    const void **ppPattern;
+    size_t *ppatternSize;
+    size_t *poffset;
+    size_t *psize;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_buffer_fill_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferFill 
+/// @brief Callback function-pointer for urEnqueueMemBufferFill
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferFillCb_t)(
-    ur_enqueue_mem_buffer_fill_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferFillCb_t)(
+    ur_enqueue_mem_buffer_fill_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemImageRead 
+/// @brief Callback function parameters for urEnqueueMemImageRead
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_image_read_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phImage;
-    bool* pblockingRead;
-    ur_rect_offset_t* porigin;
-    ur_rect_region_t* pregion;
-    size_t* prowPitch;
-    size_t* pslicePitch;
-    void** ppDst;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_image_read_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phImage;
+    bool *pblockingRead;
+    ur_rect_offset_t *porigin;
+    ur_rect_region_t *pregion;
+    size_t *prowPitch;
+    size_t *pslicePitch;
+    void **ppDst;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_image_read_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemImageRead 
+/// @brief Callback function-pointer for urEnqueueMemImageRead
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemImageReadCb_t)(
-    ur_enqueue_mem_image_read_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemImageReadCb_t)(
+    ur_enqueue_mem_image_read_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemImageWrite 
+/// @brief Callback function parameters for urEnqueueMemImageWrite
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_image_write_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phImage;
-    bool* pblockingWrite;
-    ur_rect_offset_t* porigin;
-    ur_rect_region_t* pregion;
-    size_t* pinputRowPitch;
-    size_t* pinputSlicePitch;
-    void** ppSrc;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_image_write_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phImage;
+    bool *pblockingWrite;
+    ur_rect_offset_t *porigin;
+    ur_rect_region_t *pregion;
+    size_t *pinputRowPitch;
+    size_t *pinputSlicePitch;
+    void **ppSrc;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_image_write_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemImageWrite 
+/// @brief Callback function-pointer for urEnqueueMemImageWrite
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemImageWriteCb_t)(
-    ur_enqueue_mem_image_write_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemImageWriteCb_t)(
+    ur_enqueue_mem_image_write_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemImageCopy 
+/// @brief Callback function parameters for urEnqueueMemImageCopy
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_image_copy_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phImageSrc;
-    ur_mem_handle_t* phImageDst;
-    ur_rect_offset_t* psrcOrigin;
-    ur_rect_offset_t* pdstOrigin;
-    ur_rect_region_t* pregion;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_image_copy_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phImageSrc;
+    ur_mem_handle_t *phImageDst;
+    ur_rect_offset_t *psrcOrigin;
+    ur_rect_offset_t *pdstOrigin;
+    ur_rect_region_t *pregion;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_image_copy_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemImageCopy 
+/// @brief Callback function-pointer for urEnqueueMemImageCopy
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemImageCopyCb_t)(
-    ur_enqueue_mem_image_copy_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemImageCopyCb_t)(
+    ur_enqueue_mem_image_copy_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemBufferMap 
+/// @brief Callback function parameters for urEnqueueMemBufferMap
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_buffer_map_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phBuffer;
-    bool* pblockingMap;
-    ur_map_flags_t* pmapFlags;
-    size_t* poffset;
-    size_t* psize;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
-    void*** pppRetMap;
+typedef struct ur_enqueue_mem_buffer_map_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phBuffer;
+    bool *pblockingMap;
+    ur_map_flags_t *pmapFlags;
+    size_t *poffset;
+    size_t *psize;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
+    void ***pppRetMap;
 } ur_enqueue_mem_buffer_map_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemBufferMap 
+/// @brief Callback function-pointer for urEnqueueMemBufferMap
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemBufferMapCb_t)(
-    ur_enqueue_mem_buffer_map_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemBufferMapCb_t)(
+    ur_enqueue_mem_buffer_map_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueMemUnmap 
+/// @brief Callback function parameters for urEnqueueMemUnmap
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_mem_unmap_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_mem_handle_t* phMem;
-    void** ppMappedPtr;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_mem_unmap_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_mem_handle_t *phMem;
+    void **ppMappedPtr;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_mem_unmap_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueMemUnmap 
+/// @brief Callback function-pointer for urEnqueueMemUnmap
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueMemUnmapCb_t)(
-    ur_enqueue_mem_unmap_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueMemUnmapCb_t)(
+    ur_enqueue_mem_unmap_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMMemset 
+/// @brief Callback function parameters for urEnqueueUSMMemset
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_memset_params_t
-{
-    ur_queue_handle_t* phQueue;
-    void** pptr;
-    int8_t* pbyteValue;
-    size_t* pcount;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_memset_params_t {
+    ur_queue_handle_t *phQueue;
+    void **pptr;
+    int8_t *pbyteValue;
+    size_t *pcount;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_memset_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMMemset 
+/// @brief Callback function-pointer for urEnqueueUSMMemset
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMMemsetCb_t)(
-    ur_enqueue_usm_memset_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMMemsetCb_t)(
+    ur_enqueue_usm_memset_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMMemcpy 
+/// @brief Callback function parameters for urEnqueueUSMMemcpy
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_memcpy_params_t
-{
-    ur_queue_handle_t* phQueue;
-    bool* pblocking;
-    void** ppDst;
-    const void** ppSrc;
-    size_t* psize;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_memcpy_params_t {
+    ur_queue_handle_t *phQueue;
+    bool *pblocking;
+    void **ppDst;
+    const void **ppSrc;
+    size_t *psize;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_memcpy_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMMemcpy 
+/// @brief Callback function-pointer for urEnqueueUSMMemcpy
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMMemcpyCb_t)(
-    ur_enqueue_usm_memcpy_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMMemcpyCb_t)(
+    ur_enqueue_usm_memcpy_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMPrefetch 
+/// @brief Callback function parameters for urEnqueueUSMPrefetch
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_prefetch_params_t
-{
-    ur_queue_handle_t* phQueue;
-    const void** ppMem;
-    size_t* psize;
-    ur_usm_migration_flags_t* pflags;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_prefetch_params_t {
+    ur_queue_handle_t *phQueue;
+    const void **ppMem;
+    size_t *psize;
+    ur_usm_migration_flags_t *pflags;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_prefetch_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMPrefetch 
+/// @brief Callback function-pointer for urEnqueueUSMPrefetch
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMPrefetchCb_t)(
-    ur_enqueue_usm_prefetch_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMPrefetchCb_t)(
+    ur_enqueue_usm_prefetch_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMMemAdvise 
+/// @brief Callback function parameters for urEnqueueUSMMemAdvise
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_mem_advise_params_t
-{
-    ur_queue_handle_t* phQueue;
-    const void** ppMem;
-    size_t* psize;
-    ur_mem_advice_t* padvice;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_mem_advise_params_t {
+    ur_queue_handle_t *phQueue;
+    const void **ppMem;
+    size_t *psize;
+    ur_mem_advice_t *padvice;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_mem_advise_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMMemAdvise 
+/// @brief Callback function-pointer for urEnqueueUSMMemAdvise
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMMemAdviseCb_t)(
-    ur_enqueue_usm_mem_advise_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMMemAdviseCb_t)(
+    ur_enqueue_usm_mem_advise_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMFill2D 
+/// @brief Callback function parameters for urEnqueueUSMFill2D
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_fill2_d_params_t
-{
-    ur_queue_handle_t* phQueue;
-    void** ppMem;
-    size_t* ppitch;
-    size_t* ppatternSize;
-    const void** ppPattern;
-    size_t* pwidth;
-    size_t* pheight;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_fill2_d_params_t {
+    ur_queue_handle_t *phQueue;
+    void **ppMem;
+    size_t *ppitch;
+    size_t *ppatternSize;
+    const void **ppPattern;
+    size_t *pwidth;
+    size_t *pheight;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_fill2_d_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMFill2D 
+/// @brief Callback function-pointer for urEnqueueUSMFill2D
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMFill2DCb_t)(
-    ur_enqueue_usm_fill2_d_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMFill2DCb_t)(
+    ur_enqueue_usm_fill2_d_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMMemset2D 
+/// @brief Callback function parameters for urEnqueueUSMMemset2D
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_memset2_d_params_t
-{
-    ur_queue_handle_t* phQueue;
-    void** ppMem;
-    size_t* ppitch;
-    int* pvalue;
-    size_t* pwidth;
-    size_t* pheight;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_memset2_d_params_t {
+    ur_queue_handle_t *phQueue;
+    void **ppMem;
+    size_t *ppitch;
+    int *pvalue;
+    size_t *pwidth;
+    size_t *pheight;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_memset2_d_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMMemset2D 
+/// @brief Callback function-pointer for urEnqueueUSMMemset2D
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMMemset2DCb_t)(
-    ur_enqueue_usm_memset2_d_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMMemset2DCb_t)(
+    ur_enqueue_usm_memset2_d_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueUSMMemcpy2D 
+/// @brief Callback function parameters for urEnqueueUSMMemcpy2D
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_usm_memcpy2_d_params_t
-{
-    ur_queue_handle_t* phQueue;
-    bool* pblocking;
-    void** ppDst;
-    size_t* pdstPitch;
-    const void** ppSrc;
-    size_t* psrcPitch;
-    size_t* pwidth;
-    size_t* pheight;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_usm_memcpy2_d_params_t {
+    ur_queue_handle_t *phQueue;
+    bool *pblocking;
+    void **ppDst;
+    size_t *pdstPitch;
+    const void **ppSrc;
+    size_t *psrcPitch;
+    size_t *pwidth;
+    size_t *pheight;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_memcpy2_d_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueUSMMemcpy2D 
+/// @brief Callback function-pointer for urEnqueueUSMMemcpy2D
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueUSMMemcpy2DCb_t)(
-    ur_enqueue_usm_memcpy2_d_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueUSMMemcpy2DCb_t)(
+    ur_enqueue_usm_memcpy2_d_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueDeviceGlobalVariableWrite 
+/// @brief Callback function parameters for urEnqueueDeviceGlobalVariableWrite
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_device_global_variable_write_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_program_handle_t* phProgram;
-    const char** pname;
-    bool* pblockingWrite;
-    size_t* pcount;
-    size_t* poffset;
-    const void** ppSrc;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_device_global_variable_write_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_program_handle_t *phProgram;
+    const char **pname;
+    bool *pblockingWrite;
+    size_t *pcount;
+    size_t *poffset;
+    const void **ppSrc;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_device_global_variable_write_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueDeviceGlobalVariableWrite 
+/// @brief Callback function-pointer for urEnqueueDeviceGlobalVariableWrite
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableWriteCb_t)(
-    ur_enqueue_device_global_variable_write_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableWriteCb_t)(
+    ur_enqueue_device_global_variable_write_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urEnqueueDeviceGlobalVariableRead 
+/// @brief Callback function parameters for urEnqueueDeviceGlobalVariableRead
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_device_global_variable_read_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_program_handle_t* phProgram;
-    const char** pname;
-    bool* pblockingRead;
-    size_t* pcount;
-    size_t* poffset;
-    void** ppDst;
-    uint32_t* pnumEventsInWaitList;
-    const ur_event_handle_t** pphEventWaitList;
-    ur_event_handle_t** pphEvent;
+typedef struct ur_enqueue_device_global_variable_read_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_program_handle_t *phProgram;
+    const char **pname;
+    bool *pblockingRead;
+    size_t *pcount;
+    size_t *poffset;
+    void **ppDst;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_device_global_variable_read_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urEnqueueDeviceGlobalVariableRead 
+/// @brief Callback function-pointer for urEnqueueDeviceGlobalVariableRead
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableReadCb_t)(
-    ur_enqueue_device_global_variable_read_params_t* params,
+typedef void(UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableReadCb_t)(
+    ur_enqueue_device_global_variable_read_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Enqueue callback functions pointers
-typedef struct ur_enqueue_callbacks_t
-{
-    ur_pfnEnqueueKernelLaunchCb_t                                   pfnKernelLaunchCb;
-    ur_pfnEnqueueEventsWaitCb_t                                     pfnEventsWaitCb;
-    ur_pfnEnqueueEventsWaitWithBarrierCb_t                          pfnEventsWaitWithBarrierCb;
-    ur_pfnEnqueueMemBufferReadCb_t                                  pfnMemBufferReadCb;
-    ur_pfnEnqueueMemBufferWriteCb_t                                 pfnMemBufferWriteCb;
-    ur_pfnEnqueueMemBufferReadRectCb_t                              pfnMemBufferReadRectCb;
-    ur_pfnEnqueueMemBufferWriteRectCb_t                             pfnMemBufferWriteRectCb;
-    ur_pfnEnqueueMemBufferCopyCb_t                                  pfnMemBufferCopyCb;
-    ur_pfnEnqueueMemBufferCopyRectCb_t                              pfnMemBufferCopyRectCb;
-    ur_pfnEnqueueMemBufferFillCb_t                                  pfnMemBufferFillCb;
-    ur_pfnEnqueueMemImageReadCb_t                                   pfnMemImageReadCb;
-    ur_pfnEnqueueMemImageWriteCb_t                                  pfnMemImageWriteCb;
-    ur_pfnEnqueueMemImageCopyCb_t                                   pfnMemImageCopyCb;
-    ur_pfnEnqueueMemBufferMapCb_t                                   pfnMemBufferMapCb;
-    ur_pfnEnqueueMemUnmapCb_t                                       pfnMemUnmapCb;
-    ur_pfnEnqueueUSMMemsetCb_t                                      pfnUSMMemsetCb;
-    ur_pfnEnqueueUSMMemcpyCb_t                                      pfnUSMMemcpyCb;
-    ur_pfnEnqueueUSMPrefetchCb_t                                    pfnUSMPrefetchCb;
-    ur_pfnEnqueueUSMMemAdviseCb_t                                   pfnUSMMemAdviseCb;
-    ur_pfnEnqueueUSMFill2DCb_t                                      pfnUSMFill2DCb;
-    ur_pfnEnqueueUSMMemset2DCb_t                                    pfnUSMMemset2DCb;
-    ur_pfnEnqueueUSMMemcpy2DCb_t                                    pfnUSMMemcpy2DCb;
-    ur_pfnEnqueueDeviceGlobalVariableWriteCb_t                      pfnDeviceGlobalVariableWriteCb;
-    ur_pfnEnqueueDeviceGlobalVariableReadCb_t                       pfnDeviceGlobalVariableReadCb;
+typedef struct ur_enqueue_callbacks_t {
+    ur_pfnEnqueueKernelLaunchCb_t pfnKernelLaunchCb;
+    ur_pfnEnqueueEventsWaitCb_t pfnEventsWaitCb;
+    ur_pfnEnqueueEventsWaitWithBarrierCb_t pfnEventsWaitWithBarrierCb;
+    ur_pfnEnqueueMemBufferReadCb_t pfnMemBufferReadCb;
+    ur_pfnEnqueueMemBufferWriteCb_t pfnMemBufferWriteCb;
+    ur_pfnEnqueueMemBufferReadRectCb_t pfnMemBufferReadRectCb;
+    ur_pfnEnqueueMemBufferWriteRectCb_t pfnMemBufferWriteRectCb;
+    ur_pfnEnqueueMemBufferCopyCb_t pfnMemBufferCopyCb;
+    ur_pfnEnqueueMemBufferCopyRectCb_t pfnMemBufferCopyRectCb;
+    ur_pfnEnqueueMemBufferFillCb_t pfnMemBufferFillCb;
+    ur_pfnEnqueueMemImageReadCb_t pfnMemImageReadCb;
+    ur_pfnEnqueueMemImageWriteCb_t pfnMemImageWriteCb;
+    ur_pfnEnqueueMemImageCopyCb_t pfnMemImageCopyCb;
+    ur_pfnEnqueueMemBufferMapCb_t pfnMemBufferMapCb;
+    ur_pfnEnqueueMemUnmapCb_t pfnMemUnmapCb;
+    ur_pfnEnqueueUSMMemsetCb_t pfnUSMMemsetCb;
+    ur_pfnEnqueueUSMMemcpyCb_t pfnUSMMemcpyCb;
+    ur_pfnEnqueueUSMPrefetchCb_t pfnUSMPrefetchCb;
+    ur_pfnEnqueueUSMMemAdviseCb_t pfnUSMMemAdviseCb;
+    ur_pfnEnqueueUSMFill2DCb_t pfnUSMFill2DCb;
+    ur_pfnEnqueueUSMMemset2DCb_t pfnUSMMemset2DCb;
+    ur_pfnEnqueueUSMMemcpy2DCb_t pfnUSMMemcpy2DCb;
+    ur_pfnEnqueueDeviceGlobalVariableWriteCb_t pfnDeviceGlobalVariableWriteCb;
+    ur_pfnEnqueueDeviceGlobalVariableReadCb_t pfnDeviceGlobalVariableReadCb;
 } ur_enqueue_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urUSMHostAlloc 
+/// @brief Callback function parameters for urUSMHostAlloc
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_host_alloc_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_usm_mem_flags_t** ppUSMFlag;
-    size_t* psize;
-    uint32_t* palign;
-    void*** pppMem;
+typedef struct ur_usm_host_alloc_params_t {
+    ur_context_handle_t *phContext;
+    ur_usm_mem_flags_t **ppUSMFlag;
+    size_t *psize;
+    uint32_t *palign;
+    void ***pppMem;
 } ur_usm_host_alloc_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urUSMHostAlloc 
+/// @brief Callback function-pointer for urUSMHostAlloc
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnUSMHostAllocCb_t)(
-    ur_usm_host_alloc_params_t* params,
+typedef void(UR_APICALL *ur_pfnUSMHostAllocCb_t)(
+    ur_usm_host_alloc_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urUSMDeviceAlloc 
+/// @brief Callback function parameters for urUSMDeviceAlloc
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_device_alloc_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_device_handle_t* phDevice;
-    ur_usm_mem_flags_t** ppUSMProp;
-    size_t* psize;
-    uint32_t* palign;
-    void*** pppMem;
+typedef struct ur_usm_device_alloc_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    ur_usm_mem_flags_t **ppUSMProp;
+    size_t *psize;
+    uint32_t *palign;
+    void ***pppMem;
 } ur_usm_device_alloc_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urUSMDeviceAlloc 
+/// @brief Callback function-pointer for urUSMDeviceAlloc
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnUSMDeviceAllocCb_t)(
-    ur_usm_device_alloc_params_t* params,
+typedef void(UR_APICALL *ur_pfnUSMDeviceAllocCb_t)(
+    ur_usm_device_alloc_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urUSMSharedAlloc 
+/// @brief Callback function parameters for urUSMSharedAlloc
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_shared_alloc_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_device_handle_t* phDevice;
-    ur_usm_mem_flags_t** ppUSMProp;
-    size_t* psize;
-    uint32_t* palign;
-    void*** pppMem;
+typedef struct ur_usm_shared_alloc_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    ur_usm_mem_flags_t **ppUSMProp;
+    size_t *psize;
+    uint32_t *palign;
+    void ***pppMem;
 } ur_usm_shared_alloc_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urUSMSharedAlloc 
+/// @brief Callback function-pointer for urUSMSharedAlloc
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnUSMSharedAllocCb_t)(
-    ur_usm_shared_alloc_params_t* params,
+typedef void(UR_APICALL *ur_pfnUSMSharedAllocCb_t)(
+    ur_usm_shared_alloc_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urUSMFree 
+/// @brief Callback function parameters for urUSMFree
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_free_params_t
-{
-    ur_context_handle_t* phContext;
-    void** ppMem;
+typedef struct ur_usm_free_params_t {
+    ur_context_handle_t *phContext;
+    void **ppMem;
 } ur_usm_free_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urUSMFree 
+/// @brief Callback function-pointer for urUSMFree
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnUSMFreeCb_t)(
-    ur_usm_free_params_t* params,
+typedef void(UR_APICALL *ur_pfnUSMFreeCb_t)(
+    ur_usm_free_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urUSMGetMemAllocInfo 
+/// @brief Callback function parameters for urUSMGetMemAllocInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_get_mem_alloc_info_params_t
-{
-    ur_context_handle_t* phContext;
-    const void** ppMem;
-    ur_usm_alloc_info_t* ppropName;
-    size_t* ppropValueSize;
-    void** ppPropValue;
-    size_t** ppPropValueSizeRet;
+typedef struct ur_usm_get_mem_alloc_info_params_t {
+    ur_context_handle_t *phContext;
+    const void **ppMem;
+    ur_usm_alloc_info_t *ppropName;
+    size_t *ppropValueSize;
+    void **ppPropValue;
+    size_t **ppPropValueSizeRet;
 } ur_usm_get_mem_alloc_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urUSMGetMemAllocInfo 
+/// @brief Callback function-pointer for urUSMGetMemAllocInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnUSMGetMemAllocInfoCb_t)(
-    ur_usm_get_mem_alloc_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnUSMGetMemAllocInfoCb_t)(
+    ur_usm_get_mem_alloc_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of USM callback functions pointers
-typedef struct ur_usm_callbacks_t
-{
-    ur_pfnUSMHostAllocCb_t                                          pfnHostAllocCb;
-    ur_pfnUSMDeviceAllocCb_t                                        pfnDeviceAllocCb;
-    ur_pfnUSMSharedAllocCb_t                                        pfnSharedAllocCb;
-    ur_pfnUSMFreeCb_t                                               pfnFreeCb;
-    ur_pfnUSMGetMemAllocInfoCb_t                                    pfnGetMemAllocInfoCb;
+typedef struct ur_usm_callbacks_t {
+    ur_pfnUSMHostAllocCb_t pfnHostAllocCb;
+    ur_pfnUSMDeviceAllocCb_t pfnDeviceAllocCb;
+    ur_pfnUSMSharedAllocCb_t pfnSharedAllocCb;
+    ur_pfnUSMFreeCb_t pfnFreeCb;
+    ur_pfnUSMGetMemAllocInfoCb_t pfnGetMemAllocInfoCb;
 } ur_usm_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urTearDown 
+/// @brief Callback function parameters for urTearDown
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_tear_down_params_t
-{
-    void** ppParams;
+typedef struct ur_tear_down_params_t {
+    void **ppParams;
 } ur_tear_down_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urTearDown 
+/// @brief Callback function-pointer for urTearDown
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnTearDownCb_t)(
-    ur_tear_down_params_t* params,
+typedef void(UR_APICALL *ur_pfnTearDownCb_t)(
+    ur_tear_down_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urGetLastResult 
+/// @brief Callback function parameters for urGetLastResult
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_get_last_result_params_t
-{
-    ur_platform_handle_t* phPlatform;
-    const char*** pppMessage;
+typedef struct ur_get_last_result_params_t {
+    ur_platform_handle_t *phPlatform;
+    const char ***pppMessage;
 } ur_get_last_result_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urGetLastResult 
+/// @brief Callback function-pointer for urGetLastResult
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnGetLastResultCb_t)(
-    ur_get_last_result_params_t* params,
+typedef void(UR_APICALL *ur_pfnGetLastResultCb_t)(
+    ur_get_last_result_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urInit 
+/// @brief Callback function parameters for urInit
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_init_params_t
-{
-    ur_device_init_flags_t* pdevice_flags;
+typedef struct ur_init_params_t {
+    ur_device_init_flags_t *pdevice_flags;
 } ur_init_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urInit 
+/// @brief Callback function-pointer for urInit
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnInitCb_t)(
-    ur_init_params_t* params,
+typedef void(UR_APICALL *ur_pfnInitCb_t)(
+    ur_init_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Global callback functions pointers
-typedef struct ur_global_callbacks_t
-{
-    ur_pfnTearDownCb_t                                              pfnTearDownCb;
-    ur_pfnGetLastResultCb_t                                         pfnGetLastResultCb;
-    ur_pfnInitCb_t                                                  pfnInitCb;
+typedef struct ur_global_callbacks_t {
+    ur_pfnTearDownCb_t pfnTearDownCb;
+    ur_pfnGetLastResultCb_t pfnGetLastResultCb;
+    ur_pfnInitCb_t pfnInitCb;
 } ur_global_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueGetInfo 
+/// @brief Callback function parameters for urQueueGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_get_info_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_queue_info_t* ppropName;
-    size_t* ppropValueSize;
-    void** ppPropValue;
-    size_t** ppPropSizeRet;
+typedef struct ur_queue_get_info_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_queue_info_t *ppropName;
+    size_t *ppropValueSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
 } ur_queue_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueGetInfo 
+/// @brief Callback function-pointer for urQueueGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueGetInfoCb_t)(
-    ur_queue_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueGetInfoCb_t)(
+    ur_queue_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueCreate 
+/// @brief Callback function parameters for urQueueCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_create_params_t
-{
-    ur_context_handle_t* phContext;
-    ur_device_handle_t* phDevice;
-    const ur_queue_property_t** ppProps;
-    ur_queue_handle_t** pphQueue;
+typedef struct ur_queue_create_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_queue_property_t **ppProps;
+    ur_queue_handle_t **pphQueue;
 } ur_queue_create_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueCreate 
+/// @brief Callback function-pointer for urQueueCreate
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueCreateCb_t)(
-    ur_queue_create_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueCreateCb_t)(
+    ur_queue_create_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueRetain 
+/// @brief Callback function parameters for urQueueRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_retain_params_t
-{
-    ur_queue_handle_t* phQueue;
+typedef struct ur_queue_retain_params_t {
+    ur_queue_handle_t *phQueue;
 } ur_queue_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueRetain 
+/// @brief Callback function-pointer for urQueueRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueRetainCb_t)(
-    ur_queue_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueRetainCb_t)(
+    ur_queue_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueRelease 
+/// @brief Callback function parameters for urQueueRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_release_params_t
-{
-    ur_queue_handle_t* phQueue;
+typedef struct ur_queue_release_params_t {
+    ur_queue_handle_t *phQueue;
 } ur_queue_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueRelease 
+/// @brief Callback function-pointer for urQueueRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueReleaseCb_t)(
-    ur_queue_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueReleaseCb_t)(
+    ur_queue_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueGetNativeHandle 
+/// @brief Callback function parameters for urQueueGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_get_native_handle_params_t
-{
-    ur_queue_handle_t* phQueue;
-    ur_native_handle_t** pphNativeQueue;
+typedef struct ur_queue_get_native_handle_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_native_handle_t **pphNativeQueue;
 } ur_queue_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueGetNativeHandle 
+/// @brief Callback function-pointer for urQueueGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueGetNativeHandleCb_t)(
-    ur_queue_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueGetNativeHandleCb_t)(
+    ur_queue_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueCreateWithNativeHandle 
+/// @brief Callback function parameters for urQueueCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeQueue;
-    ur_context_handle_t* phContext;
-    ur_queue_handle_t** pphQueue;
+typedef struct ur_queue_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeQueue;
+    ur_context_handle_t *phContext;
+    ur_queue_handle_t **pphQueue;
 } ur_queue_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueCreateWithNativeHandle 
+/// @brief Callback function-pointer for urQueueCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueCreateWithNativeHandleCb_t)(
-    ur_queue_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueCreateWithNativeHandleCb_t)(
+    ur_queue_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueFinish 
+/// @brief Callback function parameters for urQueueFinish
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_finish_params_t
-{
-    ur_queue_handle_t* phQueue;
+typedef struct ur_queue_finish_params_t {
+    ur_queue_handle_t *phQueue;
 } ur_queue_finish_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueFinish 
+/// @brief Callback function-pointer for urQueueFinish
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueFinishCb_t)(
-    ur_queue_finish_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueFinishCb_t)(
+    ur_queue_finish_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urQueueFlush 
+/// @brief Callback function parameters for urQueueFlush
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_flush_params_t
-{
-    ur_queue_handle_t* phQueue;
+typedef struct ur_queue_flush_params_t {
+    ur_queue_handle_t *phQueue;
 } ur_queue_flush_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urQueueFlush 
+/// @brief Callback function-pointer for urQueueFlush
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnQueueFlushCb_t)(
-    ur_queue_flush_params_t* params,
+typedef void(UR_APICALL *ur_pfnQueueFlushCb_t)(
+    ur_queue_flush_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Queue callback functions pointers
-typedef struct ur_queue_callbacks_t
-{
-    ur_pfnQueueGetInfoCb_t                                          pfnGetInfoCb;
-    ur_pfnQueueCreateCb_t                                           pfnCreateCb;
-    ur_pfnQueueRetainCb_t                                           pfnRetainCb;
-    ur_pfnQueueReleaseCb_t                                          pfnReleaseCb;
-    ur_pfnQueueGetNativeHandleCb_t                                  pfnGetNativeHandleCb;
-    ur_pfnQueueCreateWithNativeHandleCb_t                           pfnCreateWithNativeHandleCb;
-    ur_pfnQueueFinishCb_t                                           pfnFinishCb;
-    ur_pfnQueueFlushCb_t                                            pfnFlushCb;
+typedef struct ur_queue_callbacks_t {
+    ur_pfnQueueGetInfoCb_t pfnGetInfoCb;
+    ur_pfnQueueCreateCb_t pfnCreateCb;
+    ur_pfnQueueRetainCb_t pfnRetainCb;
+    ur_pfnQueueReleaseCb_t pfnReleaseCb;
+    ur_pfnQueueGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnQueueCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnQueueFinishCb_t pfnFinishCb;
+    ur_pfnQueueFlushCb_t pfnFlushCb;
 } ur_queue_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceGet 
+/// @brief Callback function parameters for urDeviceGet
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_get_params_t
-{
-    ur_platform_handle_t* phPlatform;
-    ur_device_type_t* pDeviceType;
-    uint32_t* pNumEntries;
-    ur_device_handle_t** pphDevices;
-    uint32_t** ppNumDevices;
+typedef struct ur_device_get_params_t {
+    ur_platform_handle_t *phPlatform;
+    ur_device_type_t *pDeviceType;
+    uint32_t *pNumEntries;
+    ur_device_handle_t **pphDevices;
+    uint32_t **ppNumDevices;
 } ur_device_get_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceGet 
+/// @brief Callback function-pointer for urDeviceGet
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceGetCb_t)(
-    ur_device_get_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceGetCb_t)(
+    ur_device_get_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceGetInfo 
+/// @brief Callback function parameters for urDeviceGetInfo
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_get_info_params_t
-{
-    ur_device_handle_t* phDevice;
-    ur_device_info_t* pinfoType;
-    size_t* ppropSize;
-    void** ppDeviceInfo;
-    size_t** ppPropSizeRet;
+typedef struct ur_device_get_info_params_t {
+    ur_device_handle_t *phDevice;
+    ur_device_info_t *pinfoType;
+    size_t *ppropSize;
+    void **ppDeviceInfo;
+    size_t **ppPropSizeRet;
 } ur_device_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceGetInfo 
+/// @brief Callback function-pointer for urDeviceGetInfo
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceGetInfoCb_t)(
-    ur_device_get_info_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceGetInfoCb_t)(
+    ur_device_get_info_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceRetain 
+/// @brief Callback function parameters for urDeviceRetain
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_retain_params_t
-{
-    ur_device_handle_t* phDevice;
+typedef struct ur_device_retain_params_t {
+    ur_device_handle_t *phDevice;
 } ur_device_retain_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceRetain 
+/// @brief Callback function-pointer for urDeviceRetain
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceRetainCb_t)(
-    ur_device_retain_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceRetainCb_t)(
+    ur_device_retain_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceRelease 
+/// @brief Callback function parameters for urDeviceRelease
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_release_params_t
-{
-    ur_device_handle_t* phDevice;
+typedef struct ur_device_release_params_t {
+    ur_device_handle_t *phDevice;
 } ur_device_release_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceRelease 
+/// @brief Callback function-pointer for urDeviceRelease
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceReleaseCb_t)(
-    ur_device_release_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceReleaseCb_t)(
+    ur_device_release_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDevicePartition 
+/// @brief Callback function parameters for urDevicePartition
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_partition_params_t
-{
-    ur_device_handle_t* phDevice;
-    const ur_device_partition_property_t** ppProperties;
-    uint32_t* pNumDevices;
-    ur_device_handle_t** pphSubDevices;
-    uint32_t** ppNumDevicesRet;
+typedef struct ur_device_partition_params_t {
+    ur_device_handle_t *phDevice;
+    const ur_device_partition_property_t **ppProperties;
+    uint32_t *pNumDevices;
+    ur_device_handle_t **pphSubDevices;
+    uint32_t **ppNumDevicesRet;
 } ur_device_partition_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDevicePartition 
+/// @brief Callback function-pointer for urDevicePartition
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDevicePartitionCb_t)(
-    ur_device_partition_params_t* params,
+typedef void(UR_APICALL *ur_pfnDevicePartitionCb_t)(
+    ur_device_partition_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceSelectBinary 
+/// @brief Callback function parameters for urDeviceSelectBinary
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_select_binary_params_t
-{
-    ur_device_handle_t* phDevice;
-    const uint8_t*** pppBinaries;
-    uint32_t* pNumBinaries;
-    uint32_t** ppSelectedBinary;
+typedef struct ur_device_select_binary_params_t {
+    ur_device_handle_t *phDevice;
+    const uint8_t ***pppBinaries;
+    uint32_t *pNumBinaries;
+    uint32_t **ppSelectedBinary;
 } ur_device_select_binary_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceSelectBinary 
+/// @brief Callback function-pointer for urDeviceSelectBinary
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceSelectBinaryCb_t)(
-    ur_device_select_binary_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceSelectBinaryCb_t)(
+    ur_device_select_binary_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceGetNativeHandle 
+/// @brief Callback function parameters for urDeviceGetNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_get_native_handle_params_t
-{
-    ur_device_handle_t* phDevice;
-    ur_native_handle_t** pphNativeDevice;
+typedef struct ur_device_get_native_handle_params_t {
+    ur_device_handle_t *phDevice;
+    ur_native_handle_t **pphNativeDevice;
 } ur_device_get_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceGetNativeHandle 
+/// @brief Callback function-pointer for urDeviceGetNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceGetNativeHandleCb_t)(
-    ur_device_get_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceGetNativeHandleCb_t)(
+    ur_device_get_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceCreateWithNativeHandle 
+/// @brief Callback function parameters for urDeviceCreateWithNativeHandle
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_create_with_native_handle_params_t
-{
-    ur_native_handle_t* phNativeDevice;
-    ur_platform_handle_t* phPlatform;
-    ur_device_handle_t** pphDevice;
+typedef struct ur_device_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeDevice;
+    ur_platform_handle_t *phPlatform;
+    ur_device_handle_t **pphDevice;
 } ur_device_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceCreateWithNativeHandle 
+/// @brief Callback function-pointer for urDeviceCreateWithNativeHandle
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceCreateWithNativeHandleCb_t)(
-    ur_device_create_with_native_handle_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceCreateWithNativeHandleCb_t)(
+    ur_device_create_with_native_handle_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function parameters for urDeviceGetGlobalTimestamps 
+/// @brief Callback function parameters for urDeviceGetGlobalTimestamps
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_device_get_global_timestamps_params_t
-{
-    ur_device_handle_t* phDevice;
-    uint64_t** ppDeviceTimestamp;
-    uint64_t** ppHostTimestamp;
+typedef struct ur_device_get_global_timestamps_params_t {
+    ur_device_handle_t *phDevice;
+    uint64_t **ppDeviceTimestamp;
+    uint64_t **ppHostTimestamp;
 } ur_device_get_global_timestamps_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Callback function-pointer for urDeviceGetGlobalTimestamps 
+/// @brief Callback function-pointer for urDeviceGetGlobalTimestamps
 /// @param[in] params Parameters passed to this instance
 /// @param[in] result Return value
 /// @param[in] pTracerUserData Per-Tracer user data
 /// @param[in,out] ppTracerInstanceUserData Per-Tracer, Per-Instance user data
-typedef void (UR_APICALL *ur_pfnDeviceGetGlobalTimestampsCb_t)(
-    ur_device_get_global_timestamps_params_t* params,
+typedef void(UR_APICALL *ur_pfnDeviceGetGlobalTimestampsCb_t)(
+    ur_device_get_global_timestamps_params_t *params,
     ur_result_t result,
-    void* pTracerUserData,
-    void** ppTracerInstanceUserData
-    );
+    void *pTracerUserData,
+    void **ppTracerInstanceUserData);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Device callback functions pointers
-typedef struct ur_device_callbacks_t
-{
-    ur_pfnDeviceGetCb_t                                             pfnGetCb;
-    ur_pfnDeviceGetInfoCb_t                                         pfnGetInfoCb;
-    ur_pfnDeviceRetainCb_t                                          pfnRetainCb;
-    ur_pfnDeviceReleaseCb_t                                         pfnReleaseCb;
-    ur_pfnDevicePartitionCb_t                                       pfnPartitionCb;
-    ur_pfnDeviceSelectBinaryCb_t                                    pfnSelectBinaryCb;
-    ur_pfnDeviceGetNativeHandleCb_t                                 pfnGetNativeHandleCb;
-    ur_pfnDeviceCreateWithNativeHandleCb_t                          pfnCreateWithNativeHandleCb;
-    ur_pfnDeviceGetGlobalTimestampsCb_t                             pfnGetGlobalTimestampsCb;
+typedef struct ur_device_callbacks_t {
+    ur_pfnDeviceGetCb_t pfnGetCb;
+    ur_pfnDeviceGetInfoCb_t pfnGetInfoCb;
+    ur_pfnDeviceRetainCb_t pfnRetainCb;
+    ur_pfnDeviceReleaseCb_t pfnReleaseCb;
+    ur_pfnDevicePartitionCb_t pfnPartitionCb;
+    ur_pfnDeviceSelectBinaryCb_t pfnSelectBinaryCb;
+    ur_pfnDeviceGetNativeHandleCb_t pfnGetNativeHandleCb;
+    ur_pfnDeviceCreateWithNativeHandleCb_t pfnCreateWithNativeHandleCb;
+    ur_pfnDeviceGetGlobalTimestampsCb_t pfnGetGlobalTimestampsCb;
 } ur_device_callbacks_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Container for all callbacks
-typedef struct ur_callbacks_t
-{
-    ur_platform_callbacks_t             Platform;
-    ur_context_callbacks_t              Context;
-    ur_event_callbacks_t                Event;
-    ur_program_callbacks_t              Program;
-    ur_module_callbacks_t               Module;
-    ur_kernel_callbacks_t               Kernel;
-    ur_sampler_callbacks_t              Sampler;
-    ur_mem_callbacks_t                  Mem;
-    ur_enqueue_callbacks_t              Enqueue;
-    ur_usm_callbacks_t                  USM;
-    ur_global_callbacks_t               Global;
-    ur_queue_callbacks_t                Queue;
-    ur_device_callbacks_t               Device;
+typedef struct ur_callbacks_t {
+    ur_platform_callbacks_t Platform;
+    ur_context_callbacks_t Context;
+    ur_event_callbacks_t Event;
+    ur_program_callbacks_t Program;
+    ur_module_callbacks_t Module;
+    ur_kernel_callbacks_t Kernel;
+    ur_sampler_callbacks_t Sampler;
+    ur_mem_callbacks_t Mem;
+    ur_enqueue_callbacks_t Enqueue;
+    ur_usm_callbacks_t USM;
+    ur_global_callbacks_t Global;
+    ur_queue_callbacks_t Queue;
+    ur_device_callbacks_t Device;
 } ur_callbacks_t;
 
 #if !defined(__GNUC__)

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -20,53 +20,47 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urPlatformGet 
-typedef ur_result_t (UR_APICALL *ur_pfnPlatformGet_t)(
+/// @brief Function-pointer for urPlatformGet
+typedef ur_result_t(UR_APICALL *ur_pfnPlatformGet_t)(
     uint32_t,
-    ur_platform_handle_t*,
-    uint32_t*
-    );
+    ur_platform_handle_t *,
+    uint32_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urPlatformGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnPlatformGetInfo_t)(
+/// @brief Function-pointer for urPlatformGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetInfo_t)(
     ur_platform_handle_t,
     ur_platform_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urPlatformGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnPlatformGetNativeHandle_t)(
+/// @brief Function-pointer for urPlatformGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetNativeHandle_t)(
     ur_platform_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urPlatformCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urPlatformCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
     ur_native_handle_t,
-    ur_platform_handle_t*
-    );
+    ur_platform_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urPlatformGetApiVersion 
-typedef ur_result_t (UR_APICALL *ur_pfnPlatformGetApiVersion_t)(
+/// @brief Function-pointer for urPlatformGetApiVersion
+typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetApiVersion_t)(
     ur_platform_handle_t,
-    ur_api_version_t*
-    );
+    ur_api_version_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Platform functions pointers
-typedef struct ur_platform_dditable_t
-{
-    ur_pfnPlatformGet_t                                         pfnGet;
-    ur_pfnPlatformGetInfo_t                                     pfnGetInfo;
-    ur_pfnPlatformGetNativeHandle_t                             pfnGetNativeHandle;
-    ur_pfnPlatformCreateWithNativeHandle_t                      pfnCreateWithNativeHandle;
-    ur_pfnPlatformGetApiVersion_t                               pfnGetApiVersion;
+typedef struct ur_platform_dditable_t {
+    ur_pfnPlatformGet_t pfnGet;
+    ur_pfnPlatformGetInfo_t pfnGetInfo;
+    ur_pfnPlatformGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnPlatformCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnPlatformGetApiVersion_t pfnGetApiVersion;
 } ur_platform_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -80,80 +74,71 @@ typedef struct ur_platform_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetPlatformProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_platform_dditable_t* pDdiTable               ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,         ///< [in] API version requested
+    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetPlatformProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetPlatformProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetPlatformProcAddrTable_t)(
     ur_api_version_t,
-    ur_platform_dditable_t*
-    );
+    ur_platform_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnContextCreate_t)(
+/// @brief Function-pointer for urContextCreate
+typedef ur_result_t(UR_APICALL *ur_pfnContextCreate_t)(
     uint32_t,
-    ur_device_handle_t*,
-    ur_context_handle_t*
-    );
+    ur_device_handle_t *,
+    ur_context_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnContextRetain_t)(
-    ur_context_handle_t
-    );
+/// @brief Function-pointer for urContextRetain
+typedef ur_result_t(UR_APICALL *ur_pfnContextRetain_t)(
+    ur_context_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnContextRelease_t)(
-    ur_context_handle_t
-    );
+/// @brief Function-pointer for urContextRelease
+typedef ur_result_t(UR_APICALL *ur_pfnContextRelease_t)(
+    ur_context_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnContextGetInfo_t)(
+/// @brief Function-pointer for urContextGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnContextGetInfo_t)(
     ur_context_handle_t,
     ur_context_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnContextGetNativeHandle_t)(
+/// @brief Function-pointer for urContextGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnContextGetNativeHandle_t)(
     ur_context_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnContextCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urContextCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnContextCreateWithNativeHandle_t)(
     ur_native_handle_t,
-    ur_context_handle_t*
-    );
+    ur_context_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urContextSetExtendedDeleter 
-typedef ur_result_t (UR_APICALL *ur_pfnContextSetExtendedDeleter_t)(
+/// @brief Function-pointer for urContextSetExtendedDeleter
+typedef ur_result_t(UR_APICALL *ur_pfnContextSetExtendedDeleter_t)(
     ur_context_handle_t,
     ur_context_extended_deleter_t,
-    void*
-    );
+    void *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Context functions pointers
-typedef struct ur_context_dditable_t
-{
-    ur_pfnContextCreate_t                                       pfnCreate;
-    ur_pfnContextRetain_t                                       pfnRetain;
-    ur_pfnContextRelease_t                                      pfnRelease;
-    ur_pfnContextGetInfo_t                                      pfnGetInfo;
-    ur_pfnContextGetNativeHandle_t                              pfnGetNativeHandle;
-    ur_pfnContextCreateWithNativeHandle_t                       pfnCreateWithNativeHandle;
-    ur_pfnContextSetExtendedDeleter_t                           pfnSetExtendedDeleter;
+typedef struct ur_context_dditable_t {
+    ur_pfnContextCreate_t pfnCreate;
+    ur_pfnContextRetain_t pfnRetain;
+    ur_pfnContextRelease_t pfnRelease;
+    ur_pfnContextGetInfo_t pfnGetInfo;
+    ur_pfnContextGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnContextCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnContextSetExtendedDeleter_t pfnSetExtendedDeleter;
 } ur_context_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -167,92 +152,82 @@ typedef struct ur_context_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetContextProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_context_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetContextProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetContextProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetContextProcAddrTable_t)(
     ur_api_version_t,
-    ur_context_dditable_t*
-    );
+    ur_context_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnEventGetInfo_t)(
+/// @brief Function-pointer for urEventGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnEventGetInfo_t)(
     ur_event_handle_t,
     ur_event_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventGetProfilingInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnEventGetProfilingInfo_t)(
+/// @brief Function-pointer for urEventGetProfilingInfo
+typedef ur_result_t(UR_APICALL *ur_pfnEventGetProfilingInfo_t)(
     ur_event_handle_t,
     ur_profiling_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventWait 
-typedef ur_result_t (UR_APICALL *ur_pfnEventWait_t)(
+/// @brief Function-pointer for urEventWait
+typedef ur_result_t(UR_APICALL *ur_pfnEventWait_t)(
     uint32_t,
-    const ur_event_handle_t*
-    );
+    const ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnEventRetain_t)(
-    ur_event_handle_t
-    );
+/// @brief Function-pointer for urEventRetain
+typedef ur_result_t(UR_APICALL *ur_pfnEventRetain_t)(
+    ur_event_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnEventRelease_t)(
-    ur_event_handle_t
-    );
+/// @brief Function-pointer for urEventRelease
+typedef ur_result_t(UR_APICALL *ur_pfnEventRelease_t)(
+    ur_event_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnEventGetNativeHandle_t)(
+/// @brief Function-pointer for urEventGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnEventGetNativeHandle_t)(
     ur_event_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnEventCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urEventCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnEventCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_event_handle_t*
-    );
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEventSetCallback 
-typedef ur_result_t (UR_APICALL *ur_pfnEventSetCallback_t)(
+/// @brief Function-pointer for urEventSetCallback
+typedef ur_result_t(UR_APICALL *ur_pfnEventSetCallback_t)(
     ur_event_handle_t,
     ur_execution_info_t,
     ur_event_callback_t,
-    void*
-    );
+    void *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Event functions pointers
-typedef struct ur_event_dditable_t
-{
-    ur_pfnEventGetInfo_t                                        pfnGetInfo;
-    ur_pfnEventGetProfilingInfo_t                               pfnGetProfilingInfo;
-    ur_pfnEventWait_t                                           pfnWait;
-    ur_pfnEventRetain_t                                         pfnRetain;
-    ur_pfnEventRelease_t                                        pfnRelease;
-    ur_pfnEventGetNativeHandle_t                                pfnGetNativeHandle;
-    ur_pfnEventCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
-    ur_pfnEventSetCallback_t                                    pfnSetCallback;
+typedef struct ur_event_dditable_t {
+    ur_pfnEventGetInfo_t pfnGetInfo;
+    ur_pfnEventGetProfilingInfo_t pfnGetProfilingInfo;
+    ur_pfnEventWait_t pfnWait;
+    ur_pfnEventRetain_t pfnRetain;
+    ur_pfnEventRelease_t pfnRelease;
+    ur_pfnEventGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnEventCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnEventSetCallback_t pfnSetCallback;
 } ur_event_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -266,117 +241,105 @@ typedef struct ur_event_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetEventProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_event_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetEventProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetEventProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetEventProcAddrTable_t)(
     ur_api_version_t,
-    ur_event_dditable_t*
-    );
+    ur_event_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramCreate_t)(
+/// @brief Function-pointer for urProgramCreate
+typedef ur_result_t(UR_APICALL *ur_pfnProgramCreate_t)(
     ur_context_handle_t,
     uint32_t,
-    const ur_module_handle_t*,
-    const char*,
-    ur_program_handle_t*
-    );
+    const ur_module_handle_t *,
+    const char *,
+    ur_program_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramCreateWithBinary 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramCreateWithBinary_t)(
+/// @brief Function-pointer for urProgramCreateWithBinary
+typedef ur_result_t(UR_APICALL *ur_pfnProgramCreateWithBinary_t)(
     ur_context_handle_t,
     ur_device_handle_t,
     size_t,
-    const uint8_t*,
-    ur_program_handle_t*
-    );
+    const uint8_t *,
+    ur_program_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramRetain_t)(
-    ur_program_handle_t
-    );
+/// @brief Function-pointer for urProgramRetain
+typedef ur_result_t(UR_APICALL *ur_pfnProgramRetain_t)(
+    ur_program_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramRelease_t)(
-    ur_program_handle_t
-    );
+/// @brief Function-pointer for urProgramRelease
+typedef ur_result_t(UR_APICALL *ur_pfnProgramRelease_t)(
+    ur_program_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramGetFunctionPointer 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramGetFunctionPointer_t)(
+/// @brief Function-pointer for urProgramGetFunctionPointer
+typedef ur_result_t(UR_APICALL *ur_pfnProgramGetFunctionPointer_t)(
     ur_device_handle_t,
     ur_program_handle_t,
-    const char*,
-    void**
-    );
+    const char *,
+    void **);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramGetInfo_t)(
+/// @brief Function-pointer for urProgramGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnProgramGetInfo_t)(
     ur_program_handle_t,
     ur_program_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramGetBuildInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramGetBuildInfo_t)(
+/// @brief Function-pointer for urProgramGetBuildInfo
+typedef ur_result_t(UR_APICALL *ur_pfnProgramGetBuildInfo_t)(
     ur_program_handle_t,
     ur_device_handle_t,
     ur_program_build_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramSetSpecializationConstant 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramSetSpecializationConstant_t)(
+/// @brief Function-pointer for urProgramSetSpecializationConstant
+typedef ur_result_t(UR_APICALL *ur_pfnProgramSetSpecializationConstant_t)(
     ur_program_handle_t,
     uint32_t,
     size_t,
-    const void*
-    );
+    const void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramGetNativeHandle_t)(
+/// @brief Function-pointer for urProgramGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnProgramGetNativeHandle_t)(
     ur_program_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urProgramCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnProgramCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urProgramCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnProgramCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_program_handle_t*
-    );
+    ur_program_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Program functions pointers
-typedef struct ur_program_dditable_t
-{
-    ur_pfnProgramCreate_t                                       pfnCreate;
-    ur_pfnProgramCreateWithBinary_t                             pfnCreateWithBinary;
-    ur_pfnProgramRetain_t                                       pfnRetain;
-    ur_pfnProgramRelease_t                                      pfnRelease;
-    ur_pfnProgramGetFunctionPointer_t                           pfnGetFunctionPointer;
-    ur_pfnProgramGetInfo_t                                      pfnGetInfo;
-    ur_pfnProgramGetBuildInfo_t                                 pfnGetBuildInfo;
-    ur_pfnProgramSetSpecializationConstant_t                    pfnSetSpecializationConstant;
-    ur_pfnProgramGetNativeHandle_t                              pfnGetNativeHandle;
-    ur_pfnProgramCreateWithNativeHandle_t                       pfnCreateWithNativeHandle;
+typedef struct ur_program_dditable_t {
+    ur_pfnProgramCreate_t pfnCreate;
+    ur_pfnProgramCreateWithBinary_t pfnCreateWithBinary;
+    ur_pfnProgramRetain_t pfnRetain;
+    ur_pfnProgramRelease_t pfnRelease;
+    ur_pfnProgramGetFunctionPointer_t pfnGetFunctionPointer;
+    ur_pfnProgramGetInfo_t pfnGetInfo;
+    ur_pfnProgramGetBuildInfo_t pfnGetBuildInfo;
+    ur_pfnProgramSetSpecializationConstant_t pfnSetSpecializationConstant;
+    ur_pfnProgramGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnProgramCreateWithNativeHandle_t pfnCreateWithNativeHandle;
 } ur_program_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -390,65 +353,58 @@ typedef struct ur_program_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetProgramProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_program_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetProgramProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetProgramProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetProgramProcAddrTable_t)(
     ur_api_version_t,
-    ur_program_dditable_t*
-    );
+    ur_program_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urModuleCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnModuleCreate_t)(
+/// @brief Function-pointer for urModuleCreate
+typedef ur_result_t(UR_APICALL *ur_pfnModuleCreate_t)(
     ur_context_handle_t,
-    const void*,
+    const void *,
     size_t,
-    const char*,
+    const char *,
     ur_modulecreate_callback_t,
-    void*,
-    ur_module_handle_t*
-    );
+    void *,
+    ur_module_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urModuleRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnModuleRetain_t)(
-    ur_module_handle_t
-    );
+/// @brief Function-pointer for urModuleRetain
+typedef ur_result_t(UR_APICALL *ur_pfnModuleRetain_t)(
+    ur_module_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urModuleRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnModuleRelease_t)(
-    ur_module_handle_t
-    );
+/// @brief Function-pointer for urModuleRelease
+typedef ur_result_t(UR_APICALL *ur_pfnModuleRelease_t)(
+    ur_module_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urModuleGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnModuleGetNativeHandle_t)(
+/// @brief Function-pointer for urModuleGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnModuleGetNativeHandle_t)(
     ur_module_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urModuleCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnModuleCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urModuleCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnModuleCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_module_handle_t*
-    );
+    ur_module_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Module functions pointers
-typedef struct ur_module_dditable_t
-{
-    ur_pfnModuleCreate_t                                        pfnCreate;
-    ur_pfnModuleRetain_t                                        pfnRetain;
-    ur_pfnModuleRelease_t                                       pfnRelease;
-    ur_pfnModuleGetNativeHandle_t                               pfnGetNativeHandle;
-    ur_pfnModuleCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
+typedef struct ur_module_dditable_t {
+    ur_pfnModuleCreate_t pfnCreate;
+    ur_pfnModuleRetain_t pfnRetain;
+    ur_pfnModuleRelease_t pfnRelease;
+    ur_pfnModuleGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnModuleCreateWithNativeHandle_t pfnCreateWithNativeHandle;
 } ur_module_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -462,153 +418,137 @@ typedef struct ur_module_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetModuleProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_module_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_module_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetModuleProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetModuleProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetModuleProcAddrTable_t)(
     ur_api_version_t,
-    ur_module_dditable_t*
-    );
+    ur_module_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelCreate_t)(
+/// @brief Function-pointer for urKernelCreate
+typedef ur_result_t(UR_APICALL *ur_pfnKernelCreate_t)(
     ur_program_handle_t,
-    const char*,
-    ur_kernel_handle_t*
-    );
+    const char *,
+    ur_kernel_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelGetInfo_t)(
+/// @brief Function-pointer for urKernelGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnKernelGetInfo_t)(
     ur_kernel_handle_t,
     ur_kernel_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelGetGroupInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelGetGroupInfo_t)(
+/// @brief Function-pointer for urKernelGetGroupInfo
+typedef ur_result_t(UR_APICALL *ur_pfnKernelGetGroupInfo_t)(
     ur_kernel_handle_t,
     ur_device_handle_t,
     ur_kernel_group_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelGetSubGroupInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelGetSubGroupInfo_t)(
+/// @brief Function-pointer for urKernelGetSubGroupInfo
+typedef ur_result_t(UR_APICALL *ur_pfnKernelGetSubGroupInfo_t)(
     ur_kernel_handle_t,
     ur_device_handle_t,
     ur_kernel_sub_group_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelRetain_t)(
-    ur_kernel_handle_t
-    );
+/// @brief Function-pointer for urKernelRetain
+typedef ur_result_t(UR_APICALL *ur_pfnKernelRetain_t)(
+    ur_kernel_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelRelease_t)(
-    ur_kernel_handle_t
-    );
+/// @brief Function-pointer for urKernelRelease
+typedef ur_result_t(UR_APICALL *ur_pfnKernelRelease_t)(
+    ur_kernel_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelGetNativeHandle_t)(
+/// @brief Function-pointer for urKernelGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnKernelGetNativeHandle_t)(
     ur_kernel_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urKernelCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnKernelCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_kernel_handle_t*
-    );
+    ur_kernel_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelSetArgValue 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgValue_t)(
+/// @brief Function-pointer for urKernelSetArgValue
+typedef ur_result_t(UR_APICALL *ur_pfnKernelSetArgValue_t)(
     ur_kernel_handle_t,
     uint32_t,
     size_t,
-    const void*
-    );
+    const void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelSetArgLocal 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgLocal_t)(
+/// @brief Function-pointer for urKernelSetArgLocal
+typedef ur_result_t(UR_APICALL *ur_pfnKernelSetArgLocal_t)(
     ur_kernel_handle_t,
     uint32_t,
-    size_t
-    );
+    size_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelSetArgPointer 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgPointer_t)(
+/// @brief Function-pointer for urKernelSetArgPointer
+typedef ur_result_t(UR_APICALL *ur_pfnKernelSetArgPointer_t)(
     ur_kernel_handle_t,
     uint32_t,
     size_t,
-    const void*
-    );
+    const void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelSetExecInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelSetExecInfo_t)(
+/// @brief Function-pointer for urKernelSetExecInfo
+typedef ur_result_t(UR_APICALL *ur_pfnKernelSetExecInfo_t)(
     ur_kernel_handle_t,
     ur_kernel_exec_info_t,
     size_t,
-    const void*
-    );
+    const void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelSetArgSampler 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgSampler_t)(
+/// @brief Function-pointer for urKernelSetArgSampler
+typedef ur_result_t(UR_APICALL *ur_pfnKernelSetArgSampler_t)(
     ur_kernel_handle_t,
     uint32_t,
-    ur_sampler_handle_t
-    );
+    ur_sampler_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urKernelSetArgMemObj 
-typedef ur_result_t (UR_APICALL *ur_pfnKernelSetArgMemObj_t)(
+/// @brief Function-pointer for urKernelSetArgMemObj
+typedef ur_result_t(UR_APICALL *ur_pfnKernelSetArgMemObj_t)(
     ur_kernel_handle_t,
     uint32_t,
-    ur_mem_handle_t
-    );
+    ur_mem_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Kernel functions pointers
-typedef struct ur_kernel_dditable_t
-{
-    ur_pfnKernelCreate_t                                        pfnCreate;
-    ur_pfnKernelGetInfo_t                                       pfnGetInfo;
-    ur_pfnKernelGetGroupInfo_t                                  pfnGetGroupInfo;
-    ur_pfnKernelGetSubGroupInfo_t                               pfnGetSubGroupInfo;
-    ur_pfnKernelRetain_t                                        pfnRetain;
-    ur_pfnKernelRelease_t                                       pfnRelease;
-    ur_pfnKernelGetNativeHandle_t                               pfnGetNativeHandle;
-    ur_pfnKernelCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
-    ur_pfnKernelSetArgValue_t                                   pfnSetArgValue;
-    ur_pfnKernelSetArgLocal_t                                   pfnSetArgLocal;
-    ur_pfnKernelSetArgPointer_t                                 pfnSetArgPointer;
-    ur_pfnKernelSetExecInfo_t                                   pfnSetExecInfo;
-    ur_pfnKernelSetArgSampler_t                                 pfnSetArgSampler;
-    ur_pfnKernelSetArgMemObj_t                                  pfnSetArgMemObj;
+typedef struct ur_kernel_dditable_t {
+    ur_pfnKernelCreate_t pfnCreate;
+    ur_pfnKernelGetInfo_t pfnGetInfo;
+    ur_pfnKernelGetGroupInfo_t pfnGetGroupInfo;
+    ur_pfnKernelGetSubGroupInfo_t pfnGetSubGroupInfo;
+    ur_pfnKernelRetain_t pfnRetain;
+    ur_pfnKernelRelease_t pfnRelease;
+    ur_pfnKernelGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnKernelCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnKernelSetArgValue_t pfnSetArgValue;
+    ur_pfnKernelSetArgLocal_t pfnSetArgLocal;
+    ur_pfnKernelSetArgPointer_t pfnSetArgPointer;
+    ur_pfnKernelSetExecInfo_t pfnSetExecInfo;
+    ur_pfnKernelSetArgSampler_t pfnSetArgSampler;
+    ur_pfnKernelSetArgMemObj_t pfnSetArgMemObj;
 } ur_kernel_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -622,72 +562,64 @@ typedef struct ur_kernel_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetKernelProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_kernel_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetKernelProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetKernelProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetKernelProcAddrTable_t)(
     ur_api_version_t,
-    ur_kernel_dditable_t*
-    );
+    ur_kernel_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreate_t)(
+/// @brief Function-pointer for urSamplerCreate
+typedef ur_result_t(UR_APICALL *ur_pfnSamplerCreate_t)(
     ur_context_handle_t,
-    const ur_sampler_property_t*,
-    ur_sampler_handle_t*
-    );
+    const ur_sampler_property_t *,
+    ur_sampler_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerRetain_t)(
-    ur_sampler_handle_t
-    );
+/// @brief Function-pointer for urSamplerRetain
+typedef ur_result_t(UR_APICALL *ur_pfnSamplerRetain_t)(
+    ur_sampler_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerRelease_t)(
-    ur_sampler_handle_t
-    );
+/// @brief Function-pointer for urSamplerRelease
+typedef ur_result_t(UR_APICALL *ur_pfnSamplerRelease_t)(
+    ur_sampler_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerGetInfo_t)(
+/// @brief Function-pointer for urSamplerGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnSamplerGetInfo_t)(
     ur_sampler_handle_t,
     ur_sampler_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerGetNativeHandle_t)(
+/// @brief Function-pointer for urSamplerGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnSamplerGetNativeHandle_t)(
     ur_sampler_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urSamplerCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnSamplerCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urSamplerCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnSamplerCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_sampler_handle_t*
-    );
+    ur_sampler_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Sampler functions pointers
-typedef struct ur_sampler_dditable_t
-{
-    ur_pfnSamplerCreate_t                                       pfnCreate;
-    ur_pfnSamplerRetain_t                                       pfnRetain;
-    ur_pfnSamplerRelease_t                                      pfnRelease;
-    ur_pfnSamplerGetInfo_t                                      pfnGetInfo;
-    ur_pfnSamplerGetNativeHandle_t                              pfnGetNativeHandle;
-    ur_pfnSamplerCreateWithNativeHandle_t                       pfnCreateWithNativeHandle;
+typedef struct ur_sampler_dditable_t {
+    ur_pfnSamplerCreate_t pfnCreate;
+    ur_pfnSamplerRetain_t pfnRetain;
+    ur_pfnSamplerRelease_t pfnRelease;
+    ur_pfnSamplerGetInfo_t pfnGetInfo;
+    ur_pfnSamplerGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnSamplerCreateWithNativeHandle_t pfnCreateWithNativeHandle;
 } ur_sampler_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -701,108 +633,97 @@ typedef struct ur_sampler_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetSamplerProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_sampler_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetSamplerProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetSamplerProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetSamplerProcAddrTable_t)(
     ur_api_version_t,
-    ur_sampler_dditable_t*
-    );
+    ur_sampler_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemImageCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnMemImageCreate_t)(
+/// @brief Function-pointer for urMemImageCreate
+typedef ur_result_t(UR_APICALL *ur_pfnMemImageCreate_t)(
     ur_context_handle_t,
     ur_mem_flags_t,
-    const ur_image_format_t*,
-    const ur_image_desc_t*,
-    void*,
-    ur_mem_handle_t*
-    );
+    const ur_image_format_t *,
+    const ur_image_desc_t *,
+    void *,
+    ur_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemBufferCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnMemBufferCreate_t)(
+/// @brief Function-pointer for urMemBufferCreate
+typedef ur_result_t(UR_APICALL *ur_pfnMemBufferCreate_t)(
     ur_context_handle_t,
     ur_mem_flags_t,
     size_t,
-    void*,
-    ur_mem_handle_t*
-    );
+    void *,
+    ur_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnMemRetain_t)(
-    ur_mem_handle_t
-    );
+/// @brief Function-pointer for urMemRetain
+typedef ur_result_t(UR_APICALL *ur_pfnMemRetain_t)(
+    ur_mem_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnMemRelease_t)(
-    ur_mem_handle_t
-    );
+/// @brief Function-pointer for urMemRelease
+typedef ur_result_t(UR_APICALL *ur_pfnMemRelease_t)(
+    ur_mem_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemBufferPartition 
-typedef ur_result_t (UR_APICALL *ur_pfnMemBufferPartition_t)(
+/// @brief Function-pointer for urMemBufferPartition
+typedef ur_result_t(UR_APICALL *ur_pfnMemBufferPartition_t)(
     ur_mem_handle_t,
     ur_mem_flags_t,
     ur_buffer_create_type_t,
-    ur_buffer_region_t*,
-    ur_mem_handle_t*
-    );
+    ur_buffer_region_t *,
+    ur_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnMemGetNativeHandle_t)(
+/// @brief Function-pointer for urMemGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnMemGetNativeHandle_t)(
     ur_mem_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnMemCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urMemCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnMemCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_mem_handle_t*
-    );
+    ur_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnMemGetInfo_t)(
+/// @brief Function-pointer for urMemGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnMemGetInfo_t)(
     ur_mem_handle_t,
     ur_mem_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urMemImageGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnMemImageGetInfo_t)(
+/// @brief Function-pointer for urMemImageGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnMemImageGetInfo_t)(
     ur_mem_handle_t,
     ur_image_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Mem functions pointers
-typedef struct ur_mem_dditable_t
-{
-    ur_pfnMemImageCreate_t                                      pfnImageCreate;
-    ur_pfnMemBufferCreate_t                                     pfnBufferCreate;
-    ur_pfnMemRetain_t                                           pfnRetain;
-    ur_pfnMemRelease_t                                          pfnRelease;
-    ur_pfnMemBufferPartition_t                                  pfnBufferPartition;
-    ur_pfnMemGetNativeHandle_t                                  pfnGetNativeHandle;
-    ur_pfnMemCreateWithNativeHandle_t                           pfnCreateWithNativeHandle;
-    ur_pfnMemGetInfo_t                                          pfnGetInfo;
-    ur_pfnMemImageGetInfo_t                                     pfnImageGetInfo;
+typedef struct ur_mem_dditable_t {
+    ur_pfnMemImageCreate_t pfnImageCreate;
+    ur_pfnMemBufferCreate_t pfnBufferCreate;
+    ur_pfnMemRetain_t pfnRetain;
+    ur_pfnMemRelease_t pfnRelease;
+    ur_pfnMemBufferPartition_t pfnBufferPartition;
+    ur_pfnMemGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnMemCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnMemGetInfo_t pfnGetInfo;
+    ur_pfnMemImageGetInfo_t pfnImageGetInfo;
 } ur_mem_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -816,80 +737,74 @@ typedef struct ur_mem_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetMemProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_mem_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetMemProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetMemProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetMemProcAddrTable_t)(
     ur_api_version_t,
-    ur_mem_dditable_t*
-    );
+    ur_mem_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueKernelLaunch 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueKernelLaunch_t)(
+/// @brief Function-pointer for urEnqueueKernelLaunch
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueKernelLaunch_t)(
     ur_queue_handle_t,
     ur_kernel_handle_t,
     uint32_t,
-    const size_t*,
-    const size_t*,
-    const size_t*,
+    const size_t *,
+    const size_t *,
+    const size_t *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueEventsWait 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueEventsWait_t)(
+/// @brief Function-pointer for urEnqueueEventsWait
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueEventsWait_t)(
     ur_queue_handle_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueEventsWaitWithBarrier 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueEventsWaitWithBarrier_t)(
+/// @brief Function-pointer for urEnqueueEventsWaitWithBarrier
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueEventsWaitWithBarrier_t)(
     ur_queue_handle_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferRead 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferRead_t)(
+/// @brief Function-pointer for urEnqueueMemBufferRead
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferRead_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     bool,
     size_t,
     size_t,
-    void*,
+    void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferWrite 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferWrite_t)(
+/// @brief Function-pointer for urEnqueueMemBufferWrite
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferWrite_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     bool,
     size_t,
     size_t,
-    const void*,
+    const void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferReadRect 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferReadRect_t)(
+/// @brief Function-pointer for urEnqueueMemBufferReadRect
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferReadRect_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     bool,
@@ -900,15 +815,14 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferReadRect_t)(
     size_t,
     size_t,
     size_t,
-    void*,
+    void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferWriteRect 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferWriteRect_t)(
+/// @brief Function-pointer for urEnqueueMemBufferWriteRect
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferWriteRect_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     bool,
@@ -919,15 +833,14 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferWriteRect_t)(
     size_t,
     size_t,
     size_t,
-    void*,
+    void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferCopy 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopy_t)(
+/// @brief Function-pointer for urEnqueueMemBufferCopy
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferCopy_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     ur_mem_handle_t,
@@ -935,13 +848,12 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopy_t)(
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferCopyRect 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopyRect_t)(
+/// @brief Function-pointer for urEnqueueMemBufferCopyRect
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferCopyRect_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     ur_mem_handle_t,
@@ -953,43 +865,25 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferCopyRect_t)(
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferFill 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferFill_t)(
+/// @brief Function-pointer for urEnqueueMemBufferFill
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferFill_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
-    const void*,
+    const void *,
     size_t,
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemImageRead 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageRead_t)(
-    ur_queue_handle_t,
-    ur_mem_handle_t,
-    bool,
-    ur_rect_offset_t,
-    ur_rect_region_t,
-    size_t,
-    size_t,
-    void*,
-    uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemImageWrite 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageWrite_t)(
+/// @brief Function-pointer for urEnqueueMemImageRead
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemImageRead_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     bool,
@@ -997,15 +891,29 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageWrite_t)(
     ur_rect_region_t,
     size_t,
     size_t,
-    void*,
+    void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemImageCopy 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageCopy_t)(
+/// @brief Function-pointer for urEnqueueMemImageWrite
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemImageWrite_t)(
+    ur_queue_handle_t,
+    ur_mem_handle_t,
+    bool,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    void *,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueMemImageCopy
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemImageCopy_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     ur_mem_handle_t,
@@ -1013,13 +921,12 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemImageCopy_t)(
     ur_rect_offset_t,
     ur_rect_region_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemBufferMap 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferMap_t)(
+/// @brief Function-pointer for urEnqueueMemBufferMap
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemBufferMap_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
     bool,
@@ -1027,172 +934,160 @@ typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemBufferMap_t)(
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*,
-    void**
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *,
+    void **);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueMemUnmap 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueMemUnmap_t)(
+/// @brief Function-pointer for urEnqueueMemUnmap
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueMemUnmap_t)(
     ur_queue_handle_t,
     ur_mem_handle_t,
-    void*,
+    void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMMemset 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemset_t)(
+/// @brief Function-pointer for urEnqueueUSMMemset
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMMemset_t)(
     ur_queue_handle_t,
-    void*,
+    void *,
     int8_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMMemcpy 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemcpy_t)(
+/// @brief Function-pointer for urEnqueueUSMMemcpy
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMMemcpy_t)(
     ur_queue_handle_t,
     bool,
-    void*,
-    const void*,
+    void *,
+    const void *,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMPrefetch 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMPrefetch_t)(
+/// @brief Function-pointer for urEnqueueUSMPrefetch
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMPrefetch_t)(
     ur_queue_handle_t,
-    const void*,
+    const void *,
     size_t,
     ur_usm_migration_flags_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMMemAdvise 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemAdvise_t)(
+/// @brief Function-pointer for urEnqueueUSMMemAdvise
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMMemAdvise_t)(
     ur_queue_handle_t,
-    const void*,
+    const void *,
     size_t,
     ur_mem_advice_t,
-    ur_event_handle_t*
-    );
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMFill2D 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMFill2D_t)(
+/// @brief Function-pointer for urEnqueueUSMFill2D
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMFill2D_t)(
     ur_queue_handle_t,
-    void*,
+    void *,
     size_t,
     size_t,
-    const void*,
+    const void *,
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMMemset2D 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemset2D_t)(
+/// @brief Function-pointer for urEnqueueUSMMemset2D
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMMemset2D_t)(
     ur_queue_handle_t,
-    void*,
+    void *,
     size_t,
     int,
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueUSMMemcpy2D 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueUSMMemcpy2D_t)(
+/// @brief Function-pointer for urEnqueueUSMMemcpy2D
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMMemcpy2D_t)(
     ur_queue_handle_t,
     bool,
-    void*,
+    void *,
     size_t,
-    const void*,
+    const void *,
     size_t,
     size_t,
     size_t,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueDeviceGlobalVariableWrite 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableWrite_t)(
+/// @brief Function-pointer for urEnqueueDeviceGlobalVariableWrite
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableWrite_t)(
     ur_queue_handle_t,
     ur_program_handle_t,
-    const char*,
+    const char *,
     bool,
     size_t,
     size_t,
-    const void*,
+    const void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueDeviceGlobalVariableRead 
-typedef ur_result_t (UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableRead_t)(
+/// @brief Function-pointer for urEnqueueDeviceGlobalVariableRead
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueDeviceGlobalVariableRead_t)(
     ur_queue_handle_t,
     ur_program_handle_t,
-    const char*,
+    const char *,
     bool,
     size_t,
     size_t,
-    void*,
+    void *,
     uint32_t,
-    const ur_event_handle_t*,
-    ur_event_handle_t*
-    );
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Enqueue functions pointers
-typedef struct ur_enqueue_dditable_t
-{
-    ur_pfnEnqueueKernelLaunch_t                                 pfnKernelLaunch;
-    ur_pfnEnqueueEventsWait_t                                   pfnEventsWait;
-    ur_pfnEnqueueEventsWaitWithBarrier_t                        pfnEventsWaitWithBarrier;
-    ur_pfnEnqueueMemBufferRead_t                                pfnMemBufferRead;
-    ur_pfnEnqueueMemBufferWrite_t                               pfnMemBufferWrite;
-    ur_pfnEnqueueMemBufferReadRect_t                            pfnMemBufferReadRect;
-    ur_pfnEnqueueMemBufferWriteRect_t                           pfnMemBufferWriteRect;
-    ur_pfnEnqueueMemBufferCopy_t                                pfnMemBufferCopy;
-    ur_pfnEnqueueMemBufferCopyRect_t                            pfnMemBufferCopyRect;
-    ur_pfnEnqueueMemBufferFill_t                                pfnMemBufferFill;
-    ur_pfnEnqueueMemImageRead_t                                 pfnMemImageRead;
-    ur_pfnEnqueueMemImageWrite_t                                pfnMemImageWrite;
-    ur_pfnEnqueueMemImageCopy_t                                 pfnMemImageCopy;
-    ur_pfnEnqueueMemBufferMap_t                                 pfnMemBufferMap;
-    ur_pfnEnqueueMemUnmap_t                                     pfnMemUnmap;
-    ur_pfnEnqueueUSMMemset_t                                    pfnUSMMemset;
-    ur_pfnEnqueueUSMMemcpy_t                                    pfnUSMMemcpy;
-    ur_pfnEnqueueUSMPrefetch_t                                  pfnUSMPrefetch;
-    ur_pfnEnqueueUSMMemAdvise_t                                 pfnUSMMemAdvise;
-    ur_pfnEnqueueUSMFill2D_t                                    pfnUSMFill2D;
-    ur_pfnEnqueueUSMMemset2D_t                                  pfnUSMMemset2D;
-    ur_pfnEnqueueUSMMemcpy2D_t                                  pfnUSMMemcpy2D;
-    ur_pfnEnqueueDeviceGlobalVariableWrite_t                    pfnDeviceGlobalVariableWrite;
-    ur_pfnEnqueueDeviceGlobalVariableRead_t                     pfnDeviceGlobalVariableRead;
+typedef struct ur_enqueue_dditable_t {
+    ur_pfnEnqueueKernelLaunch_t pfnKernelLaunch;
+    ur_pfnEnqueueEventsWait_t pfnEventsWait;
+    ur_pfnEnqueueEventsWaitWithBarrier_t pfnEventsWaitWithBarrier;
+    ur_pfnEnqueueMemBufferRead_t pfnMemBufferRead;
+    ur_pfnEnqueueMemBufferWrite_t pfnMemBufferWrite;
+    ur_pfnEnqueueMemBufferReadRect_t pfnMemBufferReadRect;
+    ur_pfnEnqueueMemBufferWriteRect_t pfnMemBufferWriteRect;
+    ur_pfnEnqueueMemBufferCopy_t pfnMemBufferCopy;
+    ur_pfnEnqueueMemBufferCopyRect_t pfnMemBufferCopyRect;
+    ur_pfnEnqueueMemBufferFill_t pfnMemBufferFill;
+    ur_pfnEnqueueMemImageRead_t pfnMemImageRead;
+    ur_pfnEnqueueMemImageWrite_t pfnMemImageWrite;
+    ur_pfnEnqueueMemImageCopy_t pfnMemImageCopy;
+    ur_pfnEnqueueMemBufferMap_t pfnMemBufferMap;
+    ur_pfnEnqueueMemUnmap_t pfnMemUnmap;
+    ur_pfnEnqueueUSMMemset_t pfnUSMMemset;
+    ur_pfnEnqueueUSMMemcpy_t pfnUSMMemcpy;
+    ur_pfnEnqueueUSMPrefetch_t pfnUSMPrefetch;
+    ur_pfnEnqueueUSMMemAdvise_t pfnUSMMemAdvise;
+    ur_pfnEnqueueUSMFill2D_t pfnUSMFill2D;
+    ur_pfnEnqueueUSMMemset2D_t pfnUSMMemset2D;
+    ur_pfnEnqueueUSMMemcpy2D_t pfnUSMMemcpy2D;
+    ur_pfnEnqueueDeviceGlobalVariableWrite_t pfnDeviceGlobalVariableWrite;
+    ur_pfnEnqueueDeviceGlobalVariableRead_t pfnDeviceGlobalVariableRead;
 } ur_enqueue_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1206,76 +1101,69 @@ typedef struct ur_enqueue_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetEnqueueProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_enqueue_dditable_t* pDdiTable                ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetEnqueueProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetEnqueueProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetEnqueueProcAddrTable_t)(
     ur_api_version_t,
-    ur_enqueue_dditable_t*
-    );
+    ur_enqueue_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMHostAlloc 
-typedef ur_result_t (UR_APICALL *ur_pfnUSMHostAlloc_t)(
+/// @brief Function-pointer for urUSMHostAlloc
+typedef ur_result_t(UR_APICALL *ur_pfnUSMHostAlloc_t)(
     ur_context_handle_t,
-    ur_usm_mem_flags_t*,
+    ur_usm_mem_flags_t *,
     size_t,
     uint32_t,
-    void**
-    );
+    void **);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMDeviceAlloc 
-typedef ur_result_t (UR_APICALL *ur_pfnUSMDeviceAlloc_t)(
+/// @brief Function-pointer for urUSMDeviceAlloc
+typedef ur_result_t(UR_APICALL *ur_pfnUSMDeviceAlloc_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_usm_mem_flags_t*,
+    ur_usm_mem_flags_t *,
     size_t,
     uint32_t,
-    void**
-    );
+    void **);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMSharedAlloc 
-typedef ur_result_t (UR_APICALL *ur_pfnUSMSharedAlloc_t)(
+/// @brief Function-pointer for urUSMSharedAlloc
+typedef ur_result_t(UR_APICALL *ur_pfnUSMSharedAlloc_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_usm_mem_flags_t*,
+    ur_usm_mem_flags_t *,
     size_t,
     uint32_t,
-    void**
-    );
+    void **);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMFree 
-typedef ur_result_t (UR_APICALL *ur_pfnUSMFree_t)(
+/// @brief Function-pointer for urUSMFree
+typedef ur_result_t(UR_APICALL *ur_pfnUSMFree_t)(
     ur_context_handle_t,
-    void*
-    );
+    void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMGetMemAllocInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnUSMGetMemAllocInfo_t)(
+/// @brief Function-pointer for urUSMGetMemAllocInfo
+typedef ur_result_t(UR_APICALL *ur_pfnUSMGetMemAllocInfo_t)(
     ur_context_handle_t,
-    const void*,
+    const void *,
     ur_usm_alloc_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of USM functions pointers
-typedef struct ur_usm_dditable_t
-{
-    ur_pfnUSMHostAlloc_t                                        pfnHostAlloc;
-    ur_pfnUSMDeviceAlloc_t                                      pfnDeviceAlloc;
-    ur_pfnUSMSharedAlloc_t                                      pfnSharedAlloc;
-    ur_pfnUSMFree_t                                             pfnFree;
-    ur_pfnUSMGetMemAllocInfo_t                                  pfnGetMemAllocInfo;
+typedef struct ur_usm_dditable_t {
+    ur_pfnUSMHostAlloc_t pfnHostAlloc;
+    ur_pfnUSMDeviceAlloc_t pfnDeviceAlloc;
+    ur_pfnUSMSharedAlloc_t pfnSharedAlloc;
+    ur_pfnUSMFree_t pfnFree;
+    ur_pfnUSMGetMemAllocInfo_t pfnGetMemAllocInfo;
 } ur_usm_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1289,43 +1177,38 @@ typedef struct ur_usm_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetUSMProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_usm_dditable_t* pDdiTable                    ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetUSMProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
     ur_api_version_t,
-    ur_usm_dditable_t*
-    );
+    ur_usm_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urTearDown 
-typedef ur_result_t (UR_APICALL *ur_pfnTearDown_t)(
-    void*
-    );
+/// @brief Function-pointer for urTearDown
+typedef ur_result_t(UR_APICALL *ur_pfnTearDown_t)(
+    void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetLastResult 
-typedef ur_result_t (UR_APICALL *ur_pfnGetLastResult_t)(
+/// @brief Function-pointer for urGetLastResult
+typedef ur_result_t(UR_APICALL *ur_pfnGetLastResult_t)(
     ur_platform_handle_t,
-    const char**
-    );
+    const char **);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urInit 
-typedef ur_result_t (UR_APICALL *ur_pfnInit_t)(
-    ur_device_init_flags_t
-    );
+/// @brief Function-pointer for urInit
+typedef ur_result_t(UR_APICALL *ur_pfnInit_t)(
+    ur_device_init_flags_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Global functions pointers
-typedef struct ur_global_dditable_t
-{
-    ur_pfnTearDown_t                                            pfnTearDown;
-    ur_pfnGetLastResult_t                                       pfnGetLastResult;
-    ur_pfnInit_t                                                pfnInit;
+typedef struct ur_global_dditable_t {
+    ur_pfnTearDown_t pfnTearDown;
+    ur_pfnGetLastResult_t pfnGetLastResult;
+    ur_pfnInit_t pfnInit;
 } ur_global_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1339,87 +1222,77 @@ typedef struct ur_global_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetGlobalProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_global_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetGlobalProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
     ur_api_version_t,
-    ur_global_dditable_t*
-    );
+    ur_global_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueGetInfo_t)(
+/// @brief Function-pointer for urQueueGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnQueueGetInfo_t)(
     ur_queue_handle_t,
     ur_queue_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueCreate 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueCreate_t)(
+/// @brief Function-pointer for urQueueCreate
+typedef ur_result_t(UR_APICALL *ur_pfnQueueCreate_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    const ur_queue_property_t*,
-    ur_queue_handle_t*
-    );
+    const ur_queue_property_t *,
+    ur_queue_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueRetain_t)(
-    ur_queue_handle_t
-    );
+/// @brief Function-pointer for urQueueRetain
+typedef ur_result_t(UR_APICALL *ur_pfnQueueRetain_t)(
+    ur_queue_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueRelease_t)(
-    ur_queue_handle_t
-    );
+/// @brief Function-pointer for urQueueRelease
+typedef ur_result_t(UR_APICALL *ur_pfnQueueRelease_t)(
+    ur_queue_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueGetNativeHandle_t)(
+/// @brief Function-pointer for urQueueGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnQueueGetNativeHandle_t)(
     ur_queue_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urQueueCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnQueueCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
-    ur_queue_handle_t*
-    );
+    ur_queue_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueFinish 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueFinish_t)(
-    ur_queue_handle_t
-    );
+/// @brief Function-pointer for urQueueFinish
+typedef ur_result_t(UR_APICALL *ur_pfnQueueFinish_t)(
+    ur_queue_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueFlush 
-typedef ur_result_t (UR_APICALL *ur_pfnQueueFlush_t)(
-    ur_queue_handle_t
-    );
+/// @brief Function-pointer for urQueueFlush
+typedef ur_result_t(UR_APICALL *ur_pfnQueueFlush_t)(
+    ur_queue_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Queue functions pointers
-typedef struct ur_queue_dditable_t
-{
-    ur_pfnQueueGetInfo_t                                        pfnGetInfo;
-    ur_pfnQueueCreate_t                                         pfnCreate;
-    ur_pfnQueueRetain_t                                         pfnRetain;
-    ur_pfnQueueRelease_t                                        pfnRelease;
-    ur_pfnQueueGetNativeHandle_t                                pfnGetNativeHandle;
-    ur_pfnQueueCreateWithNativeHandle_t                         pfnCreateWithNativeHandle;
-    ur_pfnQueueFinish_t                                         pfnFinish;
-    ur_pfnQueueFlush_t                                          pfnFlush;
+typedef struct ur_queue_dditable_t {
+    ur_pfnQueueGetInfo_t pfnGetInfo;
+    ur_pfnQueueCreate_t pfnCreate;
+    ur_pfnQueueRetain_t pfnRetain;
+    ur_pfnQueueRelease_t pfnRelease;
+    ur_pfnQueueGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnQueueCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnQueueFinish_t pfnFinish;
+    ur_pfnQueueFlush_t pfnFlush;
 } ur_queue_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1433,104 +1306,93 @@ typedef struct ur_queue_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetQueueProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_queue_dditable_t* pDdiTable                  ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetQueueProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
     ur_api_version_t,
-    ur_queue_dditable_t*
-    );
+    ur_queue_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceGet 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceGet_t)(
+/// @brief Function-pointer for urDeviceGet
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceGet_t)(
     ur_platform_handle_t,
     ur_device_type_t,
     uint32_t,
-    ur_device_handle_t*,
-    uint32_t*
-    );
+    ur_device_handle_t *,
+    uint32_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceGetInfo 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetInfo_t)(
+/// @brief Function-pointer for urDeviceGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceGetInfo_t)(
     ur_device_handle_t,
     ur_device_info_t,
     size_t,
-    void*,
-    size_t*
-    );
+    void *,
+    size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceRetain 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceRetain_t)(
-    ur_device_handle_t
-    );
+/// @brief Function-pointer for urDeviceRetain
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceRetain_t)(
+    ur_device_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceRelease 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceRelease_t)(
-    ur_device_handle_t
-    );
+/// @brief Function-pointer for urDeviceRelease
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceRelease_t)(
+    ur_device_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDevicePartition 
-typedef ur_result_t (UR_APICALL *ur_pfnDevicePartition_t)(
+/// @brief Function-pointer for urDevicePartition
+typedef ur_result_t(UR_APICALL *ur_pfnDevicePartition_t)(
     ur_device_handle_t,
-    const ur_device_partition_property_t*,
+    const ur_device_partition_property_t *,
     uint32_t,
-    ur_device_handle_t*,
-    uint32_t*
-    );
+    ur_device_handle_t *,
+    uint32_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceSelectBinary 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceSelectBinary_t)(
+/// @brief Function-pointer for urDeviceSelectBinary
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceSelectBinary_t)(
     ur_device_handle_t,
-    const uint8_t**,
+    const uint8_t **,
     uint32_t,
-    uint32_t*
-    );
+    uint32_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceGetNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetNativeHandle_t)(
+/// @brief Function-pointer for urDeviceGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceGetNativeHandle_t)(
     ur_device_handle_t,
-    ur_native_handle_t*
-    );
+    ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceCreateWithNativeHandle 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceCreateWithNativeHandle_t)(
+/// @brief Function-pointer for urDeviceCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_platform_handle_t,
-    ur_device_handle_t*
-    );
+    ur_device_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urDeviceGetGlobalTimestamps 
-typedef ur_result_t (UR_APICALL *ur_pfnDeviceGetGlobalTimestamps_t)(
+/// @brief Function-pointer for urDeviceGetGlobalTimestamps
+typedef ur_result_t(UR_APICALL *ur_pfnDeviceGetGlobalTimestamps_t)(
     ur_device_handle_t,
-    uint64_t*,
-    uint64_t*
-    );
+    uint64_t *,
+    uint64_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Device functions pointers
-typedef struct ur_device_dditable_t
-{
-    ur_pfnDeviceGet_t                                           pfnGet;
-    ur_pfnDeviceGetInfo_t                                       pfnGetInfo;
-    ur_pfnDeviceRetain_t                                        pfnRetain;
-    ur_pfnDeviceRelease_t                                       pfnRelease;
-    ur_pfnDevicePartition_t                                     pfnPartition;
-    ur_pfnDeviceSelectBinary_t                                  pfnSelectBinary;
-    ur_pfnDeviceGetNativeHandle_t                               pfnGetNativeHandle;
-    ur_pfnDeviceCreateWithNativeHandle_t                        pfnCreateWithNativeHandle;
-    ur_pfnDeviceGetGlobalTimestamps_t                           pfnGetGlobalTimestamps;
+typedef struct ur_device_dditable_t {
+    ur_pfnDeviceGet_t pfnGet;
+    ur_pfnDeviceGetInfo_t pfnGetInfo;
+    ur_pfnDeviceRetain_t pfnRetain;
+    ur_pfnDeviceRelease_t pfnRelease;
+    ur_pfnDevicePartition_t pfnPartition;
+    ur_pfnDeviceSelectBinary_t pfnSelectBinary;
+    ur_pfnDeviceGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnDeviceCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnDeviceGetGlobalTimestamps_t pfnGetGlobalTimestamps;
 } ur_device_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1544,34 +1406,32 @@ typedef struct ur_device_dditable_t
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetDeviceProcAddrTable(
-    ur_api_version_t version,                       ///< [in] API version requested
-    ur_device_dditable_t* pDdiTable                 ///< [in,out] pointer to table of DDI function pointers
-    );
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urGetDeviceProcAddrTable
-typedef ur_result_t (UR_APICALL *ur_pfnGetDeviceProcAddrTable_t)(
+typedef ur_result_t(UR_APICALL *ur_pfnGetDeviceProcAddrTable_t)(
     ur_api_version_t,
-    ur_device_dditable_t*
-    );
+    ur_device_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Container for all DDI tables
-typedef struct ur_dditable_t
-{
-    ur_platform_dditable_t              Platform;
-    ur_context_dditable_t               Context;
-    ur_event_dditable_t                 Event;
-    ur_program_dditable_t               Program;
-    ur_module_dditable_t                Module;
-    ur_kernel_dditable_t                Kernel;
-    ur_sampler_dditable_t               Sampler;
-    ur_mem_dditable_t                   Mem;
-    ur_enqueue_dditable_t               Enqueue;
-    ur_usm_dditable_t                   USM;
-    ur_global_dditable_t                Global;
-    ur_queue_dditable_t                 Queue;
-    ur_device_dditable_t                Device;
+typedef struct ur_dditable_t {
+    ur_platform_dditable_t Platform;
+    ur_context_dditable_t Context;
+    ur_event_dditable_t Event;
+    ur_program_dditable_t Program;
+    ur_module_dditable_t Module;
+    ur_kernel_dditable_t Kernel;
+    ur_sampler_dditable_t Sampler;
+    ur_mem_dditable_t Mem;
+    ur_enqueue_dditable_t Enqueue;
+    ur_usm_dditable_t USM;
+    ur_global_dditable_t Global;
+    ur_queue_dditable_t Queue;
+    ur_device_dditable_t Device;
 } ur_dditable_t;
 
 #if defined(__cplusplus)

--- a/source/common/unified_memory_allocation/include/uma/base.h
+++ b/source/common/unified_memory_allocation/include/uma/base.h
@@ -17,8 +17,7 @@ extern "C" {
 #endif
 
 /// \brief Generates generic 'UMA' API versions
-#define UMA_MAKE_VERSION(_major, _minor)                                       \
-    ((_major << 16) | (_minor & 0x0000ffff))
+#define UMA_MAKE_VERSION(_major, _minor) ((_major << 16) | (_minor & 0x0000ffff))
 
 /// \brief Extracts 'UMA' API major version
 #define UMA_MAJOR_VERSION(_ver) (_ver >> 16)
@@ -31,17 +30,13 @@ extern "C" {
 
 /// \brief Operation results
 enum uma_result_t {
-    UMA_RESULT_SUCCESS = 0, ///< Success
-    UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY =
-        1, ///< Insufficient host memory to satisfy call,
-    UMA_RESULT_ERROR_POOL_SPECIFIC =
-        2, ///< A pool specific warning/error has been reported and can be
-           ///< Retrieved via the umaPoolGetLastResult entry point.
-    UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC =
-        3, ///< A provider specific warning/error has been reported and can be
-           ///< Retrieved via the umaMemoryProviderGetLastResult entry point.
-    UR_RESULT_ERROR_INVALID_ARGUMENT =
-        4, ///< Generic error code for invalid arguments
+    UMA_RESULT_SUCCESS = 0,                        ///< Success
+    UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY = 1,       ///< Insufficient host memory to satisfy call,
+    UMA_RESULT_ERROR_POOL_SPECIFIC = 2,            ///< A pool specific warning/error has been reported and can be
+                                                   ///< Retrieved via the umaPoolGetLastResult entry point.
+    UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC = 3, ///< A provider specific warning/error has been reported and can be
+                                                   ///< Retrieved via the umaMemoryProviderGetLastResult entry point.
+    UR_RESULT_ERROR_INVALID_ARGUMENT = 4,          ///< Generic error code for invalid arguments
 
     UMA_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
 };

--- a/source/common/unified_memory_allocation/include/uma/memory_pool.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool.h
@@ -24,8 +24,7 @@ typedef struct uma_memory_pool_t *uma_memory_pool_handle_t;
 /// \param params pointer to pool-specific parameters
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params,
-                                uma_memory_pool_handle_t *hPool);
+enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params, uma_memory_pool_handle_t *hPool);
 
 ///
 /// \brief Destroys memory pool
@@ -49,8 +48,7 @@ void *umaPoolMalloc(uma_memory_pool_handle_t hPool, size_t size);
 /// \param alignment alignment of the allocation
 /// \return Pointer to the allocated memory
 ///
-void *umaPoolAlignedMalloc(uma_memory_pool_handle_t hPool, size_t size,
-                           size_t alignment);
+void *umaPoolAlignedMalloc(uma_memory_pool_handle_t hPool, size_t size, size_t alignment);
 
 ///
 /// \brief Allocates memory of the specified hPool for an array of num elements
@@ -108,8 +106,7 @@ void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr);
 /// \return UMA_RESULT_SUCCESS if the result being
 ///         reported is to be considered a warning. Any other result code
 ///         returned indicates that the adapter specific result is an error.
-enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
-                                       const char **ppMessage);
+enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool, const char **ppMessage);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -24,9 +24,7 @@ typedef struct uma_memory_provider_t *uma_memory_provider_handle_t;
 /// \param params pointer to provider-specific parameters
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t
-umaMemoryProviderCreate(struct uma_memory_provider_ops_t *ops, void *params,
-                        uma_memory_provider_handle_t *hProvider);
+enum uma_result_t umaMemoryProviderCreate(struct uma_memory_provider_ops_t *ops, void *params, uma_memory_provider_handle_t *hProvider);
 
 ///
 /// \brief Destroys memory provider
@@ -44,9 +42,7 @@ void umaMemoryProviderDestroy(uma_memory_provider_handle_t hProvider);
 /// \param ptr returns pointer to the allocated memory
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,
-                                         size_t size, size_t alignment,
-                                         void **ptr);
+enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider, size_t size, size_t alignment, void **ptr);
 
 ///
 /// \brief Frees the memory space pointed by ptr from the memory provider
@@ -54,8 +50,7 @@ enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,
 /// \param ptr pointer to the allocated memory
 /// \param size size of the allocation
 ///
-enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
-                                        void *ptr, size_t size);
+enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider, void *ptr, size_t size);
 
 ///
 /// \brief Retrieve string representation of the underlying provider specific
@@ -78,9 +73,7 @@ enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
 /// \return UMA_RESULT_SUCCESS if the result being reported is to be considered
 ///         a warning. Any other result code returned indicates that the
 ///         adapter specific result is an error.
-enum uma_result_t
-umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
-                               const char **ppMessage);
+enum uma_result_t umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider, const char **ppMessage);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -37,11 +37,9 @@ struct uma_memory_provider_ops_t {
     void (*finalize)(void *pool);
 
     /// Refer to memory_provider.h for description of those functions
-    enum uma_result_t (*alloc)(void *provider, size_t size, size_t alignment,
-                               void **ptr);
+    enum uma_result_t (*alloc)(void *provider, size_t size, size_t alignment, void **ptr);
     enum uma_result_t (*free)(void *provider, void *ptr, size_t size);
-    enum uma_result_t (*get_last_result)(void *provider,
-                                         const char **ppMessage);
+    enum uma_result_t (*get_last_result)(void *provider, const char **ppMessage);
 };
 
 #ifdef __cplusplus

--- a/source/common/ur_singleton.hpp
+++ b/source/common/ur_singleton.hpp
@@ -15,11 +15,11 @@
 
 //////////////////////////////////////////////////////////////////////////
 /// a abstract factory for creation of singleton objects
-template <typename singleton_tn, typename key_tn> class singleton_factory_t {
+template <typename singleton_tn, typename key_tn>
+class singleton_factory_t {
   protected:
     using singleton_t = singleton_tn;
-    using key_t = typename std::conditional<std::is_pointer<key_tn>::value,
-                                            size_t, key_tn>::type;
+    using key_t = typename std::conditional<std::is_pointer<key_tn>::value, size_t, key_tn>::type;
 
     using ptr_t = std::unique_ptr<singleton_t>;
     using map_t = std::unordered_map<key_t, ptr_t>;
@@ -29,9 +29,8 @@ template <typename singleton_tn, typename key_tn> class singleton_factory_t {
 
     //////////////////////////////////////////////////////////////////////////
     /// extract the key from parameter list and if necessary, convert type
-    template <typename... Ts> key_t getKey(key_tn key, Ts &&...params) {
-        return reinterpret_cast<key_t>(key);
-    }
+    template <typename... Ts>
+    key_t getKey(key_tn key, Ts &&...params) { return reinterpret_cast<key_t>(key); }
 
   public:
     //////////////////////////////////////////////////////////////////////////
@@ -44,7 +43,8 @@ template <typename singleton_tn, typename key_tn> class singleton_factory_t {
     /// if no instance exists, then creates a new instance
     /// the params are forwarded to the ctor of the singleton
     /// the first parameter must be the unique identifier of the instance
-    template <typename... Ts> singleton_tn *getInstance(Ts &&...params) {
+    template <typename... Ts>
+    singleton_tn *getInstance(Ts &&...params) {
         auto key = getKey(std::forward<Ts>(params)...);
 
         if (key == 0) { // No zero keys allowed in map
@@ -55,8 +55,7 @@ template <typename singleton_tn, typename key_tn> class singleton_factory_t {
         auto iter = map.find(key);
 
         if (map.end() == iter) {
-            auto ptr =
-                std::make_unique<singleton_t>(std::forward<Ts>(params)...);
+            auto ptr = std::make_unique<singleton_t>(std::forward<Ts>(params)...);
             iter = map.emplace(key, std::move(ptr)).first;
         }
         return iter->second.get();

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -41,8 +41,8 @@
 #define MAKE_LIBRARY_NAME(NAME, VERSION) NAME ".dll"
 #define MAKE_LAYER_NAME(NAME) NAME ".dll"
 #define LOAD_DRIVER_LIBRARY(NAME) LoadLibraryExA(NAME, nullptr, 0)
-#define FREE_DRIVER_LIBRARY(LIB)                                               \
-    if (LIB)                                                                   \
+#define FREE_DRIVER_LIBRARY(LIB) \
+    if (LIB)                     \
     FreeLibrary(LIB)
 #define GET_FUNCTION_PTR(LIB, FUNC_NAME) GetProcAddress(LIB, FUNC_NAME)
 #define string_copy_s strncpy_s
@@ -50,16 +50,14 @@
 #include <dlfcn.h>
 #define HMODULE void *
 #define MAKE_LIBRARY_NAME(NAME, VERSION) "lib" NAME ".so." VERSION
-#define MAKE_LAYER_NAME(NAME)                                                  \
-    "lib" NAME ".so." L0_VALIDATION_LAYER_SUPPORTED_VERSION
+#define MAKE_LAYER_NAME(NAME) "lib" NAME ".so." L0_VALIDATION_LAYER_SUPPORTED_VERSION
 #if defined(SANITIZER_ANY)
 #define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY | RTLD_LOCAL)
 #else
-#define LOAD_DRIVER_LIBRARY(NAME)                                              \
-    dlopen(NAME, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND)
+#define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND)
 #endif
-#define FREE_DRIVER_LIBRARY(LIB)                                               \
-    if (LIB)                                                                   \
+#define FREE_DRIVER_LIBRARY(LIB) \
+    if (LIB)                     \
     dlclose(LIB)
 #define GET_FUNCTION_PTR(LIB, FUNC_NAME) dlsym(LIB, FUNC_NAME)
 #define string_copy_s strncpy

--- a/source/drivers/null/ur_null.cpp
+++ b/source/drivers/null/ur_null.cpp
@@ -16,9 +16,7 @@ context_t d_context;
 //////////////////////////////////////////////////////////////////////////
 context_t::context_t() {
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGet = [](uint32_t NumEntries,
-                                    ur_platform_handle_t *phPlatforms,
-                                    uint32_t *pNumPlatforms) {
+    urDdiTable.Platform.pfnGet = [](uint32_t NumEntries, ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
         if (phPlatforms != nullptr && NumEntries != 1) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
@@ -32,113 +30,103 @@ context_t::context_t() {
     };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGetApiVersion = [](ur_platform_handle_t,
-                                              ur_api_version_t *version) {
+    urDdiTable.Platform.pfnGetApiVersion = [](ur_platform_handle_t, ur_api_version_t *version) {
         *version = d_context.version;
         return UR_RESULT_SUCCESS;
     };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGetInfo =
-        [](ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType,
-           size_t Size, void *pPlatformInfo, size_t *pSizeRet) {
-            if (!hPlatform) {
-                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-            }
+    urDdiTable.Platform.pfnGetInfo = [](ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType, size_t Size,
+                                        void *pPlatformInfo, size_t *pSizeRet) {
+        if (!hPlatform) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
 
-            switch (PlatformInfoType) {
-            case UR_PLATFORM_INFO_NAME: {
-                const char null_platform_name[] = "UR_NULL_PLATFORM";
-                if (pSizeRet) {
-                    *pSizeRet = sizeof(null_platform_name);
-                }
-                if (pPlatformInfo && Size != sizeof(null_platform_name)) {
-                    return UR_RESULT_ERROR_INVALID_SIZE;
-                }
-                if (pPlatformInfo) {
-#if defined(_WIN32)
-                    strncpy_s(reinterpret_cast<char *>(pPlatformInfo), Size,
-                              null_platform_name, sizeof(null_platform_name));
-#else
-                    strncpy(reinterpret_cast<char *>(pPlatformInfo),
-                            null_platform_name, Size);
-#endif
-                }
-            } break;
-
-            default:
-                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        switch (PlatformInfoType) {
+        case UR_PLATFORM_INFO_NAME: {
+            const char null_platform_name[] = "UR_NULL_PLATFORM";
+            if (pSizeRet) {
+                *pSizeRet = sizeof(null_platform_name);
             }
-
-            return UR_RESULT_SUCCESS;
-        };
-
-    //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Device.pfnGet =
-        [](ur_platform_handle_t hPlatform, ur_device_type_t DevicesType,
-           uint32_t NumEntries, ur_device_handle_t *phDevices,
-           uint32_t *pNumDevices) {
-            (void)DevicesType;
-            if (hPlatform == nullptr) {
-                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-            }
-            if (UR_DEVICE_TYPE_VPU < DevicesType) {
-                return UR_RESULT_ERROR_INVALID_ENUMERATION;
-            }
-            if (phDevices != nullptr && NumEntries != 1) {
+            if (pPlatformInfo && Size != sizeof(null_platform_name)) {
                 return UR_RESULT_ERROR_INVALID_SIZE;
             }
-            if (pNumDevices != nullptr) {
-                *pNumDevices = 1;
+            if (pPlatformInfo) {
+#if defined(_WIN32)
+                strncpy_s(reinterpret_cast<char *>(pPlatformInfo), Size, null_platform_name, sizeof(null_platform_name));
+#else
+                strncpy(reinterpret_cast<char *>(pPlatformInfo), null_platform_name, Size);
+#endif
             }
-            if (nullptr != phDevices) {
-                *reinterpret_cast<void **>(phDevices) = d_context.get();
-            }
-            return UR_RESULT_SUCCESS;
-        };
+        } break;
+
+        default:
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
+
+        return UR_RESULT_SUCCESS;
+    };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Device.pfnGetInfo =
-        [](ur_device_handle_t hDevice, ur_device_info_t infoType,
-           size_t propSize, void *pDeviceInfo, size_t *pPropSizeRet) {
-            switch (infoType) {
-            case UR_DEVICE_INFO_TYPE:
-                if (pDeviceInfo && propSize != sizeof(ur_device_type_t)) {
-                    return UR_RESULT_ERROR_INVALID_SIZE;
-                }
+    urDdiTable.Device.pfnGet = [](ur_platform_handle_t hPlatform, ur_device_type_t DevicesType, uint32_t NumEntries,
+                                  ur_device_handle_t *phDevices, uint32_t *pNumDevices) {
+        (void)DevicesType;
+        if (hPlatform == nullptr) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+        if (UR_DEVICE_TYPE_VPU < DevicesType) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
+        if (phDevices != nullptr && NumEntries != 1) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        if (pNumDevices != nullptr) {
+            *pNumDevices = 1;
+        }
+        if (nullptr != phDevices) {
+            *reinterpret_cast<void **>(phDevices) = d_context.get();
+        }
+        return UR_RESULT_SUCCESS;
+    };
 
-                if (pDeviceInfo != nullptr) {
-                    *reinterpret_cast<ur_device_type_t *>(pDeviceInfo) =
-                        UR_DEVICE_TYPE_GPU;
-                }
-                if (pPropSizeRet != nullptr) {
-                    *pPropSizeRet = sizeof(ur_device_type_t);
-                }
-                break;
-
-            case UR_DEVICE_INFO_NAME: {
-                char deviceName[] = "Null Device";
-                if (pDeviceInfo && propSize < sizeof(deviceName)) {
-                    return UR_RESULT_ERROR_INVALID_SIZE;
-                }
-                if (pDeviceInfo != nullptr) {
-#if defined(_WIN32)
-                    strncpy_s(reinterpret_cast<char *>(pDeviceInfo), propSize,
-                              deviceName, sizeof(deviceName));
-#else
-                    strncpy(reinterpret_cast<char *>(pDeviceInfo), deviceName,
-                            propSize);
-#endif
-                }
-                if (pPropSizeRet != nullptr) {
-                    *pPropSizeRet = sizeof(deviceName);
-                }
-            } break;
-
-            default:
-                return UR_RESULT_ERROR_INVALID_ARGUMENT;
+    //////////////////////////////////////////////////////////////////////////
+    urDdiTable.Device.pfnGetInfo = [](ur_device_handle_t hDevice, ur_device_info_t infoType, size_t propSize, void *pDeviceInfo,
+                                      size_t *pPropSizeRet) {
+        switch (infoType) {
+        case UR_DEVICE_INFO_TYPE:
+            if (pDeviceInfo && propSize != sizeof(ur_device_type_t)) {
+                return UR_RESULT_ERROR_INVALID_SIZE;
             }
-            return UR_RESULT_SUCCESS;
-        };
+
+            if (pDeviceInfo != nullptr) {
+                *reinterpret_cast<ur_device_type_t *>(pDeviceInfo) = UR_DEVICE_TYPE_GPU;
+            }
+            if (pPropSizeRet != nullptr) {
+                *pPropSizeRet = sizeof(ur_device_type_t);
+            }
+            break;
+
+        case UR_DEVICE_INFO_NAME: {
+            char deviceName[] = "Null Device";
+            if (pDeviceInfo && propSize < sizeof(deviceName)) {
+                return UR_RESULT_ERROR_INVALID_SIZE;
+            }
+            if (pDeviceInfo != nullptr) {
+#if defined(_WIN32)
+                strncpy_s(reinterpret_cast<char *>(pDeviceInfo), propSize, deviceName, sizeof(deviceName));
+#else
+                strncpy(reinterpret_cast<char *>(pDeviceInfo), deviceName, propSize);
+#endif
+            }
+            if (pPropSizeRet != nullptr) {
+                *pPropSizeRet = sizeof(deviceName);
+            }
+        } break;
+
+        default:
+            return UR_RESULT_ERROR_INVALID_ARGUMENT;
+        }
+        return UR_RESULT_SUCCESS;
+    };
 }
 } // namespace driver

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -12,12 +12,11 @@
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
-    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
-    ur_device_handle_t
-        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t
-        *phContext ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL
+urContextCreate(
+    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
+    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -35,9 +34,9 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
-    ur_context_handle_t
-        hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL
+urContextRetain(
+    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -54,7 +53,8 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+__urdlllocal ur_result_t UR_APICALL
+urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -72,26 +72,24 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-    ///< if propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
+                                       ///< if propSize is not equal to or greater than the real number of bytes
+                                       ///< needed to return
+                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                       ///< pContextInfo is not used.
+    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Context.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                            pPropSizeRet);
+        result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -101,10 +99,10 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_native_handle_t *
-        phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,       ///< [in] handle of the context.
+    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -114,8 +112,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
         result = pfnGetNativeHandle(hContext, phNativeContext);
     } else {
         // generic implementation
-        *phNativeContext =
-            reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativeContext = reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -123,17 +120,15 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *
-        phContext ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Context.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeContext, phContext);
     } else {
@@ -146,18 +141,16 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_context_extended_deleter_t
-        pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL
+urContextSetExtendedDeleter(
+    ur_context_handle_t hContext,             ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnSetExtendedDeleter =
-        d_context.urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter = d_context.urDdiTable.Context.pfnSetExtendedDeleter;
     if (nullptr != pfnSetExtendedDeleter) {
         result = pfnSetExtendedDeleter(hContext, pfnDeleter, pUserData);
     } else {
@@ -169,43 +162,36 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t
-        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                 ///< work-group work-items
-    const size_t *
-        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< offset used to calculate the global ID of a work-item
-    const size_t *
-        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< number of global work-items in workDim that will execute the kernel
-    ///< function
-    const size_t *
-        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
-    ///< specify the number of local work-items forming a work-group that will
-    ///< execute the kernel function.
-    ///< If nullptr, the runtime implementation will choose the work-group
-    ///< size.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
+    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                              ///< work-group work-items
+    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< number of global work-items in workDim that will execute the kernel
+                                              ///< function
+    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
+                                              ///< specify the number of local work-items forming a work-group that will
+                                              ///< execute the kernel function.
+                                              ///< If nullptr, the runtime implementation will choose the work-group
+                                              ///< size.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnKernelLaunch = d_context.urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr != pfnKernelLaunch) {
-        result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
-                                 pGlobalWorkSize, pLocalWorkSize,
-                                 numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -218,26 +204,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnEventsWait = d_context.urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr != pfnEventsWait) {
-        result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList,
-                               phEvent);
+        result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -250,27 +234,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnEventsWaitWithBarrier =
-        d_context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier = d_context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr != pfnEventsWaitWithBarrier) {
-        result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
-                                          phEventWaitList, phEvent);
+        result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -283,31 +264,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being read
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being read
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferRead = d_context.urDdiTable.Enqueue.pfnMemBufferRead;
     if (nullptr != pfnMemBufferRead) {
-        result =
-            pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
-                             numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -320,33 +298,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being written
-    const void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being written
+    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferWrite = d_context.urDdiTable.Enqueue.pfnMemBufferWrite;
     if (nullptr != pfnMemBufferWrite) {
-        result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size,
-                                   pSrc, numEventsInWaitList, phEventWaitList,
-                                   phEvent);
+        result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -359,45 +332,35 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< dst
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by dst
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< dst
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by dst
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemBufferReadRect =
-        d_context.urDdiTable.Enqueue.pfnMemBufferReadRect;
+    auto pfnMemBufferReadRect = d_context.urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr != pfnMemBufferReadRect) {
-        result = pfnMemBufferReadRect(
-            hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region,
-            bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
-            pDst, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -410,48 +373,36 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
-                          ///< written
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< src
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by src
-    void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
+                                              ///< written
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< src
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by src
+    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemBufferWriteRect =
-        d_context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect = d_context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr != pfnMemBufferWriteRect) {
-        result = pfnMemBufferWriteRect(
-            hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region,
-            bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
-            pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -464,31 +415,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
-    size_t size,      ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
+    size_t size,                              ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferCopy = d_context.urDdiTable.Enqueue.pfnMemBufferCopy;
     if (nullptr != pfnMemBufferCopy) {
-        result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
-                                  dstOffset, size, numEventsInWaitList,
-                                  phEventWaitList, phEvent);
+        result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -501,42 +449,32 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t
-        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t
-        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
-    size_t
-        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t
-        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
-    size_t
-        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemBufferCopyRect =
-        d_context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
+    auto pfnMemBufferCopyRect = d_context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr != pfnMemBufferCopyRect) {
-        result = pfnMemBufferCopyRect(
-            hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion,
-            srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
-            numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -549,31 +487,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    const void *pPattern,     ///< [in] pointer to the fill pattern
-    size_t patternSize,       ///< [in] size in bytes of the pattern
-    size_t offset,            ///< [in] offset into the buffer
-    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    const void *pPattern,                     ///< [in] pointer to the fill pattern
+    size_t patternSize,                       ///< [in] size in bytes of the pattern
+    size_t offset,                            ///< [in] offset into the buffer
+    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferFill = d_context.urDdiTable.Enqueue.pfnMemBufferFill;
     if (nullptr != pfnMemBufferFill) {
-        result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize,
-                                  offset, size, numEventsInWaitList,
-                                  phEventWaitList, phEvent);
+        result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -586,36 +521,31 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t rowPitch,   ///< [in] length of each row in bytes
-    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pDst, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
+    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageRead = d_context.urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr != pfnMemImageRead) {
-        result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
-                                 rowPitch, slicePitch, pDst,
-                                 numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -628,38 +558,31 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t inputRowPitch,   ///< [in] length of each row in bytes
-    size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pSrc, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t inputRowPitch,                     ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageWrite = d_context.urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr != pfnMemImageWrite) {
-        result =
-            pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
-                             inputRowPitch, inputSlicePitch, pSrc,
-                             numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -672,37 +595,31 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
-    ur_rect_offset_t
-        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                              ///< image
+    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                              ///< or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageCopy = d_context.urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr != pfnMemImageCopy) {
-        result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin,
-                                 dstOrigin, region, numEventsInWaitList,
-                                 phEventWaitList, phEvent);
+        result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -715,33 +632,30 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
-    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,   ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent, ///< [in,out][optional] return an event object that identifies this
-                 ///< particular command instance.
-    void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
-                    ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+                                              ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferMap = d_context.urDdiTable.Enqueue.pfnMemBufferMap;
     if (nullptr != pfnMemBufferMap) {
-        result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset,
-                                 size, numEventsInWaitList, phEventWaitList,
-                                 phEvent, ppRetMap);
+        result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -754,28 +668,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t
-        hMem,         ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr, ///< [in] mapped host address
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr,                         ///< [in] mapped host address
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemUnmap = d_context.urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr != pfnMemUnmap) {
-        result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
-                             phEventWaitList, phEvent);
+        result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -788,28 +699,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemset
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    void *ptr,                    ///< [in] pointer to USM memory object
-    int8_t byteValue,             ///< [in] byte value to fill
-    size_t count,                 ///< [in] size in bytes to be set
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    void *ptr,                                ///< [in] pointer to USM memory object
+    int8_t byteValue,                         ///< [in] byte value to fill
+    size_t count,                             ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemset = d_context.urDdiTable.Enqueue.pfnUSMMemset;
     if (nullptr != pfnUSMMemset) {
-        result = pfnUSMMemset(hQueue, ptr, byteValue, count,
-                              numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -822,29 +731,27 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool blocking,            ///< [in] blocking or non-blocking copy
-    void *pDst,       ///< [in] pointer to the destination USM memory object
-    const void *pSrc, ///< [in] pointer to the source USM memory object
-    size_t size,      ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking copy
+    void *pDst,                               ///< [in] pointer to the destination USM memory object
+    const void *pSrc,                         ///< [in] pointer to the source USM memory object
+    size_t size,                              ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemcpy = d_context.urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr != pfnUSMMemcpy) {
-        result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size,
-                              numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -857,28 +764,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
-    const void *pMem,               ///< [in] pointer to the USM memory object
-    size_t size,                    ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMPrefetch = d_context.urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr != pfnUSMPrefetch) {
-        result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
-                                phEventWaitList, phEvent);
+        result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -891,14 +796,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    const void *pMem,         ///< [in] pointer to the USM memory object
-    size_t size,              ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    const void *pMem,          ///< [in] pointer to the USM memory object
+    size_t size,               ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,    ///< [in] USM memory advice
+    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
+                               ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -918,34 +823,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    size_t patternSize, ///< [in] the size in bytes of the pattern.
-    const void
-        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,  ///< [in] the width in bytes of each row to fill.
-    size_t height, ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    size_t patternSize,                       ///< [in] the size in bytes of the pattern.
+    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
+    size_t width,                             ///< [in] the width in bytes of each row to fill.
+    size_t height,                            ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMFill2D = d_context.urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr != pfnUSMFill2D) {
-        result =
-            pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
-                         height, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -958,31 +858,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemset2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    int value,     ///< [in] the value to fill into the region in pMem.
-    size_t width,  ///< [in] the width in bytes of each row to set.
-    size_t height, ///< [in] the height of the columns to set.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemset2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    int value,                                ///< [in] the value to fill into the region in pMem.
+    size_t width,                             ///< [in] the width in bytes of each row to set.
+    size_t height,                            ///< [in] the height of the columns to set.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemset2D = d_context.urDdiTable.Enqueue.pfnUSMMemset2D;
     if (nullptr != pfnUSMMemset2D) {
-        result = pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height,
-                                numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -995,35 +892,30 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    bool blocking, ///< [in] indicates if this operation should block the host.
-    void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t
-        dstPitch, ///< [in] the total width of the source memory including padding.
-    const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t
-        srcPitch, ///< [in] the total width of the source memory including padding.
-    size_t width,  ///< [in] the width in bytes of each row to be copied.
-    size_t height, ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    bool blocking,                            ///< [in] indicates if this operation should block the host.
+    void *pDst,                               ///< [in] pointer to memory where data will be copied.
+    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
+    const void *pSrc,                         ///< [in] pointer to memory to be copied.
+    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
+    size_t width,                             ///< [in] the width in bytes of each row to be copied.
+    size_t height,                            ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemcpy2D = d_context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr != pfnUSMMemcpy2D) {
-        result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc,
-                                srcPitch, width, height, numEventsInWaitList,
-                                phEventWaitList, phEvent);
+        result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -1036,36 +928,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite, ///< [in] indicates if this operation should block.
-    size_t count,       ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc, ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                       ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnDeviceGlobalVariableWrite =
-        d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite = d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr != pfnDeviceGlobalVariableWrite) {
-        result = pfnDeviceGlobalVariableWrite(
-            hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
-            numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -1078,36 +963,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingRead, ///< [in] indicates if this operation should block.
-    size_t count,      ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst, ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                        ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst,                               ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnDeviceGlobalVariableRead =
-        d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead = d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr != pfnDeviceGlobalVariableRead) {
-        result = pfnDeviceGlobalVariableRead(
-            hQueue, hProgram, name, blockingRead, count, offset, pDst,
-            numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -1120,21 +998,20 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize,     ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional] value of the event property
+    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Event.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                            pPropValueSizeRet);
+        result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
     } else {
         // generic implementation
     }
@@ -1144,24 +1021,21 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
-    ur_event_handle_t hEvent, ///< [in] handle of the event object
-    ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+__urdlllocal ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t hEvent,     ///< [in] handle of the event object
+    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
+    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional] value of the profiling property
+    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+                                  ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetProfilingInfo = d_context.urDdiTable.Event.pfnGetProfilingInfo;
     if (nullptr != pfnGetProfilingInfo) {
-        result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
-                                     pPropValue, pPropValueSizeRet);
+        result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
     } else {
         // generic implementation
     }
@@ -1171,11 +1045,11 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
-    uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t *
-        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                        ///< completion
+__urdlllocal ur_result_t UR_APICALL
+urEventWait(
+    uint32_t numEvents,                      ///< [in] number of events in the event list
+    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                             ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1192,7 +1066,8 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+__urdlllocal ur_result_t UR_APICALL
+urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1210,7 +1085,8 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+__urdlllocal ur_result_t UR_APICALL
+urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1228,10 +1104,10 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ///< [in] handle of the event.
-    ur_native_handle_t
-        *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,         ///< [in] handle of the event.
+    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1249,17 +1125,16 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t
-        *phEvent ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Event.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeEvent, hContext, phEvent);
     } else {
@@ -1272,12 +1147,12 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL
+urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1294,22 +1169,21 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    void *pHost,                       ///< [in] pointer to the buffer data
-    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    void *pHost,                           ///< [in] pointer to the buffer data
+    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageCreate = d_context.urDdiTable.Mem.pfnImageCreate;
     if (nullptr != pfnImageCreate) {
-        result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc,
-                                pHost, phMem);
+        result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
     } else {
         // generic implementation
         *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());
@@ -1320,13 +1194,13 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL
+urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t
-        *phBuffer ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
+    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
+    void *pHost,                  ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1344,7 +1218,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+__urdlllocal ur_result_t UR_APICALL
+urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1362,7 +1237,8 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+__urdlllocal ur_result_t UR_APICALL
+urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1380,23 +1256,20 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t
-        hBuffer,          ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
+    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnBufferPartition = d_context.urDdiTable.Mem.pfnBufferPartition;
     if (nullptr != pfnBufferPartition) {
-        result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                                    pBufferCreateInfo, phMem);
+        result = pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
     } else {
         // generic implementation
         *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());
@@ -1407,10 +1280,10 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
-    ur_mem_handle_t hMem, ///< [in] handle of the mem.
-    ur_native_handle_t
-        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1428,17 +1301,16 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Mem.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeMem, hContext, phMem);
     } else {
@@ -1451,26 +1323,23 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
-    ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL
+urMemGetInfo(
+    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
+                               ///< If propSize is less than the real number of bytes needed to return
+                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                               ///< pMemInfo is not used.
+    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Mem.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result =
-            pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+        result = pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1480,25 +1349,23 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
-    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL
+urMemImageGetInfo(
+    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
+                                 ///< If propSize is less than the real number of bytes needed to return
+                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                 ///< pImgInfo is not used.
+    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageGetInfo = d_context.urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr != pfnImageGetInfo) {
-        result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
-                                 pPropSizeRet);
+        result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1508,7 +1375,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL urTearDown(
+__urdlllocal ur_result_t UR_APICALL
+urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1526,22 +1394,20 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out] value of the queue property
-    size_t
-        *pPropSizeRet ///< [out] size in bytes returned in queue property value
+    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out] value of the queue property
+    size_t *pPropSizeRet      ///< [out] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Queue.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
-                            pPropSizeRet);
+        result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1551,17 +1417,16 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_device_handle_t hDevice,        ///< [in] handle of the device object
+    const ur_queue_property_t *pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+                                       ///< Each property name is immediately followed by the corresponding
+                                       ///< desired value.
+                                       ///< The list is terminated with a 0.
+                                       ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1579,7 +1444,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL
+urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1597,7 +1463,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL
+urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1615,10 +1482,10 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
-    ur_native_handle_t
-        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1636,17 +1503,16 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Queue.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeQueue, hContext, phQueue);
     } else {
@@ -1659,7 +1525,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL
+urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1677,7 +1544,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL
+urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1695,13 +1563,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
-    ur_sampler_handle_t
-        *phSampler ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context object
+    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
+                                         ///< corresponding values.
+    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1719,9 +1586,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL
+urSamplerRetain(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1738,9 +1605,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1757,22 +1624,20 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
-    size_t *
-        pPropSizeRet ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
+    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out] value of the sampler property
+    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Sampler.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
-                            pPropSizeRet);
+        result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1782,10 +1647,10 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
-    ur_native_handle_t *
-        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
+    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1795,8 +1660,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
         result = pfnGetNativeHandle(hSampler, phNativeSampler);
     } else {
         // generic implementation
-        *phNativeSampler =
-            reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativeSampler = reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -1804,18 +1668,16 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeSampler,           ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_sampler_handle_t *
-        phSampler ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
     } else {
@@ -1828,13 +1690,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_mem_flags_t *pUSMFlag, ///< [in] USM memory allocation flags
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM host memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1851,22 +1713,21 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM device memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnDeviceAlloc = d_context.urDdiTable.USM.pfnDeviceAlloc;
     if (nullptr != pfnDeviceAlloc) {
-        result =
-            pfnDeviceAlloc(hContext, hDevice, pUSMProp, size, align, ppMem);
+        result = pfnDeviceAlloc(hContext, hDevice, pUSMProp, size, align, ppMem);
     } else {
         // generic implementation
     }
@@ -1876,22 +1737,21 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM shared memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSharedAlloc = d_context.urDdiTable.USM.pfnSharedAlloc;
     if (nullptr != pfnSharedAlloc) {
-        result =
-            pfnSharedAlloc(hContext, hDevice, pUSMProp, size, align, ppMem);
+        result = pfnSharedAlloc(hContext, hDevice, pUSMProp, size, align, ppMem);
     } else {
         // generic implementation
     }
@@ -1901,7 +1761,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+__urdlllocal ur_result_t UR_APICALL
+urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1920,24 +1781,21 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL
+urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t
-        propName, ///< [in] the name of the USM allocation property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional] value of the USM allocation property
+    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetMemAllocInfo = d_context.urDdiTable.USM.pfnGetMemAllocInfo;
     if (nullptr != pfnGetMemAllocInfo) {
-        result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                                    pPropValue, pPropValueSizeRet);
+        result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
     } else {
         // generic implementation
     }
@@ -1947,33 +1805,30 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t
-        NumEntries, ///< [in] the number of devices to be added to phDevices.
-    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-    ///< will be returned.
-    ur_device_handle_t *
-        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-    ///< If NumEntries is less than the number of devices available, then
-    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
+                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+                                    ///< will be returned.
+    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                    ///< If NumEntries is less than the number of devices available, then
+                                    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
+                                    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGet = d_context.urDdiTable.Device.pfnGet;
     if (nullptr != pfnGet) {
-        result =
-            pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
+        result = pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phDevices) && (i < NumEntries); ++i) {
-            phDevices[i] =
-                reinterpret_cast<ur_device_handle_t>(d_context.get());
+            phDevices[i] = reinterpret_cast<ur_device_handle_t>(d_context.get());
         }
     }
 
@@ -1982,25 +1837,24 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info
-    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return the info
+                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+                                ///< pDeviceInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Device.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result =
-            pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+        result = pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -2010,9 +1864,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
-    ur_device_handle_t
-        hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceRetain(
+    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2029,7 +1883,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2047,31 +1902,27 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t *
-        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-    ///< If NumDevices is less than the number of sub-devices available, then
-    ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *
-        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
-    ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                       ///< If NumDevices is less than the number of sub-devices available, then
+                                                       ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                       ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnPartition = d_context.urDdiTable.Device.pfnPartition;
     if (nullptr != pfnPartition) {
-        result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
-                              pNumDevicesRet);
+        result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phSubDevices) && (i < NumDevices); ++i) {
-            phSubDevices[i] =
-                reinterpret_cast<ur_device_handle_t>(d_context.get());
+            phSubDevices[i] = reinterpret_cast<ur_device_handle_t>(d_context.get());
         }
     }
 
@@ -2080,24 +1931,22 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
-                          ///< Must greater than or equal to zero otherwise
-                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
+                                ///< Must greater than or equal to zero otherwise
+                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
+                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSelectBinary = d_context.urDdiTable.Device.pfnSelectBinary;
     if (nullptr != pfnSelectBinary) {
-        result =
-            pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+        result = pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
     } else {
         // generic implementation
     }
@@ -2107,10 +1956,10 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ///< [in] handle of the device.
-    ur_native_handle_t
-        *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,        ///< [in] handle of the device.
+    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2128,17 +1977,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t
-        *phDevice ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Device.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
     } else {
@@ -2151,23 +1999,20 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *
-        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                          ///< correlates with the Host's global timestamp value
-    uint64_t *
-        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
-                       ///< correlates with the Device's global timestamp value
+    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                                ///< correlates with the Host's global timestamp value
+    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
+                                ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnGetGlobalTimestamps =
-        d_context.urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps = d_context.urDdiTable.Device.pfnGetGlobalTimestamps;
     if (nullptr != pfnGetGlobalTimestamps) {
-        result =
-            pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
+        result = pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
     } else {
         // generic implementation
     }
@@ -2177,11 +2022,11 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL
+urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2199,12 +2044,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void
-        *pArgValue ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in] argument value represented as matching arg type.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2221,11 +2066,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t
-        argSize ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2242,27 +2087,25 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return
+                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                ///< pKernelInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
+                                ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Kernel.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result =
-            pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+        result = pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -2272,26 +2115,23 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_group_info_t
-        propName,    ///< [in] name of the work Group property to query
-    size_t propSize, ///< [in] size of the Kernel Work Group property value
-    void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
+    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
+    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                     ///< property.
+    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
+                                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetGroupInfo = d_context.urDdiTable.Kernel.pfnGetGroupInfo;
     if (nullptr != pfnGetGroupInfo) {
-        result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize,
-                                 pPropValue, pPropSizeRet);
+        result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -2301,26 +2141,23 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t
-        propName,    ///< [in] name of the SubGroup property to query
-    size_t propSize, ///< [in] size of the Kernel SubGroup property value
-    void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
+    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
+    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                         ///< property.
+    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
+                                         ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetSubGroupInfo = d_context.urDdiTable.Kernel.pfnGetSubGroupInfo;
     if (nullptr != pfnGetSubGroupInfo) {
-        result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
-                                    pPropValue, pPropSizeRet);
+        result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -2330,7 +2167,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL
+urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2348,7 +2186,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL
+urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2366,13 +2205,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void *
-        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
-                  ///< value. If null then argument value is considered null.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
+                                ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2389,13 +2228,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
-                   ///< property value.
+    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                    ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2412,9 +2251,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
+    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2432,10 +2272,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2452,10 +2293,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
-    ur_native_handle_t
-        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2473,17 +2314,16 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeKernel, hContext, phKernel);
     } else {
@@ -2496,27 +2336,23 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleCreate
-__urdlllocal ur_result_t UR_APICALL urModuleCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    const void *pIL,              ///< [in] pointer to IL string.
-    size_t length,                ///< [in] length of IL in bytes.
-    const char
-        *pOptions, ///< [in] pointer to compiler options null-terminated string.
-    ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
-                   ///< called when program compilation is complete.
-    void *
-        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to handle of Module object created.
+__urdlllocal ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,         ///< [in] handle of the context instance.
+    const void *pIL,                      ///< [in] pointer to IL string.
+    size_t length,                        ///< [in] length of IL in bytes.
+    const char *pOptions,                 ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                                          ///< called when program compilation is complete.
+    void *pUserData,                      ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t *phModule          ///< [out] pointer to handle of Module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Module.pfnCreate;
     if (nullptr != pfnCreate) {
-        result = pfnCreate(hContext, pIL, length, pOptions, pfnNotify,
-                           pUserData, phModule);
+        result = pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData, phModule);
     } else {
         // generic implementation
         *phModule = reinterpret_cast<ur_module_handle_t>(d_context.get());
@@ -2527,7 +2363,8 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleRetain
-__urdlllocal ur_result_t UR_APICALL urModuleRetain(
+__urdlllocal ur_result_t UR_APICALL
+urModuleRetain(
     ur_module_handle_t hModule ///< [in] handle for the Module to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2545,7 +2382,8 @@ __urdlllocal ur_result_t UR_APICALL urModuleRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleRelease
-__urdlllocal ur_result_t UR_APICALL urModuleRelease(
+__urdlllocal ur_result_t UR_APICALL
+urModuleRelease(
     ur_module_handle_t hModule ///< [in] handle for the Module to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2563,10 +2401,10 @@ __urdlllocal ur_result_t UR_APICALL urModuleRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
-    ur_module_handle_t hModule, ///< [in] handle of the module.
-    ur_native_handle_t
-        *phNativeModule ///< [out] a pointer to the native handle of the module.
+__urdlllocal ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,        ///< [in] handle of the module.
+    ur_native_handle_t *phNativeModule ///< [out] a pointer to the native handle of the module.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2584,17 +2422,16 @@ __urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
     ur_native_handle_t hNativeModule, ///< [in] the native handle of the module.
     ur_context_handle_t hContext,     ///< [in] handle of the context instance.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to the handle of the module object created.
+    ur_module_handle_t *phModule      ///< [out] pointer to the handle of the module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Module.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Module.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeModule, hContext, phModule);
     } else {
@@ -2607,18 +2444,16 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
-    uint32_t
-        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
-    ///< If phPlatforms is not NULL, then NumEntries should be greater than
-    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-    ///< will be returned.
-    ur_platform_handle_t *
-        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-    ///< If NumEntries is less than the number of platforms available, then
-    ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *
-        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGet(
+    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
+                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                       ///< will be returned.
+    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                       ///< If NumEntries is less than the number of platforms available, then
+                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2629,8 +2464,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phPlatforms) && (i < NumEntries); ++i) {
-            phPlatforms[i] =
-                reinterpret_cast<ur_platform_handle_t>(d_context.get());
+            phPlatforms[i] = reinterpret_cast<ur_platform_handle_t>(d_context.get());
         }
     }
 
@@ -2639,24 +2473,23 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If Size is not equal to or greater to the real number of bytes needed
-    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-    ///< returned and pPlatformInfo is not used.
-    size_t *
-        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
+                                         ///< If Size is not equal to or greater to the real number of bytes needed
+                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                         ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Platform.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
-                            pSizeRet);
+        result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
     } else {
         // generic implementation
     }
@@ -2666,7 +2499,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -2685,10 +2519,10 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
-    ur_native_handle_t *
-        phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
+    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2698,8 +2532,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
         result = pfnGetNativeHandle(hPlatform, phNativePlatform);
     } else {
         // generic implementation
-        *phNativePlatform =
-            reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativePlatform = reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -2707,17 +2540,15 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *
-        phPlatform ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
     } else {
@@ -2730,11 +2561,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL
+urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage ///< [out] pointer to a string containing adapter specific result in string
-                  ///< representation.
+    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
+                                    ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2751,15 +2582,13 @@ __urdlllocal ur_result_t UR_APICALL urGetLastResult(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreate
-__urdlllocal ur_result_t UR_APICALL urProgramCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    uint32_t count, ///< [in] number of module handles in module list.
-    const ur_module_handle_t
-        *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *
-        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context instance
+    uint32_t count,                      ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2777,22 +2606,20 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_device_handle_t
-        hDevice,            ///< [in] handle to device associated with binary.
-    size_t size,            ///< [in] size in bytes.
-    const uint8_t *pBinary, ///< [in] pointer to binary.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,  ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
+    size_t size,                   ///< [in] size in bytes.
+    const uint8_t *pBinary,        ///< [in] pointer to binary.
+    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithBinary = d_context.urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr != pfnCreateWithBinary) {
-        result =
-            pfnCreateWithBinary(hContext, hDevice, size, pBinary, phProgram);
+        result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, phProgram);
     } else {
         // generic implementation
         *phProgram = reinterpret_cast<ur_program_handle_t>(d_context.get());
@@ -2803,7 +2630,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL
+urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2821,7 +2649,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL
+urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2839,26 +2668,21 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program to search for function in.
-    ///< The program must already be built to the specified device, or
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *
-        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
-    void **
-        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
+                                  ///< The program must already be built to the specified device, or
+                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
+    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnGetFunctionPointer =
-        d_context.urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer = d_context.urDdiTable.Program.pfnGetFunctionPointer;
     if (nullptr != pfnGetFunctionPointer) {
-        result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
-                                       ppFunctionPointer);
+        result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
     } else {
         // generic implementation
     }
@@ -2868,26 +2692,24 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName, ///< [in] name of the Program property to query
-    size_t propSize,            ///< [in] the size of the Program property.
-    void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+    ur_program_info_t propName,   ///< [in] name of the Program property to query
+    size_t propSize,              ///< [in] the size of the Program property.
+    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+                                  ///< If propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pProgramInfo is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Program.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo,
-                            pPropSizeRet);
+        result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -2897,28 +2719,25 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
-    ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
-    ur_program_build_info_t
-        propName,    ///< [in] name of the Program build info to query
-    size_t propSize, ///< [in] size of the Program build info property.
-    void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
+    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
+    size_t propSize,                  ///< [in] size of the Program build info property.
+    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+                                      ///< If propSize is not equal to or greater than the real number of bytes
+                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                      ///< error is returned and pKernelInfo is not used.
+    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
+                                      ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetBuildInfo = d_context.urDdiTable.Program.pfnGetBuildInfo;
     if (nullptr != pfnGetBuildInfo) {
-        result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize,
-                                 pPropValue, pPropSizeRet);
+        result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -2928,20 +2747,19 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstant
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
+__urdlllocal ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t specId,              ///< [in] specification constant Id
-    size_t specSize,       ///< [in] size of the specialization constant value
-    const void *pSpecValue ///< [in] pointer to the specialization value bytes
+    size_t specSize,              ///< [in] size of the specialization constant value
+    const void *pSpecValue        ///< [in] pointer to the specialization value bytes
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnSetSpecializationConstant =
-        d_context.urDdiTable.Program.pfnSetSpecializationConstant;
+    auto pfnSetSpecializationConstant = d_context.urDdiTable.Program.pfnSetSpecializationConstant;
     if (nullptr != pfnSetSpecializationConstant) {
-        result = pfnSetSpecializationConstant(hProgram, specId, specSize,
-                                              pSpecValue);
+        result = pfnSetSpecializationConstant(hProgram, specId, specSize, pSpecValue);
     } else {
         // generic implementation
     }
@@ -2951,10 +2769,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ///< [in] handle of the program.
-    ur_native_handle_t *
-        phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,       ///< [in] handle of the program.
+    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2964,8 +2782,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
         result = pfnGetNativeHandle(hProgram, phNativeProgram);
     } else {
         // generic implementation
-        *phNativeProgram =
-            reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativeProgram = reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -2973,18 +2790,16 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeProgram,           ///< [in] the native handle of the program.
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_program_handle_t *
-        phProgram ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,      ///< [in] handle of the context instance
+    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle =
-        d_context.urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Program.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
     } else {
@@ -2997,9 +2812,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL urInit(
+__urdlllocal ur_result_t UR_APICALL
+urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3028,10 +2844,10 @@ extern "C" {
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_global_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetGlobalProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3060,10 +2876,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_context_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetContextProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3085,8 +2901,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urContextGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urContextCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urContextCreateWithNativeHandle;
 
     pDdiTable->pfnSetExtendedDeleter = driver::urContextSetExtendedDeleter;
 
@@ -3101,10 +2916,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_enqueue_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEnqueueProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3120,8 +2935,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 
     pDdiTable->pfnEventsWait = driver::urEnqueueEventsWait;
 
-    pDdiTable->pfnEventsWaitWithBarrier =
-        driver::urEnqueueEventsWaitWithBarrier;
+    pDdiTable->pfnEventsWaitWithBarrier = driver::urEnqueueEventsWaitWithBarrier;
 
     pDdiTable->pfnMemBufferRead = driver::urEnqueueMemBufferRead;
 
@@ -3161,11 +2975,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 
     pDdiTable->pfnUSMMemcpy2D = driver::urEnqueueUSMMemcpy2D;
 
-    pDdiTable->pfnDeviceGlobalVariableWrite =
-        driver::urEnqueueDeviceGlobalVariableWrite;
+    pDdiTable->pfnDeviceGlobalVariableWrite = driver::urEnqueueDeviceGlobalVariableWrite;
 
-    pDdiTable->pfnDeviceGlobalVariableRead =
-        driver::urEnqueueDeviceGlobalVariableRead;
+    pDdiTable->pfnDeviceGlobalVariableRead = driver::urEnqueueDeviceGlobalVariableRead;
 
     return result;
 }
@@ -3178,10 +2990,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_event_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEventProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3205,8 +3017,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urEventGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urEventCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urEventCreateWithNativeHandle;
 
     pDdiTable->pfnSetCallback = driver::urEventSetCallback;
 
@@ -3221,10 +3032,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_kernel_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetKernelProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3250,8 +3061,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urKernelGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urKernelCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urKernelCreateWithNativeHandle;
 
     pDdiTable->pfnSetArgValue = driver::urKernelSetArgValue;
 
@@ -3276,10 +3086,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_mem_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3320,10 +3130,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_module_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetModuleProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_module_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3343,8 +3153,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urModuleGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urModuleCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urModuleCreateWithNativeHandle;
 
     return result;
 }
@@ -3357,10 +3166,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_platform_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetPlatformProcAddrTable(
+    ur_api_version_t version,         ///< [in] API version requested
+    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3378,8 +3187,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urPlatformGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urPlatformCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urPlatformCreateWithNativeHandle;
 
     pDdiTable->pfnGetApiVersion = driver::urPlatformGetApiVersion;
 
@@ -3394,10 +3202,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_program_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetProgramProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3423,13 +3231,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
 
     pDdiTable->pfnGetBuildInfo = driver::urProgramGetBuildInfo;
 
-    pDdiTable->pfnSetSpecializationConstant =
-        driver::urProgramSetSpecializationConstant;
+    pDdiTable->pfnSetSpecializationConstant = driver::urProgramSetSpecializationConstant;
 
     pDdiTable->pfnGetNativeHandle = driver::urProgramGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urProgramCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urProgramCreateWithNativeHandle;
 
     return result;
 }
@@ -3442,10 +3248,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_queue_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetQueueProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3467,8 +3273,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urQueueGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urQueueCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urQueueCreateWithNativeHandle;
 
     pDdiTable->pfnFinish = driver::urQueueFinish;
 
@@ -3485,10 +3290,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_sampler_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetSamplerProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3510,8 +3315,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urSamplerGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urSamplerCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urSamplerCreateWithNativeHandle;
 
     return result;
 }
@@ -3524,10 +3328,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_usm_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3560,10 +3364,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_device_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetDeviceProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3589,8 +3393,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urDeviceGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle =
-        driver::urDeviceCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = driver::urDeviceCreateWithNativeHandle;
 
     pDdiTable->pfnGetGlobalTimestamps = driver::urDeviceGetGlobalTimestamps;
 

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -21,8 +21,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Context.pfnCreate;
     if (nullptr != pfnCreate) {
         result = pfnCreate(DeviceCount, phDevices, phContext);
@@ -42,8 +41,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Context.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hContext);
@@ -61,8 +59,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Context.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hContext);
@@ -78,20 +75,19 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,    ///< [in] the number of bytes of memory pointed to by
-                        ///< pContextInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
     void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-                        ///< if propSize is not equal to or greater than the
-                        ///< real number of bytes needed to return the info then
-                        ///< the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                        ///< returned and pContextInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by ContextInfoType.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Context.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
@@ -106,14 +102,13 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native
-                                        ///< handle of the context.
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Context.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hContext, phNativeContext);
@@ -130,14 +125,13 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 /// @brief Intercept function for urContextCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeContext,            ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext ///< [out] pointer to the handle of the
-                                   ///< context object created.
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Context.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -156,13 +150,12 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetExtendedDeleter =
         d_context.urDdiTable.Context.pfnSetExtendedDeleter;
     if (nullptr != pfnSetExtendedDeleter) {
@@ -179,37 +172,35 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t workDim, ///< [in] number of dimensions, from 1 to 3, to specify
-                      ///< the global and work-group work-items
-    const size_t
-        *pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned
-                            ///< values that specify the offset used to
-                            ///< calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize, ///< [in] pointer to an array of workDim
-                                   ///< unsigned values that specify the number
-                                   ///< of global work-items in workDim that
-                                   ///< will execute the kernel function
-    const size_t
-        *pLocalWorkSize, ///< [in][optional] pointer to an array of workDim
-                         ///< unsigned values that specify the number of local
-                         ///< work-items forming a work-group that will execute
-                         ///< the kernel function. If nullptr, the runtime
-                         ///< implementation will choose the work-group size.
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnKernelLaunch = d_context.urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr != pfnKernelLaunch) {
         result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
@@ -231,19 +222,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnEventsWait = d_context.urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr != pfnEventsWait) {
         result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList,
@@ -264,19 +254,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnEventsWaitWithBarrier =
         d_context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr != pfnEventsWaitWithBarrier) {
@@ -302,21 +291,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     size_t size,       ///< [in] size in bytes of data being read
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferRead = d_context.urDdiTable.Enqueue.pfnMemBufferRead;
     if (nullptr != pfnMemBufferRead) {
         result =
@@ -344,21 +330,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     const void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferWrite = d_context.urDdiTable.Enqueue.pfnMemBufferWrite;
     if (nullptr != pfnMemBufferWrite) {
         result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size,
@@ -384,31 +367,30 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being read
-    size_t hostRowPitch,     ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by dst
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by dst
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferReadRect =
         d_context.urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr != pfnMemBufferReadRect) {
@@ -437,32 +419,32 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being written
-    size_t hostRowPitch, ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by src
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by src
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
     void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< points to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferWriteRect =
         d_context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr != pfnMemBufferWriteRect) {
@@ -490,21 +472,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
     size_t size,      ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferCopy = d_context.urDdiTable.Enqueue.pfnMemBufferCopy;
     if (nullptr != pfnMemBufferCopy) {
         result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
@@ -528,32 +507,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion, ///< [in] source 3D rectangular region
-                                ///< descriptor: width, height, depth
-    size_t srcRowPitch,   ///< [in] length of each row in bytes in the source
-                          ///< buffer object
-    size_t srcSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< source buffer object
-    size_t dstRowPitch, ///< [in] length of each row in bytes in the destination
-                        ///< buffer object
-    size_t dstSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< destination buffer object
+    ur_rect_region_t
+        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferCopyRect =
         d_context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr != pfnMemBufferCopyRect) {
@@ -581,21 +557,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t offset,            ///< [in] offset into the buffer
     size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferFill = d_context.urDdiTable.Enqueue.pfnMemBufferFill;
     if (nullptr != pfnMemBufferFill) {
         result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize,
@@ -617,29 +590,27 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t rowPitch,   ///< [in] length of each row in bytes
     size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pDst, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageRead = d_context.urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr != pfnMemImageRead) {
         result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
@@ -662,29 +633,27 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool
         blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t inputRowPitch,   ///< [in] length of each row in bytes
     size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pSrc, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageWrite = d_context.urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr != pfnMemImageWrite) {
         result =
@@ -704,31 +673,31 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
 __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,  ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,  ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the source 1D, 2D, or 3D image
-    ur_rect_offset_t dstOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the destination 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageCopy = d_context.urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr != pfnMemImageCopy) {
         result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin,
@@ -754,23 +723,20 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     size_t offset, ///< [in] offset in bytes of the buffer region being mapped
     size_t size,   ///< [in] size in bytes of the buffer region being mapped
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent, ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [in,out][optional] return an event object that identifies this
+                 ///< particular command instance.
     void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
                     ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferMap = d_context.urDdiTable.Enqueue.pfnMemBufferMap;
     if (nullptr != pfnMemBufferMap) {
         result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset,
@@ -794,21 +760,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
         hMem,         ///< [in] handle of the memory (buffer or image) object
     void *pMappedPtr, ///< [in] mapped host address
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemUnmap = d_context.urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr != pfnMemUnmap) {
         result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
@@ -831,21 +794,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
     int8_t byteValue,             ///< [in] byte value to fill
     size_t count,                 ///< [in] size in bytes to be set
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemset = d_context.urDdiTable.Enqueue.pfnUSMMemset;
     if (nullptr != pfnUSMMemset) {
         result = pfnUSMMemset(hQueue, ptr, byteValue, count,
@@ -869,21 +829,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     const void *pSrc, ///< [in] pointer to the source USM memory object
     size_t size,      ///< [in] size in bytes to be copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemcpy = d_context.urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr != pfnUSMMemcpy) {
         result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size,
@@ -906,21 +863,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     size_t size,                    ///< [in] size in bytes to be fetched
     ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
     uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMPrefetch = d_context.urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr != pfnUSMPrefetch) {
         result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
@@ -942,14 +896,13 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
     const void *pMem,         ///< [in] pointer to the USM memory object
     size_t size,              ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemAdvise = d_context.urDdiTable.Enqueue.pfnUSMMemAdvise;
     if (nullptr != pfnUSMMemAdvise) {
         result = pfnUSMMemAdvise(hQueue, pMem, size, advice, phEvent);
@@ -968,28 +921,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch, ///< [in] the total width of the destination memory including
-                  ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     size_t patternSize, ///< [in] the size in bytes of the pattern.
     const void
         *pPattern, ///< [in] pointer with the bytes of the pattern to set.
     size_t width,  ///< [in] the width in bytes of each row to fill.
     size_t height, ///< [in] the height of the columns to fill.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMFill2D = d_context.urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr != pfnUSMFill2D) {
         result =
@@ -1010,26 +961,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch,  ///< [in] the total width of the destination memory including
-                   ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     int value,     ///< [in] the value to fill into the region in pMem.
     size_t width,  ///< [in] the width in bytes of each row to set.
     size_t height, ///< [in] the height of the columns to set.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemset2D = d_context.urDdiTable.Enqueue.pfnUSMMemset2D;
     if (nullptr != pfnUSMMemset2D) {
         result = pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height,
@@ -1050,28 +999,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
     const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t srcPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
-    size_t width,     ///< [in] the width in bytes of each row to be copied.
-    size_t height,    ///< [in] the height of columns to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemcpy2D = d_context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr != pfnUSMMemcpy2D) {
         result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc,
@@ -1090,31 +1037,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
 __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingWrite, ///< [in] indicates if this operation should block.
     size_t count,       ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
     const void *pSrc, ///< [in] pointer to where the data must be copied from.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnDeviceGlobalVariableWrite =
         d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr != pfnDeviceGlobalVariableWrite) {
@@ -1134,31 +1079,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
 __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingRead, ///< [in] indicates if this operation should block.
     size_t count,      ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
-    void *pDst,    ///< [in] pointer to where the data must be copied to.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnDeviceGlobalVariableRead =
         d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr != pfnDeviceGlobalVariableRead) {
@@ -1187,8 +1130,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Event.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
@@ -1209,13 +1151,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     size_t
         propValueSize, ///< [in] size in bytes of the profiling property value
     void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet ///< [out][optional] pointer to the actual size in
-                              ///< bytes returned in propValue
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetProfilingInfo = d_context.urDdiTable.Event.pfnGetProfilingInfo;
     if (nullptr != pfnGetProfilingInfo) {
         result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
@@ -1231,14 +1173,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 /// @brief Intercept function for urEventWait
 __urdlllocal ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t
-        *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of
-                         ///< events to wait for completion
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnWait = d_context.urDdiTable.Event.pfnWait;
     if (nullptr != pfnWait) {
         result = pfnWait(numEvents, phEventWaitList);
@@ -1256,8 +1197,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Event.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hEvent);
@@ -1275,8 +1215,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Event.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hEvent);
@@ -1296,8 +1235,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Event.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hEvent, phNativeEvent);
@@ -1319,8 +1257,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Event.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -1339,13 +1276,12 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetCallback = d_context.urDdiTable.Event.pfnSetCallback;
     if (nullptr != pfnSetCallback) {
         result = pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
@@ -1369,8 +1305,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageCreate = d_context.urDdiTable.Mem.pfnImageCreate;
     if (nullptr != pfnImageCreate) {
         result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc,
@@ -1395,8 +1330,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnBufferCreate = d_context.urDdiTable.Mem.pfnBufferCreate;
     if (nullptr != pfnBufferCreate) {
         result = pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
@@ -1415,8 +1349,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Mem.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hMem);
@@ -1434,8 +1367,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Mem.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hMem);
@@ -1460,8 +1392,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnBufferPartition = d_context.urDdiTable.Mem.pfnBufferPartition;
     if (nullptr != pfnBufferPartition) {
         result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
@@ -1483,8 +1414,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Mem.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hMem, phNativeMem);
@@ -1506,8 +1436,7 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Mem.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -1526,20 +1455,18 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointed to by
-                     ///< pMemInfo.
-    void *pMemInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pMemInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Mem.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result =
@@ -1556,20 +1483,18 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointer to by
-                     ///< pImgInfo.
-    void *pImgInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pImgInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageGetInfo = d_context.urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr != pfnImageGetInfo) {
         result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
@@ -1588,8 +1513,7 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnTearDown = d_context.urDdiTable.Global.pfnTearDown;
     if (nullptr != pfnTearDown) {
         result = pfnTearDown(pParams);
@@ -1605,16 +1529,15 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize, ///< [in] size in bytes of the queue property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the queue property
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out] value of the queue property
     size_t
         *pPropSizeRet ///< [out] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Queue.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
@@ -1631,19 +1554,18 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t
-        *pProps, ///< [in] specifies a list of queue properties and their
-                 ///< corresponding values. Each property name is immediately
-                 ///< followed by the corresponding desired value. The list is
-                 ///< terminated with a 0. If a property value is not specified,
-                 ///< then its default value will be used.
+    const ur_queue_property_t *
+        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Queue.pfnCreate;
     if (nullptr != pfnCreate) {
         result = pfnCreate(hContext, hDevice, pProps, phQueue);
@@ -1662,8 +1584,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Queue.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hQueue);
@@ -1681,8 +1602,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Queue.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hQueue);
@@ -1702,8 +1622,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Queue.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hQueue, phNativeQueue);
@@ -1725,8 +1644,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Queue.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -1746,8 +1664,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnFinish = d_context.urDdiTable.Queue.pfnFinish;
     if (nullptr != pfnFinish) {
         result = pfnFinish(hQueue);
@@ -1765,8 +1682,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnFlush = d_context.urDdiTable.Queue.pfnFlush;
     if (nullptr != pfnFlush) {
         result = pfnFlush(hQueue);
@@ -1789,8 +1705,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Sampler.pfnCreate;
     if (nullptr != pfnCreate) {
         result = pfnCreate(hContext, pProps, phSampler);
@@ -1810,8 +1725,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Sampler.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hSampler);
@@ -1830,8 +1744,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Sampler.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hSampler);
@@ -1847,16 +1760,15 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t propValueSize, ///< [in] size in bytes of the sampler property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the sampler property
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Sampler.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
@@ -1871,14 +1783,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native
-                                        ///< handle of the sampler.
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Sampler.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hSampler, phNativeSampler);
@@ -1895,15 +1806,14 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeSampler,            ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler ///< [out] pointer to the handle of the
-                                   ///< sampler object created.
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -1928,8 +1838,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnHostAlloc = d_context.urDdiTable.USM.pfnHostAlloc;
     if (nullptr != pfnHostAlloc) {
         result = pfnHostAlloc(hContext, pUSMFlag, size, align, ppMem);
@@ -1953,8 +1862,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnDeviceAlloc = d_context.urDdiTable.USM.pfnDeviceAlloc;
     if (nullptr != pfnDeviceAlloc) {
         result =
@@ -1979,8 +1887,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSharedAlloc = d_context.urDdiTable.USM.pfnSharedAlloc;
     if (nullptr != pfnSharedAlloc) {
         result =
@@ -2000,8 +1907,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnFree = d_context.urDdiTable.USM.pfnFree;
     if (nullptr != pfnFree) {
         result = pfnFree(hContext, pMem);
@@ -2019,16 +1925,15 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize, ///< [in] size in bytes of the USM allocation property
-                          ///< value
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
     void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in USM
-                              ///< allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetMemAllocInfo = d_context.urDdiTable.USM.pfnGetMemAllocInfo;
     if (nullptr != pfnGetMemAllocInfo) {
         result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
@@ -2045,23 +1950,21 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries, ///< [in] the number of devices to be added to
-                         ///< phDevices. If phDevices in not NULL then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_VALUE, will be returned.
-    ur_device_handle_t
-        *phDevices, ///< [out][optional][range(0, NumEntries)] array of handle
-                    ///< of devices. If NumEntries is less than the number of
-                    ///< devices available, then platform shall only retrieve
-                    ///< that number of devices.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
     uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-                          ///< pNumDevices will be updated with the total number
-                          ///< of devices available.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGet = d_context.urDdiTable.Device.pfnGet;
     if (nullptr != pfnGet) {
         result =
@@ -2084,17 +1987,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
     size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
     void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-                       ///< If propSize is not equal to or greater than the real
-                       ///< number of bytes needed to return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_VALUE error is returned
-                       ///< and pDeviceInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of the queried infoType.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Device.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result =
@@ -2114,8 +2016,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Device.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hDevice);
@@ -2133,8 +2034,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Device.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hDevice);
@@ -2149,23 +2049,20 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t
-        *pProperties, ///< [in] null-terminated array of <$_device_partition_t
-                      ///< enum, value> pairs.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t
-        *phSubDevices, ///< [out][optional][range(0, NumDevices)] array of
-                       ///< handle of devices. If NumDevices is less than the
-                       ///< number of sub-devices available, then the function
-                       ///< shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet ///< [out][optional] pointer to the number of
-                             ///< sub-devices the device can be partitioned into
-                             ///< according to the partitioning property.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnPartition = d_context.urDdiTable.Device.pfnPartition;
     if (nullptr != pfnPartition) {
         result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
@@ -2191,14 +2088,12 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input
-                        ///< array of binaries. If a suitable binary was not
-                        ///< found the function returns ${X}_INVALID_BINARY.
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSelectBinary = d_context.urDdiTable.Device.pfnSelectBinary;
     if (nullptr != pfnSelectBinary) {
         result =
@@ -2219,8 +2114,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Device.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hDevice, phNativeDevice);
@@ -2242,8 +2136,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Device.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -2260,17 +2153,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
 __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's
-                                ///< global timestamp that correlates with the
-                                ///< Host's global timestamp value
-    uint64_t *pHostTimestamp ///< [out][optional] pointer to the Host's global
-                             ///< timestamp that correlates with the Device's
-                             ///< global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetGlobalTimestamps =
         d_context.urDdiTable.Device.pfnGetGlobalTimestamps;
     if (nullptr != pfnGetGlobalTimestamps) {
@@ -2293,8 +2185,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Kernel.pfnCreate;
     if (nullptr != pfnCreate) {
         result = pfnCreate(hProgram, pKernelName, phKernel);
@@ -2317,8 +2208,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetArgValue = d_context.urDdiTable.Kernel.pfnSetArgValue;
     if (nullptr != pfnSetArgValue) {
         result = pfnSetArgValue(hKernel, argIndex, argSize, pArgValue);
@@ -2334,13 +2224,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize     ///< [in] size of the local buffer to be allocated by the
-                       ///< runtime
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetArgLocal = d_context.urDdiTable.Kernel.pfnSetArgLocal;
     if (nullptr != pfnSetArgLocal) {
         result = pfnSetArgLocal(hKernel, argIndex, argSize);
@@ -2357,19 +2246,19 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel
-                       ///< info property. If propSize is not equal to or
-                       ///< greater than the real number of bytes needed to
-                       ///< return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                       ///< pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Kernel.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result =
@@ -2387,17 +2276,18 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
-        propName,     ///< [in] name of the work Group property to query
-    size_t propSize,  ///< [in] size of the Kernel Work Group property value
-    void *pPropValue, ///< [in,out][optional][range(0, propSize)] value of the
-                      ///< Kernel Work Group property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetGroupInfo = d_context.urDdiTable.Kernel.pfnGetGroupInfo;
     if (nullptr != pfnGetGroupInfo) {
         result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize,
@@ -2415,17 +2305,18 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
-        propName,     ///< [in] name of the SubGroup property to query
-    size_t propSize,  ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue, ///< [in,out][range(0, propSize)][optional] value of the
-                      ///< Kernel SubGroup property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetSubGroupInfo = d_context.urDdiTable.Kernel.pfnGetSubGroupInfo;
     if (nullptr != pfnGetSubGroupInfo) {
         result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
@@ -2444,8 +2335,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Kernel.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hKernel);
@@ -2463,8 +2353,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Kernel.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hKernel);
@@ -2479,16 +2368,15 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 /// @brief Intercept function for urKernelSetArgPointer
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,    ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,       ///< [in] size of argument type
-    const void *pArgValue ///< [in][optional] SVM pointer to memory location
-                          ///< holding the argument value. If null then argument
-                          ///< value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetArgPointer = d_context.urDdiTable.Kernel.pfnSetArgPointer;
     if (nullptr != pfnSetArgPointer) {
         result = pfnSetArgPointer(hKernel, argIndex, argSize, pArgValue);
@@ -2505,13 +2393,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue ///< [in][range(0, propSize)] pointer to memory
-                           ///< location holding the property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetExecInfo = d_context.urDdiTable.Kernel.pfnSetExecInfo;
     if (nullptr != pfnSetExecInfo) {
         result = pfnSetExecInfo(hKernel, propName, propSize, pPropValue);
@@ -2531,8 +2419,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetArgSampler = d_context.urDdiTable.Kernel.pfnSetArgSampler;
     if (nullptr != pfnSetArgSampler) {
         result = pfnSetArgSampler(hKernel, argIndex, hArgValue);
@@ -2552,8 +2439,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetArgMemObj = d_context.urDdiTable.Kernel.pfnSetArgMemObj;
     if (nullptr != pfnSetArgMemObj) {
         result = pfnSetArgMemObj(hKernel, argIndex, hArgValue);
@@ -2573,8 +2459,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Kernel.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hKernel, phNativeKernel);
@@ -2596,8 +2481,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -2619,18 +2503,16 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
     const char
         *pOptions, ///< [in] pointer to compiler options null-terminated string.
     ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification
-                   ///< routine that is called when program compilation is
-                   ///< complete.
-    void *pUserData, ///< [in][optional] Passed as an argument when pfnNotify is
-                     ///< called.
+        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                   ///< called when program compilation is complete.
+    void *
+        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
     ur_module_handle_t
         *phModule ///< [out] pointer to handle of Module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Module.pfnCreate;
     if (nullptr != pfnCreate) {
         result = pfnCreate(hContext, pIL, length, pOptions, pfnNotify,
@@ -2650,8 +2532,7 @@ __urdlllocal ur_result_t UR_APICALL urModuleRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Module.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hModule);
@@ -2669,8 +2550,7 @@ __urdlllocal ur_result_t UR_APICALL urModuleRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Module.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hModule);
@@ -2690,8 +2570,7 @@ __urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Module.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hModule, phNativeModule);
@@ -2713,8 +2592,7 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Module.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -2730,23 +2608,21 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
-    uint32_t NumEntries, ///< [in] the number of platforms to be added to
-                         ///< phPlatforms. If phPlatforms is not NULL, then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE, will be returned.
-    ur_platform_handle_t
-        *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle
-                      ///< of platforms. If NumEntries is less than the number
-                      ///< of platforms available, then
-                      ///< ::urPlatformGet shall only retrieve that number of
-                      ///< platforms.
-    uint32_t *pNumPlatforms ///< [out][optional] returns the total number of
-                            ///< platforms available.
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGet = d_context.urDdiTable.Platform.pfnGet;
     if (nullptr != pfnGet) {
         result = pfnGet(NumEntries, phPlatforms, pNumPlatforms);
@@ -2768,17 +2644,15 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
     size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-                         ///< If Size is not equal to or greater to the real
-                         ///< number of bytes needed to return the info then the
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                         ///< and pPlatformInfo is not used.
-    size_t *pSizeRet ///< [out][optional] pointer to the actual number of bytes
-                     ///< being queried by pPlatformInfo.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Platform.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
@@ -2798,8 +2672,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetApiVersion = d_context.urDdiTable.Platform.pfnGetApiVersion;
     if (nullptr != pfnGetApiVersion) {
         result = pfnGetApiVersion(hDriver, pVersion);
@@ -2813,14 +2686,13 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native
-                                         ///< handle of the platform.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Platform.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hPlatform, phNativePlatform);
@@ -2838,13 +2710,12 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform ///< [out] pointer to the handle of the
-                                     ///< platform object created.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -2861,13 +2732,13 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 /// @brief Intercept function for urGetLastResult
 __urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage ///< [out] pointer to a string containing adapter
-                           ///< specific result in string representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetLastResult = d_context.urDdiTable.Global.pfnGetLastResult;
     if (nullptr != pfnGetLastResult) {
         result = pfnGetLastResult(hPlatform, ppMessage);
@@ -2885,15 +2756,14 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
     uint32_t count, ///< [in] number of module handles in module list.
     const ur_module_handle_t
         *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions, ///< [in][optional] pointer to linker options
-                          ///< null-terminated string.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
     ur_program_handle_t
         *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Program.pfnCreate;
     if (nullptr != pfnCreate) {
         result = pfnCreate(hContext, count, phModules, pOptions, phProgram);
@@ -2918,8 +2788,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithBinary = d_context.urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr != pfnCreateWithBinary) {
         result =
@@ -2939,8 +2808,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRetain = d_context.urDdiTable.Program.pfnRetain;
     if (nullptr != pfnRetain) {
         result = pfnRetain(hProgram);
@@ -2958,8 +2826,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnRelease = d_context.urDdiTable.Program.pfnRelease;
     if (nullptr != pfnRelease) {
         result = pfnRelease(hProgram);
@@ -2977,18 +2844,16 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program to search for function in.
-                  ///< The program must already be built to the specified
-                  ///< device, or otherwise
-                  ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName, ///< [in] A null-terminates string denoting the
-                               ///< mangled function name.
-    void **ppFunctionPointer   ///< [out] Returns the pointer to the function if
-                               ///< it is found in the program.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetFunctionPointer =
         d_context.urDdiTable.Program.pfnGetFunctionPointer;
     if (nullptr != pfnGetFunctionPointer) {
@@ -3007,19 +2872,18 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
-    void *pProgramInfo, ///< [in,out][optional] array of bytes of holding the
-                        ///< program info property. If propSize is not equal to
-                        ///< or greater than the real number of bytes needed to
-                        ///< return the info then the
-                        ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                        ///< and pProgramInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data copied to propName.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Program.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo,
@@ -3037,20 +2901,20 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
-        propName,     ///< [in] name of the Program build info to query
-    size_t propSize,  ///< [in] size of the Program build info property.
-    void *pPropValue, ///< [in,out][optional] value of the Program build
-                      ///< property. If propSize is not equal to or greater than
-                      ///< the real number of bytes needed to return the info
-                      ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                      ///< returned and pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetBuildInfo = d_context.urDdiTable.Program.pfnGetBuildInfo;
     if (nullptr != pfnGetBuildInfo) {
         result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize,
@@ -3072,8 +2936,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSetSpecializationConstant =
         d_context.urDdiTable.Program.pfnSetSpecializationConstant;
     if (nullptr != pfnSetSpecializationConstant) {
@@ -3089,14 +2952,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native
-                                        ///< handle of the program.
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Program.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
         result = pfnGetNativeHandle(hProgram, phNativeProgram);
@@ -3113,15 +2975,14 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 /// @brief Intercept function for urProgramCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeProgram,            ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram ///< [out] pointer to the handle of the
-                                   ///< program object created.
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Program.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
@@ -3137,15 +2998,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
-    ur_device_init_flags_t
-        device_flags ///< [in] device initialization flags.
-                     ///< must be 0 (default) or a combination of
-                     ///< ::ur_device_init_flag_t.
+    ur_device_init_flags_t device_flags ///< [in] device initialization flags.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    // if the driver has created a custom function, then call it instead of
-    // using the generic path
+    // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnInit = d_context.urDdiTable.Global.pfnInit;
     if (nullptr != pfnInit) {
         result = pfnInit(device_flags);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -84,15 +84,15 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,    ///< [in] the number of bytes of memory pointed to by
-                        ///< pContextInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
     void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-                        ///< if propSize is not equal to or greater than the
-                        ///< real number of bytes needed to return the info then
-                        ///< the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                        ///< returned and pContextInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by ContextInfoType.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
 
@@ -117,9 +117,9 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native
-                                        ///< handle of the context.
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Context.pfnGetNativeHandle;
 
@@ -144,9 +144,9 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 /// @brief Intercept function for urContextCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeContext,            ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext ///< [out] pointer to the handle of the
-                                   ///< context object created.
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     auto pfnCreateWithNativeHandle =
         context.urDdiTable.Context.pfnCreateWithNativeHandle;
@@ -174,8 +174,8 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetExtendedDeleter =
         context.urDdiTable.Context.pfnSetExtendedDeleter;
@@ -202,32 +202,31 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t workDim, ///< [in] number of dimensions, from 1 to 3, to specify
-                      ///< the global and work-group work-items
-    const size_t
-        *pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned
-                            ///< values that specify the offset used to
-                            ///< calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize, ///< [in] pointer to an array of workDim
-                                   ///< unsigned values that specify the number
-                                   ///< of global work-items in workDim that
-                                   ///< will execute the kernel function
-    const size_t
-        *pLocalWorkSize, ///< [in][optional] pointer to an array of workDim
-                         ///< unsigned values that specify the number of local
-                         ///< work-items forming a work-group that will execute
-                         ///< the kernel function. If nullptr, the runtime
-                         ///< implementation will choose the work-group size.
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -264,14 +263,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
 
@@ -294,14 +293,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnEventsWaitWithBarrier =
         context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -330,16 +329,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     size_t size,       ///< [in] size in bytes of data being read
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -377,16 +374,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     const void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -422,26 +417,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being read
-    size_t hostRowPitch,     ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by dst
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by dst
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
 
@@ -480,27 +475,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being written
-    size_t hostRowPitch, ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by src
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by src
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
     void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< points to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferWriteRect =
         context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -539,16 +535,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
     size_t size,      ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -583,27 +577,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion, ///< [in] source 3D rectangular region
-                                ///< descriptor: width, height, depth
-    size_t srcRowPitch,   ///< [in] length of each row in bytes in the source
-                          ///< buffer object
-    size_t srcSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< source buffer object
-    size_t dstRowPitch, ///< [in] length of each row in bytes in the destination
-                        ///< buffer object
-    size_t dstSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< destination buffer object
+    ur_rect_region_t
+        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
@@ -641,16 +633,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t offset,            ///< [in] offset into the buffer
     size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -683,24 +673,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t rowPitch,   ///< [in] length of each row in bytes
     size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pDst, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -734,24 +723,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool
         blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t inputRowPitch,   ///< [in] length of each row in bytes
     size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pSrc, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -781,26 +769,27 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
 __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,  ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,  ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the source 1D, 2D, or 3D image
-    ur_rect_offset_t dstOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the destination 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -837,16 +826,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     size_t offset, ///< [in] offset in bytes of the buffer region being mapped
     size_t size,   ///< [in] size in bytes of the buffer region being mapped
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent, ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [in,out][optional] return an event object that identifies this
+                 ///< particular command instance.
     void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
                     ///< numEventsInWaitList?
 ) {
@@ -887,16 +874,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
         hMem,         ///< [in] handle of the memory (buffer or image) object
     void *pMappedPtr, ///< [in] mapped host address
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -930,16 +915,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
     int8_t byteValue,             ///< [in] byte value to fill
     size_t count,                 ///< [in] size in bytes to be set
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMMemset = context.urDdiTable.Enqueue.pfnUSMMemset;
 
@@ -970,16 +953,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     const void *pSrc, ///< [in] pointer to the source USM memory object
     size_t size,      ///< [in] size in bytes to be copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -1013,16 +994,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     size_t size,                    ///< [in] size in bytes to be fetched
     ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
     uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -1055,9 +1034,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
     const void *pMem,         ///< [in] pointer to the USM memory object
     size_t size,              ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMMemAdvise = context.urDdiTable.Enqueue.pfnUSMMemAdvise;
 
@@ -1087,23 +1066,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch, ///< [in] the total width of the destination memory including
-                  ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     size_t patternSize, ///< [in] the size in bytes of the pattern.
     const void
         *pPattern, ///< [in] pointer with the bytes of the pattern to set.
     size_t width,  ///< [in] the width in bytes of each row to fill.
     size_t height, ///< [in] the height of the columns to fill.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -1134,21 +1112,20 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch,  ///< [in] the total width of the destination memory including
-                   ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     int value,     ///< [in] the value to fill into the region in pMem.
     size_t width,  ///< [in] the width in bytes of each row to set.
     size_t height, ///< [in] the height of the columns to set.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemset2D = context.urDdiTable.Enqueue.pfnUSMMemset2D;
 
@@ -1176,23 +1153,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
     const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t srcPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
-    size_t width,     ///< [in] the width in bytes of each row to be copied.
-    size_t height,    ///< [in] the height of columns to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -1222,26 +1198,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
 __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingWrite, ///< [in] indicates if this operation should block.
     size_t count,       ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
     const void *pSrc, ///< [in] pointer to where the data must be copied from.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableWrite =
         context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -1276,26 +1251,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
 __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingRead, ///< [in] indicates if this operation should block.
     size_t count,      ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
-    void *pDst,    ///< [in] pointer to where the data must be copied to.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableRead =
         context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -1366,8 +1340,9 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     size_t
         propValueSize, ///< [in] size in bytes of the profiling property value
     void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet ///< [out][optional] pointer to the actual size in
-                              ///< bytes returned in propValue
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
 
@@ -1393,9 +1368,9 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 /// @brief Intercept function for urEventWait
 __urdlllocal ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t
-        *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of
-                         ///< events to wait for completion
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     auto pfnWait = context.urDdiTable.Event.pfnWait;
 
@@ -1516,8 +1491,8 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = context.urDdiTable.Event.pfnSetCallback;
 
@@ -1774,15 +1749,14 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointed to by
-                     ///< pMemInfo.
-    void *pMemInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pMemInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
 
@@ -1808,15 +1782,14 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointer to by
-                     ///< pImgInfo.
-    void *pImgInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pImgInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
 
@@ -1863,9 +1836,9 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize, ///< [in] size in bytes of the queue property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the queue property
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out] value of the queue property
     size_t
         *pPropSizeRet ///< [out] size in bytes returned in queue property value
 ) {
@@ -1902,12 +1875,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t
-        *pProps, ///< [in] specifies a list of queue properties and their
-                 ///< corresponding values. Each property name is immediately
-                 ///< followed by the corresponding desired value. The list is
-                 ///< terminated with a 0. If a property value is not specified,
-                 ///< then its default value will be used.
+    const ur_queue_property_t *
+        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2156,9 +2129,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t propValueSize, ///< [in] size in bytes of the sampler property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the sampler property
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -2193,9 +2166,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native
-                                        ///< handle of the sampler.
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Sampler.pfnGetNativeHandle;
 
@@ -2220,10 +2193,10 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeSampler,            ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler ///< [out] pointer to the handle of the
-                                   ///< sampler object created.
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     auto pfnCreateWithNativeHandle =
         context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
@@ -2390,11 +2363,11 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize, ///< [in] size in bytes of the USM allocation property
-                          ///< value
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
     void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in USM
-                              ///< allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo = context.urDdiTable.USM.pfnGetMemAllocInfo;
 
@@ -2425,18 +2398,17 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries, ///< [in] the number of devices to be added to
-                         ///< phDevices. If phDevices in not NULL then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_VALUE, will be returned.
-    ur_device_handle_t
-        *phDevices, ///< [out][optional][range(0, NumEntries)] array of handle
-                    ///< of devices. If NumEntries is less than the number of
-                    ///< devices available, then platform shall only retrieve
-                    ///< that number of devices.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
     uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-                          ///< pNumDevices will be updated with the total number
-                          ///< of devices available.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = context.urDdiTable.Device.pfnGet;
 
@@ -2464,12 +2436,12 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
     size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
     void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-                       ///< If propSize is not equal to or greater than the real
-                       ///< number of bytes needed to return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_VALUE error is returned
-                       ///< and pDeviceInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of the queried infoType.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
 
@@ -2535,18 +2507,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t
-        *pProperties, ///< [in] null-terminated array of <$_device_partition_t
-                      ///< enum, value> pairs.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t
-        *phSubDevices, ///< [out][optional][range(0, NumDevices)] array of
-                       ///< handle of devices. If NumDevices is less than the
-                       ///< number of sub-devices available, then the function
-                       ///< shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet ///< [out][optional] pointer to the number of
-                             ///< sub-devices the device can be partitioned into
-                             ///< according to the partitioning property.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = context.urDdiTable.Device.pfnPartition;
 
@@ -2578,9 +2548,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input
-                        ///< array of binaries. If a suitable binary was not
-                        ///< found the function returns ${X}_INVALID_BINARY.
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
 
@@ -2667,12 +2636,12 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
 __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's
-                                ///< global timestamp that correlates with the
-                                ///< Host's global timestamp value
-    uint64_t *pHostTimestamp ///< [out][optional] pointer to the Host's global
-                             ///< timestamp that correlates with the Device's
-                             ///< global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     auto pfnGetGlobalTimestamps =
         context.urDdiTable.Device.pfnGetGlobalTimestamps;
@@ -2754,8 +2723,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize     ///< [in] size of the local buffer to be allocated by the
-                       ///< runtime
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = context.urDdiTable.Kernel.pfnSetArgLocal;
 
@@ -2778,14 +2747,15 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel
-                       ///< info property. If propSize is not equal to or
-                       ///< greater than the real number of bytes needed to
-                       ///< return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                       ///< pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Kernel.pfnGetInfo;
 
@@ -2812,12 +2782,14 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
-        propName,     ///< [in] name of the work Group property to query
-    size_t propSize,  ///< [in] size of the Kernel Work Group property value
-    void *pPropValue, ///< [in,out][optional][range(0, propSize)] value of the
-                      ///< Kernel Work Group property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = context.urDdiTable.Kernel.pfnGetGroupInfo;
 
@@ -2849,12 +2821,14 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
-        propName,     ///< [in] name of the SubGroup property to query
-    size_t propSize,  ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue, ///< [in,out][range(0, propSize)][optional] value of the
-                      ///< Kernel SubGroup property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetSubGroupInfo = context.urDdiTable.Kernel.pfnGetSubGroupInfo;
 
@@ -2924,11 +2898,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 /// @brief Intercept function for urKernelSetArgPointer
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,    ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,       ///< [in] size of argument type
-    const void *pArgValue ///< [in][optional] SVM pointer to memory location
-                          ///< holding the argument value. If null then argument
-                          ///< value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = context.urDdiTable.Kernel.pfnSetArgPointer;
 
@@ -2951,8 +2925,9 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue ///< [in][range(0, propSize)] pointer to memory
-                           ///< location holding the property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
 
@@ -3092,11 +3067,10 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
     const char
         *pOptions, ///< [in] pointer to compiler options null-terminated string.
     ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification
-                   ///< routine that is called when program compilation is
-                   ///< complete.
-    void *pUserData, ///< [in][optional] Passed as an argument when pfnNotify is
-                     ///< called.
+        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                   ///< called when program compilation is complete.
+    void *
+        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
     ur_module_handle_t
         *phModule ///< [out] pointer to handle of Module object created.
 ) {
@@ -3229,18 +3203,17 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
-    uint32_t NumEntries, ///< [in] the number of platforms to be added to
-                         ///< phPlatforms. If phPlatforms is not NULL, then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE, will be returned.
-    ur_platform_handle_t
-        *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle
-                      ///< of platforms. If NumEntries is less than the number
-                      ///< of platforms available, then
-                      ///< ::urPlatformGet shall only retrieve that number of
-                      ///< platforms.
-    uint32_t *pNumPlatforms ///< [out][optional] returns the total number of
-                            ///< platforms available.
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = context.urDdiTable.Platform.pfnGet;
 
@@ -3261,12 +3234,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
     size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-                         ///< If Size is not equal to or greater to the real
-                         ///< number of bytes needed to return the info then the
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                         ///< and pPlatformInfo is not used.
-    size_t *pSizeRet ///< [out][optional] pointer to the actual number of bytes
-                     ///< being queried by pPlatformInfo.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Platform.pfnGetInfo;
 
@@ -3316,9 +3288,9 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native
-                                         ///< handle of the platform.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Platform.pfnGetNativeHandle;
 
@@ -3344,8 +3316,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform ///< [out] pointer to the handle of the
-                                     ///< platform object created.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     auto pfnCreateWithNativeHandle =
         context.urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -3371,8 +3343,9 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 /// @brief Intercept function for urGetLastResult
 __urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage ///< [out] pointer to a string containing adapter
-                           ///< specific result in string representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     auto pfnGetLastResult = context.urDdiTable.Global.pfnGetLastResult;
 
@@ -3400,8 +3373,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
     uint32_t count, ///< [in] number of module handles in module list.
     const ur_module_handle_t
         *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions, ///< [in][optional] pointer to linker options
-                          ///< null-terminated string.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
     ur_program_handle_t
         *phProgram ///< [out] pointer to handle of program object created.
 ) {
@@ -3513,13 +3486,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program to search for function in.
-                  ///< The program must already be built to the specified
-                  ///< device, or otherwise
-                  ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName, ///< [in] A null-terminates string denoting the
-                               ///< mangled function name.
-    void **ppFunctionPointer   ///< [out] Returns the pointer to the function if
-                               ///< it is found in the program.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     auto pfnGetFunctionPointer =
         context.urDdiTable.Program.pfnGetFunctionPointer;
@@ -3556,14 +3528,14 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
-    void *pProgramInfo, ///< [in,out][optional] array of bytes of holding the
-                        ///< program info property. If propSize is not equal to
-                        ///< or greater than the real number of bytes needed to
-                        ///< return the info then the
-                        ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                        ///< and pProgramInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data copied to propName.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
 
@@ -3590,15 +3562,16 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
-        propName,     ///< [in] name of the Program build info to query
-    size_t propSize,  ///< [in] size of the Program build info property.
-    void *pPropValue, ///< [in,out][optional] value of the Program build
-                      ///< property. If propSize is not equal to or greater than
-                      ///< the real number of bytes needed to return the info
-                      ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                      ///< returned and pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = context.urDdiTable.Program.pfnGetBuildInfo;
 
@@ -3655,9 +3628,9 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native
-                                        ///< handle of the program.
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Program.pfnGetNativeHandle;
 
@@ -3682,10 +3655,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 /// @brief Intercept function for urProgramCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeProgram,            ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram ///< [out] pointer to the handle of the
-                                   ///< program object created.
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     auto pfnCreateWithNativeHandle =
         context.urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -3714,10 +3687,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
-    ur_device_init_flags_t
-        device_flags ///< [in] device initialization flags.
-                     ///< must be 0 (default) or a combination of
-                     ///< ::ur_device_init_flag_t.
+    ur_device_init_flags_t device_flags ///< [in] device initialization flags.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     auto pfnInit = context.urDdiTable.Global.pfnInit;
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -12,12 +12,11 @@
 namespace validation_layer {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
-    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
-    ur_device_handle_t
-        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t
-        *phContext ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL
+urContextCreate(
+    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
+    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = context.urDdiTable.Context.pfnCreate;
 
@@ -40,9 +39,9 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
-    ur_context_handle_t
-        hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL
+urContextRetain(
+    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
 ) {
     auto pfnRetain = context.urDdiTable.Context.pfnRetain;
 
@@ -61,7 +60,8 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+__urdlllocal ur_result_t UR_APICALL
+urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     auto pfnRelease = context.urDdiTable.Context.pfnRelease;
@@ -81,18 +81,17 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-    ///< if propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
+                                       ///< if propSize is not equal to or greater than the real number of bytes
+                                       ///< needed to return
+                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                       ///< pContextInfo is not used.
+    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
 
@@ -110,16 +109,15 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
         }
     }
 
-    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                      pPropSizeRet);
+    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_native_handle_t *
-        phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,       ///< [in] handle of the context.
+    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Context.pfnGetNativeHandle;
 
@@ -142,14 +140,12 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *
-        phContext ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Context.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -170,15 +166,13 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_context_extended_deleter_t
-        pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL
+urContextSetExtendedDeleter(
+    ur_context_handle_t hContext,             ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
-    auto pfnSetExtendedDeleter =
-        context.urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter = context.urDdiTable.Context.pfnSetExtendedDeleter;
 
     if (nullptr == pfnSetExtendedDeleter) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -199,34 +193,29 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t
-        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                 ///< work-group work-items
-    const size_t *
-        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< offset used to calculate the global ID of a work-item
-    const size_t *
-        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< number of global work-items in workDim that will execute the kernel
-    ///< function
-    const size_t *
-        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
-    ///< specify the number of local work-items forming a work-group that will
-    ///< execute the kernel function.
-    ///< If nullptr, the runtime implementation will choose the work-group
-    ///< size.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
+    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                              ///< work-group work-items
+    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< number of global work-items in workDim that will execute the kernel
+                                              ///< function
+    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
+                                              ///< specify the number of local work-items forming a work-group that will
+                                              ///< execute the kernel function.
+                                              ///< If nullptr, the runtime implementation will choose the work-group
+                                              ///< size.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -252,25 +241,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
         }
     }
 
-    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
-                           pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList,
-                           phEventWaitList, phEvent);
+    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
 
@@ -289,21 +275,19 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnEventsWaitWithBarrier =
-        context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier = context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
 
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -315,28 +299,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
         }
     }
 
-    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
-                                    phEventWaitList, phEvent);
+    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being read
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being read
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -358,30 +340,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
         }
     }
 
-    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
-                            numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being written
-    const void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being written
+    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -403,40 +381,33 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
         }
     }
 
-    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
-                             numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< dst
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by dst
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< dst
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by dst
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
 
@@ -458,48 +429,36 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
         }
     }
 
-    return pfnMemBufferReadRect(
-        hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region,
-        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
-                          ///< written
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< src
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by src
-    void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
+                                              ///< written
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< src
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by src
+    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferWriteRect =
-        context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect = context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
 
     if (nullptr == pfnMemBufferWriteRect) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -519,30 +478,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
         }
     }
 
-    return pfnMemBufferWriteRect(
-        hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region,
-        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
-    size_t size,      ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
+    size_t size,                              ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -564,38 +519,30 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
         }
     }
 
-    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
-                            dstOffset, size, numEventsInWaitList,
-                            phEventWaitList, phEvent);
+    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t
-        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t
-        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
-    size_t
-        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t
-        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
-    size_t
-        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
@@ -617,30 +564,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
         }
     }
 
-    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin,
-                                dstOrigin, srcRegion, srcRowPitch,
-                                srcSlicePitch, dstRowPitch, dstSlicePitch,
-                                numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    const void *pPattern,     ///< [in] pointer to the fill pattern
-    size_t patternSize,       ///< [in] size in bytes of the pattern
-    size_t offset,            ///< [in] offset into the buffer
-    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    const void *pPattern,                     ///< [in] pointer to the fill pattern
+    size_t patternSize,                       ///< [in] size in bytes of the pattern
+    size_t offset,                            ///< [in] offset into the buffer
+    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -662,34 +605,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
         }
     }
 
-    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset,
-                            size, numEventsInWaitList, phEventWaitList,
-                            phEvent);
+    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t rowPitch,   ///< [in] length of each row in bytes
-    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pDst, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
+    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -711,35 +649,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
         }
     }
 
-    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
-                           rowPitch, slicePitch, pDst, numEventsInWaitList,
-                           phEventWaitList, phEvent);
+    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t inputRowPitch,   ///< [in] length of each row in bytes
-    size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pSrc, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t inputRowPitch,                     ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -761,35 +693,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
         }
     }
 
-    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
-                            inputRowPitch, inputSlicePitch, pSrc,
-                            numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
-    ur_rect_offset_t
-        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                              ///< image
+    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                              ///< or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -811,31 +737,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
         }
     }
 
-    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
-                           region, numEventsInWaitList, phEventWaitList,
-                           phEvent);
+    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
-    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,   ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent, ///< [in,out][optional] return an event object that identifies this
-                 ///< particular command instance.
-    void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
-                    ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+                                              ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = context.urDdiTable.Enqueue.pfnMemBufferMap;
 
@@ -861,27 +784,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
         }
     }
 
-    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size,
-                           numEventsInWaitList, phEventWaitList, phEvent,
-                           ppRetMap);
+    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t
-        hMem,         ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr, ///< [in] mapped host address
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr,                         ///< [in] mapped host address
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -903,26 +822,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
         }
     }
 
-    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
-                       phEventWaitList, phEvent);
+    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemset
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    void *ptr,                    ///< [in] pointer to USM memory object
-    int8_t byteValue,             ///< [in] byte value to fill
-    size_t count,                 ///< [in] size in bytes to be set
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    void *ptr,                                ///< [in] pointer to USM memory object
+    int8_t byteValue,                         ///< [in] byte value to fill
+    size_t count,                             ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnUSMMemset = context.urDdiTable.Enqueue.pfnUSMMemset;
 
@@ -940,27 +857,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
         }
     }
 
-    return pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList,
-                        phEventWaitList, phEvent);
+    return pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool blocking,            ///< [in] blocking or non-blocking copy
-    void *pDst,       ///< [in] pointer to the destination USM memory object
-    const void *pSrc, ///< [in] pointer to the source USM memory object
-    size_t size,      ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking copy
+    void *pDst,                               ///< [in] pointer to the destination USM memory object
+    const void *pSrc,                         ///< [in] pointer to the source USM memory object
+    size_t size,                              ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -982,26 +897,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
         }
     }
 
-    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
-                        phEventWaitList, phEvent);
+    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
-    const void *pMem,               ///< [in] pointer to the USM memory object
-    size_t size,                    ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -1023,20 +936,19 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
         }
     }
 
-    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
-                          phEventWaitList, phEvent);
+    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    const void *pMem,         ///< [in] pointer to the USM memory object
-    size_t size,              ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    const void *pMem,          ///< [in] pointer to the USM memory object
+    size_t size,               ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,    ///< [in] USM memory advice
+    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
+                               ///< particular command instance.
 ) {
     auto pfnUSMMemAdvise = context.urDdiTable.Enqueue.pfnUSMMemAdvise;
 
@@ -1063,25 +975,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    size_t patternSize, ///< [in] the size in bytes of the pattern.
-    const void
-        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,  ///< [in] the width in bytes of each row to fill.
-    size_t height, ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    size_t patternSize,                       ///< [in] the size in bytes of the pattern.
+    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
+    size_t width,                             ///< [in] the width in bytes of each row to fill.
+    size_t height,                            ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -1103,29 +1012,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
         }
     }
 
-    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
-                        height, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemset2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    int value,     ///< [in] the value to fill into the region in pMem.
-    size_t width,  ///< [in] the width in bytes of each row to set.
-    size_t height, ///< [in] the height of the columns to set.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemset2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    int value,                                ///< [in] the value to fill into the region in pMem.
+    size_t width,                             ///< [in] the width in bytes of each row to set.
+    size_t height,                            ///< [in] the height of the columns to set.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemset2D = context.urDdiTable.Enqueue.pfnUSMMemset2D;
 
@@ -1143,32 +1049,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
         }
     }
 
-    return pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height,
-                          numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    bool blocking, ///< [in] indicates if this operation should block the host.
-    void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t
-        dstPitch, ///< [in] the total width of the source memory including padding.
-    const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t
-        srcPitch, ///< [in] the total width of the source memory including padding.
-    size_t width,  ///< [in] the width in bytes of each row to be copied.
-    size_t height, ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    bool blocking,                            ///< [in] indicates if this operation should block the host.
+    void *pDst,                               ///< [in] pointer to memory where data will be copied.
+    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
+    const void *pSrc,                         ///< [in] pointer to memory to be copied.
+    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
+    size_t width,                             ///< [in] the width in bytes of each row to be copied.
+    size_t height,                            ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -1190,36 +1092,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
         }
     }
 
-    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch,
-                          width, height, numEventsInWaitList, phEventWaitList,
-                          phEvent);
+    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite, ///< [in] indicates if this operation should block.
-    size_t count,       ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc, ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                       ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableWrite =
-        context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
 
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1243,36 +1138,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         }
     }
 
-    return pfnDeviceGlobalVariableWrite(
-        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingRead, ///< [in] indicates if this operation should block.
-    size_t count,      ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst, ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                        ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst,                               ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableRead =
-        context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
 
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1296,20 +1184,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
         }
     }
 
-    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead,
-                                       count, offset, pDst, numEventsInWaitList,
-                                       phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize,     ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional] value of the event property
+    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
 
@@ -1327,22 +1213,19 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
         }
     }
 
-    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                      pPropValueSizeRet);
+    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
-    ur_event_handle_t hEvent, ///< [in] handle of the event object
-    ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+__urdlllocal ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t hEvent,     ///< [in] handle of the event object
+    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
+    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional] value of the profiling property
+    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+                                  ///< propValue
 ) {
     auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
 
@@ -1360,17 +1243,16 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
         }
     }
 
-    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
-                               pPropValueSizeRet);
+    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
-    uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t *
-        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                        ///< completion
+__urdlllocal ur_result_t UR_APICALL
+urEventWait(
+    uint32_t numEvents,                      ///< [in] number of events in the event list
+    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                             ///< completion
 ) {
     auto pfnWait = context.urDdiTable.Event.pfnWait;
 
@@ -1389,7 +1271,8 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+__urdlllocal ur_result_t UR_APICALL
+urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRetain = context.urDdiTable.Event.pfnRetain;
@@ -1409,7 +1292,8 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+__urdlllocal ur_result_t UR_APICALL
+urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRelease = context.urDdiTable.Event.pfnRelease;
@@ -1429,10 +1313,10 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ///< [in] handle of the event.
-    ur_native_handle_t
-        *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,         ///< [in] handle of the event.
+    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Event.pfnGetNativeHandle;
 
@@ -1455,14 +1339,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t
-        *phEvent ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Event.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1487,12 +1370,12 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL
+urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = context.urDdiTable.Event.pfnSetCallback;
 
@@ -1519,14 +1402,14 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    void *pHost,                       ///< [in] pointer to the buffer data
-    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    void *pHost,                           ///< [in] pointer to the buffer data
+    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
 ) {
     auto pfnImageCreate = context.urDdiTable.Mem.pfnImageCreate;
 
@@ -1564,19 +1447,18 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
         }
     }
 
-    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost,
-                          phMem);
+    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL
+urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t
-        *phBuffer ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
+    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
+    void *pHost,                  ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
 ) {
     auto pfnBufferCreate = context.urDdiTable.Mem.pfnBufferCreate;
 
@@ -1603,7 +1485,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+__urdlllocal ur_result_t UR_APICALL
+urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Mem.pfnRetain;
@@ -1623,7 +1506,8 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+__urdlllocal ur_result_t UR_APICALL
+urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     auto pfnRelease = context.urDdiTable.Mem.pfnRelease;
@@ -1643,15 +1527,13 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t
-        hBuffer,          ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
+    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
 ) {
     auto pfnBufferPartition = context.urDdiTable.Mem.pfnBufferPartition;
 
@@ -1681,16 +1563,15 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
         }
     }
 
-    return pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                              pBufferCreateInfo, phMem);
+    return pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
-    ur_mem_handle_t hMem, ///< [in] handle of the mem.
-    ur_native_handle_t
-        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Mem.pfnGetNativeHandle;
 
@@ -1713,14 +1594,13 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Mem.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1745,18 +1625,16 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
-    ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL
+urMemGetInfo(
+    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
+                               ///< If propSize is less than the real number of bytes needed to return
+                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                               ///< pMemInfo is not used.
+    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
 
@@ -1779,17 +1657,16 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
-    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL
+urMemImageGetInfo(
+    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
+                                 ///< If propSize is less than the real number of bytes needed to return
+                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                 ///< pImgInfo is not used.
+    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
 
@@ -1807,13 +1684,13 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
         }
     }
 
-    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
-                           pPropSizeRet);
+    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL urTearDown(
+__urdlllocal ur_result_t UR_APICALL
+urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     auto pfnTearDown = context.urDdiTable.Global.pfnTearDown;
@@ -1833,14 +1710,13 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out] value of the queue property
-    size_t
-        *pPropSizeRet ///< [out] size in bytes returned in queue property value
+    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out] value of the queue property
+    size_t *pPropSizeRet      ///< [out] size in bytes returned in queue property value
 ) {
     auto pfnGetInfo = context.urDdiTable.Queue.pfnGetInfo;
 
@@ -1866,23 +1742,21 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
         }
     }
 
-    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
-                      pPropSizeRet);
+    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_device_handle_t hDevice,        ///< [in] handle of the device object
+    const ur_queue_property_t *pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+                                       ///< Each property name is immediately followed by the corresponding
+                                       ///< desired value.
+                                       ///< The list is terminated with a 0.
+                                       ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
 ) {
     auto pfnCreate = context.urDdiTable.Queue.pfnCreate;
 
@@ -1913,7 +1787,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL
+urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Queue.pfnRetain;
@@ -1933,7 +1808,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL
+urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     auto pfnRelease = context.urDdiTable.Queue.pfnRelease;
@@ -1953,10 +1829,10 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
-    ur_native_handle_t
-        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Queue.pfnGetNativeHandle;
 
@@ -1979,14 +1855,13 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Queue.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2011,7 +1886,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL
+urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = context.urDdiTable.Queue.pfnFinish;
@@ -2031,7 +1907,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL
+urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = context.urDdiTable.Queue.pfnFlush;
@@ -2051,13 +1928,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
-    ur_sampler_handle_t
-        *phSampler ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context object
+    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
+                                         ///< corresponding values.
+    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
 ) {
     auto pfnCreate = context.urDdiTable.Sampler.pfnCreate;
 
@@ -2084,9 +1960,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL
+urSamplerRetain(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Sampler.pfnRetain;
 
@@ -2105,9 +1981,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
 ) {
     auto pfnRelease = context.urDdiTable.Sampler.pfnRelease;
 
@@ -2126,14 +2002,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
-    size_t *
-        pPropSizeRet ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
+    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out] value of the sampler property
+    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 ) {
     auto pfnGetInfo = context.urDdiTable.Sampler.pfnGetInfo;
 
@@ -2159,16 +2034,15 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
         }
     }
 
-    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
-                      pPropSizeRet);
+    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
-    ur_native_handle_t *
-        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
+    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Sampler.pfnGetNativeHandle;
 
@@ -2191,15 +2065,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeSampler,           ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_sampler_handle_t *
-        phSampler ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2224,13 +2096,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_mem_flags_t *pUSMFlag, ///< [in] USM memory allocation flags
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM host memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = context.urDdiTable.USM.pfnHostAlloc;
 
@@ -2257,14 +2129,14 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM device memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = context.urDdiTable.USM.pfnDeviceAlloc;
 
@@ -2295,14 +2167,14 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM shared memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = context.urDdiTable.USM.pfnSharedAlloc;
 
@@ -2333,7 +2205,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+__urdlllocal ur_result_t UR_APICALL
+urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -2358,16 +2231,14 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL
+urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t
-        propName, ///< [in] the name of the USM allocation property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional] value of the USM allocation property
+    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo = context.urDdiTable.USM.pfnGetMemAllocInfo;
 
@@ -2389,26 +2260,24 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
         }
     }
 
-    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                              pPropValue, pPropValueSizeRet);
+    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t
-        NumEntries, ///< [in] the number of devices to be added to phDevices.
-    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-    ///< will be returned.
-    ur_device_handle_t *
-        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-    ///< If NumEntries is less than the number of devices available, then
-    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
+                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+                                    ///< will be returned.
+    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                    ///< If NumEntries is less than the number of devices available, then
+                                    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
+                                    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = context.urDdiTable.Device.pfnGet;
 
@@ -2431,17 +2300,17 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info
-    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return the info
+                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+                                ///< pDeviceInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
 
@@ -2464,9 +2333,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
-    ur_device_handle_t
-        hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceRetain(
+    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
 ) {
     auto pfnRetain = context.urDdiTable.Device.pfnRetain;
 
@@ -2485,7 +2354,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     auto pfnRelease = context.urDdiTable.Device.pfnRelease;
@@ -2505,18 +2375,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t *
-        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-    ///< If NumDevices is less than the number of sub-devices available, then
-    ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *
-        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
-    ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                       ///< If NumDevices is less than the number of sub-devices available, then
+                                                       ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                       ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = context.urDdiTable.Device.pfnPartition;
 
@@ -2534,22 +2402,20 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
         }
     }
 
-    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
-                        pNumDevicesRet);
+    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
-                          ///< Must greater than or equal to zero otherwise
-                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
+                                ///< Must greater than or equal to zero otherwise
+                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
+                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
 
@@ -2576,10 +2442,10 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ///< [in] handle of the device.
-    ur_native_handle_t
-        *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,        ///< [in] handle of the device.
+    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Device.pfnGetNativeHandle;
 
@@ -2602,14 +2468,13 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t
-        *phDevice ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Device.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2634,17 +2499,15 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *
-        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                          ///< correlates with the Host's global timestamp value
-    uint64_t *
-        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
-                       ///< correlates with the Device's global timestamp value
+    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                                ///< correlates with the Host's global timestamp value
+    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
+                                ///< correlates with the Device's global timestamp value
 ) {
-    auto pfnGetGlobalTimestamps =
-        context.urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps = context.urDdiTable.Device.pfnGetGlobalTimestamps;
 
     if (nullptr == pfnGetGlobalTimestamps) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2661,11 +2524,11 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL
+urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
 ) {
     auto pfnCreate = context.urDdiTable.Kernel.pfnCreate;
 
@@ -2692,12 +2555,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void
-        *pArgValue ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in] argument value represented as matching arg type.
 ) {
     auto pfnSetArgValue = context.urDdiTable.Kernel.pfnSetArgValue;
 
@@ -2720,11 +2583,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t
-        argSize ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = context.urDdiTable.Kernel.pfnSetArgLocal;
 
@@ -2743,19 +2606,18 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return
+                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                ///< pKernelInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
+                                ///< queried by propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Kernel.pfnGetInfo;
 
@@ -2778,18 +2640,16 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_group_info_t
-        propName,    ///< [in] name of the work Group property to query
-    size_t propSize, ///< [in] size of the Kernel Work Group property value
-    void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
+    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
+    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                     ///< property.
+    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
+                                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = context.urDdiTable.Kernel.pfnGetGroupInfo;
 
@@ -2811,24 +2671,21 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         }
     }
 
-    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
-                           pPropSizeRet);
+    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t
-        propName,    ///< [in] name of the SubGroup property to query
-    size_t propSize, ///< [in] size of the Kernel SubGroup property value
-    void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
+    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
+    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                         ///< property.
+    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
+                                         ///< queried by propName.
 ) {
     auto pfnGetSubGroupInfo = context.urDdiTable.Kernel.pfnGetSubGroupInfo;
 
@@ -2850,13 +2707,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         }
     }
 
-    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
-                              pPropSizeRet);
+    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL
+urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     auto pfnRetain = context.urDdiTable.Kernel.pfnRetain;
@@ -2876,7 +2733,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL
+urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     auto pfnRelease = context.urDdiTable.Kernel.pfnRelease;
@@ -2896,13 +2754,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void *
-        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
-                  ///< value. If null then argument value is considered null.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
+                                ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = context.urDdiTable.Kernel.pfnSetArgPointer;
 
@@ -2921,13 +2779,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
-                   ///< property value.
+    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                    ///< property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
 
@@ -2954,9 +2812,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
+    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     auto pfnSetArgSampler = context.urDdiTable.Kernel.pfnSetArgSampler;
@@ -2980,10 +2839,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = context.urDdiTable.Kernel.pfnSetArgMemObj;
 
@@ -3002,10 +2862,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
-    ur_native_handle_t
-        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Kernel.pfnGetNativeHandle;
 
@@ -3028,14 +2888,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3060,19 +2919,16 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleCreate
-__urdlllocal ur_result_t UR_APICALL urModuleCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    const void *pIL,              ///< [in] pointer to IL string.
-    size_t length,                ///< [in] length of IL in bytes.
-    const char
-        *pOptions, ///< [in] pointer to compiler options null-terminated string.
-    ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
-                   ///< called when program compilation is complete.
-    void *
-        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to handle of Module object created.
+__urdlllocal ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,         ///< [in] handle of the context instance.
+    const void *pIL,                      ///< [in] pointer to IL string.
+    size_t length,                        ///< [in] length of IL in bytes.
+    const char *pOptions,                 ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                                          ///< called when program compilation is complete.
+    void *pUserData,                      ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t *phModule          ///< [out] pointer to handle of Module object created.
 ) {
     auto pfnCreate = context.urDdiTable.Module.pfnCreate;
 
@@ -3098,13 +2954,13 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
         }
     }
 
-    return pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData,
-                     phModule);
+    return pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData, phModule);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleRetain
-__urdlllocal ur_result_t UR_APICALL urModuleRetain(
+__urdlllocal ur_result_t UR_APICALL
+urModuleRetain(
     ur_module_handle_t hModule ///< [in] handle for the Module to retain
 ) {
     auto pfnRetain = context.urDdiTable.Module.pfnRetain;
@@ -3124,7 +2980,8 @@ __urdlllocal ur_result_t UR_APICALL urModuleRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleRelease
-__urdlllocal ur_result_t UR_APICALL urModuleRelease(
+__urdlllocal ur_result_t UR_APICALL
+urModuleRelease(
     ur_module_handle_t hModule ///< [in] handle for the Module to release
 ) {
     auto pfnRelease = context.urDdiTable.Module.pfnRelease;
@@ -3144,10 +3001,10 @@ __urdlllocal ur_result_t UR_APICALL urModuleRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
-    ur_module_handle_t hModule, ///< [in] handle of the module.
-    ur_native_handle_t
-        *phNativeModule ///< [out] a pointer to the native handle of the module.
+__urdlllocal ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,        ///< [in] handle of the module.
+    ur_native_handle_t *phNativeModule ///< [out] a pointer to the native handle of the module.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Module.pfnGetNativeHandle;
 
@@ -3170,14 +3027,13 @@ __urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
     ur_native_handle_t hNativeModule, ///< [in] the native handle of the module.
     ur_context_handle_t hContext,     ///< [in] handle of the context instance.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to the handle of the module object created.
+    ur_module_handle_t *phModule      ///< [out] pointer to the handle of the module object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Module.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Module.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3202,18 +3058,16 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
-    uint32_t
-        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
-    ///< If phPlatforms is not NULL, then NumEntries should be greater than
-    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-    ///< will be returned.
-    ur_platform_handle_t *
-        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-    ///< If NumEntries is less than the number of platforms available, then
-    ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *
-        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGet(
+    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
+                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                       ///< will be returned.
+    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                       ///< If NumEntries is less than the number of platforms available, then
+                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = context.urDdiTable.Platform.pfnGet;
 
@@ -3229,16 +3083,16 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If Size is not equal to or greater to the real number of bytes needed
-    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-    ///< returned and pPlatformInfo is not used.
-    size_t *
-        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
+                                         ///< If Size is not equal to or greater to the real number of bytes needed
+                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                         ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Platform.pfnGetInfo;
 
@@ -3256,13 +3110,13 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
         }
     }
 
-    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
-                      pSizeRet);
+    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -3287,10 +3141,10 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
-    ur_native_handle_t *
-        phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
+    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Platform.pfnGetNativeHandle;
 
@@ -3313,14 +3167,12 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *
-        phPlatform ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Platform.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3341,11 +3193,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL
+urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage ///< [out] pointer to a string containing adapter specific result in string
-                  ///< representation.
+    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
+                                    ///< representation.
 ) {
     auto pfnGetLastResult = context.urDdiTable.Global.pfnGetLastResult;
 
@@ -3368,15 +3220,13 @@ __urdlllocal ur_result_t UR_APICALL urGetLastResult(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreate
-__urdlllocal ur_result_t UR_APICALL urProgramCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    uint32_t count, ///< [in] number of module handles in module list.
-    const ur_module_handle_t
-        *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *
-        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context instance
+    uint32_t count,                      ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreate = context.urDdiTable.Program.pfnCreate;
 
@@ -3403,14 +3253,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_device_handle_t
-        hDevice,            ///< [in] handle to device associated with binary.
-    size_t size,            ///< [in] size in bytes.
-    const uint8_t *pBinary, ///< [in] pointer to binary.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,  ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
+    size_t size,                   ///< [in] size in bytes.
+    const uint8_t *pBinary,        ///< [in] pointer to binary.
+    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     auto pfnCreateWithBinary = context.urDdiTable.Program.pfnCreateWithBinary;
 
@@ -3441,7 +3290,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL
+urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     auto pfnRetain = context.urDdiTable.Program.pfnRetain;
@@ -3461,7 +3311,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL
+urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     auto pfnRelease = context.urDdiTable.Program.pfnRelease;
@@ -3481,20 +3332,16 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program to search for function in.
-    ///< The program must already be built to the specified device, or
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *
-        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
-    void **
-        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
+                                  ///< The program must already be built to the specified device, or
+                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
+    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
-    auto pfnGetFunctionPointer =
-        context.urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer = context.urDdiTable.Program.pfnGetFunctionPointer;
 
     if (nullptr == pfnGetFunctionPointer) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3518,24 +3365,22 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
         }
     }
 
-    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
-                                 ppFunctionPointer);
+    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName, ///< [in] name of the Program property to query
-    size_t propSize,            ///< [in] the size of the Program property.
-    void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+    ur_program_info_t propName,   ///< [in] name of the Program property to query
+    size_t propSize,              ///< [in] the size of the Program property.
+    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+                                  ///< If propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pProgramInfo is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
 
@@ -3558,20 +3403,18 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
-    ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
-    ur_program_build_info_t
-        propName,    ///< [in] name of the Program build info to query
-    size_t propSize, ///< [in] size of the Program build info property.
-    void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
+    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
+    size_t propSize,                  ///< [in] size of the Program build info property.
+    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+                                      ///< If propSize is not equal to or greater than the real number of bytes
+                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                      ///< error is returned and pKernelInfo is not used.
+    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
+                                      ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = context.urDdiTable.Program.pfnGetBuildInfo;
 
@@ -3593,20 +3436,19 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         }
     }
 
-    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
-                           pPropSizeRet);
+    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstant
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
+__urdlllocal ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t specId,              ///< [in] specification constant Id
-    size_t specSize,       ///< [in] size of the specialization constant value
-    const void *pSpecValue ///< [in] pointer to the specialization value bytes
+    size_t specSize,              ///< [in] size of the specialization constant value
+    const void *pSpecValue        ///< [in] pointer to the specialization value bytes
 ) {
-    auto pfnSetSpecializationConstant =
-        context.urDdiTable.Program.pfnSetSpecializationConstant;
+    auto pfnSetSpecializationConstant = context.urDdiTable.Program.pfnSetSpecializationConstant;
 
     if (nullptr == pfnSetSpecializationConstant) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3627,10 +3469,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ///< [in] handle of the program.
-    ur_native_handle_t *
-        phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,       ///< [in] handle of the program.
+    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Program.pfnGetNativeHandle;
 
@@ -3653,15 +3495,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeProgram,           ///< [in] the native handle of the program.
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_program_handle_t *
-        phProgram ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,      ///< [in] handle of the context instance
+    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        context.urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = context.urDdiTable.Program.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3686,9 +3526,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL urInit(
+__urdlllocal ur_result_t UR_APICALL
+urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     auto pfnInit = context.urDdiTable.Global.pfnInit;
 
@@ -3713,10 +3554,10 @@ __urdlllocal ur_result_t UR_APICALL urInit(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_global_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetGlobalProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Global;
 
@@ -3724,10 +3565,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3753,10 +3592,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_context_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetContextProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Context;
 
@@ -3764,10 +3603,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3789,12 +3626,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urContextGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urContextCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urContextCreateWithNativeHandle;
 
     dditable.pfnSetExtendedDeleter = pDdiTable->pfnSetExtendedDeleter;
-    pDdiTable->pfnSetExtendedDeleter =
-        validation_layer::urContextSetExtendedDeleter;
+    pDdiTable->pfnSetExtendedDeleter = validation_layer::urContextSetExtendedDeleter;
 
     return result;
 }
@@ -3807,10 +3642,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_enqueue_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEnqueueProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Enqueue;
 
@@ -3818,10 +3653,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3834,8 +3667,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     pDdiTable->pfnEventsWait = validation_layer::urEnqueueEventsWait;
 
     dditable.pfnEventsWaitWithBarrier = pDdiTable->pfnEventsWaitWithBarrier;
-    pDdiTable->pfnEventsWaitWithBarrier =
-        validation_layer::urEnqueueEventsWaitWithBarrier;
+    pDdiTable->pfnEventsWaitWithBarrier = validation_layer::urEnqueueEventsWaitWithBarrier;
 
     dditable.pfnMemBufferRead = pDdiTable->pfnMemBufferRead;
     pDdiTable->pfnMemBufferRead = validation_layer::urEnqueueMemBufferRead;
@@ -3844,19 +3676,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     pDdiTable->pfnMemBufferWrite = validation_layer::urEnqueueMemBufferWrite;
 
     dditable.pfnMemBufferReadRect = pDdiTable->pfnMemBufferReadRect;
-    pDdiTable->pfnMemBufferReadRect =
-        validation_layer::urEnqueueMemBufferReadRect;
+    pDdiTable->pfnMemBufferReadRect = validation_layer::urEnqueueMemBufferReadRect;
 
     dditable.pfnMemBufferWriteRect = pDdiTable->pfnMemBufferWriteRect;
-    pDdiTable->pfnMemBufferWriteRect =
-        validation_layer::urEnqueueMemBufferWriteRect;
+    pDdiTable->pfnMemBufferWriteRect = validation_layer::urEnqueueMemBufferWriteRect;
 
     dditable.pfnMemBufferCopy = pDdiTable->pfnMemBufferCopy;
     pDdiTable->pfnMemBufferCopy = validation_layer::urEnqueueMemBufferCopy;
 
     dditable.pfnMemBufferCopyRect = pDdiTable->pfnMemBufferCopyRect;
-    pDdiTable->pfnMemBufferCopyRect =
-        validation_layer::urEnqueueMemBufferCopyRect;
+    pDdiTable->pfnMemBufferCopyRect = validation_layer::urEnqueueMemBufferCopyRect;
 
     dditable.pfnMemBufferFill = pDdiTable->pfnMemBufferFill;
     pDdiTable->pfnMemBufferFill = validation_layer::urEnqueueMemBufferFill;
@@ -3897,15 +3726,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     dditable.pfnUSMMemcpy2D = pDdiTable->pfnUSMMemcpy2D;
     pDdiTable->pfnUSMMemcpy2D = validation_layer::urEnqueueUSMMemcpy2D;
 
-    dditable.pfnDeviceGlobalVariableWrite =
-        pDdiTable->pfnDeviceGlobalVariableWrite;
-    pDdiTable->pfnDeviceGlobalVariableWrite =
-        validation_layer::urEnqueueDeviceGlobalVariableWrite;
+    dditable.pfnDeviceGlobalVariableWrite = pDdiTable->pfnDeviceGlobalVariableWrite;
+    pDdiTable->pfnDeviceGlobalVariableWrite = validation_layer::urEnqueueDeviceGlobalVariableWrite;
 
-    dditable.pfnDeviceGlobalVariableRead =
-        pDdiTable->pfnDeviceGlobalVariableRead;
-    pDdiTable->pfnDeviceGlobalVariableRead =
-        validation_layer::urEnqueueDeviceGlobalVariableRead;
+    dditable.pfnDeviceGlobalVariableRead = pDdiTable->pfnDeviceGlobalVariableRead;
+    pDdiTable->pfnDeviceGlobalVariableRead = validation_layer::urEnqueueDeviceGlobalVariableRead;
 
     return result;
 }
@@ -3918,10 +3743,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_event_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEventProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Event;
 
@@ -3929,10 +3754,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3957,8 +3780,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urEventGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urEventCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urEventCreateWithNativeHandle;
 
     dditable.pfnSetCallback = pDdiTable->pfnSetCallback;
     pDdiTable->pfnSetCallback = validation_layer::urEventSetCallback;
@@ -3974,10 +3796,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_kernel_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetKernelProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Kernel;
 
@@ -3985,10 +3807,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4016,8 +3836,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urKernelGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urKernelCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urKernelCreateWithNativeHandle;
 
     dditable.pfnSetArgValue = pDdiTable->pfnSetArgValue;
     pDdiTable->pfnSetArgValue = validation_layer::urKernelSetArgValue;
@@ -4048,10 +3867,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_mem_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Mem;
 
@@ -4059,10 +3878,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4087,8 +3904,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urMemGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urMemCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urMemCreateWithNativeHandle;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = validation_layer::urMemGetInfo;
@@ -4107,10 +3923,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_module_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetModuleProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_module_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Module;
 
@@ -4118,10 +3934,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4140,8 +3954,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urModuleGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urModuleCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urModuleCreateWithNativeHandle;
 
     return result;
 }
@@ -4154,10 +3967,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_platform_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetPlatformProcAddrTable(
+    ur_api_version_t version,         ///< [in] API version requested
+    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Platform;
 
@@ -4165,10 +3978,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4184,8 +3995,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urPlatformGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urPlatformCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urPlatformCreateWithNativeHandle;
 
     dditable.pfnGetApiVersion = pDdiTable->pfnGetApiVersion;
     pDdiTable->pfnGetApiVersion = validation_layer::urPlatformGetApiVersion;
@@ -4201,10 +4011,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_program_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetProgramProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Program;
 
@@ -4212,10 +4022,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4225,8 +4033,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
     pDdiTable->pfnCreate = validation_layer::urProgramCreate;
 
     dditable.pfnCreateWithBinary = pDdiTable->pfnCreateWithBinary;
-    pDdiTable->pfnCreateWithBinary =
-        validation_layer::urProgramCreateWithBinary;
+    pDdiTable->pfnCreateWithBinary = validation_layer::urProgramCreateWithBinary;
 
     dditable.pfnRetain = pDdiTable->pfnRetain;
     pDdiTable->pfnRetain = validation_layer::urProgramRetain;
@@ -4235,8 +4042,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
     pDdiTable->pfnRelease = validation_layer::urProgramRelease;
 
     dditable.pfnGetFunctionPointer = pDdiTable->pfnGetFunctionPointer;
-    pDdiTable->pfnGetFunctionPointer =
-        validation_layer::urProgramGetFunctionPointer;
+    pDdiTable->pfnGetFunctionPointer = validation_layer::urProgramGetFunctionPointer;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = validation_layer::urProgramGetInfo;
@@ -4244,17 +4050,14 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
     dditable.pfnGetBuildInfo = pDdiTable->pfnGetBuildInfo;
     pDdiTable->pfnGetBuildInfo = validation_layer::urProgramGetBuildInfo;
 
-    dditable.pfnSetSpecializationConstant =
-        pDdiTable->pfnSetSpecializationConstant;
-    pDdiTable->pfnSetSpecializationConstant =
-        validation_layer::urProgramSetSpecializationConstant;
+    dditable.pfnSetSpecializationConstant = pDdiTable->pfnSetSpecializationConstant;
+    pDdiTable->pfnSetSpecializationConstant = validation_layer::urProgramSetSpecializationConstant;
 
     dditable.pfnGetNativeHandle = pDdiTable->pfnGetNativeHandle;
     pDdiTable->pfnGetNativeHandle = validation_layer::urProgramGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urProgramCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urProgramCreateWithNativeHandle;
 
     return result;
 }
@@ -4267,10 +4070,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_queue_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetQueueProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Queue;
 
@@ -4278,10 +4081,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4303,8 +4104,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urQueueGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urQueueCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urQueueCreateWithNativeHandle;
 
     dditable.pfnFinish = pDdiTable->pfnFinish;
     pDdiTable->pfnFinish = validation_layer::urQueueFinish;
@@ -4323,10 +4123,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_sampler_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetSamplerProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Sampler;
 
@@ -4334,10 +4134,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4359,8 +4157,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urSamplerGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urSamplerCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urSamplerCreateWithNativeHandle;
 
     return result;
 }
@@ -4373,10 +4170,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_usm_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.USM;
 
@@ -4384,10 +4181,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4419,10 +4214,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_device_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetDeviceProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Device;
 
@@ -4430,10 +4225,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
-            UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) >
-            UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4461,82 +4254,68 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urDeviceGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle =
-        validation_layer::urDeviceCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urDeviceCreateWithNativeHandle;
 
     dditable.pfnGetGlobalTimestamps = pDdiTable->pfnGetGlobalTimestamps;
-    pDdiTable->pfnGetGlobalTimestamps =
-        validation_layer::urDeviceGetGlobalTimestamps;
+    pDdiTable->pfnGetGlobalTimestamps = validation_layer::urDeviceGetGlobalTimestamps;
 
     return result;
 }
 
-ur_result_t context_t::init(ur_dditable_t *dditable) {
+ur_result_t context_t::init(
+    ur_dditable_t *dditable) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetGlobalProcAddrTable(UR_API_VERSION_0_9,
-                                                            &dditable->Global);
+        result = validation_layer::urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &dditable->Global);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetContextProcAddrTable(
-            UR_API_VERSION_0_9, &dditable->Context);
+        result = validation_layer::urGetContextProcAddrTable(UR_API_VERSION_0_9, &dditable->Context);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetEnqueueProcAddrTable(
-            UR_API_VERSION_0_9, &dditable->Enqueue);
+        result = validation_layer::urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &dditable->Enqueue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetEventProcAddrTable(UR_API_VERSION_0_9,
-                                                           &dditable->Event);
+        result = validation_layer::urGetEventProcAddrTable(UR_API_VERSION_0_9, &dditable->Event);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetKernelProcAddrTable(UR_API_VERSION_0_9,
-                                                            &dditable->Kernel);
+        result = validation_layer::urGetKernelProcAddrTable(UR_API_VERSION_0_9, &dditable->Kernel);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetMemProcAddrTable(UR_API_VERSION_0_9,
-                                                         &dditable->Mem);
+        result = validation_layer::urGetMemProcAddrTable(UR_API_VERSION_0_9, &dditable->Mem);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetModuleProcAddrTable(UR_API_VERSION_0_9,
-                                                            &dditable->Module);
+        result = validation_layer::urGetModuleProcAddrTable(UR_API_VERSION_0_9, &dditable->Module);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetPlatformProcAddrTable(
-            UR_API_VERSION_0_9, &dditable->Platform);
+        result = validation_layer::urGetPlatformProcAddrTable(UR_API_VERSION_0_9, &dditable->Platform);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetProgramProcAddrTable(
-            UR_API_VERSION_0_9, &dditable->Program);
+        result = validation_layer::urGetProgramProcAddrTable(UR_API_VERSION_0_9, &dditable->Program);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetQueueProcAddrTable(UR_API_VERSION_0_9,
-                                                           &dditable->Queue);
+        result = validation_layer::urGetQueueProcAddrTable(UR_API_VERSION_0_9, &dditable->Queue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetSamplerProcAddrTable(
-            UR_API_VERSION_0_9, &dditable->Sampler);
+        result = validation_layer::urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &dditable->Sampler);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetUSMProcAddrTable(UR_API_VERSION_0_9,
-                                                         &dditable->USM);
+        result = validation_layer::urGetUSMProcAddrTable(UR_API_VERSION_0_9, &dditable->USM);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetDeviceProcAddrTable(UR_API_VERSION_0_9,
-                                                            &dditable->Device);
+        result = validation_layer::urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &dditable->Device);
     }
 
     return result;

--- a/source/loader/linux/lib_init.cpp
+++ b/source/loader/linux/lib_init.cpp
@@ -10,9 +10,7 @@
 
 namespace ur_lib {
 
-void __attribute__((constructor)) createLibContext() {
-    context = new context_t;
-}
+void __attribute__((constructor)) createLibContext() { context = new context_t; }
 
 void __attribute__((destructor)) deleteLibContext() { delete context; }
 

--- a/source/loader/linux/loader_init.cpp
+++ b/source/loader/linux/loader_init.cpp
@@ -10,9 +10,7 @@
 
 namespace loader {
 
-void __attribute__((constructor)) createLoaderContext() {
-    context = new context_t;
-}
+void __attribute__((constructor)) createLoaderContext() { context = new context_t; }
 
 void __attribute__((destructor)) deleteLoaderContext() { delete context; }
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -120,15 +120,15 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,    ///< [in] the number of bytes of memory pointed to by
-                        ///< pContextInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
     void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-                        ///< if propSize is not equal to or greater than the
-                        ///< real number of bytes needed to return the info then
-                        ///< the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                        ///< returned and pContextInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by ContextInfoType.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -152,9 +152,9 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native
-                                        ///< handle of the context.
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -190,9 +190,9 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 /// @brief Intercept function for urContextCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeContext,            ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext ///< [out] pointer to the handle of the
-                                   ///< context object created.
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -233,8 +233,8 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -259,32 +259,31 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t workDim, ///< [in] number of dimensions, from 1 to 3, to specify
-                      ///< the global and work-group work-items
-    const size_t
-        *pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned
-                            ///< values that specify the offset used to
-                            ///< calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize, ///< [in] pointer to an array of workDim
-                                   ///< unsigned values that specify the number
-                                   ///< of global work-items in workDim that
-                                   ///< will execute the kernel function
-    const size_t
-        *pLocalWorkSize, ///< [in][optional] pointer to an array of workDim
-                         ///< unsigned values that specify the number of local
-                         ///< work-items forming a work-group that will execute
-                         ///< the kernel function. If nullptr, the runtime
-                         ///< implementation will choose the work-group size.
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -338,14 +337,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -395,14 +394,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -457,16 +456,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     size_t size,       ///< [in] size in bytes of data being read
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -525,16 +522,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     const void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -592,26 +587,26 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being read
-    size_t hostRowPitch,     ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by dst
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by dst
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -671,27 +666,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being written
-    size_t hostRowPitch, ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by src
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by src
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
     void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< points to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -750,16 +746,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
     size_t size,      ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -818,27 +812,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion, ///< [in] source 3D rectangular region
-                                ///< descriptor: width, height, depth
-    size_t srcRowPitch,   ///< [in] length of each row in bytes in the source
-                          ///< buffer object
-    size_t srcSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< source buffer object
-    size_t dstRowPitch, ///< [in] length of each row in bytes in the destination
-                        ///< buffer object
-    size_t dstSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< destination buffer object
+    ur_rect_region_t
+        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -900,16 +892,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t offset,            ///< [in] offset into the buffer
     size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -963,24 +953,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t rowPitch,   ///< [in] length of each row in bytes
     size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pDst, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1035,24 +1024,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool
         blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t inputRowPitch,   ///< [in] length of each row in bytes
     size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pSrc, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1103,26 +1091,27 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
 __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,  ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,  ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the source 1D, 2D, or 3D image
-    ur_rect_offset_t dstOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the destination 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1183,16 +1172,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     size_t offset, ///< [in] offset in bytes of the buffer region being mapped
     size_t size,   ///< [in] size in bytes of the buffer region being mapped
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent, ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [in,out][optional] return an event object that identifies this
+                 ///< particular command instance.
     void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
                     ///< numEventsInWaitList?
 ) {
@@ -1250,16 +1237,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
         hMem,         ///< [in] handle of the memory (buffer or image) object
     void *pMappedPtr, ///< [in] mapped host address
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1314,16 +1299,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
     int8_t byteValue,             ///< [in] byte value to fill
     size_t count,                 ///< [in] size in bytes to be set
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1376,16 +1359,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     const void *pSrc, ///< [in] pointer to the source USM memory object
     size_t size,      ///< [in] size in bytes to be copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1437,16 +1418,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     size_t size,                    ///< [in] size in bytes to be fetched
     ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
     uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1497,9 +1476,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
     const void *pMem,         ///< [in] pointer to the USM memory object
     size_t size,              ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1538,23 +1517,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch, ///< [in] the total width of the destination memory including
-                  ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     size_t patternSize, ///< [in] the size in bytes of the pattern.
     const void
         *pPattern, ///< [in] pointer with the bytes of the pattern to set.
     size_t width,  ///< [in] the width in bytes of each row to fill.
     size_t height, ///< [in] the height of the columns to fill.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1604,21 +1582,20 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch,  ///< [in] the total width of the destination memory including
-                   ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     int value,     ///< [in] the value to fill into the region in pMem.
     size_t width,  ///< [in] the width in bytes of each row to set.
     size_t height, ///< [in] the height of the columns to set.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1668,23 +1645,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
     const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t srcPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
-    size_t width,     ///< [in] the width in bytes of each row to be copied.
-    size_t height,    ///< [in] the height of columns to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1732,26 +1708,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
 __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingWrite, ///< [in] indicates if this operation should block.
     size_t count,       ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
     const void *pSrc, ///< [in] pointer to where the data must be copied from.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1803,26 +1778,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
 __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingRead, ///< [in] indicates if this operation should block.
     size_t count,      ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
-    void *pDst,    ///< [in] pointer to where the data must be copied to.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1909,8 +1883,9 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     size_t
         propValueSize, ///< [in] size in bytes of the profiling property value
     void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet ///< [out][optional] pointer to the actual size in
-                              ///< bytes returned in propValue
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1935,9 +1910,9 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 /// @brief Intercept function for urEventWait
 __urdlllocal ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t
-        *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of
-                         ///< events to wait for completion
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2095,8 +2070,8 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2372,15 +2347,14 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointed to by
-                     ///< pMemInfo.
-    void *pMemInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pMemInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2405,15 +2379,14 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointer to by
-                     ///< pImgInfo.
-    void *pImgInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pImgInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2453,9 +2426,9 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize, ///< [in] size in bytes of the queue property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the queue property
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out] value of the queue property
     size_t
         *pPropSizeRet ///< [out] size in bytes returned in queue property value
 ) {
@@ -2483,12 +2456,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t
-        *pProps, ///< [in] specifies a list of queue properties and their
-                 ///< corresponding values. Each property name is immediately
-                 ///< followed by the corresponding desired value. The list is
-                 ///< terminated with a 0. If a property value is not specified,
-                 ///< then its default value will be used.
+    const ur_queue_property_t *
+        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2790,9 +2763,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t propValueSize, ///< [in] size in bytes of the sampler property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the sampler property
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -2818,9 +2791,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native
-                                        ///< handle of the sampler.
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2856,10 +2829,10 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeSampler,            ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler ///< [out] pointer to the handle of the
-                                   ///< sampler object created.
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3020,11 +2993,11 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize, ///< [in] size in bytes of the USM allocation property
-                          ///< value
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
     void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in USM
-                              ///< allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3050,18 +3023,17 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries, ///< [in] the number of devices to be added to
-                         ///< phDevices. If phDevices in not NULL then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_VALUE, will be returned.
-    ur_device_handle_t
-        *phDevices, ///< [out][optional][range(0, NumEntries)] array of handle
-                    ///< of devices. If NumEntries is less than the number of
-                    ///< devices available, then platform shall only retrieve
-                    ///< that number of devices.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
     uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-                          ///< pNumDevices will be updated with the total number
-                          ///< of devices available.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3103,12 +3075,12 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
     size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
     void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-                       ///< If propSize is not equal to or greater than the real
-                       ///< number of bytes needed to return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_VALUE error is returned
-                       ///< and pDeviceInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of the queried infoType.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3179,18 +3151,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t
-        *pProperties, ///< [in] null-terminated array of <$_device_partition_t
-                      ///< enum, value> pairs.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t
-        *phSubDevices, ///< [out][optional][range(0, NumDevices)] array of
-                       ///< handle of devices. If NumDevices is less than the
-                       ///< number of sub-devices available, then the function
-                       ///< shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet ///< [out][optional] pointer to the number of
-                             ///< sub-devices the device can be partitioned into
-                             ///< according to the partitioning property.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3235,9 +3205,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input
-                        ///< array of binaries. If a suitable binary was not
-                        ///< found the function returns ${X}_INVALID_BINARY.
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3342,12 +3311,12 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
 __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's
-                                ///< global timestamp that correlates with the
-                                ///< Host's global timestamp value
-    uint64_t *pHostTimestamp ///< [out][optional] pointer to the Host's global
-                             ///< timestamp that correlates with the Device's
-                             ///< global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3437,8 +3406,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize     ///< [in] size of the local buffer to be allocated by the
-                       ///< runtime
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3464,14 +3433,15 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel
-                       ///< info property. If propSize is not equal to or
-                       ///< greater than the real number of bytes needed to
-                       ///< return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                       ///< pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3497,12 +3467,14 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
-        propName,     ///< [in] name of the work Group property to query
-    size_t propSize,  ///< [in] size of the Kernel Work Group property value
-    void *pPropValue, ///< [in,out][optional][range(0, propSize)] value of the
-                      ///< Kernel Work Group property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3532,12 +3504,14 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
-        propName,     ///< [in] name of the SubGroup property to query
-    size_t propSize,  ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue, ///< [in,out][range(0, propSize)][optional] value of the
-                      ///< Kernel SubGroup property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3611,11 +3585,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 /// @brief Intercept function for urKernelSetArgPointer
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,    ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,       ///< [in] size of argument type
-    const void *pArgValue ///< [in][optional] SVM pointer to memory location
-                          ///< holding the argument value. If null then argument
-                          ///< value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3641,8 +3615,9 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue ///< [in][range(0, propSize)] pointer to memory
-                           ///< location holding the property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3810,11 +3785,10 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
     const char
         *pOptions, ///< [in] pointer to compiler options null-terminated string.
     ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification
-                   ///< routine that is called when program compilation is
-                   ///< complete.
-    void *pUserData, ///< [in][optional] Passed as an argument when pfnNotify is
-                     ///< called.
+        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                   ///< called when program compilation is complete.
+    void *
+        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
     ur_module_handle_t
         *phModule ///< [out] pointer to handle of Module object created.
 ) {
@@ -3979,18 +3953,17 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
-    uint32_t NumEntries, ///< [in] the number of platforms to be added to
-                         ///< phPlatforms. If phPlatforms is not NULL, then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE, will be returned.
-    ur_platform_handle_t
-        *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle
-                      ///< of platforms. If NumEntries is less than the number
-                      ///< of platforms available, then
-                      ///< ::urPlatformGet shall only retrieve that number of
-                      ///< platforms.
-    uint32_t *pNumPlatforms ///< [out][optional] returns the total number of
-                            ///< platforms available.
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4057,12 +4030,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
     size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-                         ///< If Size is not equal to or greater to the real
-                         ///< number of bytes needed to return the info then the
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                         ///< and pPlatformInfo is not used.
-    size_t *pSizeRet ///< [out][optional] pointer to the actual number of bytes
-                     ///< being queried by pPlatformInfo.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4111,9 +4083,9 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native
-                                         ///< handle of the platform.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4151,8 +4123,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform ///< [out] pointer to the handle of the
-                                     ///< platform object created.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4191,8 +4163,9 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 /// @brief Intercept function for urGetLastResult
 __urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage ///< [out] pointer to a string containing adapter
-                           ///< specific result in string representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4220,8 +4193,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
     uint32_t count, ///< [in] number of module handles in module list.
     const ur_module_handle_t
         *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions, ///< [in][optional] pointer to linker options
-                          ///< null-terminated string.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
     ur_program_handle_t
         *phProgram ///< [out] pointer to handle of program object created.
 ) {
@@ -4360,13 +4333,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program to search for function in.
-                  ///< The program must already be built to the specified
-                  ///< device, or otherwise
-                  ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName, ///< [in] A null-terminates string denoting the
-                               ///< mangled function name.
-    void **ppFunctionPointer   ///< [out] Returns the pointer to the function if
-                               ///< it is found in the program.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4396,14 +4368,14 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
-    void *pProgramInfo, ///< [in,out][optional] array of bytes of holding the
-                        ///< program info property. If propSize is not equal to
-                        ///< or greater than the real number of bytes needed to
-                        ///< return the info then the
-                        ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                        ///< and pProgramInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data copied to propName.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4430,15 +4402,16 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
-        propName,     ///< [in] name of the Program build info to query
-    size_t propSize,  ///< [in] size of the Program build info property.
-    void *pPropValue, ///< [in,out][optional] value of the Program build
-                      ///< property. If propSize is not equal to or greater than
-                      ///< the real number of bytes needed to return the info
-                      ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                      ///< returned and pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4493,9 +4466,9 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native
-                                        ///< handle of the program.
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4531,10 +4504,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 /// @brief Intercept function for urProgramCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeProgram,            ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram ///< [out] pointer to the handle of the
-                                   ///< program object created.
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4575,10 +4548,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
-    ur_device_init_flags_t
-        device_flags ///< [in] device initialization flags.
-                     ///< must be 0 (default) or a combination of
-                     ///< ::ur_device_init_flag_t.
+    ur_device_init_flags_t device_flags ///< [in] device initialization flags.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -25,18 +25,16 @@ ur_mem_factory_t ur_mem_factory;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
-    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
-    ur_device_handle_t
-        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t
-        *phContext ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL
+urContextCreate(
+    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
+    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_device_object_t *>(*phDevices)->dditable;
+    auto dditable = reinterpret_cast<ur_device_object_t *>(*phDevices)->dditable;
     auto pfnCreate = dditable->ur.Context.pfnCreate;
     if (nullptr == pfnCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -45,8 +43,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     // convert loader handles to platform handles
     auto phDevicesLocal = new ur_device_handle_t[DeviceCount];
     for (size_t i = 0; (nullptr != phDevices) && (i < DeviceCount); ++i) {
-        phDevicesLocal[i] =
-            reinterpret_cast<ur_device_object_t *>(phDevices[i])->handle;
+        phDevicesLocal[i] = reinterpret_cast<ur_device_object_t *>(phDevices[i])->handle;
     }
 
     // forward to device-platform
@@ -70,9 +67,9 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
-    ur_context_handle_t
-        hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL
+urContextRetain(
+    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -94,7 +91,8 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+__urdlllocal ur_result_t UR_APICALL
+urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -117,18 +115,17 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-    ///< if propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
+                                       ///< if propSize is not equal to or greater than the real number of bytes
+                                       ///< needed to return
+                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                       ///< pContextInfo is not used.
+    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -143,18 +140,17 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                        pPropSizeRet);
+    result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_native_handle_t *
-        phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,       ///< [in] handle of the context.
+    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -188,26 +184,22 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *
-        phContext ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeContext)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Context.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeContext)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Context.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeContext =
-        reinterpret_cast<ur_native_object_t *>(hNativeContext)->handle;
+    hNativeContext = reinterpret_cast<ur_native_object_t *>(hNativeContext)->handle;
 
     // forward to device-platform
     result = pfnCreateWithNativeHandle(hNativeContext, phContext);
@@ -229,12 +221,11 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_context_extended_deleter_t
-        pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL
+urContextSetExtendedDeleter(
+    ur_context_handle_t hContext,             ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -256,34 +247,29 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t
-        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                 ///< work-group work-items
-    const size_t *
-        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< offset used to calculate the global ID of a work-item
-    const size_t *
-        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< number of global work-items in workDim that will execute the kernel
-    ///< function
-    const size_t *
-        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
-    ///< specify the number of local work-items forming a work-group that will
-    ///< execute the kernel function.
-    ///< If nullptr, the runtime implementation will choose the work-group
-    ///< size.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
+    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                              ///< work-group work-items
+    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< number of global work-items in workDim that will execute the kernel
+                                              ///< function
+    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
+                                              ///< specify the number of local work-items forming a work-group that will
+                                              ///< execute the kernel function.
+                                              ///< If nullptr, the runtime implementation will choose the work-group
+                                              ///< size.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -302,16 +288,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
-                             pGlobalWorkSize, pLocalWorkSize,
-                             numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -333,18 +315,17 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -360,15 +341,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -390,25 +368,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnEventsWaitWithBarrier =
-        dditable->ur.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier = dditable->ur.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -418,15 +394,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
-                                      phEventWaitList, phEvent);
+    result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -448,22 +421,21 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being read
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being read
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -482,15 +454,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
-                              numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -512,24 +481,21 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being written
-    const void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being written
+    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -548,16 +514,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
-                          numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -579,34 +541,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< dst
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by dst
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< dst
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by dst
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -625,17 +581,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferReadRect(
-        hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region,
-        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -657,37 +608,29 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
-                          ///< written
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< src
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by src
-    void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
+                                              ///< written
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< src
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by src
+    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -706,17 +649,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferWriteRect(
-        hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region,
-        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -738,22 +676,21 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
-    size_t size,      ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
+    size_t size,                              ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -775,16 +712,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset,
-                         size, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -806,31 +739,25 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t
-        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t
-        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
-    size_t
-        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t
-        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
-    size_t
-        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -852,17 +779,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferCopyRect(
-        hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion,
-        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -884,22 +806,21 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    const void *pPattern,     ///< [in] pointer to the fill pattern
-    size_t patternSize,       ///< [in] size in bytes of the pattern
-    size_t offset,            ///< [in] offset into the buffer
-    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    const void *pPattern,                     ///< [in] pointer to the fill pattern
+    size_t patternSize,                       ///< [in] size in bytes of the pattern
+    size_t offset,                            ///< [in] offset into the buffer
+    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -918,16 +839,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size,
-                         numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -949,27 +866,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t rowPitch,   ///< [in] length of each row in bytes
-    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pDst, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
+    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -988,16 +902,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
-                             rowPitch, slicePitch, pDst, numEventsInWaitList,
-                             phEventWaitList, phEvent);
+    result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1019,28 +929,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t inputRowPitch,   ///< [in] length of each row in bytes
-    size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pSrc, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t inputRowPitch,                     ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1059,16 +965,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
-                              inputRowPitch, inputSlicePitch, pSrc,
-                              numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1090,28 +992,24 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
-    ur_rect_offset_t
-        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                              ///< image
+    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                              ///< or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1133,16 +1031,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
-                        region, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1164,24 +1058,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
-    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,   ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent, ///< [in,out][optional] return an event object that identifies this
-                 ///< particular command instance.
-    void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
-                    ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+                                              ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1200,16 +1093,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset,
-                             size, numEventsInWaitList, phEventWaitList,
-                             phEvent, ppRetMap);
+    result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1231,20 +1120,18 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t
-        hMem,         ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr, ///< [in] mapped host address
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr,                         ///< [in] mapped host address
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1263,15 +1150,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
-                         phEventWaitList, phEvent);
+    result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1293,20 +1177,19 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemset
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    void *ptr,                    ///< [in] pointer to USM memory object
-    int8_t byteValue,             ///< [in] byte value to fill
-    size_t count,                 ///< [in] size in bytes to be set
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    void *ptr,                                ///< [in] pointer to USM memory object
+    int8_t byteValue,                         ///< [in] byte value to fill
+    size_t count,                             ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1322,15 +1205,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList,
-                          phEventWaitList, phEvent);
+    result = pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1352,21 +1232,20 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool blocking,            ///< [in] blocking or non-blocking copy
-    void *pDst,       ///< [in] pointer to the destination USM memory object
-    const void *pSrc, ///< [in] pointer to the source USM memory object
-    size_t size,      ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking copy
+    void *pDst,                               ///< [in] pointer to the destination USM memory object
+    const void *pSrc,                         ///< [in] pointer to the source USM memory object
+    size_t size,                              ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1382,15 +1261,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size,
-                          numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1412,20 +1288,19 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
-    const void *pMem,               ///< [in] pointer to the USM memory object
-    size_t size,                    ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1441,15 +1316,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
-                            phEventWaitList, phEvent);
+    result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1471,14 +1343,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    const void *pMem,         ///< [in] pointer to the USM memory object
-    size_t size,              ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    const void *pMem,          ///< [in] pointer to the USM memory object
+    size_t size,               ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,    ///< [in] USM memory advice
+    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
+                               ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1514,25 +1386,22 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    size_t patternSize, ///< [in] the size in bytes of the pattern.
-    const void
-        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,  ///< [in] the width in bytes of each row to fill.
-    size_t height, ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    size_t patternSize,                       ///< [in] the size in bytes of the pattern.
+    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
+    size_t width,                             ///< [in] the width in bytes of each row to fill.
+    size_t height,                            ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1548,16 +1417,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height,
-                     numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1579,23 +1444,21 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemset2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    int value,     ///< [in] the value to fill into the region in pMem.
-    size_t width,  ///< [in] the width in bytes of each row to set.
-    size_t height, ///< [in] the height of the columns to set.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemset2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    int value,                                ///< [in] the value to fill into the region in pMem.
+    size_t width,                             ///< [in] the width in bytes of each row to set.
+    size_t height,                            ///< [in] the height of the columns to set.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1611,15 +1474,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height,
-                            numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1641,26 +1501,23 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemset2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    bool blocking, ///< [in] indicates if this operation should block the host.
-    void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t
-        dstPitch, ///< [in] the total width of the source memory including padding.
-    const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t
-        srcPitch, ///< [in] the total width of the source memory including padding.
-    size_t width,  ///< [in] the width in bytes of each row to be copied.
-    size_t height, ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    bool blocking,                            ///< [in] indicates if this operation should block the host.
+    void *pDst,                               ///< [in] pointer to memory where data will be copied.
+    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
+    const void *pSrc,                         ///< [in] pointer to memory to be copied.
+    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
+    size_t width,                             ///< [in] the width in bytes of each row to be copied.
+    size_t height,                            ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1676,16 +1533,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result =
-        pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width,
-                       height, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1707,33 +1560,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite, ///< [in] indicates if this operation should block.
-    size_t count,       ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc, ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                       ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnDeviceGlobalVariableWrite =
-        dditable->ur.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite = dditable->ur.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1746,16 +1594,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnDeviceGlobalVariableWrite(
-        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1777,33 +1621,28 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingRead, ///< [in] indicates if this operation should block.
-    size_t count,      ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst, ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                        ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst,                               ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnDeviceGlobalVariableRead =
-        dditable->ur.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead = dditable->ur.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1816,16 +1655,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnDeviceGlobalVariableRead(
-        hQueue, hProgram, name, blockingRead, count, offset, pDst,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -1847,13 +1682,13 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize,     ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional] value of the event property
+    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1868,24 +1703,21 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                        pPropValueSizeRet);
+    result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
-    ur_event_handle_t hEvent, ///< [in] handle of the event object
-    ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+__urdlllocal ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t hEvent,     ///< [in] handle of the event object
+    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
+    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional] value of the profiling property
+    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+                                  ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1900,25 +1732,23 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;
 
     // forward to device-platform
-    result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
-                                 pPropValueSizeRet);
+    result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
-    uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t *
-        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                        ///< completion
+__urdlllocal ur_result_t UR_APICALL
+urEventWait(
+    uint32_t numEvents,                      ///< [in] number of events in the event list
+    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                             ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_event_object_t *>(*phEventWaitList)->dditable;
+    auto dditable = reinterpret_cast<ur_event_object_t *>(*phEventWaitList)->dditable;
     auto pfnWait = dditable->ur.Event.pfnWait;
     if (nullptr == pfnWait) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -1927,8 +1757,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEvents];
     for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEvents); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
@@ -1940,7 +1769,8 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+__urdlllocal ur_result_t UR_APICALL
+urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1963,7 +1793,8 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+__urdlllocal ur_result_t UR_APICALL
+urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1986,10 +1817,10 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ///< [in] handle of the event.
-    ur_native_handle_t
-        *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,         ///< [in] handle of the event.
+    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2023,19 +1854,17 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t
-        *phEvent ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeEvent)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Event.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeEvent)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Event.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2066,12 +1895,12 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL
+urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2093,14 +1922,14 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    void *pHost,                       ///< [in] pointer to the buffer data
-    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    void *pHost,                           ///< [in] pointer to the buffer data
+    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2115,8 +1944,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result =
-        pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
+    result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -2135,13 +1963,13 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL
+urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t
-        *phBuffer ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
+    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
+    void *pHost,                  ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2175,7 +2003,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+__urdlllocal ur_result_t UR_APICALL
+urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2198,7 +2027,8 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+__urdlllocal ur_result_t UR_APICALL
+urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2221,15 +2051,13 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t
-        hBuffer,          ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
+    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2244,8 +2072,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
 
     // forward to device-platform
-    result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                                pBufferCreateInfo, phMem);
+    result = pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -2264,10 +2091,10 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
-    ur_mem_handle_t hMem, ///< [in] handle of the mem.
-    ur_native_handle_t
-        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2301,17 +2128,16 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeMem)->dditable;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeMem)->dditable;
     auto pfnCreateWithNativeHandle = dditable->ur.Mem.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -2343,18 +2169,16 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
-    ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL
+urMemGetInfo(
+    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
+                               ///< If propSize is less than the real number of bytes needed to return
+                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                               ///< pMemInfo is not used.
+    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2376,17 +2200,16 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
-    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL
+urMemImageGetInfo(
+    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
+                                 ///< If propSize is less than the real number of bytes needed to return
+                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                 ///< pImgInfo is not used.
+    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2401,15 +2224,15 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     hMemory = reinterpret_cast<ur_mem_object_t *>(hMemory)->handle;
 
     // forward to device-platform
-    result =
-        pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+    result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL urTearDown(
+__urdlllocal ur_result_t UR_APICALL
+urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2423,14 +2246,13 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out] value of the queue property
-    size_t
-        *pPropSizeRet ///< [out] size in bytes returned in queue property value
+    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out] value of the queue property
+    size_t *pPropSizeRet      ///< [out] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2445,25 +2267,23 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+    result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_device_handle_t hDevice,        ///< [in] handle of the device object
+    const ur_queue_property_t *pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+                                       ///< Each property name is immediately followed by the corresponding
+                                       ///< desired value.
+                                       ///< The list is terminated with a 0.
+                                       ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2500,7 +2320,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL
+urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2523,7 +2344,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL
+urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2546,10 +2368,10 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
-    ur_native_handle_t
-        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2583,19 +2405,17 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeQueue)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Queue.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeQueue)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Queue.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2626,7 +2446,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL
+urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2649,7 +2470,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL
+urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2672,13 +2494,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
-    ur_sampler_handle_t
-        *phSampler ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context object
+    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
+                                         ///< corresponding values.
+    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2712,9 +2533,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL
+urSamplerRetain(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2736,9 +2557,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2760,14 +2581,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
-    size_t *
-        pPropSizeRet ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
+    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out] value of the sampler property
+    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2782,18 +2602,17 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     hSampler = reinterpret_cast<ur_sampler_object_t *>(hSampler)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+    result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
-    ur_native_handle_t *
-        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
+    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2827,27 +2646,23 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeSampler,           ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_sampler_handle_t *
-        phSampler ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeSampler)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Sampler.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeSampler)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Sampler.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeSampler =
-        reinterpret_cast<ur_native_object_t *>(hNativeSampler)->handle;
+    hNativeSampler = reinterpret_cast<ur_native_object_t *>(hNativeSampler)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -2872,13 +2687,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_mem_flags_t *pUSMFlag, ///< [in] USM memory allocation flags
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM host memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2900,14 +2715,14 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM device memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2932,14 +2747,14 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL
+urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM shared memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2964,7 +2779,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+__urdlllocal ur_result_t UR_APICALL
+urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -2988,16 +2804,14 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL
+urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t
-        propName, ///< [in] the name of the USM allocation property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional] value of the USM allocation property
+    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3012,34 +2826,31 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                                pPropValue, pPropValueSizeRet);
+    result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t
-        NumEntries, ///< [in] the number of devices to be added to phDevices.
-    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-    ///< will be returned.
-    ur_device_handle_t *
-        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-    ///< If NumEntries is less than the number of devices available, then
-    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
+                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+                                    ///< will be returned.
+    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                    ///< If NumEntries is less than the number of devices available, then
+                                    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
+                                    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGet = dditable->ur.Device.pfnGet;
     if (nullptr == pfnGet) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -3070,17 +2881,17 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info
-    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return the info
+                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+                                ///< pDeviceInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3102,9 +2913,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
-    ur_device_handle_t
-        hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceRetain(
+    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3126,7 +2937,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3149,18 +2961,16 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t *
-        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-    ///< If NumDevices is less than the number of sub-devices available, then
-    ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *
-        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
-    ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                       ///< If NumDevices is less than the number of sub-devices available, then
+                                                       ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                       ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3175,8 +2985,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
-                          pNumDevicesRet);
+    result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -3197,16 +3006,15 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
-                          ///< Must greater than or equal to zero otherwise
-                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
+                                ///< Must greater than or equal to zero otherwise
+                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
+                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3228,10 +3036,10 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ///< [in] handle of the device.
-    ur_native_handle_t
-        *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,        ///< [in] handle of the device.
+    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3265,26 +3073,23 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t
-        *phDevice ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeDevice)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Device.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeDevice)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Device.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeDevice =
-        reinterpret_cast<ur_native_object_t *>(hNativeDevice)->handle;
+    hNativeDevice = reinterpret_cast<ur_native_object_t *>(hNativeDevice)->handle;
 
     // convert loader handle to platform handle
     hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
@@ -3309,14 +3114,13 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL
+urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *
-        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                          ///< correlates with the Host's global timestamp value
-    uint64_t *
-        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
-                       ///< correlates with the Device's global timestamp value
+    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                                ///< correlates with the Host's global timestamp value
+    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
+                                ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3338,11 +3142,11 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL
+urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3376,12 +3180,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void
-        *pArgValue ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in] argument value represented as matching arg type.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3403,11 +3207,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t
-        argSize ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3429,19 +3233,18 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return
+                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                ///< pKernelInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
+                                ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3463,18 +3266,16 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_group_info_t
-        propName,    ///< [in] name of the work Group property to query
-    size_t propSize, ///< [in] size of the Kernel Work Group property value
-    void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
+    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
+    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                     ///< property.
+    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
+                                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3492,26 +3293,23 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
-                             pPropSizeRet);
+    result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t
-        propName,    ///< [in] name of the SubGroup property to query
-    size_t propSize, ///< [in] size of the Kernel SubGroup property value
-    void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
+    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
+    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                         ///< property.
+    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
+                                         ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3529,15 +3327,15 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
-                                pPropValue, pPropSizeRet);
+    result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL
+urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3560,7 +3358,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL
+urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3583,13 +3382,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void *
-        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
-                  ///< value. If null then argument value is considered null.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
+                                ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3611,13 +3410,13 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
-                   ///< property value.
+    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                    ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3639,9 +3438,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
+    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3667,10 +3467,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL
+urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3685,9 +3486,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
 
     // convert loader handle to platform handle
-    hArgValue = (hArgValue)
-                    ? reinterpret_cast<ur_mem_object_t *>(hArgValue)->handle
-                    : nullptr;
+    hArgValue = (hArgValue) ? reinterpret_cast<ur_mem_object_t *>(hArgValue)->handle : nullptr;
 
     // forward to device-platform
     result = pfnSetArgMemObj(hKernel, argIndex, hArgValue);
@@ -3697,10 +3496,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
-    ur_native_handle_t
-        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3734,26 +3533,23 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeKernel)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Kernel.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeKernel)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Kernel.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeKernel =
-        reinterpret_cast<ur_native_object_t *>(hNativeKernel)->handle;
+    hNativeKernel = reinterpret_cast<ur_native_object_t *>(hNativeKernel)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -3778,19 +3574,16 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleCreate
-__urdlllocal ur_result_t UR_APICALL urModuleCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    const void *pIL,              ///< [in] pointer to IL string.
-    size_t length,                ///< [in] length of IL in bytes.
-    const char
-        *pOptions, ///< [in] pointer to compiler options null-terminated string.
-    ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
-                   ///< called when program compilation is complete.
-    void *
-        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to handle of Module object created.
+__urdlllocal ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,         ///< [in] handle of the context instance.
+    const void *pIL,                      ///< [in] pointer to IL string.
+    size_t length,                        ///< [in] length of IL in bytes.
+    const char *pOptions,                 ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                                          ///< called when program compilation is complete.
+    void *pUserData,                      ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t *phModule          ///< [out] pointer to handle of Module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3805,8 +3598,7 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData,
-                       phModule);
+    result = pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData, phModule);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -3825,7 +3617,8 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleRetain
-__urdlllocal ur_result_t UR_APICALL urModuleRetain(
+__urdlllocal ur_result_t UR_APICALL
+urModuleRetain(
     ur_module_handle_t hModule ///< [in] handle for the Module to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3848,7 +3641,8 @@ __urdlllocal ur_result_t UR_APICALL urModuleRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleRelease
-__urdlllocal ur_result_t UR_APICALL urModuleRelease(
+__urdlllocal ur_result_t UR_APICALL
+urModuleRelease(
     ur_module_handle_t hModule ///< [in] handle for the Module to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3871,10 +3665,10 @@ __urdlllocal ur_result_t UR_APICALL urModuleRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
-    ur_module_handle_t hModule, ///< [in] handle of the module.
-    ur_native_handle_t
-        *phNativeModule ///< [out] a pointer to the native handle of the module.
+__urdlllocal ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,        ///< [in] handle of the module.
+    ur_native_handle_t *phNativeModule ///< [out] a pointer to the native handle of the module.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3908,26 +3702,23 @@ __urdlllocal ur_result_t UR_APICALL urModuleGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urModuleCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
     ur_native_handle_t hNativeModule, ///< [in] the native handle of the module.
     ur_context_handle_t hContext,     ///< [in] handle of the context instance.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to the handle of the module object created.
+    ur_module_handle_t *phModule      ///< [out] pointer to the handle of the module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeModule)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Module.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeModule)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Module.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeModule =
-        reinterpret_cast<ur_native_object_t *>(hNativeModule)->handle;
+    hNativeModule = reinterpret_cast<ur_native_object_t *>(hNativeModule)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -3952,18 +3743,16 @@ __urdlllocal ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
-    uint32_t
-        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
-    ///< If phPlatforms is not NULL, then NumEntries should be greater than
-    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-    ///< will be returned.
-    ur_platform_handle_t *
-        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-    ///< If NumEntries is less than the number of platforms available, then
-    ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *
-        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGet(
+    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
+                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                       ///< will be returned.
+    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                       ///< If NumEntries is less than the number of platforms available, then
+                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3980,21 +3769,16 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
         uint32_t library_platform_handle_count = 0;
 
-        result = platform.dditable.ur.Platform.pfnGet(
-            0, nullptr, &library_platform_handle_count);
+        result = platform.dditable.ur.Platform.pfnGet(0, nullptr, &library_platform_handle_count);
         if (UR_RESULT_SUCCESS != result) {
             break;
         }
 
         if (nullptr != phPlatforms && NumEntries != 0) {
-            if (total_platform_handle_count + library_platform_handle_count >
-                NumEntries) {
-                library_platform_handle_count =
-                    NumEntries - total_platform_handle_count;
+            if (total_platform_handle_count + library_platform_handle_count > NumEntries) {
+                library_platform_handle_count = NumEntries - total_platform_handle_count;
             }
-            result = platform.dditable.ur.Platform.pfnGet(
-                library_platform_handle_count,
-                &phPlatforms[total_platform_handle_count], nullptr);
+            result = platform.dditable.ur.Platform.pfnGet(library_platform_handle_count, &phPlatforms[total_platform_handle_count], nullptr);
             if (UR_RESULT_SUCCESS != result) {
                 break;
             }
@@ -4002,11 +3786,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
             try {
                 for (uint32_t i = 0; i < library_platform_handle_count; ++i) {
                     uint32_t platform_index = total_platform_handle_count + i;
-                    phPlatforms[platform_index] =
-                        reinterpret_cast<ur_platform_handle_t>(
-                            ur_platform_factory.getInstance(
-                                phPlatforms[platform_index],
-                                &platform.dditable));
+                    phPlatforms[platform_index] = reinterpret_cast<ur_platform_handle_t>(
+                        ur_platform_factory.getInstance(phPlatforms[platform_index], &platform.dditable));
                 }
             } catch (std::bad_alloc &) {
                 result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
@@ -4025,22 +3806,21 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If Size is not equal to or greater to the real number of bytes needed
-    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-    ///< returned and pPlatformInfo is not used.
-    size_t *
-        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
+                                         ///< If Size is not equal to or greater to the real number of bytes needed
+                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                         ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetInfo = dditable->ur.Platform.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4050,15 +3830,15 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+    result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -4082,16 +3862,15 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
-    ur_native_handle_t *
-        phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
+    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetNativeHandle = dditable->ur.Platform.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4120,26 +3899,22 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *
-        phPlatform ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativePlatform)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Platform.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativePlatform)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Platform.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativePlatform =
-        reinterpret_cast<ur_native_object_t *>(hNativePlatform)->handle;
+    hNativePlatform = reinterpret_cast<ur_native_object_t *>(hNativePlatform)->handle;
 
     // forward to device-platform
     result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
@@ -4161,17 +3936,16 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL
+urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage ///< [out] pointer to a string containing adapter specific result in string
-                  ///< representation.
+    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
+                                    ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetLastResult = dditable->ur.Global.pfnGetLastResult;
     if (nullptr == pfnGetLastResult) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4188,15 +3962,13 @@ __urdlllocal ur_result_t UR_APICALL urGetLastResult(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreate
-__urdlllocal ur_result_t UR_APICALL urProgramCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    uint32_t count, ///< [in] number of module handles in module list.
-    const ur_module_handle_t
-        *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *
-        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context instance
+    uint32_t count,                      ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4213,8 +3985,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
     // convert loader handles to platform handles
     auto phModulesLocal = new ur_module_handle_t[count];
     for (size_t i = 0; (nullptr != phModules) && (i < count); ++i) {
-        phModulesLocal[i] =
-            reinterpret_cast<ur_module_object_t *>(phModules[i])->handle;
+        phModulesLocal[i] = reinterpret_cast<ur_module_object_t *>(phModules[i])->handle;
     }
 
     // forward to device-platform
@@ -4238,14 +4009,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_device_handle_t
-        hDevice,            ///< [in] handle to device associated with binary.
-    size_t size,            ///< [in] size in bytes.
-    const uint8_t *pBinary, ///< [in] pointer to binary.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,  ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
+    size_t size,                   ///< [in] size in bytes.
+    const uint8_t *pBinary,        ///< [in] pointer to binary.
+    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4282,7 +4052,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL
+urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4305,7 +4076,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL
+urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4328,17 +4100,14 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program to search for function in.
-    ///< The program must already be built to the specified device, or
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *
-        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
-    void **
-        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
+                                  ///< The program must already be built to the specified device, or
+                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
+    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4356,26 +4125,24 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
     hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
 
     // forward to device-platform
-    result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
-                                   ppFunctionPointer);
+    result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName, ///< [in] name of the Program property to query
-    size_t propSize,            ///< [in] the size of the Program property.
-    void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+    ur_program_info_t propName,   ///< [in] name of the Program property to query
+    size_t propSize,              ///< [in] the size of the Program property.
+    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+                                  ///< If propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pProgramInfo is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4390,28 +4157,25 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+    result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
-    ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
-    ur_program_build_info_t
-        propName,    ///< [in] name of the Program build info to query
-    size_t propSize, ///< [in] size of the Program build info property.
-    void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
+    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
+    size_t propSize,                  ///< [in] size of the Program build info property.
+    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+                                      ///< If propSize is not equal to or greater than the real number of bytes
+                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                      ///< error is returned and pKernelInfo is not used.
+    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
+                                      ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4429,26 +4193,25 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
-                             pPropSizeRet);
+    result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstant
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
+__urdlllocal ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t specId,              ///< [in] specification constant Id
-    size_t specSize,       ///< [in] size of the specialization constant value
-    const void *pSpecValue ///< [in] pointer to the specialization value bytes
+    size_t specSize,              ///< [in] size of the specialization constant value
+    const void *pSpecValue        ///< [in] pointer to the specialization value bytes
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_program_object_t *>(hProgram)->dditable;
-    auto pfnSetSpecializationConstant =
-        dditable->ur.Program.pfnSetSpecializationConstant;
+    auto pfnSetSpecializationConstant = dditable->ur.Program.pfnSetSpecializationConstant;
     if (nullptr == pfnSetSpecializationConstant) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4457,18 +4220,17 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstant(
     hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
 
     // forward to device-platform
-    result =
-        pfnSetSpecializationConstant(hProgram, specId, specSize, pSpecValue);
+    result = pfnSetSpecializationConstant(hProgram, specId, specSize, pSpecValue);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ///< [in] handle of the program.
-    ur_native_handle_t *
-        phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,       ///< [in] handle of the program.
+    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4502,27 +4264,23 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeProgram,           ///< [in] the native handle of the program.
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_program_handle_t *
-        phProgram ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,      ///< [in] handle of the context instance
+    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativeProgram)->dditable;
-    auto pfnCreateWithNativeHandle =
-        dditable->ur.Program.pfnCreateWithNativeHandle;
+    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeProgram)->dditable;
+    auto pfnCreateWithNativeHandle = dditable->ur.Program.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeProgram =
-        reinterpret_cast<ur_native_object_t *>(hNativeProgram)->handle;
+    hNativeProgram = reinterpret_cast<ur_native_object_t *>(hNativeProgram)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -4547,9 +4305,10 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL urInit(
+__urdlllocal ur_result_t UR_APICALL
+urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4586,10 +4345,10 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_global_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetGlobalProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4631,8 +4390,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnTearDown = loader::urTearDown;
             pDdiTable->pfnGetLastResult = loader::urGetLastResult;
@@ -4655,10 +4413,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_context_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetContextProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4700,18 +4458,15 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urContextCreate;
             pDdiTable->pfnRetain = loader::urContextRetain;
             pDdiTable->pfnRelease = loader::urContextRelease;
             pDdiTable->pfnGetInfo = loader::urContextGetInfo;
             pDdiTable->pfnGetNativeHandle = loader::urContextGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urContextCreateWithNativeHandle;
-            pDdiTable->pfnSetExtendedDeleter =
-                loader::urContextSetExtendedDeleter;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urContextCreateWithNativeHandle;
+            pDdiTable->pfnSetExtendedDeleter = loader::urContextSetExtendedDeleter;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Context;
@@ -4730,10 +4485,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_enqueue_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEnqueueProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4775,22 +4530,17 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnKernelLaunch = loader::urEnqueueKernelLaunch;
             pDdiTable->pfnEventsWait = loader::urEnqueueEventsWait;
-            pDdiTable->pfnEventsWaitWithBarrier =
-                loader::urEnqueueEventsWaitWithBarrier;
+            pDdiTable->pfnEventsWaitWithBarrier = loader::urEnqueueEventsWaitWithBarrier;
             pDdiTable->pfnMemBufferRead = loader::urEnqueueMemBufferRead;
             pDdiTable->pfnMemBufferWrite = loader::urEnqueueMemBufferWrite;
-            pDdiTable->pfnMemBufferReadRect =
-                loader::urEnqueueMemBufferReadRect;
-            pDdiTable->pfnMemBufferWriteRect =
-                loader::urEnqueueMemBufferWriteRect;
+            pDdiTable->pfnMemBufferReadRect = loader::urEnqueueMemBufferReadRect;
+            pDdiTable->pfnMemBufferWriteRect = loader::urEnqueueMemBufferWriteRect;
             pDdiTable->pfnMemBufferCopy = loader::urEnqueueMemBufferCopy;
-            pDdiTable->pfnMemBufferCopyRect =
-                loader::urEnqueueMemBufferCopyRect;
+            pDdiTable->pfnMemBufferCopyRect = loader::urEnqueueMemBufferCopyRect;
             pDdiTable->pfnMemBufferFill = loader::urEnqueueMemBufferFill;
             pDdiTable->pfnMemImageRead = loader::urEnqueueMemImageRead;
             pDdiTable->pfnMemImageWrite = loader::urEnqueueMemImageWrite;
@@ -4804,10 +4554,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
             pDdiTable->pfnUSMFill2D = loader::urEnqueueUSMFill2D;
             pDdiTable->pfnUSMMemset2D = loader::urEnqueueUSMMemset2D;
             pDdiTable->pfnUSMMemcpy2D = loader::urEnqueueUSMMemcpy2D;
-            pDdiTable->pfnDeviceGlobalVariableWrite =
-                loader::urEnqueueDeviceGlobalVariableWrite;
-            pDdiTable->pfnDeviceGlobalVariableRead =
-                loader::urEnqueueDeviceGlobalVariableRead;
+            pDdiTable->pfnDeviceGlobalVariableWrite = loader::urEnqueueDeviceGlobalVariableWrite;
+            pDdiTable->pfnDeviceGlobalVariableRead = loader::urEnqueueDeviceGlobalVariableRead;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Enqueue;
@@ -4826,10 +4574,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_event_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetEventProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4871,8 +4619,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetInfo = loader::urEventGetInfo;
             pDdiTable->pfnGetProfilingInfo = loader::urEventGetProfilingInfo;
@@ -4880,8 +4627,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
             pDdiTable->pfnRetain = loader::urEventRetain;
             pDdiTable->pfnRelease = loader::urEventRelease;
             pDdiTable->pfnGetNativeHandle = loader::urEventGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urEventCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urEventCreateWithNativeHandle;
             pDdiTable->pfnSetCallback = loader::urEventSetCallback;
         } else {
             // return pointers directly to platform's DDIs
@@ -4901,10 +4647,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_kernel_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetKernelProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4946,8 +4692,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urKernelCreate;
             pDdiTable->pfnGetInfo = loader::urKernelGetInfo;
@@ -4956,8 +4701,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
             pDdiTable->pfnRetain = loader::urKernelRetain;
             pDdiTable->pfnRelease = loader::urKernelRelease;
             pDdiTable->pfnGetNativeHandle = loader::urKernelGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urKernelCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urKernelCreateWithNativeHandle;
             pDdiTable->pfnSetArgValue = loader::urKernelSetArgValue;
             pDdiTable->pfnSetArgLocal = loader::urKernelSetArgLocal;
             pDdiTable->pfnSetArgPointer = loader::urKernelSetArgPointer;
@@ -4982,10 +4726,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_mem_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5027,8 +4771,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnImageCreate = loader::urMemImageCreate;
             pDdiTable->pfnBufferCreate = loader::urMemBufferCreate;
@@ -5036,8 +4779,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
             pDdiTable->pfnRelease = loader::urMemRelease;
             pDdiTable->pfnBufferPartition = loader::urMemBufferPartition;
             pDdiTable->pfnGetNativeHandle = loader::urMemGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urMemCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urMemCreateWithNativeHandle;
             pDdiTable->pfnGetInfo = loader::urMemGetInfo;
             pDdiTable->pfnImageGetInfo = loader::urMemImageGetInfo;
         } else {
@@ -5058,10 +4800,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_module_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetModuleProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_module_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5103,15 +4845,13 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urModuleCreate;
             pDdiTable->pfnRetain = loader::urModuleRetain;
             pDdiTable->pfnRelease = loader::urModuleRelease;
             pDdiTable->pfnGetNativeHandle = loader::urModuleGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urModuleCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urModuleCreateWithNativeHandle;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Module;
@@ -5130,10 +4870,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetModuleProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_platform_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetPlatformProcAddrTable(
+    ur_api_version_t version,         ///< [in] API version requested
+    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5175,19 +4915,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet = loader::urPlatformGet;
             pDdiTable->pfnGetInfo = loader::urPlatformGetInfo;
             pDdiTable->pfnGetNativeHandle = loader::urPlatformGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urPlatformCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urPlatformCreateWithNativeHandle;
             pDdiTable->pfnGetApiVersion = loader::urPlatformGetApiVersion;
         } else {
             // return pointers directly to platform's DDIs
-            *pDdiTable =
-                loader::context->platforms.front().dditable.ur.Platform;
+            *pDdiTable = loader::context->platforms.front().dditable.ur.Platform;
         }
     }
 
@@ -5203,10 +4940,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_program_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetProgramProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5248,22 +4985,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urProgramCreate;
             pDdiTable->pfnCreateWithBinary = loader::urProgramCreateWithBinary;
             pDdiTable->pfnRetain = loader::urProgramRetain;
             pDdiTable->pfnRelease = loader::urProgramRelease;
-            pDdiTable->pfnGetFunctionPointer =
-                loader::urProgramGetFunctionPointer;
+            pDdiTable->pfnGetFunctionPointer = loader::urProgramGetFunctionPointer;
             pDdiTable->pfnGetInfo = loader::urProgramGetInfo;
             pDdiTable->pfnGetBuildInfo = loader::urProgramGetBuildInfo;
-            pDdiTable->pfnSetSpecializationConstant =
-                loader::urProgramSetSpecializationConstant;
+            pDdiTable->pfnSetSpecializationConstant = loader::urProgramSetSpecializationConstant;
             pDdiTable->pfnGetNativeHandle = loader::urProgramGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urProgramCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urProgramCreateWithNativeHandle;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Program;
@@ -5282,10 +5015,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_queue_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetQueueProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5327,16 +5060,14 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetInfo = loader::urQueueGetInfo;
             pDdiTable->pfnCreate = loader::urQueueCreate;
             pDdiTable->pfnRetain = loader::urQueueRetain;
             pDdiTable->pfnRelease = loader::urQueueRelease;
             pDdiTable->pfnGetNativeHandle = loader::urQueueGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urQueueCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urQueueCreateWithNativeHandle;
             pDdiTable->pfnFinish = loader::urQueueFinish;
             pDdiTable->pfnFlush = loader::urQueueFlush;
         } else {
@@ -5357,10 +5088,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_sampler_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetSamplerProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5402,16 +5133,14 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urSamplerCreate;
             pDdiTable->pfnRetain = loader::urSamplerRetain;
             pDdiTable->pfnRelease = loader::urSamplerRelease;
             pDdiTable->pfnGetInfo = loader::urSamplerGetInfo;
             pDdiTable->pfnGetNativeHandle = loader::urSamplerGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urSamplerCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urSamplerCreateWithNativeHandle;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Sampler;
@@ -5430,10 +5159,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_usm_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5475,8 +5204,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnHostAlloc = loader::urUSMHostAlloc;
             pDdiTable->pfnDeviceAlloc = loader::urUSMDeviceAlloc;
@@ -5501,10 +5229,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
-    ur_api_version_t version, ///< [in] API version requested
-    ur_device_dditable_t
-        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetDeviceProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5546,8 +5274,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) ||
-            loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet = loader::urDeviceGet;
             pDdiTable->pfnGetInfo = loader::urDeviceGetInfo;
@@ -5556,10 +5283,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
             pDdiTable->pfnPartition = loader::urDevicePartition;
             pDdiTable->pfnSelectBinary = loader::urDeviceSelectBinary;
             pDdiTable->pfnGetNativeHandle = loader::urDeviceGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle =
-                loader::urDeviceCreateWithNativeHandle;
-            pDdiTable->pfnGetGlobalTimestamps =
-                loader::urDeviceGetGlobalTimestamps;
+            pDdiTable->pfnCreateWithNativeHandle = loader::urDeviceCreateWithNativeHandle;
+            pDdiTable->pfnGetGlobalTimestamps = loader::urDeviceGetGlobalTimestamps;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Device;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -13,44 +13,34 @@
 namespace loader {
 ///////////////////////////////////////////////////////////////////////////////
 using ur_platform_object_t = object_t<ur_platform_handle_t>;
-using ur_platform_factory_t =
-    singleton_factory_t<ur_platform_object_t, ur_platform_handle_t>;
+using ur_platform_factory_t = singleton_factory_t<ur_platform_object_t, ur_platform_handle_t>;
 
 using ur_device_object_t = object_t<ur_device_handle_t>;
-using ur_device_factory_t =
-    singleton_factory_t<ur_device_object_t, ur_device_handle_t>;
+using ur_device_factory_t = singleton_factory_t<ur_device_object_t, ur_device_handle_t>;
 
 using ur_context_object_t = object_t<ur_context_handle_t>;
-using ur_context_factory_t =
-    singleton_factory_t<ur_context_object_t, ur_context_handle_t>;
+using ur_context_factory_t = singleton_factory_t<ur_context_object_t, ur_context_handle_t>;
 
 using ur_event_object_t = object_t<ur_event_handle_t>;
-using ur_event_factory_t =
-    singleton_factory_t<ur_event_object_t, ur_event_handle_t>;
+using ur_event_factory_t = singleton_factory_t<ur_event_object_t, ur_event_handle_t>;
 
 using ur_program_object_t = object_t<ur_program_handle_t>;
-using ur_program_factory_t =
-    singleton_factory_t<ur_program_object_t, ur_program_handle_t>;
+using ur_program_factory_t = singleton_factory_t<ur_program_object_t, ur_program_handle_t>;
 
 using ur_module_object_t = object_t<ur_module_handle_t>;
-using ur_module_factory_t =
-    singleton_factory_t<ur_module_object_t, ur_module_handle_t>;
+using ur_module_factory_t = singleton_factory_t<ur_module_object_t, ur_module_handle_t>;
 
 using ur_kernel_object_t = object_t<ur_kernel_handle_t>;
-using ur_kernel_factory_t =
-    singleton_factory_t<ur_kernel_object_t, ur_kernel_handle_t>;
+using ur_kernel_factory_t = singleton_factory_t<ur_kernel_object_t, ur_kernel_handle_t>;
 
 using ur_queue_object_t = object_t<ur_queue_handle_t>;
-using ur_queue_factory_t =
-    singleton_factory_t<ur_queue_object_t, ur_queue_handle_t>;
+using ur_queue_factory_t = singleton_factory_t<ur_queue_object_t, ur_queue_handle_t>;
 
 using ur_native_object_t = object_t<ur_native_handle_t>;
-using ur_native_factory_t =
-    singleton_factory_t<ur_native_object_t, ur_native_handle_t>;
+using ur_native_factory_t = singleton_factory_t<ur_native_object_t, ur_native_handle_t>;
 
 using ur_sampler_object_t = object_t<ur_sampler_handle_t>;
-using ur_sampler_factory_t =
-    singleton_factory_t<ur_sampler_object_t, ur_sampler_handle_t>;
+using ur_sampler_factory_t = singleton_factory_t<ur_sampler_object_t, ur_sampler_handle_t>;
 
 using ur_mem_object_t = object_t<ur_mem_handle_t>;
 using ur_mem_factory_t = singleton_factory_t<ur_mem_object_t, ur_mem_handle_t>;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -139,15 +139,15 @@ ur_result_t UR_APICALL urContextRelease(
 ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,    ///< [in] the number of bytes of memory pointed to by
-                        ///< pContextInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
     void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-                        ///< if propSize is not equal to or greater than the
-                        ///< real number of bytes needed to return the info then
-                        ///< the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                        ///< returned and pContextInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by ContextInfoType.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Context.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -179,9 +179,9 @@ ur_result_t UR_APICALL urContextGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeContext`
 ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native
-                                        ///< handle of the context.
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     auto pfnGetNativeHandle =
         ur_lib::context->urDdiTable.Context.pfnGetNativeHandle;
@@ -211,9 +211,9 @@ ur_result_t UR_APICALL urContextGetNativeHandle(
 ///         + `NULL == phContext`
 ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeContext,            ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext ///< [out] pointer to the handle of the
-                                   ///< context object created.
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     auto pfnCreateWithNativeHandle =
         ur_lib::context->urDdiTable.Context.pfnCreateWithNativeHandle;
@@ -249,8 +249,8 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetExtendedDeleter =
         ur_lib::context->urDdiTable.Context.pfnSetExtendedDeleter;
@@ -289,32 +289,31 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t workDim, ///< [in] number of dimensions, from 1 to 3, to specify
-                      ///< the global and work-group work-items
-    const size_t
-        *pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned
-                            ///< values that specify the offset used to
-                            ///< calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize, ///< [in] pointer to an array of workDim
-                                   ///< unsigned values that specify the number
-                                   ///< of global work-items in workDim that
-                                   ///< will execute the kernel function
-    const size_t
-        *pLocalWorkSize, ///< [in][optional] pointer to an array of workDim
-                         ///< unsigned values that specify the number of local
-                         ///< work-items forming a work-group that will execute
-                         ///< the kernel function. If nullptr, the runtime
-                         ///< implementation will choose the work-group size.
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnKernelLaunch = ur_lib::context->urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr == pfnKernelLaunch) {
@@ -354,14 +353,14 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnEventsWait = ur_lib::context->urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr == pfnEventsWait) {
@@ -401,14 +400,14 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnEventsWaitWithBarrier =
         ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -453,16 +452,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     size_t size,       ///< [in] size in bytes of data being read
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferRead =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
@@ -509,16 +506,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     const void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferWrite =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
@@ -566,26 +561,26 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being read
-    size_t hostRowPitch,     ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by dst
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by dst
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferReadRect =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -636,27 +631,28 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being written
-    size_t hostRowPitch, ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by src
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by src
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
     void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< points to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferWriteRect =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -698,16 +694,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
     size_t size,      ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferCopy =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
@@ -747,27 +741,25 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion, ///< [in] source 3D rectangular region
-                                ///< descriptor: width, height, depth
-    size_t srcRowPitch,   ///< [in] length of each row in bytes in the source
-                          ///< buffer object
-    size_t srcSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< source buffer object
-    size_t dstRowPitch, ///< [in] length of each row in bytes in the destination
-                        ///< buffer object
-    size_t dstSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< destination buffer object
+    ur_rect_region_t
+        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferCopyRect =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -811,16 +803,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t offset,            ///< [in] offset into the buffer
     size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemBufferFill =
         ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
@@ -863,24 +853,23 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t rowPitch,   ///< [in] length of each row in bytes
     size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pDst, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemImageRead = ur_lib::context->urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr == pfnMemImageRead) {
@@ -923,24 +912,23 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool
         blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t inputRowPitch,   ///< [in] length of each row in bytes
     size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pSrc, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemImageWrite =
         ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
@@ -974,26 +962,27 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,  ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,  ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the source 1D, 2D, or 3D image
-    ur_rect_offset_t dstOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the destination 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemImageCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr == pfnMemImageCopy) {
@@ -1044,16 +1033,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
     size_t offset, ///< [in] offset in bytes of the buffer region being mapped
     size_t size,   ///< [in] size in bytes of the buffer region being mapped
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent, ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [in,out][optional] return an event object that identifies this
+                 ///< particular command instance.
     void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
                     ///< numEventsInWaitList?
 ) {
@@ -1095,16 +1082,14 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
         hMem,         ///< [in] handle of the memory (buffer or image) object
     void *pMappedPtr, ///< [in] mapped host address
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnMemUnmap = ur_lib::context->urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr == pfnMemUnmap) {
@@ -1137,16 +1122,14 @@ ur_result_t UR_APICALL urEnqueueUSMMemset(
     int8_t byteValue,             ///< [in] byte value to fill
     size_t count,                 ///< [in] size in bytes to be set
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMMemset = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemset;
     if (nullptr == pfnUSMMemset) {
@@ -1181,16 +1164,14 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     const void *pSrc, ///< [in] pointer to the source USM memory object
     size_t size,      ///< [in] size in bytes to be copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMMemcpy = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr == pfnUSMMemcpy) {
@@ -1225,16 +1206,14 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     size_t size,                    ///< [in] size in bytes to be fetched
     ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
     uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMPrefetch = ur_lib::context->urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr == pfnUSMPrefetch) {
@@ -1268,9 +1247,9 @@ ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
     const void *pMem,         ///< [in] pointer to the USM memory object
     size_t size,              ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     auto pfnUSMMemAdvise = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvise;
     if (nullptr == pfnUSMMemAdvise) {
@@ -1296,23 +1275,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch, ///< [in] the total width of the destination memory including
-                  ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     size_t patternSize, ///< [in] the size in bytes of the pattern.
     const void
         *pPattern, ///< [in] pointer with the bytes of the pattern to set.
     size_t width,  ///< [in] the width in bytes of each row to fill.
     size_t height, ///< [in] the height of the columns to fill.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnUSMFill2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr == pfnUSMFill2D) {
@@ -1338,21 +1316,20 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
 ur_result_t UR_APICALL urEnqueueUSMMemset2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch,  ///< [in] the total width of the destination memory including
-                   ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     int value,     ///< [in] the value to fill into the region in pMem.
     size_t width,  ///< [in] the width in bytes of each row to set.
     size_t height, ///< [in] the height of the columns to set.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemset2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemset2D;
     if (nullptr == pfnUSMMemset2D) {
@@ -1380,23 +1357,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
     const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t srcPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
-    size_t width,     ///< [in] the width in bytes of each row to be copied.
-    size_t height,    ///< [in] the height of columns to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr == pfnUSMMemcpy2D) {
@@ -1423,26 +1399,25 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///         + `NULL == name`
 ///         + `NULL == pSrc`
 ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingWrite, ///< [in] indicates if this operation should block.
     size_t count,       ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
     const void *pSrc, ///< [in] pointer to where the data must be copied from.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableWrite =
         ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -1470,26 +1445,25 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///         + `NULL == name`
 ///         + `NULL == pDst`
 ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingRead, ///< [in] indicates if this operation should block.
     size_t count,      ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
-    void *pDst,    ///< [in] pointer to where the data must be copied to.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableRead =
         ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -1565,8 +1539,9 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
     size_t
         propValueSize, ///< [in] size in bytes of the profiling property value
     void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet ///< [out][optional] pointer to the actual size in
-                              ///< bytes returned in propValue
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     auto pfnGetProfilingInfo =
         ur_lib::context->urDdiTable.Event.pfnGetProfilingInfo;
@@ -1598,9 +1573,9 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t
-        *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of
-                         ///< events to wait for completion
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     auto pfnWait = ur_lib::context->urDdiTable.Event.pfnWait;
     if (nullptr == pfnWait) {
@@ -1759,8 +1734,8 @@ ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = ur_lib::context->urDdiTable.Event.pfnSetCallback;
     if (nullptr == pfnSetCallback) {
@@ -1889,8 +1864,7 @@ ur_result_t UR_APICALL urMemRetain(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Decrement the memory object's reference count and delete the object
-/// if
+/// @brief Decrement the memory object's reference count and delete the object if
 ///        the reference count becomes zero.
 ///
 /// @remarks
@@ -2051,15 +2025,14 @@ ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointed to by
-                     ///< pMemInfo.
-    void *pMemInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pMemInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Mem.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -2090,15 +2063,14 @@ ur_result_t UR_APICALL urMemGetInfo(
 ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointer to by
-                     ///< pImgInfo.
-    void *pImgInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pImgInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = ur_lib::context->urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr == pfnImageGetInfo) {
@@ -2155,9 +2127,9 @@ ur_result_t UR_APICALL urTearDown(
 ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize, ///< [in] size in bytes of the queue property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the queue property
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out] value of the queue property
     size_t
         *pPropSizeRet ///< [out] size in bytes returned in queue property value
 ) {
@@ -2196,12 +2168,12 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t
-        *pProps, ///< [in] specifies a list of queue properties and their
-                 ///< corresponding values. Each property name is immediately
-                 ///< followed by the corresponding desired value. The list is
-                 ///< terminated with a 0. If a property value is not specified,
-                 ///< then its default value will be used.
+    const ur_queue_property_t *
+        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2539,9 +2511,9 @@ ur_result_t UR_APICALL urSamplerRelease(
 ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t propValueSize, ///< [in] size in bytes of the sampler property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the sampler property
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -2575,9 +2547,9 @@ ur_result_t UR_APICALL urSamplerGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeSampler`
 ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native
-                                        ///< handle of the sampler.
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     auto pfnGetNativeHandle =
         ur_lib::context->urDdiTable.Sampler.pfnGetNativeHandle;
@@ -2608,10 +2580,10 @@ ur_result_t UR_APICALL urSamplerGetNativeHandle(
 ///         + `NULL == phSampler`
 ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeSampler,            ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler ///< [out] pointer to the handle of the
-                                   ///< sampler object created.
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     auto pfnCreateWithNativeHandle =
         ur_lib::context->urDdiTable.Sampler.pfnCreateWithNativeHandle;
@@ -2772,11 +2744,11 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize, ///< [in] size in bytes of the USM allocation property
-                          ///< value
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
     void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in USM
-                              ///< allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo =
         ur_lib::context->urDdiTable.USM.pfnGetMemAllocInfo;
@@ -2818,18 +2790,17 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries, ///< [in] the number of devices to be added to
-                         ///< phDevices. If phDevices in not NULL then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_VALUE, will be returned.
-    ur_device_handle_t
-        *phDevices, ///< [out][optional][range(0, NumEntries)] array of handle
-                    ///< of devices. If NumEntries is less than the number of
-                    ///< devices available, then platform shall only retrieve
-                    ///< that number of devices.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
     uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-                          ///< pNumDevices will be updated with the total number
-                          ///< of devices available.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = ur_lib::context->urDdiTable.Device.pfnGet;
     if (nullptr == pfnGet) {
@@ -2864,12 +2835,12 @@ ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
     size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
     void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-                       ///< If propSize is not equal to or greater than the real
-                       ///< number of bytes needed to return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_VALUE error is returned
-                       ///< and pDeviceInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of the queried infoType.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Device.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -2969,18 +2940,16 @@ ur_result_t UR_APICALL urDeviceRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t
-        *pProperties, ///< [in] null-terminated array of <$_device_partition_t
-                      ///< enum, value> pairs.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t
-        *phSubDevices, ///< [out][optional][range(0, NumDevices)] array of
-                       ///< handle of devices. If NumDevices is less than the
-                       ///< number of sub-devices available, then the function
-                       ///< shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet ///< [out][optional] pointer to the number of
-                             ///< sub-devices the device can be partitioned into
-                             ///< according to the partitioning property.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = ur_lib::context->urDdiTable.Device.pfnPartition;
     if (nullptr == pfnPartition) {
@@ -3023,9 +2992,8 @@ ur_result_t UR_APICALL urDeviceSelectBinary(
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input
-                        ///< array of binaries. If a suitable binary was not
-                        ///< found the function returns ${X}_INVALID_BINARY.
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = ur_lib::context->urDdiTable.Device.pfnSelectBinary;
     if (nullptr == pfnSelectBinary) {
@@ -3122,12 +3090,12 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///         + `NULL == hDevice`
 ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's
-                                ///< global timestamp that correlates with the
-                                ///< Host's global timestamp value
-    uint64_t *pHostTimestamp ///< [out][optional] pointer to the Host's global
-                             ///< timestamp that correlates with the Device's
-                             ///< global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     auto pfnGetGlobalTimestamps =
         ur_lib::context->urDdiTable.Device.pfnGetGlobalTimestamps;
@@ -3222,8 +3190,8 @@ ur_result_t UR_APICALL urKernelSetArgValue(
 ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize     ///< [in] size of the local buffer to be allocated by the
-                       ///< runtime
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = ur_lib::context->urDdiTable.Kernel.pfnSetArgLocal;
     if (nullptr == pfnSetArgLocal) {
@@ -3252,14 +3220,15 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel
-                       ///< info property. If propSize is not equal to or
-                       ///< greater than the real number of bytes needed to
-                       ///< return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                       ///< pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Kernel.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -3289,12 +3258,14 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
-        propName,     ///< [in] name of the work Group property to query
-    size_t propSize,  ///< [in] size of the Kernel Work Group property value
-    void *pPropValue, ///< [in,out][optional][range(0, propSize)] value of the
-                      ///< Kernel Work Group property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = ur_lib::context->urDdiTable.Kernel.pfnGetGroupInfo;
     if (nullptr == pfnGetGroupInfo) {
@@ -3321,12 +3292,14 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
-        propName,     ///< [in] name of the SubGroup property to query
-    size_t propSize,  ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue, ///< [in,out][range(0, propSize)][optional] value of the
-                      ///< Kernel SubGroup property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetSubGroupInfo =
         ur_lib::context->urDdiTable.Kernel.pfnGetSubGroupInfo;
@@ -3420,11 +3393,11 @@ ur_result_t UR_APICALL urKernelRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,    ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,       ///< [in] size of argument type
-    const void *pArgValue ///< [in][optional] SVM pointer to memory location
-                          ///< holding the argument value. If null then argument
-                          ///< value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = ur_lib::context->urDdiTable.Kernel.pfnSetArgPointer;
     if (nullptr == pfnSetArgPointer) {
@@ -3460,8 +3433,9 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue ///< [in][range(0, propSize)] pointer to memory
-                           ///< location holding the property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     auto pfnSetExecInfo = ur_lib::context->urDdiTable.Kernel.pfnSetExecInfo;
     if (nullptr == pfnSetExecInfo) {
@@ -3621,11 +3595,10 @@ ur_result_t UR_APICALL urModuleCreate(
     const char
         *pOptions, ///< [in] pointer to compiler options null-terminated string.
     ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification
-                   ///< routine that is called when program compilation is
-                   ///< complete.
-    void *pUserData, ///< [in][optional] Passed as an argument when pfnNotify is
-                     ///< called.
+        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                   ///< called when program compilation is complete.
+    void *
+        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
     ur_module_handle_t
         *phModule ///< [out] pointer to handle of Module object created.
 ) {
@@ -3776,18 +3749,17 @@ ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ur_result_t UR_APICALL urPlatformGet(
-    uint32_t NumEntries, ///< [in] the number of platforms to be added to
-                         ///< phPlatforms. If phPlatforms is not NULL, then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE, will be returned.
-    ur_platform_handle_t
-        *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle
-                      ///< of platforms. If NumEntries is less than the number
-                      ///< of platforms available, then
-                      ///< ::urPlatformGet shall only retrieve that number of
-                      ///< platforms.
-    uint32_t *pNumPlatforms ///< [out][optional] returns the total number of
-                            ///< platforms available.
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = ur_lib::context->urDdiTable.Platform.pfnGet;
     if (nullptr == pfnGet) {
@@ -3821,12 +3793,11 @@ ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
     size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-                         ///< If Size is not equal to or greater to the real
-                         ///< number of bytes needed to return the info then the
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                         ///< and pPlatformInfo is not used.
-    size_t *pSizeRet ///< [out][optional] pointer to the actual number of bytes
-                     ///< being queried by pPlatformInfo.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Platform.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -3886,9 +3857,9 @@ ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativePlatform`
 ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native
-                                         ///< handle of the platform.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     auto pfnGetNativeHandle =
         ur_lib::context->urDdiTable.Platform.pfnGetNativeHandle;
@@ -3919,8 +3890,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform ///< [out] pointer to the handle of the
-                                     ///< platform object created.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     auto pfnCreateWithNativeHandle =
         ur_lib::context->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -3959,8 +3930,9 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 ///         + `NULL == ppMessage`
 ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage ///< [out] pointer to a string containing adapter
-                           ///< specific result in string representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     auto pfnGetLastResult = ur_lib::context->urDdiTable.Global.pfnGetLastResult;
     if (nullptr == pfnGetLastResult) {
@@ -3994,8 +3966,8 @@ ur_result_t UR_APICALL urProgramCreate(
     uint32_t count, ///< [in] number of module handles in module list.
     const ur_module_handle_t
         *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions, ///< [in][optional] pointer to linker options
-                          ///< null-terminated string.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
     ur_program_handle_t
         *phProgram ///< [out] pointer to handle of program object created.
 ) {
@@ -4136,13 +4108,12 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program to search for function in.
-                  ///< The program must already be built to the specified
-                  ///< device, or otherwise
-                  ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName, ///< [in] A null-terminates string denoting the
-                               ///< mangled function name.
-    void **ppFunctionPointer   ///< [out] Returns the pointer to the function if
-                               ///< it is found in the program.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     auto pfnGetFunctionPointer =
         ur_lib::context->urDdiTable.Program.pfnGetFunctionPointer;
@@ -4173,14 +4144,14 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
-    void *pProgramInfo, ///< [in,out][optional] array of bytes of holding the
-                        ///< program info property. If propSize is not equal to
-                        ///< or greater than the real number of bytes needed to
-                        ///< return the info then the
-                        ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                        ///< and pProgramInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data copied to propName.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Program.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -4210,15 +4181,16 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
-        propName,     ///< [in] name of the Program build info to query
-    size_t propSize,  ///< [in] size of the Program build info property.
-    void *pPropValue, ///< [in,out][optional] value of the Program build
-                      ///< property. If propSize is not equal to or greater than
-                      ///< the real number of bytes needed to return the info
-                      ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                      ///< returned and pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = ur_lib::context->urDdiTable.Program.pfnGetBuildInfo;
     if (nullptr == pfnGetBuildInfo) {
@@ -4276,9 +4248,9 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeProgram`
 ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native
-                                        ///< handle of the program.
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     auto pfnGetNativeHandle =
         ur_lib::context->urDdiTable.Program.pfnGetNativeHandle;
@@ -4309,10 +4281,10 @@ ur_result_t UR_APICALL urProgramGetNativeHandle(
 ///         + `NULL == phProgram`
 ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeProgram,            ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram ///< [out] pointer to the handle of the
-                                   ///< program object created.
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     auto pfnCreateWithNativeHandle =
         ur_lib::context->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -4348,10 +4320,8 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urInit(
-    ur_device_init_flags_t
-        device_flags ///< [in] device initialization flags.
-                     ///< must be 0 (default) or a combination of
-                     ///< ::ur_device_init_flag_t.
+    ur_device_init_flags_t device_flags ///< [in] device initialization flags.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     static ur_result_t result = UR_RESULT_SUCCESS;
     std::call_once(ur_lib::context->initOnce, [device_flags]() {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -40,12 +40,11 @@ extern "C" {
 ///         + `NULL == phContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
-ur_result_t UR_APICALL urContextCreate(
-    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
-    ur_device_handle_t
-        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t
-        *phContext ///< [out] pointer to handle of context object created
+ur_result_t UR_APICALL
+urContextCreate(
+    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
+    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Context.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -76,9 +75,9 @@ ur_result_t UR_APICALL urContextCreate(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL urContextRetain(
-    ur_context_handle_t
-        hContext ///< [in] handle of the context to get a reference of.
+ur_result_t UR_APICALL
+urContextRetain(
+    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Context.pfnRetain;
     if (nullptr == pfnRetain) {
@@ -106,7 +105,8 @@ ur_result_t UR_APICALL urContextRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL urContextRelease(
+ur_result_t UR_APICALL
+urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Context.pfnRelease;
@@ -136,26 +136,24 @@ ur_result_t UR_APICALL urContextRelease(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT < ContextInfoType`
-ur_result_t UR_APICALL urContextGetInfo(
+ur_result_t UR_APICALL
+urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-    ///< if propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
+                                       ///< if propSize is not equal to or greater than the real number of bytes
+                                       ///< needed to return
+                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                       ///< pContextInfo is not used.
+    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Context.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                      pPropSizeRet);
+    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -178,13 +176,12 @@ ur_result_t UR_APICALL urContextGetInfo(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeContext`
-ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_native_handle_t *
-        phNativeContext ///< [out] a pointer to the native handle of the context.
+ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,       ///< [in] handle of the context.
+    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Context.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Context.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -209,14 +206,12 @@ ur_result_t UR_APICALL urContextGetNativeHandle(
 ///         + `NULL == hNativeContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phContext`
-ur_result_t UR_APICALL urContextCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *
-        phContext ///< [out] pointer to the handle of the context object created.
+ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Context.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -245,15 +240,13 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
-ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_context_extended_deleter_t
-        pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+ur_result_t UR_APICALL
+urContextSetExtendedDeleter(
+    ur_context_handle_t hContext,             ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
-    auto pfnSetExtendedDeleter =
-        ur_lib::context->urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter = ur_lib::context->urDdiTable.Context.pfnSetExtendedDeleter;
     if (nullptr == pfnSetExtendedDeleter) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -286,43 +279,36 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t
-        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                 ///< work-group work-items
-    const size_t *
-        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< offset used to calculate the global ID of a work-item
-    const size_t *
-        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< number of global work-items in workDim that will execute the kernel
-    ///< function
-    const size_t *
-        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
-    ///< specify the number of local work-items forming a work-group that will
-    ///< execute the kernel function.
-    ///< If nullptr, the runtime implementation will choose the work-group
-    ///< size.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
+    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                              ///< work-group work-items
+    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< number of global work-items in workDim that will execute the kernel
+                                              ///< function
+    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
+                                              ///< specify the number of local work-items forming a work-group that will
+                                              ///< execute the kernel function.
+                                              ///< If nullptr, the runtime implementation will choose the work-group
+                                              ///< size.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnKernelLaunch = ur_lib::context->urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr == pfnKernelLaunch) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
-                           pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList,
-                           phEventWaitList, phEvent);
+    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -349,18 +335,17 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnEventsWait = ur_lib::context->urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr == pfnEventsWait) {
@@ -396,27 +381,24 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnEventsWaitWithBarrier =
-        ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier = ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
-                                    phEventWaitList, phEvent);
+    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -444,31 +426,28 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being read
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being read
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferRead =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
+    auto pfnMemBufferRead = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
     if (nullptr == pfnMemBufferRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
-                            numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -496,33 +475,28 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being written
-    const void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being written
+    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferWrite =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
+    auto pfnMemBufferWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
     if (nullptr == pfnMemBufferWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
-                             numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -553,45 +527,35 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< dst
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by dst
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< dst
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by dst
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferReadRect =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
+    auto pfnMemBufferReadRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr == pfnMemBufferReadRect) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferReadRect(
-        hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region,
-        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -622,48 +586,36 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
-                          ///< written
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< src
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by src
-    void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
+                                              ///< written
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< src
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by src
+    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferWriteRect =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr == pfnMemBufferWriteRect) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferWriteRect(
-        hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region,
-        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -686,32 +638,28 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
-    size_t size,      ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
+    size_t size,                              ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferCopy =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
+    auto pfnMemBufferCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
     if (nullptr == pfnMemBufferCopy) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
-                            dstOffset, size, numEventsInWaitList,
-                            phEventWaitList, phEvent);
+    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -735,42 +683,32 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t
-        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t
-        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
-    size_t
-        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t
-        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
-    size_t
-        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferCopyRect =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
+    auto pfnMemBufferCopyRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr == pfnMemBufferCopyRect) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin,
-                                dstOrigin, srcRegion, srcRowPitch,
-                                srcSlicePitch, dstRowPitch, dstSlicePitch,
-                                numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -795,32 +733,28 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    const void *pPattern,     ///< [in] pointer to the fill pattern
-    size_t patternSize,       ///< [in] size in bytes of the pattern
-    size_t offset,            ///< [in] offset into the buffer
-    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    const void *pPattern,                     ///< [in] pointer to the fill pattern
+    size_t patternSize,                       ///< [in] size in bytes of the pattern
+    size_t offset,                            ///< [in] offset into the buffer
+    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemBufferFill =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
+    auto pfnMemBufferFill = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
     if (nullptr == pfnMemBufferFill) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset,
-                            size, numEventsInWaitList, phEventWaitList,
-                            phEvent);
+    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -849,36 +783,31 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t rowPitch,   ///< [in] length of each row in bytes
-    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pDst, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
+    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemImageRead = ur_lib::context->urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr == pfnMemImageRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
-                           rowPitch, slicePitch, pDst, numEventsInWaitList,
-                           phEventWaitList, phEvent);
+    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -907,38 +836,31 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t inputRowPitch,   ///< [in] length of each row in bytes
-    size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pSrc, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t inputRowPitch,                     ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
-    auto pfnMemImageWrite =
-        ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
+    auto pfnMemImageWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr == pfnMemImageWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
-                            inputRowPitch, inputSlicePitch, pSrc,
-                            numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -961,37 +883,31 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
-    ur_rect_offset_t
-        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                              ///< image
+    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                              ///< or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemImageCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr == pfnMemImageCopy) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
-                           region, numEventsInWaitList, phEventWaitList,
-                           phEvent);
+    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1025,33 +941,30 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
-    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,   ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent, ///< [in,out][optional] return an event object that identifies this
-                 ///< particular command instance.
-    void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
-                    ///< numEventsInWaitList?
+ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+                                              ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferMap;
     if (nullptr == pfnMemBufferMap) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size,
-                           numEventsInWaitList, phEventWaitList, phEvent,
-                           ppRetMap);
+    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1076,28 +989,25 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t
-        hMem,         ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr, ///< [in] mapped host address
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr,                         ///< [in] mapped host address
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnMemUnmap = ur_lib::context->urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr == pfnMemUnmap) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
-                       phEventWaitList, phEvent);
+    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1116,28 +1026,26 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMMemset(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    void *ptr,                    ///< [in] pointer to USM memory object
-    int8_t byteValue,             ///< [in] byte value to fill
-    size_t count,                 ///< [in] size in bytes to be set
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    void *ptr,                                ///< [in] pointer to USM memory object
+    int8_t byteValue,                         ///< [in] byte value to fill
+    size_t count,                             ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnUSMMemset = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemset;
     if (nullptr == pfnUSMMemset) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList,
-                        phEventWaitList, phEvent);
+    return pfnUSMMemset(hQueue, ptr, byteValue, count, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1157,29 +1065,27 @@ ur_result_t UR_APICALL urEnqueueUSMMemset(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool blocking,            ///< [in] blocking or non-blocking copy
-    void *pDst,       ///< [in] pointer to the destination USM memory object
-    const void *pSrc, ///< [in] pointer to the source USM memory object
-    size_t size,      ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking copy
+    void *pDst,                               ///< [in] pointer to the destination USM memory object
+    const void *pSrc,                         ///< [in] pointer to the source USM memory object
+    size_t size,                              ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnUSMMemcpy = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr == pfnUSMMemcpy) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
-                        phEventWaitList, phEvent);
+    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1200,28 +1106,26 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
-    const void *pMem,               ///< [in] pointer to the USM memory object
-    size_t size,                    ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     auto pfnUSMPrefetch = ur_lib::context->urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr == pfnUSMPrefetch) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
-                          phEventWaitList, phEvent);
+    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1242,14 +1146,14 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    const void *pMem,         ///< [in] pointer to the USM memory object
-    size_t size,              ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    const void *pMem,          ///< [in] pointer to the USM memory object
+    size_t size,               ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,    ///< [in] USM memory advice
+    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
+                               ///< particular command instance.
 ) {
     auto pfnUSMMemAdvise = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvise;
     if (nullptr == pfnUSMMemAdvise) {
@@ -1272,33 +1176,29 @@ ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 ///         + `NULL == pMem`
 ///         + `NULL == pPattern`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    size_t patternSize, ///< [in] the size in bytes of the pattern.
-    const void
-        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,  ///< [in] the width in bytes of each row to fill.
-    size_t height, ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    size_t patternSize,                       ///< [in] the size in bytes of the pattern.
+    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
+    size_t width,                             ///< [in] the width in bytes of each row to fill.
+    size_t height,                            ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnUSMFill2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr == pfnUSMFill2D) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
-                        height, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1313,31 +1213,28 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL urEnqueueUSMMemset2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    int value,     ///< [in] the value to fill into the region in pMem.
-    size_t width,  ///< [in] the width in bytes of each row to set.
-    size_t height, ///< [in] the height of the columns to set.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemset2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    int value,                                ///< [in] the value to fill into the region in pMem.
+    size_t width,                             ///< [in] the width in bytes of each row to set.
+    size_t height,                            ///< [in] the height of the columns to set.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemset2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemset2D;
     if (nullptr == pfnUSMMemset2D) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height,
-                          numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMMemset2D(hQueue, pMem, pitch, value, width, height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1353,35 +1250,30 @@ ur_result_t UR_APICALL urEnqueueUSMMemset2D(
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    bool blocking, ///< [in] indicates if this operation should block the host.
-    void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t
-        dstPitch, ///< [in] the total width of the source memory including padding.
-    const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t
-        srcPitch, ///< [in] the total width of the source memory including padding.
-    size_t width,  ///< [in] the width in bytes of each row to be copied.
-    size_t height, ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    bool blocking,                            ///< [in] indicates if this operation should block the host.
+    void *pDst,                               ///< [in] pointer to memory where data will be copied.
+    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
+    const void *pSrc,                         ///< [in] pointer to memory to be copied.
+    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
+    size_t width,                             ///< [in] the width in bytes of each row to be copied.
+    size_t height,                            ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr == pfnUSMMemcpy2D) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch,
-                          width, height, numEventsInWaitList, phEventWaitList,
-                          phEvent);
+    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1398,36 +1290,29 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == name`
 ///         + `NULL == pSrc`
-ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite, ///< [in] indicates if this operation should block.
-    size_t count,       ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc, ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                       ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableWrite =
-        ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnDeviceGlobalVariableWrite(
-        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
-        numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1444,36 +1329,29 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == name`
 ///         + `NULL == pDst`
-ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingRead, ///< [in] indicates if this operation should block.
-    size_t count,      ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst, ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                        ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst,                               ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableRead =
-        ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead,
-                                       count, offset, pDst, numEventsInWaitList,
-                                       phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1495,21 +1373,20 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventGetInfo(
+ur_result_t UR_APICALL
+urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize,     ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional] value of the event property
+    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Event.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                      pPropValueSizeRet);
+    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1532,25 +1409,21 @@ ur_result_t UR_APICALL urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventGetProfilingInfo(
-    ur_event_handle_t hEvent, ///< [in] handle of the event object
-    ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t hEvent,     ///< [in] handle of the event object
+    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
+    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional] value of the profiling property
+    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+                                  ///< propValue
 ) {
-    auto pfnGetProfilingInfo =
-        ur_lib::context->urDdiTable.Event.pfnGetProfilingInfo;
+    auto pfnGetProfilingInfo = ur_lib::context->urDdiTable.Event.pfnGetProfilingInfo;
     if (nullptr == pfnGetProfilingInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
-                               pPropValueSizeRet);
+    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1571,11 +1444,11 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEventWait(
-    uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t *
-        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                        ///< completion
+ur_result_t UR_APICALL
+urEventWait(
+    uint32_t numEvents,                      ///< [in] number of events in the event list
+    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                             ///< completion
 ) {
     auto pfnWait = ur_lib::context->urDdiTable.Event.pfnWait;
     if (nullptr == pfnWait) {
@@ -1602,7 +1475,8 @@ ur_result_t UR_APICALL urEventWait(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventRetain(
+ur_result_t UR_APICALL
+urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Event.pfnRetain;
@@ -1630,7 +1504,8 @@ ur_result_t UR_APICALL urEventRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventRelease(
+ur_result_t UR_APICALL
+urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Event.pfnRelease;
@@ -1661,13 +1536,12 @@ ur_result_t UR_APICALL urEventRelease(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeEvent`
-ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ///< [in] handle of the event.
-    ur_native_handle_t
-        *phNativeEvent ///< [out] a pointer to the native handle of the event.
+ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,         ///< [in] handle of the event.
+    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Event.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Event.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1693,14 +1567,13 @@ ur_result_t UR_APICALL urEventGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
-ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t
-        *phEvent ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Event.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1730,12 +1603,12 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnNotify`
-ur_result_t UR_APICALL urEventSetCallback(
+ur_result_t UR_APICALL
+urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = ur_lib::context->urDdiTable.Event.pfnSetCallback;
     if (nullptr == pfnSetCallback) {
@@ -1774,22 +1647,21 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    void *pHost,                       ///< [in] pointer to the buffer data
-    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
+ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    void *pHost,                           ///< [in] pointer to the buffer data
+    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
 ) {
     auto pfnImageCreate = ur_lib::context->urDdiTable.Mem.pfnImageCreate;
     if (nullptr == pfnImageCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost,
-                          phMem);
+    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1815,13 +1687,13 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemBufferCreate(
+ur_result_t UR_APICALL
+urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t
-        *phBuffer ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
+    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
+    void *pHost,                  ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
 ) {
     auto pfnBufferCreate = ur_lib::context->urDdiTable.Mem.pfnBufferCreate;
     if (nullptr == pfnBufferCreate) {
@@ -1852,7 +1724,8 @@ ur_result_t UR_APICALL urMemBufferCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemRetain(
+ur_result_t UR_APICALL
+urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Mem.pfnRetain;
@@ -1879,7 +1752,8 @@ ur_result_t UR_APICALL urMemRetain(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urMemRelease(
+ur_result_t UR_APICALL
+urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Mem.pfnRelease;
@@ -1916,24 +1790,20 @@ ur_result_t UR_APICALL urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t
-        hBuffer,          ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
+    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
 ) {
-    auto pfnBufferPartition =
-        ur_lib::context->urDdiTable.Mem.pfnBufferPartition;
+    auto pfnBufferPartition = ur_lib::context->urDdiTable.Mem.pfnBufferPartition;
     if (nullptr == pfnBufferPartition) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                              pBufferCreateInfo, phMem);
+    return pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1956,13 +1826,12 @@ ur_result_t UR_APICALL urMemBufferPartition(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeMem`
-ur_result_t UR_APICALL urMemGetNativeHandle(
-    ur_mem_handle_t hMem, ///< [in] handle of the mem.
-    ur_native_handle_t
-        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Mem.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Mem.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1988,14 +1857,13 @@ ur_result_t UR_APICALL urMemGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phMem`
-ur_result_t UR_APICALL urMemCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Mem.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2021,18 +1889,16 @@ ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
-ur_result_t UR_APICALL urMemGetInfo(
-    ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
+ur_result_t UR_APICALL
+urMemGetInfo(
+    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
+                               ///< If propSize is less than the real number of bytes needed to return
+                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                               ///< pMemInfo is not used.
+    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Mem.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -2060,25 +1926,23 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
-ur_result_t UR_APICALL urMemImageGetInfo(
-    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
+ur_result_t UR_APICALL
+urMemImageGetInfo(
+    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
+                                 ///< If propSize is less than the real number of bytes needed to return
+                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                 ///< pImgInfo is not used.
+    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = ur_lib::context->urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr == pfnImageGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
-                           pPropSizeRet);
+    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2091,7 +1955,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pParams`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urTearDown(
+ur_result_t UR_APICALL
+urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     auto pfnTearDown = ur_lib::context->urDdiTable.Global.pfnTearDown;
@@ -2124,22 +1989,20 @@ ur_result_t UR_APICALL urTearDown(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueGetInfo(
+ur_result_t UR_APICALL
+urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out] value of the queue property
-    size_t
-        *pPropSizeRet ///< [out] size in bytes returned in queue property value
+    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out] value of the queue property
+    size_t *pPropSizeRet      ///< [out] size in bytes returned in queue property value
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Queue.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
-                      pPropSizeRet);
+    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2165,17 +2028,16 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to handle of queue object created
+ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_device_handle_t hDevice,        ///< [in] handle of the device object
+    const ur_queue_property_t *pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+                                       ///< Each property name is immediately followed by the corresponding
+                                       ///< desired value.
+                                       ///< The list is terminated with a 0.
+                                       ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Queue.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -2206,7 +2068,8 @@ ur_result_t UR_APICALL urQueueCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueRetain(
+ur_result_t UR_APICALL
+urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Queue.pfnRetain;
@@ -2240,7 +2103,8 @@ ur_result_t UR_APICALL urQueueRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueRelease(
+ur_result_t UR_APICALL
+urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Queue.pfnRelease;
@@ -2271,13 +2135,12 @@ ur_result_t UR_APICALL urQueueRelease(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeQueue`
-ur_result_t UR_APICALL urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
-    ur_native_handle_t
-        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Queue.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Queue.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2303,14 +2166,13 @@ ur_result_t UR_APICALL urQueueGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phQueue`
-ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Queue.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2341,7 +2203,8 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urQueueFinish(
+ur_result_t UR_APICALL
+urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = ur_lib::context->urDdiTable.Queue.pfnFinish;
@@ -2374,7 +2237,8 @@ ur_result_t UR_APICALL urQueueFinish(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urQueueFlush(
+ur_result_t UR_APICALL
+urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = ur_lib::context->urDdiTable.Queue.pfnFlush;
@@ -2412,13 +2276,12 @@ ur_result_t UR_APICALL urQueueFlush(
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
-    ur_sampler_handle_t
-        *phSampler ///< [out] pointer to handle of sampler object created
+ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context object
+    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
+                                         ///< corresponding values.
+    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Sampler.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -2445,9 +2308,9 @@ ur_result_t UR_APICALL urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerRetain(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to get access
+ur_result_t UR_APICALL
+urSamplerRetain(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Sampler.pfnRetain;
     if (nullptr == pfnRetain) {
@@ -2474,9 +2337,9 @@ ur_result_t UR_APICALL urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerRelease(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to release
+ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Sampler.pfnRelease;
     if (nullptr == pfnRelease) {
@@ -2508,22 +2371,20 @@ ur_result_t UR_APICALL urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerGetInfo(
+ur_result_t UR_APICALL
+urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
-    size_t *
-        pPropSizeRet ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
+    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out] value of the sampler property
+    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Sampler.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
-                      pPropSizeRet);
+    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2546,13 +2407,12 @@ ur_result_t UR_APICALL urSamplerGetInfo(
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeSampler`
-ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
-    ur_native_handle_t *
-        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
+    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Sampler.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Sampler.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2578,15 +2438,13 @@ ur_result_t UR_APICALL urSamplerGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phSampler`
-ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeSampler,           ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_sampler_handle_t *
-        phSampler ///< [out] pointer to the handle of the sampler object created.
+ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Sampler.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2611,13 +2469,13 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urUSMHostAlloc(
+ur_result_t UR_APICALL
+urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_mem_flags_t *pUSMFlag, ///< [in] USM memory allocation flags
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM host memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = ur_lib::context->urDdiTable.USM.pfnHostAlloc;
     if (nullptr == pfnHostAlloc) {
@@ -2645,14 +2503,14 @@ ur_result_t UR_APICALL urUSMHostAlloc(
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urUSMDeviceAlloc(
+ur_result_t UR_APICALL
+urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM device memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = ur_lib::context->urDdiTable.USM.pfnDeviceAlloc;
     if (nullptr == pfnDeviceAlloc) {
@@ -2680,14 +2538,14 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urUSMSharedAlloc(
+ur_result_t UR_APICALL
+urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM shared memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = ur_lib::context->urDdiTable.USM.pfnSharedAlloc;
     if (nullptr == pfnSharedAlloc) {
@@ -2710,7 +2568,8 @@ ur_result_t UR_APICALL urUSMSharedAlloc(
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urUSMFree(
+ur_result_t UR_APICALL
+urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -2739,25 +2598,21 @@ ur_result_t UR_APICALL urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+ur_result_t UR_APICALL
+urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t
-        propName, ///< [in] the name of the USM allocation property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional] value of the USM allocation property
+    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
 ) {
-    auto pfnGetMemAllocInfo =
-        ur_lib::context->urDdiTable.USM.pfnGetMemAllocInfo;
+    auto pfnGetMemAllocInfo = ur_lib::context->urDdiTable.USM.pfnGetMemAllocInfo;
     if (nullptr == pfnGetMemAllocInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                              pPropValue, pPropValueSizeRet);
+    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2787,20 +2642,19 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urDeviceGet(
+ur_result_t UR_APICALL
+urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t
-        NumEntries, ///< [in] the number of devices to be added to phDevices.
-    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-    ///< will be returned.
-    ur_device_handle_t *
-        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-    ///< If NumEntries is less than the number of devices available, then
-    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
+                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+                                    ///< will be returned.
+    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                    ///< If NumEntries is less than the number of devices available, then
+                                    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
+                                    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = ur_lib::context->urDdiTable.Device.pfnGet;
     if (nullptr == pfnGet) {
@@ -2830,17 +2684,17 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES < infoType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urDeviceGetInfo(
+ur_result_t UR_APICALL
+urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info
-    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return the info
+                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+                                ///< pDeviceInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Device.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -2871,9 +2725,9 @@ ur_result_t UR_APICALL urDeviceGetInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL urDeviceRetain(
-    ur_device_handle_t
-        hDevice ///< [in] handle of the device to get a reference of.
+ur_result_t UR_APICALL
+urDeviceRetain(
+    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Device.pfnRetain;
     if (nullptr == pfnRetain) {
@@ -2901,7 +2755,8 @@ ur_result_t UR_APICALL urDeviceRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL urDeviceRelease(
+ur_result_t UR_APICALL
+urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Device.pfnRelease;
@@ -2938,26 +2793,23 @@ ur_result_t UR_APICALL urDeviceRelease(
 ///         + `NULL == pProperties`
 ///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
-ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t *
-        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-    ///< If NumDevices is less than the number of sub-devices available, then
-    ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *
-        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
-    ///< partitioned into according to the partitioning property.
+ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                       ///< If NumDevices is less than the number of sub-devices available, then
+                                                       ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                       ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = ur_lib::context->urDdiTable.Device.pfnPartition;
     if (nullptr == pfnPartition) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
-                        pNumDevicesRet);
+    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2984,16 +2836,15 @@ ur_result_t UR_APICALL urDevicePartition(
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to select binary for.
+ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
-                          ///< Must greater than or equal to zero otherwise
-                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
+                                ///< Must greater than or equal to zero otherwise
+                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
+                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = ur_lib::context->urDdiTable.Device.pfnSelectBinary;
     if (nullptr == pfnSelectBinary) {
@@ -3023,13 +2874,12 @@ ur_result_t UR_APICALL urDeviceSelectBinary(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeDevice`
-ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ///< [in] handle of the device.
-    ur_native_handle_t
-        *phNativeDevice ///< [out] a pointer to the native handle of the device.
+ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,        ///< [in] handle of the device.
+    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Device.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Device.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3055,14 +2905,13 @@ ur_result_t UR_APICALL urDeviceGetNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phDevice`
-ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t
-        *phDevice ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Device.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3088,17 +2937,15 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+ur_result_t UR_APICALL
+urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *
-        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                          ///< correlates with the Host's global timestamp value
-    uint64_t *
-        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
-                       ///< correlates with the Device's global timestamp value
+    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                                ///< correlates with the Host's global timestamp value
+    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
+                                ///< correlates with the Device's global timestamp value
 ) {
-    auto pfnGetGlobalTimestamps =
-        ur_lib::context->urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps = ur_lib::context->urDdiTable.Device.pfnGetGlobalTimestamps;
     if (nullptr == pfnGetGlobalTimestamps) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3124,11 +2971,11 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pKernelName`
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL urKernelCreate(
+ur_result_t UR_APICALL
+urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Kernel.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -3156,12 +3003,12 @@ ur_result_t UR_APICALL urKernelCreate(
 ///         + `NULL == pArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL urKernelSetArgValue(
+ur_result_t UR_APICALL
+urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void
-        *pArgValue ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in] argument value represented as matching arg type.
 ) {
     auto pfnSetArgValue = ur_lib::context->urDdiTable.Kernel.pfnSetArgValue;
     if (nullptr == pfnSetArgValue) {
@@ -3187,11 +3034,11 @@ ur_result_t UR_APICALL urKernelSetArgValue(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL urKernelSetArgLocal(
+ur_result_t UR_APICALL
+urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t
-        argSize ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = ur_lib::context->urDdiTable.Kernel.pfnSetArgLocal;
     if (nullptr == pfnSetArgLocal) {
@@ -3216,19 +3063,18 @@ ur_result_t UR_APICALL urKernelSetArgLocal(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
-ur_result_t UR_APICALL urKernelGetInfo(
+ur_result_t UR_APICALL
+urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return
+                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                ///< pKernelInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
+                                ///< queried by propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Kernel.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -3254,26 +3100,23 @@ ur_result_t UR_APICALL urKernelGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
-ur_result_t UR_APICALL urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_group_info_t
-        propName,    ///< [in] name of the work Group property to query
-    size_t propSize, ///< [in] size of the Kernel Work Group property value
-    void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
+    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
+    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                     ///< property.
+    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
+                                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = ur_lib::context->urDdiTable.Kernel.pfnGetGroupInfo;
     if (nullptr == pfnGetGroupInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
-                           pPropSizeRet);
+    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3288,27 +3131,23 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
-ur_result_t UR_APICALL urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t
-        propName,    ///< [in] name of the SubGroup property to query
-    size_t propSize, ///< [in] size of the Kernel SubGroup property value
-    void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
+    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
+    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                         ///< property.
+    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
+                                         ///< queried by propName.
 ) {
-    auto pfnGetSubGroupInfo =
-        ur_lib::context->urDdiTable.Kernel.pfnGetSubGroupInfo;
+    auto pfnGetSubGroupInfo = ur_lib::context->urDdiTable.Kernel.pfnGetSubGroupInfo;
     if (nullptr == pfnGetSubGroupInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
-                              pPropSizeRet);
+    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3330,7 +3169,8 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL urKernelRetain(
+ur_result_t UR_APICALL
+urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Kernel.pfnRetain;
@@ -3360,7 +3200,8 @@ ur_result_t UR_APICALL urKernelRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL urKernelRelease(
+ur_result_t UR_APICALL
+urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Kernel.pfnRelease;
@@ -3391,13 +3232,13 @@ ur_result_t UR_APICALL urKernelRelease(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL urKernelSetArgPointer(
+ur_result_t UR_APICALL
+urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void *
-        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
-                  ///< value. If null then argument value is considered null.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
+                                ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = ur_lib::context->urDdiTable.Kernel.pfnSetArgPointer;
     if (nullptr == pfnSetArgPointer) {
@@ -3429,13 +3270,13 @@ ur_result_t UR_APICALL urKernelSetArgPointer(
 ///         + `::UR_KERNEL_EXEC_INFO_USM_PTRS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-ur_result_t UR_APICALL urKernelSetExecInfo(
+ur_result_t UR_APICALL
+urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
-                   ///< property value.
+    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                    ///< property value.
 ) {
     auto pfnSetExecInfo = ur_lib::context->urDdiTable.Kernel.pfnSetExecInfo;
     if (nullptr == pfnSetExecInfo) {
@@ -3461,9 +3302,10 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
+    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     auto pfnSetArgSampler = ur_lib::context->urDdiTable.Kernel.pfnSetArgSampler;
@@ -3489,10 +3331,11 @@ ur_result_t UR_APICALL urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL urKernelSetArgMemObj(
+ur_result_t UR_APICALL
+urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = ur_lib::context->urDdiTable.Kernel.pfnSetArgMemObj;
     if (nullptr == pfnSetArgMemObj) {
@@ -3522,13 +3365,12 @@ ur_result_t UR_APICALL urKernelSetArgMemObj(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
-ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
-    ur_native_handle_t
-        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Kernel.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Kernel.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3554,14 +3396,13 @@ ur_result_t UR_APICALL urKernelGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Kernel.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3588,27 +3429,23 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 ///         + `NULL == pIL`
 ///         + `NULL == pOptions`
 ///         + `NULL == phModule`
-ur_result_t UR_APICALL urModuleCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    const void *pIL,              ///< [in] pointer to IL string.
-    size_t length,                ///< [in] length of IL in bytes.
-    const char
-        *pOptions, ///< [in] pointer to compiler options null-terminated string.
-    ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
-                   ///< called when program compilation is complete.
-    void *
-        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to handle of Module object created.
+ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,         ///< [in] handle of the context instance.
+    const void *pIL,                      ///< [in] pointer to IL string.
+    size_t length,                        ///< [in] length of IL in bytes.
+    const char *pOptions,                 ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                                          ///< called when program compilation is complete.
+    void *pUserData,                      ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t *phModule          ///< [out] pointer to handle of Module object created.
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Module.pfnCreate;
     if (nullptr == pfnCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData,
-                     phModule);
+    return pfnCreate(hContext, pIL, length, pOptions, pfnNotify, pUserData, phModule);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3626,7 +3463,8 @@ ur_result_t UR_APICALL urModuleCreate(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hModule`
-ur_result_t UR_APICALL urModuleRetain(
+ur_result_t UR_APICALL
+urModuleRetain(
     ur_module_handle_t hModule ///< [in] handle for the Module to retain
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Module.pfnRetain;
@@ -3652,7 +3490,8 @@ ur_result_t UR_APICALL urModuleRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hModule`
-ur_result_t UR_APICALL urModuleRelease(
+ur_result_t UR_APICALL
+urModuleRelease(
     ur_module_handle_t hModule ///< [in] handle for the Module to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Module.pfnRelease;
@@ -3683,13 +3522,12 @@ ur_result_t UR_APICALL urModuleRelease(
 ///         + `NULL == hModule`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeModule`
-ur_result_t UR_APICALL urModuleGetNativeHandle(
-    ur_module_handle_t hModule, ///< [in] handle of the module.
-    ur_native_handle_t
-        *phNativeModule ///< [out] a pointer to the native handle of the module.
+ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,        ///< [in] handle of the module.
+    ur_native_handle_t *phNativeModule ///< [out] a pointer to the native handle of the module.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Module.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Module.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3715,14 +3553,13 @@ ur_result_t UR_APICALL urModuleGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phModule`
-ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
     ur_native_handle_t hNativeModule, ///< [in] the native handle of the module.
     ur_context_handle_t hContext,     ///< [in] handle of the context instance.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to the handle of the module object created.
+    ur_module_handle_t *phModule      ///< [out] pointer to the handle of the module object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Module.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Module.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3748,18 +3585,16 @@ ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL urPlatformGet(
-    uint32_t
-        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
-    ///< If phPlatforms is not NULL, then NumEntries should be greater than
-    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-    ///< will be returned.
-    ur_platform_handle_t *
-        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-    ///< If NumEntries is less than the number of platforms available, then
-    ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *
-        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
+ur_result_t UR_APICALL
+urPlatformGet(
+    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
+                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                       ///< will be returned.
+    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                       ///< If NumEntries is less than the number of platforms available, then
+                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = ur_lib::context->urDdiTable.Platform.pfnGet;
     if (nullptr == pfnGet) {
@@ -3788,24 +3623,23 @@ ur_result_t UR_APICALL urPlatformGet(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
-ur_result_t UR_APICALL urPlatformGetInfo(
+ur_result_t UR_APICALL
+urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If Size is not equal to or greater to the real number of bytes needed
-    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-    ///< returned and pPlatformInfo is not used.
-    size_t *
-        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
+                                         ///< If Size is not equal to or greater to the real number of bytes needed
+                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                         ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Platform.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
-                      pSizeRet);
+    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3823,12 +3657,12 @@ ur_result_t UR_APICALL urPlatformGetInfo(
 ///         + `NULL == hDriver`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
-ur_result_t UR_APICALL urPlatformGetApiVersion(
+ur_result_t UR_APICALL
+urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
-    auto pfnGetApiVersion =
-        ur_lib::context->urDdiTable.Platform.pfnGetApiVersion;
+    auto pfnGetApiVersion = ur_lib::context->urDdiTable.Platform.pfnGetApiVersion;
     if (nullptr == pfnGetApiVersion) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3856,13 +3690,12 @@ ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativePlatform`
-ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
-    ur_native_handle_t *
-        phNativePlatform ///< [out] a pointer to the native handle of the platform.
+ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
+    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Platform.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Platform.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3887,14 +3720,12 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ///         + `NULL == hNativePlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
-ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *
-        phPlatform ///< [out] pointer to the handle of the platform object created.
+ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3928,11 +3759,11 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
-ur_result_t UR_APICALL urGetLastResult(
+ur_result_t UR_APICALL
+urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage ///< [out] pointer to a string containing adapter specific result in string
-                  ///< representation.
+    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
+                                    ///< representation.
 ) {
     auto pfnGetLastResult = ur_lib::context->urDdiTable.Global.pfnGetLastResult;
     if (nullptr == pfnGetLastResult) {
@@ -3961,15 +3792,13 @@ ur_result_t UR_APICALL urGetLastResult(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phModules`
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL urProgramCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    uint32_t count, ///< [in] number of module handles in module list.
-    const ur_module_handle_t
-        *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *
-        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of program object created.
+ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context instance
+    uint32_t count,                      ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Program.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -3999,17 +3828,15 @@ ur_result_t UR_APICALL urProgramCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pBinary`
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL urProgramCreateWithBinary(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_device_handle_t
-        hDevice,            ///< [in] handle to device associated with binary.
-    size_t size,            ///< [in] size in bytes.
-    const uint8_t *pBinary, ///< [in] pointer to binary.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of Program object created.
+ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,  ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
+    size_t size,                   ///< [in] size in bytes.
+    const uint8_t *pBinary,        ///< [in] pointer to binary.
+    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
 ) {
-    auto pfnCreateWithBinary =
-        ur_lib::context->urDdiTable.Program.pfnCreateWithBinary;
+    auto pfnCreateWithBinary = ur_lib::context->urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr == pfnCreateWithBinary) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4036,7 +3863,8 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL urProgramRetain(
+ur_result_t UR_APICALL
+urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Program.pfnRetain;
@@ -4066,7 +3894,8 @@ ur_result_t UR_APICALL urProgramRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL urProgramRelease(
+ur_result_t UR_APICALL
+urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Program.pfnRelease;
@@ -4103,26 +3932,21 @@ ur_result_t UR_APICALL urProgramRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pFunctionName`
 ///         + `NULL == ppFunctionPointer`
-ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program to search for function in.
-    ///< The program must already be built to the specified device, or
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *
-        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
-    void **
-        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
+ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
+                                  ///< The program must already be built to the specified device, or
+                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
+    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
-    auto pfnGetFunctionPointer =
-        ur_lib::context->urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer = ur_lib::context->urDdiTable.Program.pfnGetFunctionPointer;
     if (nullptr == pfnGetFunctionPointer) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
-                                 ppFunctionPointer);
+    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4140,18 +3964,17 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
-ur_result_t UR_APICALL urProgramGetInfo(
+ur_result_t UR_APICALL
+urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName, ///< [in] name of the Program property to query
-    size_t propSize,            ///< [in] the size of the Program property.
-    void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+    ur_program_info_t propName,   ///< [in] name of the Program property to query
+    size_t propSize,              ///< [in] the size of the Program property.
+    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+                                  ///< If propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pProgramInfo is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Program.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -4177,28 +4000,25 @@ ur_result_t UR_APICALL urProgramGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
-ur_result_t UR_APICALL urProgramGetBuildInfo(
-    ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
-    ur_program_build_info_t
-        propName,    ///< [in] name of the Program build info to query
-    size_t propSize, ///< [in] size of the Program build info property.
-    void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
+    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
+    size_t propSize,                  ///< [in] size of the Program build info property.
+    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+                                      ///< If propSize is not equal to or greater than the real number of bytes
+                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                      ///< error is returned and pKernelInfo is not used.
+    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
+                                      ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = ur_lib::context->urDdiTable.Program.pfnGetBuildInfo;
     if (nullptr == pfnGetBuildInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
-                           pPropSizeRet);
+    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4212,14 +4032,14 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSpecValue`
-ur_result_t UR_APICALL urProgramSetSpecializationConstant(
+ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t specId,              ///< [in] specification constant Id
-    size_t specSize,       ///< [in] size of the specialization constant value
-    const void *pSpecValue ///< [in] pointer to the specialization value bytes
+    size_t specSize,              ///< [in] size of the specialization constant value
+    const void *pSpecValue        ///< [in] pointer to the specialization value bytes
 ) {
-    auto pfnSetSpecializationConstant =
-        ur_lib::context->urDdiTable.Program.pfnSetSpecializationConstant;
+    auto pfnSetSpecializationConstant = ur_lib::context->urDdiTable.Program.pfnSetSpecializationConstant;
     if (nullptr == pfnSetSpecializationConstant) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4247,13 +4067,12 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeProgram`
-ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ///< [in] handle of the program.
-    ur_native_handle_t *
-        phNativeProgram ///< [out] a pointer to the native handle of the program.
+ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,       ///< [in] handle of the program.
+    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
-    auto pfnGetNativeHandle =
-        ur_lib::context->urDdiTable.Program.pfnGetNativeHandle;
+    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Program.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4279,15 +4098,13 @@ ur_result_t UR_APICALL urProgramGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeProgram,           ///< [in] the native handle of the program.
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_program_handle_t *
-        phProgram ///< [out] pointer to the handle of the program object created.
+ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,      ///< [in] handle of the context instance
+    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
 ) {
-    auto pfnCreateWithNativeHandle =
-        ur_lib::context->urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Program.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4319,9 +4136,10 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urInit(
+ur_result_t UR_APICALL
+urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     static ur_result_t result = UR_RESULT_SUCCESS;
     std::call_once(ur_lib::context->initOnce, [device_flags]() {

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -19,18 +19,15 @@ __urdlllocal ur_result_t context_t::urInit() {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Global);
+        result = urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Global);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetContextProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Context);
+        result = urGetContextProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Context);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Enqueue);
+        result = urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Enqueue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -38,8 +35,7 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetKernelProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Kernel);
+        result = urGetKernelProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Kernel);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -47,18 +43,15 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetModuleProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Module);
+        result = urGetModuleProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Module);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetPlatformProcAddrTable(UR_API_VERSION_0_9,
-                                            &urDdiTable.Platform);
+        result = urGetPlatformProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Platform);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetProgramProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Program);
+        result = urGetProgramProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Program);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -66,8 +59,7 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Sampler);
+        result = urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Sampler);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -75,8 +67,7 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result =
-            urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Device);
+        result = urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Device);
     }
 
     return result;

--- a/source/loader/ur_object.hpp
+++ b/source/loader/ur_object.hpp
@@ -22,7 +22,8 @@ struct dditable_t {
 };
 
 //////////////////////////////////////////////////////////////////////////
-template <typename _handle_t> class __urdlllocal object_t {
+template <typename _handle_t>
+class __urdlllocal object_t {
   public:
     using handle_t = _handle_t;
 
@@ -31,8 +32,7 @@ template <typename _handle_t> class __urdlllocal object_t {
 
     object_t() = delete;
 
-    object_t(handle_t _handle, dditable_t *_dditable)
-        : handle(_handle), dditable(_dditable) {}
+    object_t(handle_t _handle, dditable_t *_dditable) : handle(_handle), dditable(_dditable) {}
 
     ~object_t() = default;
 };

--- a/source/loader/windows/lib_init.cpp
+++ b/source/loader/windows/lib_init.cpp
@@ -11,8 +11,7 @@
 
 namespace ur_lib {
 
-extern "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason,
-                                 LPVOID lpvReserved) {
+extern "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_DETACH) {
         delete context;
         delete loader::context;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -37,12 +37,11 @@
 ///         + `NULL == phContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
-ur_result_t UR_APICALL urContextCreate(
-    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
-    ur_device_handle_t
-        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t
-        *phContext ///< [out] pointer to handle of context object created
+ur_result_t UR_APICALL
+urContextCreate(
+    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
+    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -69,9 +68,9 @@ ur_result_t UR_APICALL urContextCreate(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL urContextRetain(
-    ur_context_handle_t
-        hContext ///< [in] handle of the context to get a reference of.
+ur_result_t UR_APICALL
+urContextRetain(
+    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -95,7 +94,8 @@ ur_result_t UR_APICALL urContextRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL urContextRelease(
+ur_result_t UR_APICALL
+urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -121,18 +121,17 @@ ur_result_t UR_APICALL urContextRelease(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT < ContextInfoType`
-ur_result_t UR_APICALL urContextGetInfo(
+ur_result_t UR_APICALL
+urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-    ///< if propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
+                                       ///< if propSize is not equal to or greater than the real number of bytes
+                                       ///< needed to return
+                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                       ///< pContextInfo is not used.
+    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -158,10 +157,10 @@ ur_result_t UR_APICALL urContextGetInfo(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeContext`
-ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_native_handle_t *
-        phNativeContext ///< [out] a pointer to the native handle of the context.
+ur_result_t UR_APICALL
+urContextGetNativeHandle(
+    ur_context_handle_t hContext,       ///< [in] handle of the context.
+    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -184,11 +183,10 @@ ur_result_t UR_APICALL urContextGetNativeHandle(
 ///         + `NULL == hNativeContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phContext`
-ur_result_t UR_APICALL urContextCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *
-        phContext ///< [out] pointer to the handle of the context object created.
+ur_result_t UR_APICALL
+urContextCreateWithNativeHandle(
+    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -215,12 +213,11 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
-ur_result_t UR_APICALL urContextSetExtendedDeleter(
-    ur_context_handle_t hContext, ///< [in] handle of the context.
-    ur_context_extended_deleter_t
-        pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+ur_result_t UR_APICALL
+urContextSetExtendedDeleter(
+    ur_context_handle_t hContext,             ///< [in] handle of the context.
+    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -251,34 +248,29 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t
-        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                 ///< work-group work-items
-    const size_t *
-        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< offset used to calculate the global ID of a work-item
-    const size_t *
-        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
-    ///< number of global work-items in workDim that will execute the kernel
-    ///< function
-    const size_t *
-        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
-    ///< specify the number of local work-items forming a work-group that will
-    ///< execute the kernel function.
-    ///< If nullptr, the runtime implementation will choose the work-group
-    ///< size.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
+    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                                              ///< work-group work-items
+    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< offset used to calculate the global ID of a work-item
+    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
+                                              ///< number of global work-items in workDim that will execute the kernel
+                                              ///< function
+    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
+                                              ///< specify the number of local work-items forming a work-group that will
+                                              ///< execute the kernel function.
+                                              ///< If nullptr, the runtime implementation will choose the work-group
+                                              ///< size.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -308,18 +300,17 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -351,18 +342,17 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-    ///< previously enqueued commands
-    ///< must be complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -393,22 +383,21 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being read
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being read
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -439,24 +428,21 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,     ///< [in] offset in bytes in the buffer object
-    size_t size,       ///< [in] size in bytes of data being written
-    const void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,                            ///< [in] offset in bytes in the buffer object
+    size_t size,                              ///< [in] size in bytes of data being written
+    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -490,34 +476,28 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< dst
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by dst
-    void *pDst, ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< dst
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by dst
+    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -551,37 +531,29 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
-    ur_rect_region_t
-        region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t
-        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
-    size_t
-        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
-                          ///< written
-    size_t
-        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
-                      ///< src
-    size_t
-        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
-                        ///< pointed by src
-    void
-        *pSrc, ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
+    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
+                                              ///< written
+    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
+                                              ///< src
+    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
+                                              ///< pointed by src
+    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -607,22 +579,21 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
-    size_t size,      ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
+    size_t size,                              ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -649,31 +620,25 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t
-        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t
-        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
-    size_t
-        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t
-        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
-    size_t
-        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
+    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
+    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -701,22 +666,21 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    const void *pPattern,     ///< [in] pointer to the fill pattern
-    size_t patternSize,       ///< [in] size in bytes of the pattern
-    size_t offset,            ///< [in] offset into the buffer
-    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    const void *pPattern,                     ///< [in] pointer to the fill pattern
+    size_t patternSize,                       ///< [in] size in bytes of the pattern
+    size_t offset,                            ///< [in] offset into the buffer
+    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -748,27 +712,24 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t rowPitch,   ///< [in] length of each row in bytes
-    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pDst, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
+    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -800,28 +761,24 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,   ///< [in] handle of the image object
-    bool
-        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t
-        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    size_t inputRowPitch,   ///< [in] length of each row in bytes
-    size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
-    void *pSrc, ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
+    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    size_t inputRowPitch,                     ///< [in] length of each row in bytes
+    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -847,28 +804,24 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
-    ur_rect_offset_t
-        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                ///< image
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
+    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                                              ///< image
+    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                                              ///< or 3D image
+    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                                              ///< image
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -905,24 +858,23 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
-    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
-    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,   ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent, ///< [in,out][optional] return an event object that identifies this
-                 ///< particular command instance.
-    void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
-                    ///< numEventsInWaitList?
+ur_result_t UR_APICALL
+urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
+    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
+    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
+    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+                                              ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -950,20 +902,18 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_mem_handle_t
-        hMem,         ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr, ///< [in] mapped host address
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr,                         ///< [in] mapped host address
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -985,20 +935,19 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMMemset(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    void *ptr,                    ///< [in] pointer to USM memory object
-    int8_t byteValue,             ///< [in] byte value to fill
-    size_t count,                 ///< [in] size in bytes to be set
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemset(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    void *ptr,                                ///< [in] pointer to USM memory object
+    int8_t byteValue,                         ///< [in] byte value to fill
+    size_t count,                             ///< [in] size in bytes to be set
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1021,21 +970,20 @@ ur_result_t UR_APICALL urEnqueueUSMMemset(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool blocking,            ///< [in] blocking or non-blocking copy
-    void *pDst,       ///< [in] pointer to the destination USM memory object
-    const void *pSrc, ///< [in] pointer to the source USM memory object
-    size_t size,      ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking copy
+    void *pDst,                               ///< [in] pointer to the destination USM memory object
+    const void *pSrc,                         ///< [in] pointer to the source USM memory object
+    size_t size,                              ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1059,20 +1007,19 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
-    const void *pMem,               ///< [in] pointer to the USM memory object
-    size_t size,                    ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before this command can be executed.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-    ///< command does not wait on any event to complete.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1096,14 +1043,14 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    const void *pMem,         ///< [in] pointer to the USM memory object
-    size_t size,              ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular command instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    const void *pMem,          ///< [in] pointer to the USM memory object
+    size_t size,               ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,    ///< [in] USM memory advice
+    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
+                               ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1122,25 +1069,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 ///         + `NULL == pMem`
 ///         + `NULL == pPattern`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    size_t patternSize, ///< [in] the size in bytes of the pattern.
-    const void
-        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,  ///< [in] the width in bytes of each row to fill.
-    size_t height, ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    size_t patternSize,                       ///< [in] the size in bytes of the pattern.
+    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
+    size_t width,                             ///< [in] the width in bytes of each row to fill.
+    size_t height,                            ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1158,23 +1102,21 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL urEnqueueUSMMemset2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t
-        pitch, ///< [in] the total width of the destination memory including padding.
-    int value,     ///< [in] the value to fill into the region in pMem.
-    size_t width,  ///< [in] the width in bytes of each row to set.
-    size_t height, ///< [in] the height of the columns to set.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemset2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    void *pMem,                               ///< [in] pointer to memory to be filled.
+    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
+    int value,                                ///< [in] the value to fill into the region in pMem.
+    size_t width,                             ///< [in] the width in bytes of each row to set.
+    size_t height,                            ///< [in] the height of the columns to set.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1193,26 +1135,23 @@ ur_result_t UR_APICALL urEnqueueUSMMemset2D(
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    bool blocking, ///< [in] indicates if this operation should block the host.
-    void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t
-        dstPitch, ///< [in] the total width of the source memory including padding.
-    const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t
-        srcPitch, ///< [in] the total width of the source memory including padding.
-    size_t width,  ///< [in] the width in bytes of each row to be copied.
-    size_t height, ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    bool blocking,                            ///< [in] indicates if this operation should block the host.
+    void *pDst,                               ///< [in] pointer to memory where data will be copied.
+    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
+    const void *pSrc,                         ///< [in] pointer to memory to be copied.
+    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
+    size_t width,                             ///< [in] the width in bytes of each row to be copied.
+    size_t height,                            ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1232,26 +1171,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == name`
 ///         + `NULL == pSrc`
-ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite, ///< [in] indicates if this operation should block.
-    size_t count,       ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc, ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite,                       ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1271,26 +1206,22 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == name`
 ///         + `NULL == pDst`
-ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program containing the device global variable.
-    const char
-        *name, ///< [in] the unique identifier for the device global variable.
-    bool blockingRead, ///< [in] indicates if this operation should block.
-    size_t count,      ///< [in] the number of bytes to copy.
-    size_t
-        offset, ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst, ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out][optional] return an event object that identifies this
-                ///< particular kernel execution instance.
+ur_result_t UR_APICALL
+urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
+    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
+    const char *name,                         ///< [in] the unique identifier for the device global variable.
+    bool blockingRead,                        ///< [in] indicates if this operation should block.
+    size_t count,                             ///< [in] the number of bytes to copy.
+    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst,                               ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
+                                              ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1315,13 +1246,13 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventGetInfo(
+ur_result_t UR_APICALL
+urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize,     ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional] value of the event property
+    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1347,16 +1278,14 @@ ur_result_t UR_APICALL urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventGetProfilingInfo(
-    ur_event_handle_t hEvent, ///< [in] handle of the event object
-    ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+ur_result_t UR_APICALL
+urEventGetProfilingInfo(
+    ur_event_handle_t hEvent,     ///< [in] handle of the event object
+    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
+    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional] value of the profiling property
+    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+                                  ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1380,11 +1309,11 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urEventWait(
-    uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t *
-        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                        ///< completion
+ur_result_t UR_APICALL
+urEventWait(
+    uint32_t numEvents,                      ///< [in] number of events in the event list
+    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                                             ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1407,7 +1336,8 @@ ur_result_t UR_APICALL urEventWait(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventRetain(
+ur_result_t UR_APICALL
+urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1431,7 +1361,8 @@ ur_result_t UR_APICALL urEventRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urEventRelease(
+ur_result_t UR_APICALL
+urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1458,10 +1389,10 @@ ur_result_t UR_APICALL urEventRelease(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeEvent`
-ur_result_t UR_APICALL urEventGetNativeHandle(
-    ur_event_handle_t hEvent, ///< [in] handle of the event.
-    ur_native_handle_t
-        *phNativeEvent ///< [out] a pointer to the native handle of the event.
+ur_result_t UR_APICALL
+urEventGetNativeHandle(
+    ur_event_handle_t hEvent,         ///< [in] handle of the event.
+    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1485,11 +1416,11 @@ ur_result_t UR_APICALL urEventGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
-ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t
-        *phEvent ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1517,12 +1448,12 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnNotify`
-ur_result_t UR_APICALL urEventSetCallback(
+ur_result_t UR_APICALL
+urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *
-        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1557,14 +1488,14 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemImageCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    void *pHost,                       ///< [in] pointer to the buffer data
-    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
+ur_result_t UR_APICALL
+urMemImageCreate(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    void *pHost,                           ///< [in] pointer to the buffer data
+    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1593,13 +1524,13 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemBufferCreate(
+ur_result_t UR_APICALL
+urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
-    size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t
-        *phBuffer ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
+    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
+    void *pHost,                  ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1626,7 +1557,8 @@ ur_result_t UR_APICALL urMemBufferCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemRetain(
+ur_result_t UR_APICALL
+urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1649,7 +1581,8 @@ ur_result_t UR_APICALL urMemRetain(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urMemRelease(
+ur_result_t UR_APICALL
+urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1682,15 +1615,13 @@ ur_result_t UR_APICALL urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urMemBufferPartition(
-    ur_mem_handle_t
-        hBuffer,          ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+ur_result_t UR_APICALL
+urMemBufferPartition(
+    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
+    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1716,10 +1647,10 @@ ur_result_t UR_APICALL urMemBufferPartition(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeMem`
-ur_result_t UR_APICALL urMemGetNativeHandle(
-    ur_mem_handle_t hMem, ///< [in] handle of the mem.
-    ur_native_handle_t
-        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+ur_result_t UR_APICALL
+urMemGetNativeHandle(
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1743,11 +1674,11 @@ ur_result_t UR_APICALL urMemGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phMem`
-ur_result_t UR_APICALL urMemCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t
-        *phMem ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1771,18 +1702,16 @@ ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
-ur_result_t UR_APICALL urMemGetInfo(
-    ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
+ur_result_t UR_APICALL
+urMemGetInfo(
+    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
+                               ///< If propSize is less than the real number of bytes needed to return
+                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                               ///< pMemInfo is not used.
+    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1806,17 +1735,16 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
-ur_result_t UR_APICALL urMemImageGetInfo(
-    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
+ur_result_t UR_APICALL
+urMemImageGetInfo(
+    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is less than the real number of bytes needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
+                                 ///< If propSize is less than the real number of bytes needed to return
+                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                 ///< pImgInfo is not used.
+    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1832,7 +1760,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pParams`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urTearDown(
+ur_result_t UR_APICALL
+urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1861,14 +1790,13 @@ ur_result_t UR_APICALL urTearDown(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueGetInfo(
+ur_result_t UR_APICALL
+urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out] value of the queue property
-    size_t
-        *pPropSizeRet ///< [out] size in bytes returned in queue property value
+    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out] value of the queue property
+    size_t *pPropSizeRet      ///< [out] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1897,17 +1825,16 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to handle of queue object created
+ur_result_t UR_APICALL
+urQueueCreate(
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_device_handle_t hDevice,        ///< [in] handle of the device object
+    const ur_queue_property_t *pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+                                       ///< Each property name is immediately followed by the corresponding
+                                       ///< desired value.
+                                       ///< The list is terminated with a 0.
+                                       ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1934,7 +1861,8 @@ ur_result_t UR_APICALL urQueueCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueRetain(
+ur_result_t UR_APICALL
+urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1964,7 +1892,8 @@ ur_result_t UR_APICALL urQueueRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urQueueRelease(
+ur_result_t UR_APICALL
+urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1991,10 +1920,10 @@ ur_result_t UR_APICALL urQueueRelease(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeQueue`
-ur_result_t UR_APICALL urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
-    ur_native_handle_t
-        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+ur_result_t UR_APICALL
+urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2018,11 +1947,11 @@ ur_result_t UR_APICALL urQueueGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phQueue`
-ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t
-        *phQueue ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2051,7 +1980,8 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urQueueFinish(
+ur_result_t UR_APICALL
+urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2080,7 +2010,8 @@ ur_result_t UR_APICALL urQueueFinish(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urQueueFlush(
+ur_result_t UR_APICALL
+urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2114,13 +2045,12 @@ ur_result_t UR_APICALL urQueueFlush(
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
-    ur_sampler_handle_t
-        *phSampler ///< [out] pointer to handle of sampler object created
+ur_result_t UR_APICALL
+urSamplerCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context object
+    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
+                                         ///< corresponding values.
+    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2143,9 +2073,9 @@ ur_result_t UR_APICALL urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerRetain(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to get access
+ur_result_t UR_APICALL
+urSamplerRetain(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2168,9 +2098,9 @@ ur_result_t UR_APICALL urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerRelease(
-    ur_sampler_handle_t
-        hSampler ///< [in] handle of the sampler object to release
+ur_result_t UR_APICALL
+urSamplerRelease(
+    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2198,14 +2128,13 @@ ur_result_t UR_APICALL urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urSamplerGetInfo(
+ur_result_t UR_APICALL
+urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
-    size_t *
-        pPropSizeRet ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
+    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out] value of the sampler property
+    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2231,10 +2160,10 @@ ur_result_t UR_APICALL urSamplerGetInfo(
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeSampler`
-ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
-    ur_native_handle_t *
-        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+ur_result_t UR_APICALL
+urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
+    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2258,12 +2187,11 @@ ur_result_t UR_APICALL urSamplerGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phSampler`
-ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeSampler,           ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_sampler_handle_t *
-        phSampler ///< [out] pointer to the handle of the sampler object created.
+ur_result_t UR_APICALL
+urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,      ///< [in] handle of the context object
+    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2286,13 +2214,13 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urUSMHostAlloc(
+ur_result_t UR_APICALL
+urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_mem_flags_t *pUSMFlag, ///< [in] USM memory allocation flags
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM host memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2316,14 +2244,14 @@ ur_result_t UR_APICALL urUSMHostAlloc(
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urUSMDeviceAlloc(
+ur_result_t UR_APICALL
+urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM device memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2347,14 +2275,14 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urUSMSharedAlloc(
+ur_result_t UR_APICALL
+urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_usm_mem_flags_t *pUSMProp, ///< [in] USM memory properties
-    size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align, ///< [in] alignment of the USM memory object
-    void **ppMem    ///< [out] pointer to USM shared memory object
+    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align,               ///< [in] alignment of the USM memory object
+    void **ppMem                  ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2373,7 +2301,8 @@ ur_result_t UR_APICALL urUSMSharedAlloc(
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urUSMFree(
+ur_result_t UR_APICALL
+urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -2398,16 +2327,14 @@ ur_result_t UR_APICALL urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+ur_result_t UR_APICALL
+urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t
-        propName, ///< [in] the name of the USM allocation property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
+    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional] value of the USM allocation property
+    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2440,20 +2367,19 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urDeviceGet(
+ur_result_t UR_APICALL
+urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t
-        NumEntries, ///< [in] the number of devices to be added to phDevices.
-    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-    ///< will be returned.
-    ur_device_handle_t *
-        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-    ///< If NumEntries is less than the number of devices available, then
-    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
+                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+                                    ///< will be returned.
+    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+                                    ///< If NumEntries is less than the number of devices available, then
+                                    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
+                                    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2479,17 +2405,17 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES < infoType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urDeviceGetInfo(
+ur_result_t UR_APICALL
+urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info
-    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return the info
+                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+                                ///< pDeviceInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2516,9 +2442,9 @@ ur_result_t UR_APICALL urDeviceGetInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL urDeviceRetain(
-    ur_device_handle_t
-        hDevice ///< [in] handle of the device to get a reference of.
+ur_result_t UR_APICALL
+urDeviceRetain(
+    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2542,7 +2468,8 @@ ur_result_t UR_APICALL urDeviceRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL urDeviceRelease(
+ur_result_t UR_APICALL
+urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2575,18 +2502,16 @@ ur_result_t UR_APICALL urDeviceRelease(
 ///         + `NULL == pProperties`
 ///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
-ur_result_t UR_APICALL urDevicePartition(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t *
-        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-    ///< If NumDevices is less than the number of sub-devices available, then
-    ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *
-        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
-    ///< partitioned into according to the partitioning property.
+ur_result_t UR_APICALL
+urDevicePartition(
+    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                       ///< If NumDevices is less than the number of sub-devices available, then
+                                                       ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                       ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2616,16 +2541,15 @@ ur_result_t UR_APICALL urDevicePartition(
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urDeviceSelectBinary(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to select binary for.
+ur_result_t UR_APICALL
+urDeviceSelectBinary(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
-                          ///< Must greater than or equal to zero otherwise
-                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
+                                ///< Must greater than or equal to zero otherwise
+                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
+                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2651,10 +2575,10 @@ ur_result_t UR_APICALL urDeviceSelectBinary(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeDevice`
-ur_result_t UR_APICALL urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice, ///< [in] handle of the device.
-    ur_native_handle_t
-        *phNativeDevice ///< [out] a pointer to the native handle of the device.
+ur_result_t UR_APICALL
+urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice,        ///< [in] handle of the device.
+    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2678,11 +2602,11 @@ ur_result_t UR_APICALL urDeviceGetNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phDevice`
-ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t
-        *phDevice ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2706,14 +2630,13 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+ur_result_t UR_APICALL
+urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *
-        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                          ///< correlates with the Host's global timestamp value
-    uint64_t *
-        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
-                       ///< correlates with the Device's global timestamp value
+    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                                ///< correlates with the Host's global timestamp value
+    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
+                                ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2737,11 +2660,11 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pKernelName`
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL urKernelCreate(
+ur_result_t UR_APICALL
+urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2765,12 +2688,12 @@ ur_result_t UR_APICALL urKernelCreate(
 ///         + `NULL == pArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL urKernelSetArgValue(
+ur_result_t UR_APICALL
+urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void
-        *pArgValue ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in] argument value represented as matching arg type.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2792,11 +2715,11 @@ ur_result_t UR_APICALL urKernelSetArgValue(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL urKernelSetArgLocal(
+ur_result_t UR_APICALL
+urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t
-        argSize ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2817,19 +2740,18 @@ ur_result_t UR_APICALL urKernelSetArgLocal(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
-ur_result_t UR_APICALL urKernelGetInfo(
+ur_result_t UR_APICALL
+urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+                                ///< If propSize is not equal to or greater than the real number of bytes
+                                ///< needed to return
+                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                ///< pKernelInfo is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
+                                ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2851,18 +2773,16 @@ ur_result_t UR_APICALL urKernelGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
-ur_result_t UR_APICALL urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_group_info_t
-        propName,    ///< [in] name of the work Group property to query
-    size_t propSize, ///< [in] size of the Kernel Work Group property value
-    void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+ur_result_t UR_APICALL
+urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
+    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
+    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
+    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                                     ///< property.
+    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
+                                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2880,18 +2800,16 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
-ur_result_t UR_APICALL urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice, ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t
-        propName,    ///< [in] name of the SubGroup property to query
-    size_t propSize, ///< [in] size of the Kernel SubGroup property value
-    void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                    ///< property.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
+    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
+    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                                         ///< property.
+    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
+                                         ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2916,7 +2834,8 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL urKernelRetain(
+ur_result_t UR_APICALL
+urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2942,7 +2861,8 @@ ur_result_t UR_APICALL urKernelRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL urKernelRelease(
+ur_result_t UR_APICALL
+urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2969,13 +2889,13 @@ ur_result_t UR_APICALL urKernelRelease(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL urKernelSetArgPointer(
+ur_result_t UR_APICALL
+urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,    ///< [in] size of argument type
-    const void *
-        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
-                  ///< value. If null then argument value is considered null.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,             ///< [in] size of argument type
+    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
+                                ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3003,13 +2923,13 @@ ur_result_t UR_APICALL urKernelSetArgPointer(
 ///         + `::UR_KERNEL_EXEC_INFO_USM_PTRS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-ur_result_t UR_APICALL urKernelSetExecInfo(
+ur_result_t UR_APICALL
+urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
-                   ///< property value.
+    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+                                    ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3031,9 +2951,10 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+ur_result_t UR_APICALL
+urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
+    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3055,10 +2976,11 @@ ur_result_t UR_APICALL urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL urKernelSetArgMemObj(
+ur_result_t UR_APICALL
+urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
+    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3084,10 +3006,10 @@ ur_result_t UR_APICALL urKernelSetArgMemObj(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
-ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
-    ur_native_handle_t
-        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+ur_result_t UR_APICALL
+urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3111,11 +3033,11 @@ ur_result_t UR_APICALL urKernelGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t
-        *phKernel ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3140,19 +3062,16 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 ///         + `NULL == pIL`
 ///         + `NULL == pOptions`
 ///         + `NULL == phModule`
-ur_result_t UR_APICALL urModuleCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    const void *pIL,              ///< [in] pointer to IL string.
-    size_t length,                ///< [in] length of IL in bytes.
-    const char
-        *pOptions, ///< [in] pointer to compiler options null-terminated string.
-    ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
-                   ///< called when program compilation is complete.
-    void *
-        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to handle of Module object created.
+ur_result_t UR_APICALL
+urModuleCreate(
+    ur_context_handle_t hContext,         ///< [in] handle of the context instance.
+    const void *pIL,                      ///< [in] pointer to IL string.
+    size_t length,                        ///< [in] length of IL in bytes.
+    const char *pOptions,                 ///< [in] pointer to compiler options null-terminated string.
+    ur_modulecreate_callback_t pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                                          ///< called when program compilation is complete.
+    void *pUserData,                      ///< [in][optional] Passed as an argument when pfnNotify is called.
+    ur_module_handle_t *phModule          ///< [out] pointer to handle of Module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3173,7 +3092,8 @@ ur_result_t UR_APICALL urModuleCreate(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hModule`
-ur_result_t UR_APICALL urModuleRetain(
+ur_result_t UR_APICALL
+urModuleRetain(
     ur_module_handle_t hModule ///< [in] handle for the Module to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3195,7 +3115,8 @@ ur_result_t UR_APICALL urModuleRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hModule`
-ur_result_t UR_APICALL urModuleRelease(
+ur_result_t UR_APICALL
+urModuleRelease(
     ur_module_handle_t hModule ///< [in] handle for the Module to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3222,10 +3143,10 @@ ur_result_t UR_APICALL urModuleRelease(
 ///         + `NULL == hModule`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeModule`
-ur_result_t UR_APICALL urModuleGetNativeHandle(
-    ur_module_handle_t hModule, ///< [in] handle of the module.
-    ur_native_handle_t
-        *phNativeModule ///< [out] a pointer to the native handle of the module.
+ur_result_t UR_APICALL
+urModuleGetNativeHandle(
+    ur_module_handle_t hModule,        ///< [in] handle of the module.
+    ur_native_handle_t *phNativeModule ///< [out] a pointer to the native handle of the module.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3249,11 +3170,11 @@ ur_result_t UR_APICALL urModuleGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phModule`
-ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
+ur_result_t UR_APICALL
+urModuleCreateWithNativeHandle(
     ur_native_handle_t hNativeModule, ///< [in] the native handle of the module.
     ur_context_handle_t hContext,     ///< [in] handle of the context instance.
-    ur_module_handle_t
-        *phModule ///< [out] pointer to the handle of the module object created.
+    ur_module_handle_t *phModule      ///< [out] pointer to the handle of the module object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3277,18 +3198,16 @@ ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL urPlatformGet(
-    uint32_t
-        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
-    ///< If phPlatforms is not NULL, then NumEntries should be greater than
-    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-    ///< will be returned.
-    ur_platform_handle_t *
-        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-    ///< If NumEntries is less than the number of platforms available, then
-    ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *
-        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
+ur_result_t UR_APICALL
+urPlatformGet(
+    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
+                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
+                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+                                       ///< will be returned.
+    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+                                       ///< If NumEntries is less than the number of platforms available, then
+                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3313,16 +3232,16 @@ ur_result_t UR_APICALL urPlatformGet(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
-ur_result_t UR_APICALL urPlatformGetInfo(
+ur_result_t UR_APICALL
+urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-    ///< If Size is not equal to or greater to the real number of bytes needed
-    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-    ///< returned and pPlatformInfo is not used.
-    size_t *
-        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
+                                         ///< If Size is not equal to or greater to the real number of bytes needed
+                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                         ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3343,7 +3262,8 @@ ur_result_t UR_APICALL urPlatformGetInfo(
 ///         + `NULL == hDriver`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
-ur_result_t UR_APICALL urPlatformGetApiVersion(
+ur_result_t UR_APICALL
+urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -3371,10 +3291,10 @@ ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativePlatform`
-ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
-    ur_native_handle_t *
-        phNativePlatform ///< [out] a pointer to the native handle of the platform.
+ur_result_t UR_APICALL
+urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
+    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3397,11 +3317,10 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ///         + `NULL == hNativePlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
-ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *
-        phPlatform ///< [out] pointer to the handle of the platform object created.
+ur_result_t UR_APICALL
+urPlatformCreateWithNativeHandle(
+    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3433,11 +3352,11 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
-ur_result_t UR_APICALL urGetLastResult(
+ur_result_t UR_APICALL
+urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage ///< [out] pointer to a string containing adapter specific result in string
-                  ///< representation.
+    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
+                                    ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3462,15 +3381,13 @@ ur_result_t UR_APICALL urGetLastResult(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phModules`
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL urProgramCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    uint32_t count, ///< [in] number of module handles in module list.
-    const ur_module_handle_t
-        *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *
-        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of program object created.
+ur_result_t UR_APICALL
+urProgramCreate(
+    ur_context_handle_t hContext,        ///< [in] handle of the context instance
+    uint32_t count,                      ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3496,14 +3413,13 @@ ur_result_t UR_APICALL urProgramCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pBinary`
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL urProgramCreateWithBinary(
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_device_handle_t
-        hDevice,            ///< [in] handle to device associated with binary.
-    size_t size,            ///< [in] size in bytes.
-    const uint8_t *pBinary, ///< [in] pointer to binary.
-    ur_program_handle_t
-        *phProgram ///< [out] pointer to handle of Program object created.
+ur_result_t UR_APICALL
+urProgramCreateWithBinary(
+    ur_context_handle_t hContext,  ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
+    size_t size,                   ///< [in] size in bytes.
+    const uint8_t *pBinary,        ///< [in] pointer to binary.
+    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3528,7 +3444,8 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL urProgramRetain(
+ur_result_t UR_APICALL
+urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3554,7 +3471,8 @@ ur_result_t UR_APICALL urProgramRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL urProgramRelease(
+ur_result_t UR_APICALL
+urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3587,17 +3505,14 @@ ur_result_t UR_APICALL urProgramRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pFunctionName`
 ///         + `NULL == ppFunctionPointer`
-ur_result_t UR_APICALL urProgramGetFunctionPointer(
-    ur_device_handle_t
-        hDevice, ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t
-        hProgram, ///< [in] handle of the program to search for function in.
-    ///< The program must already be built to the specified device, or
-    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *
-        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
-    void **
-        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
+ur_result_t UR_APICALL
+urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
+                                  ///< The program must already be built to the specified device, or
+                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
+    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3618,18 +3533,17 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
-ur_result_t UR_APICALL urProgramGetInfo(
+ur_result_t UR_APICALL
+urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName, ///< [in] name of the Program property to query
-    size_t propSize,            ///< [in] the size of the Program property.
-    void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return
-    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
+    ur_program_info_t propName,   ///< [in] name of the Program property to query
+    size_t propSize,              ///< [in] the size of the Program property.
+    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+                                  ///< If propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pProgramInfo is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3651,20 +3565,18 @@ ur_result_t UR_APICALL urProgramGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
-ur_result_t UR_APICALL urProgramGetBuildInfo(
-    ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
-    ur_program_build_info_t
-        propName,    ///< [in] name of the Program build info to query
-    size_t propSize, ///< [in] size of the Program build info property.
-    void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
-    ///< If propSize is not equal to or greater than the real number of bytes
-    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
-    size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
-                     ///< queried by propName.
+ur_result_t UR_APICALL
+urProgramGetBuildInfo(
+    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
+    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
+    size_t propSize,                  ///< [in] size of the Program build info property.
+    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+                                      ///< If propSize is not equal to or greater than the real number of bytes
+                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+                                      ///< error is returned and pKernelInfo is not used.
+    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
+                                      ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3681,11 +3593,12 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pSpecValue`
-ur_result_t UR_APICALL urProgramSetSpecializationConstant(
+ur_result_t UR_APICALL
+urProgramSetSpecializationConstant(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t specId,              ///< [in] specification constant Id
-    size_t specSize,       ///< [in] size of the specialization constant value
-    const void *pSpecValue ///< [in] pointer to the specialization value bytes
+    size_t specSize,              ///< [in] size of the specialization constant value
+    const void *pSpecValue        ///< [in] pointer to the specialization value bytes
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3711,10 +3624,10 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeProgram`
-ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram, ///< [in] handle of the program.
-    ur_native_handle_t *
-        phNativeProgram ///< [out] a pointer to the native handle of the program.
+ur_result_t UR_APICALL
+urProgramGetNativeHandle(
+    ur_program_handle_t hProgram,       ///< [in] handle of the program.
+    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3738,12 +3651,11 @@ ur_result_t UR_APICALL urProgramGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
-    ur_native_handle_t
-        hNativeProgram,           ///< [in] the native handle of the program.
-    ur_context_handle_t hContext, ///< [in] handle of the context instance
-    ur_program_handle_t *
-        phProgram ///< [out] pointer to the handle of the program object created.
+ur_result_t UR_APICALL
+urProgramCreateWithNativeHandle(
+    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,      ///< [in] handle of the context instance
+    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3773,9 +3685,10 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urInit(
+ur_result_t UR_APICALL
+urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -124,15 +124,15 @@ ur_result_t UR_APICALL urContextRelease(
 ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,    ///< [in] the number of bytes of memory pointed to by
-                        ///< pContextInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
     void *pContextInfo, ///< [out][optional] array of bytes holding the info.
-                        ///< if propSize is not equal to or greater than the
-                        ///< real number of bytes needed to return the info then
-                        ///< the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                        ///< returned and pContextInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by ContextInfoType.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -159,9 +159,9 @@ ur_result_t UR_APICALL urContextGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeContext`
 ur_result_t UR_APICALL urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native
-                                        ///< handle of the context.
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -186,9 +186,9 @@ ur_result_t UR_APICALL urContextGetNativeHandle(
 ///         + `NULL == phContext`
 ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeContext,            ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext ///< [out] pointer to the handle of the
-                                   ///< context object created.
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -219,8 +219,8 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -254,32 +254,31 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t workDim, ///< [in] number of dimensions, from 1 to 3, to specify
-                      ///< the global and work-group work-items
-    const size_t
-        *pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned
-                            ///< values that specify the offset used to
-                            ///< calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize, ///< [in] pointer to an array of workDim
-                                   ///< unsigned values that specify the number
-                                   ///< of global work-items in workDim that
-                                   ///< will execute the kernel function
-    const size_t
-        *pLocalWorkSize, ///< [in][optional] pointer to an array of workDim
-                         ///< unsigned values that specify the number of local
-                         ///< work-items forming a work-group that will execute
-                         ///< the kernel function. If nullptr, the runtime
-                         ///< implementation will choose the work-group size.
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -313,14 +312,14 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -356,14 +355,14 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                         ///< pointer to a list of events that must be complete
-                         ///< before this command can be executed. If nullptr,
-                         ///< the numEventsInWaitList must be 0, indicating that
-                         ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -402,16 +401,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     size_t size,       ///< [in] size in bytes of data being read
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -452,16 +449,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     const void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -503,26 +498,26 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being read
-    size_t hostRowPitch,     ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by dst
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by dst
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -565,27 +560,28 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region
     ur_rect_region_t
         region, ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,   ///< [in] length of each row in bytes in the buffer
-                             ///< object
-    size_t bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                             ///< buffer object being written
-    size_t hostRowPitch, ///< [in] length of each row in bytes in the host
-                         ///< memory region pointed by src
-    size_t hostSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                           ///< host memory region pointed by src
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
     void
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< points to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -619,16 +615,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
     size_t size,      ///< [in] size in bytes of data being copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -661,27 +655,25 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion, ///< [in] source 3D rectangular region
-                                ///< descriptor: width, height, depth
-    size_t srcRowPitch,   ///< [in] length of each row in bytes in the source
-                          ///< buffer object
-    size_t srcSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< source buffer object
-    size_t dstRowPitch, ///< [in] length of each row in bytes in the destination
-                        ///< buffer object
-    size_t dstSlicePitch, ///< [in] length of each 2D slice in bytes in the
-                          ///< destination buffer object
+    ur_rect_region_t
+        srcRegion, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -717,16 +709,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t offset,            ///< [in] offset into the buffer
     size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -762,24 +752,23 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t rowPitch,   ///< [in] length of each row in bytes
     size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pDst, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -816,24 +805,23 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_mem_handle_t hImage,   ///< [in] handle of the image object
     bool
         blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin, ///< [in] defines the (x,y,z) offset in pixels in
-                             ///< the 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     size_t inputRowPitch,   ///< [in] length of each row in bytes
     size_t inputSlicePitch, ///< [in] length of each 2D slice of the 3D image
     void *pSrc, ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -860,26 +848,27 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,  ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,  ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the source 1D, 2D, or 3D image
-    ur_rect_offset_t dstOrigin, ///< [in] defines the (x,y,z) offset in pixels
-                                ///< in the destination 1D, 2D, or 3D image
-    ur_rect_region_t region, ///< [in] defines the (width, height, depth) in
-                             ///< pixels of the 1D, 2D, or 3D image
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -924,16 +913,14 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
     size_t offset, ///< [in] offset in bytes of the buffer region being mapped
     size_t size,   ///< [in] size in bytes of the buffer region being mapped
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent, ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [in,out][optional] return an event object that identifies this
+                 ///< particular command instance.
     void **ppRetMap ///< [in,out] return mapped pointer.  TODO: move it before
                     ///< numEventsInWaitList?
 ) {
@@ -969,16 +956,14 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
         hMem,         ///< [in] handle of the memory (buffer or image) object
     void *pMappedPtr, ///< [in] mapped host address
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1006,16 +991,14 @@ ur_result_t UR_APICALL urEnqueueUSMMemset(
     int8_t byteValue,             ///< [in] byte value to fill
     size_t count,                 ///< [in] size in bytes to be set
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1045,16 +1028,14 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     const void *pSrc, ///< [in] pointer to the source USM memory object
     size_t size,      ///< [in] size in bytes to be copied
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1084,16 +1065,14 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     size_t size,                    ///< [in] size in bytes to be fetched
     ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
     uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1122,9 +1101,9 @@ ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
     const void *pMem,         ///< [in] pointer to the USM memory object
     size_t size,              ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,   ///< [in] USM memory advice
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1146,23 +1125,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
 ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch, ///< [in] the total width of the destination memory including
-                  ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     size_t patternSize, ///< [in] the size in bytes of the pattern.
     const void
         *pPattern, ///< [in] pointer with the bytes of the pattern to set.
     size_t width,  ///< [in] the width in bytes of each row to fill.
     size_t height, ///< [in] the height of the columns to fill.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1183,21 +1161,20 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
 ur_result_t UR_APICALL urEnqueueUSMMemset2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *pMem,               ///< [in] pointer to memory to be filled.
-    size_t pitch,  ///< [in] the total width of the destination memory including
-                   ///< padding.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
     int value,     ///< [in] the value to fill into the region in pMem.
     size_t width,  ///< [in] the width in bytes of each row to set.
     size_t height, ///< [in] the height of the columns to set.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1220,23 +1197,22 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *pDst,    ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
     const void *pSrc, ///< [in] pointer to memory to be copied.
-    size_t srcPitch,  ///< [in] the total width of the source memory including
-                      ///< padding.
-    size_t width,     ///< [in] the width in bytes of each row to be copied.
-    size_t height,    ///< [in] the height of columns to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1257,26 +1233,25 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 ///         + `NULL == name`
 ///         + `NULL == pSrc`
 ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingWrite, ///< [in] indicates if this operation should block.
     size_t count,       ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
     const void *pSrc, ///< [in] pointer to where the data must be copied from.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1297,26 +1272,25 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 ///         + `NULL == name`
 ///         + `NULL == pDst`
 ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram, ///< [in] handle of the program containing the
-                                  ///< device global variable.
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
     const char
         *name, ///< [in] the unique identifier for the device global variable.
     bool blockingRead, ///< [in] indicates if this operation should block.
     size_t count,      ///< [in] the number of bytes to copy.
-    size_t offset, ///< [in] the byte offset into the device global variable to
-                   ///< start copying.
-    void *pDst,    ///< [in] pointer to where the data must be copied to.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before the kernel execution. If nullptr, the
-                          ///< numEventsInWaitList must be 0, indicating that no
-                          ///< wait event.
-    ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular kernel execution instance.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out][optional] return an event object that identifies this
+                ///< particular kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1380,8 +1354,9 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
     size_t
         propValueSize, ///< [in] size in bytes of the profiling property value
     void *pPropValue,  ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet ///< [out][optional] pointer to the actual size in
-                              ///< bytes returned in propValue
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1407,9 +1382,9 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
-    const ur_event_handle_t
-        *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of
-                         ///< events to wait for completion
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1546,8 +1521,8 @@ ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData ///< [in][out][optional] pointer to data to be passed to
-                    ///< callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1659,8 +1634,7 @@ ur_result_t UR_APICALL urMemRetain(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Decrement the memory object's reference count and delete the object
-/// if
+/// @brief Decrement the memory object's reference count and delete the object if
 ///        the reference count becomes zero.
 ///
 /// @remarks
@@ -1801,15 +1775,14 @@ ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointed to by
-                     ///< pMemInfo.
-    void *pMemInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pMemInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1836,15 +1809,14 @@ ur_result_t UR_APICALL urMemGetInfo(
 ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize, ///< [in] the number of bytes of memory pointer to by
-                     ///< pImgInfo.
-    void *pImgInfo,  ///< [out][optional] array of bytes holding the info.
-                     ///< If propSize is less than the real number of bytes
-                    ///< needed to return the info then the
-                    ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                    ///< pImgInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1892,9 +1864,9 @@ ur_result_t UR_APICALL urTearDown(
 ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize, ///< [in] size in bytes of the queue property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the queue property
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out] value of the queue property
     size_t
         *pPropSizeRet ///< [out] size in bytes returned in queue property value
 ) {
@@ -1928,12 +1900,12 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t
-        *pProps, ///< [in] specifies a list of queue properties and their
-                 ///< corresponding values. Each property name is immediately
-                 ///< followed by the corresponding desired value. The list is
-                 ///< terminated with a 0. If a property value is not specified,
-                 ///< then its default value will be used.
+    const ur_queue_property_t *
+        pProps, ///< [in] specifies a list of queue properties and their corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2229,9 +2201,9 @@ ur_result_t UR_APICALL urSamplerRelease(
 ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
-    size_t propValueSize, ///< [in] size in bytes of the sampler property value
-                          ///< provided
-    void *pPropValue,     ///< [out] value of the sampler property
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -2260,9 +2232,9 @@ ur_result_t UR_APICALL urSamplerGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeSampler`
 ur_result_t UR_APICALL urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native
-                                        ///< handle of the sampler.
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2288,10 +2260,10 @@ ur_result_t UR_APICALL urSamplerGetNativeHandle(
 ///         + `NULL == phSampler`
 ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeSampler,            ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler ///< [out] pointer to the handle of the
-                                   ///< sampler object created.
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2431,11 +2403,11 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize, ///< [in] size in bytes of the USM allocation property
-                          ///< value
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
     void *pPropValue, ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in USM
-                              ///< allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2471,18 +2443,17 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries, ///< [in] the number of devices to be added to
-                         ///< phDevices. If phDevices in not NULL then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_VALUE, will be returned.
-    ur_device_handle_t
-        *phDevices, ///< [out][optional][range(0, NumEntries)] array of handle
-                    ///< of devices. If NumEntries is less than the number of
-                    ///< devices available, then platform shall only retrieve
-                    ///< that number of devices.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
     uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
-                          ///< pNumDevices will be updated with the total number
-                          ///< of devices available.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2513,12 +2484,12 @@ ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
     size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
     void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
-                       ///< If propSize is not equal to or greater than the real
-                       ///< number of bytes needed to return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_VALUE error is returned
-                       ///< and pDeviceInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of the queried infoType.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2606,18 +2577,16 @@ ur_result_t UR_APICALL urDeviceRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t
-        *pProperties, ///< [in] null-terminated array of <$_device_partition_t
-                      ///< enum, value> pairs.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
-    ur_device_handle_t
-        *phSubDevices, ///< [out][optional][range(0, NumDevices)] array of
-                       ///< handle of devices. If NumDevices is less than the
-                       ///< number of sub-devices available, then the function
-                       ///< shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet ///< [out][optional] pointer to the number of
-                             ///< sub-devices the device can be partitioned into
-                             ///< according to the partitioning property.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2655,9 +2624,8 @@ ur_result_t UR_APICALL urDeviceSelectBinary(
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
-        pSelectedBinary ///< [out] the index of the selected binary in the input
-                        ///< array of binaries. If a suitable binary was not
-                        ///< found the function returns ${X}_INVALID_BINARY.
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2740,12 +2708,12 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 ///         + `NULL == hDevice`
 ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's
-                                ///< global timestamp that correlates with the
-                                ///< Host's global timestamp value
-    uint64_t *pHostTimestamp ///< [out][optional] pointer to the Host's global
-                             ///< timestamp that correlates with the Device's
-                             ///< global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2827,8 +2795,8 @@ ur_result_t UR_APICALL urKernelSetArgValue(
 ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    size_t argSize     ///< [in] size of the local buffer to be allocated by the
-                       ///< runtime
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2853,14 +2821,15 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel
-                       ///< info property. If propSize is not equal to or
-                       ///< greater than the real number of bytes needed to
-                       ///< return the info then the
-                       ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                       ///< pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2886,12 +2855,14 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
-        propName,     ///< [in] name of the work Group property to query
-    size_t propSize,  ///< [in] size of the Kernel Work Group property value
-    void *pPropValue, ///< [in,out][optional][range(0, propSize)] value of the
-                      ///< Kernel Work Group property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2913,12 +2884,14 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
-        propName,     ///< [in] name of the SubGroup property to query
-    size_t propSize,  ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue, ///< [in,out][range(0, propSize)][optional] value of the
-                      ///< Kernel SubGroup property.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2998,11 +2971,11 @@ ur_result_t UR_APICALL urKernelRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
 ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,    ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,       ///< [in] size of argument type
-    const void *pArgValue ///< [in][optional] SVM pointer to memory location
-                          ///< holding the argument value. If null then argument
-                          ///< value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3034,8 +3007,9 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue ///< [in][range(0, propSize)] pointer to memory
-                           ///< location holding the property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3173,11 +3147,10 @@ ur_result_t UR_APICALL urModuleCreate(
     const char
         *pOptions, ///< [in] pointer to compiler options null-terminated string.
     ur_modulecreate_callback_t
-        pfnNotify, ///< [in][optional] A function pointer to a notification
-                   ///< routine that is called when program compilation is
-                   ///< complete.
-    void *pUserData, ///< [in][optional] Passed as an argument when pfnNotify is
-                     ///< called.
+        pfnNotify, ///< [in][optional] A function pointer to a notification routine that is
+                   ///< called when program compilation is complete.
+    void *
+        pUserData, ///< [in][optional] Passed as an argument when pfnNotify is called.
     ur_module_handle_t
         *phModule ///< [out] pointer to handle of Module object created.
 ) {
@@ -3305,18 +3278,17 @@ ur_result_t UR_APICALL urModuleCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ur_result_t UR_APICALL urPlatformGet(
-    uint32_t NumEntries, ///< [in] the number of platforms to be added to
-                         ///< phPlatforms. If phPlatforms is not NULL, then
-                         ///< NumEntries should be greater than zero, otherwise
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE, will be returned.
-    ur_platform_handle_t
-        *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle
-                      ///< of platforms. If NumEntries is less than the number
-                      ///< of platforms available, then
-                      ///< ::urPlatformGet shall only retrieve that number of
-                      ///< platforms.
-    uint32_t *pNumPlatforms ///< [out][optional] returns the total number of
-                            ///< platforms available.
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3346,12 +3318,11 @@ ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
     size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
-                         ///< If Size is not equal to or greater to the real
-                         ///< number of bytes needed to return the info then the
-                         ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                         ///< and pPlatformInfo is not used.
-    size_t *pSizeRet ///< [out][optional] pointer to the actual number of bytes
-                     ///< being queried by pPlatformInfo.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3401,9 +3372,9 @@ ur_result_t UR_APICALL urPlatformGetApiVersion(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativePlatform`
 ur_result_t UR_APICALL urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native
-                                         ///< handle of the platform.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3429,8 +3400,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform ///< [out] pointer to the handle of the
-                                     ///< platform object created.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3464,8 +3435,9 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 ///         + `NULL == ppMessage`
 ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage ///< [out] pointer to a string containing adapter
-                           ///< specific result in string representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3495,8 +3467,8 @@ ur_result_t UR_APICALL urProgramCreate(
     uint32_t count, ///< [in] number of module handles in module list.
     const ur_module_handle_t
         *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions, ///< [in][optional] pointer to linker options
-                          ///< null-terminated string.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
     ur_program_handle_t
         *phProgram ///< [out] pointer to handle of program object created.
 ) {
@@ -3620,13 +3592,12 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program to search for function in.
-                  ///< The program must already be built to the specified
-                  ///< device, or otherwise
-                  ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName, ///< [in] A null-terminates string denoting the
-                               ///< mangled function name.
-    void **ppFunctionPointer   ///< [out] Returns the pointer to the function if
-                               ///< it is found in the program.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3651,14 +3622,14 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
-    void *pProgramInfo, ///< [in,out][optional] array of bytes of holding the
-                        ///< program info property. If propSize is not equal to
-                        ///< or greater than the real number of bytes needed to
-                        ///< return the info then the
-                        ///< ::UR_RESULT_ERROR_INVALID_SIZE error is returned
-                        ///< and pProgramInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data copied to propName.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3684,15 +3655,16 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
-        propName,     ///< [in] name of the Program build info to query
-    size_t propSize,  ///< [in] size of the Program build info property.
-    void *pPropValue, ///< [in,out][optional] value of the Program build
-                      ///< property. If propSize is not equal to or greater than
-                      ///< the real number of bytes needed to return the info
-                      ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                      ///< returned and pKernelInfo is not used.
-    size_t *pPropSizeRet ///< [out][optional] pointer to the actual size in
-                         ///< bytes of data being queried by propName.
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3740,9 +3712,9 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstant(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeProgram`
 ur_result_t UR_APICALL urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native
-                                        ///< handle of the program.
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3768,10 +3740,10 @@ ur_result_t UR_APICALL urProgramGetNativeHandle(
 ///         + `NULL == phProgram`
 ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
-        hNativeProgram,            ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram ///< [out] pointer to the handle of the
-                                   ///< program object created.
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3802,10 +3774,8 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urInit(
-    ur_device_init_flags_t
-        device_flags ///< [in] device initialization flags.
-                     ///< must be 0 (default) or a combination of
-                     ///< ::ur_device_init_flag_t.
+    ur_device_init_flags_t device_flags ///< [in] device initialization flags.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/conformance/context/urContextCreate.cpp
+++ b/test/conformance/context/urContextCreate.cpp
@@ -16,14 +16,12 @@ TEST_P(urContextCreateTest, Success) {
 
 TEST_P(urContextCreateTest, InvalidNullPointerDevices) {
     ur_context_handle_t context = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urContextCreate(1, nullptr, &context));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urContextCreate(1, nullptr, &context));
 }
 
 TEST_P(urContextCreateTest, InvalidNullPointerContext) {
     auto device = GetParam();
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urContextCreate(1, &device, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urContextCreate(1, &device, nullptr));
 }
 
 using urContextCreateMultiDeviceTest = uur::urAllDevicesTest;
@@ -32,8 +30,7 @@ TEST_F(urContextCreateMultiDeviceTest, Success) {
         GTEST_SKIP();
     }
     ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(static_cast<uint32_t>(devices.size()),
-                                   devices.data(), &context));
+    ASSERT_SUCCESS(urContextCreate(static_cast<uint32_t>(devices.size()), devices.data(), &context));
     ASSERT_NE(nullptr, context);
     ASSERT_SUCCESS(urContextRelease(context));
 }

--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -4,25 +4,24 @@
 
 using urContextGetInfoTest = uur::urContextTestWithParam<ur_context_info_t>;
 
-UUR_TEST_SUITE_P(
-    urContextGetInfoTest,
-    ::testing::Values(
+UUR_TEST_SUITE_P(urContextGetInfoTest,
+                 ::testing::Values(
 
-        UR_CONTEXT_INFO_NUM_DEVICES,          //
-        UR_CONTEXT_INFO_DEVICES,              //
-        UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT, //
-        UR_CONTEXT_INFO_USM_FILL2D_SUPPORT,   //
-        UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT  //
+                     UR_CONTEXT_INFO_NUM_DEVICES,          //
+                     UR_CONTEXT_INFO_DEVICES,              //
+                     UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT, //
+                     UR_CONTEXT_INFO_USM_FILL2D_SUPPORT,   //
+                     UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT  //
 
-        ),
-    [](const ::testing::TestParamInfo<urContextGetInfoTest::ParamType> &info) {
-        ur_device_handle_t device = std::get<0>(info.param);
-        ur_context_info_t context_info = std::get<1>(info.param);
+                     ),
+                 [](const ::testing::TestParamInfo<urContextGetInfoTest::ParamType> &info) {
+                     ur_device_handle_t device = std::get<0>(info.param);
+                     ur_context_info_t context_info = std::get<1>(info.param);
 
-        std::stringstream ss;
-        ss << context_info;
-        return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
-    });
+                     std::stringstream ss;
+                     ss << context_info;
+                     return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
+                 });
 
 TEST_P(urContextGetInfoTest, Success) {
     ur_context_info_t info = getParam();
@@ -30,6 +29,5 @@ TEST_P(urContextGetInfoTest, Success) {
     ASSERT_SUCCESS(urContextGetInfo(context, info, 0, nullptr, &info_size));
     ASSERT_NE(info_size, 0);
     std::vector<uint8_t> info_data(info_size);
-    ASSERT_SUCCESS(
-        urContextGetInfo(context, info, info_size, info_data.data(), nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, info, info_size, info_data.data(), nullptr));
 }

--- a/test/conformance/context/urContextRelease.cpp
+++ b/test/conformance/context/urContextRelease.cpp
@@ -11,7 +11,4 @@ TEST_P(urContextReleaseTest, Success) {
     ASSERT_SUCCESS(urContextRelease(context));
 }
 
-TEST_P(urContextReleaseTest, InvalidNullHandleContext) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urContextRelease(nullptr));
-}
+TEST_P(urContextReleaseTest, InvalidNullHandleContext) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urContextRelease(nullptr)); }

--- a/test/conformance/context/urContextRetain.cpp
+++ b/test/conformance/context/urContextRetain.cpp
@@ -11,7 +11,4 @@ TEST_P(urContextRetainTest, Success) {
     EXPECT_SUCCESS(urContextRelease(context));
 }
 
-TEST_P(urContextRetainTest, InvalidNullHandleContext) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urContextRetain(nullptr));
-}
+TEST_P(urContextRetainTest, InvalidNullHandleContext) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urContextRetain(nullptr)); }

--- a/test/conformance/context/urContextSetExtendedDeleter.cpp
+++ b/test/conformance/context/urContextSetExtendedDeleter.cpp
@@ -13,9 +13,7 @@ TEST_P(urContextSetExtendedDeleterTest, Success) {
     ASSERT_NE(context, nullptr);
 
     bool called = false;
-    ur_context_extended_deleter_t *deleter = [](void *userdata) {
-        *static_cast<bool *>(userdata) = true;
-    };
+    ur_context_extended_deleter_t *deleter = [](void *userdata) { *static_cast<bool *>(userdata) = true; };
 
     ASSERT_SUCCESS(urContextSetExtendedDeleter(context, deleter, &called));
     ASSERT_SUCCESS(urContextRelease(context));

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -8,7 +8,6 @@ using urDeviceCreateWithNativeHandleTest = uur::urPlatformTest;
 TEST_F(urDeviceCreateWithNativeHandleTest, DISABLED_Success) {
     ur_native_handle_t native_handle = nullptr;
     ur_device_handle_t device_handle = nullptr;
-    ASSERT_SUCCESS(urDeviceCreateWithNativeHandle(native_handle, platform,
-                                                  &device_handle));
+    ASSERT_SUCCESS(urDeviceCreateWithNativeHandle(native_handle, platform, &device_handle));
     ASSERT_NE(device_handle, nullptr);
 }

--- a/test/conformance/device/urDeviceGet.cpp
+++ b/test/conformance/device/urDeviceGet.cpp
@@ -7,12 +7,10 @@ using urDeviceGetTest = uur::urPlatformTest;
 
 TEST_F(urDeviceGetTest, Success) {
     uint32_t count = 0;
-    ASSERT_SUCCESS(
-        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
     ASSERT_NE(count, 0);
     std::vector<ur_device_handle_t> devices(count);
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count,
-                               devices.data(), nullptr));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, devices.data(), nullptr));
     for (auto device : devices) {
         ASSERT_NE(nullptr, device);
     }
@@ -20,14 +18,12 @@ TEST_F(urDeviceGetTest, Success) {
 
 TEST_F(urDeviceGetTest, SuccessSubsetOfDevices) {
     uint32_t count;
-    ASSERT_SUCCESS(
-        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
     if (count < 2) {
         GTEST_SKIP();
     }
     std::vector<ur_device_handle_t> devices(count - 1);
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count - 1,
-                               devices.data(), nullptr));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count - 1, devices.data(), nullptr));
     for (auto device : devices) {
         ASSERT_NE(nullptr, device);
     }
@@ -35,25 +31,18 @@ TEST_F(urDeviceGetTest, SuccessSubsetOfDevices) {
 
 TEST_F(urDeviceGetTest, InvalidNullHandlePlatform) {
     uint32_t count;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urDeviceGet(nullptr, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceGet(nullptr, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
 }
 
 TEST_F(urDeviceGetTest, InvalidEnumerationDevicesType) {
     uint32_t count;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_ENUMERATION,
-        urDeviceGet(platform, UR_DEVICE_TYPE_FORCE_UINT32, 0, nullptr, &count));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urDeviceGet(platform, UR_DEVICE_TYPE_FORCE_UINT32, 0, nullptr, &count));
 }
 
 TEST_F(urDeviceGetTest, InvalidNumEntries) {
     uint32_t count = 0;
-    ASSERT_SUCCESS(
-        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
     ASSERT_NE(count, 0);
     std::vector<ur_device_handle_t> devices(count);
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_SIZE,
-        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, devices.data(), nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE, urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, devices.data(), nullptr));
 }

--- a/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
+++ b/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
@@ -9,8 +9,7 @@ TEST_F(urDeviceGetGlobalTimestampTest, Success) {
     for (auto device : devices) {
         uint64_t device_time = 0;
         uint64_t host_time = 0;
-        ASSERT_SUCCESS(
-            urDeviceGetGlobalTimestamps(device, &device_time, &host_time));
+        ASSERT_SUCCESS(urDeviceGetGlobalTimestamps(device, &device_time, &host_time));
         ASSERT_NE(device_time, 0);
         ASSERT_NE(host_time, 0);
         // TODO - ASSERT synchronized? - #166
@@ -20,8 +19,7 @@ TEST_F(urDeviceGetGlobalTimestampTest, Success) {
 TEST_F(urDeviceGetGlobalTimestampTest, SuccessHostTimer) {
     for (auto device : devices) {
         uint64_t host_time = 0;
-        ASSERT_SUCCESS(
-            urDeviceGetGlobalTimestamps(device, nullptr, &host_time));
+        ASSERT_SUCCESS(urDeviceGetGlobalTimestamps(device, nullptr, &host_time));
         ASSERT_NE(host_time, 0);
     }
 }

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -3,124 +3,120 @@
 
 #include <uur/fixtures.h>
 
-struct urDeviceGetInfoTest : uur::urAllDevicesTest,
-                             ::testing::WithParamInterface<ur_device_info_t> {
+struct urDeviceGetInfoTest : uur::urAllDevicesTest, ::testing::WithParamInterface<ur_device_info_t> {
 
-    void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(uur::urAllDevicesTest::SetUp());
-    }
+    void SetUp() override { UUR_RETURN_ON_FATAL_FAILURE(uur::urAllDevicesTest::SetUp()); }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    , urDeviceGetInfoTest,
-    ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(, urDeviceGetInfoTest,
+                         ::testing::Values(
 
-        UR_DEVICE_INFO_TYPE,
-        // TODO - re-enable the currently unsupported enumerations
-        // #167
+                             UR_DEVICE_INFO_TYPE,
+                             // TODO - re-enable the currently unsupported enumerations
+                             // #167
 
-        // UR_DEVICE_INFO_VENDOR_ID,
-        // UR_DEVICE_INFO_DEVICE_ID,
-        // UR_DEVICE_INFO_MAX_COMPUTE_UNITS,
-        // UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,
-        // UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
-        // UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
-        // UR_DEVICE_INFO_SINGLE_FP_CONFIG,
-        // UR_DEVICE_INFO_HALF_FP_CONFIG,
-        // UR_DEVICE_INFO_DOUBLE_FP_CONFIG,
-        // UR_DEVICE_INFO_QUEUE_PROPERTIES,
-        // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR,
-        // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT,
-        // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG,
-        // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE,
-        // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF,
-        // UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY,
-        // UR_DEVICE_INFO_MEMORY_CLOCK_RATE,
-        // UR_DEVICE_INFO_ADDRESS_BITS,
-        // UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,
-        // UR_DEVICE_INFO_IMAGE_SUPPORTED,
-        // UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS,
-        // UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS,
-        // UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS,
-        // UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH,
-        // UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT,
-        // UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH,
-        // UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT,
-        // UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH,
-        // UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE,
-        // UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE,
-        // UR_DEVICE_INFO_MAX_SAMPLERS,
-        // UR_DEVICE_INFO_MAX_PARAMETER_SIZE,
-        // UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN,
-        // UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE,
-        // UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE,
-        // UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE,
-        // UR_DEVICE_INFO_GLOBAL_MEM_SIZE,
-        // UR_DEVICE_INFO_GLOBAL_MEM_FREE,
-        // UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE,
-        // UR_DEVICE_INFO_MAX_CONSTANT_ARGS,
-        // UR_DEVICE_INFO_LOCAL_MEM_TYPE,
-        // UR_DEVICE_INFO_LOCAL_MEM_SIZE,
-        // UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT,
-        // UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,
-        // UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION,
-        // UR_DEVICE_INFO_ENDIAN_LITTLE,
-        // UR_DEVICE_INFO_AVAILABLE,
-        // UR_DEVICE_INFO_COMPILER_AVAILABLE,
-        // UR_DEVICE_INFO_LINKER_AVAILABLE,
-        // UR_DEVICE_INFO_EXECUTION_CAPABILITIES,
-        // UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,
-        // UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES,
-        // UR_DEVICE_INFO_BUILT_IN_KERNELS,
-        // UR_DEVICE_INFO_PLATFORM,
-        // UR_DEVICE_INFO_REFERENCE_COUNT,
-        // UR_DEVICE_INFO_IL_VERSION,
-        UR_DEVICE_INFO_NAME
-        // UR_DEVICE_INFO_VENDOR,
-        // UR_DEVICE_INFO_DRIVER_VERSION,
-        // UR_DEVICE_INFO_PROFILE,
-        // UR_DEVICE_INFO_VERSION,
-        // UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION,
-        // UR_DEVICE_INFO_EXTENSIONS,
-        // UR_DEVICE_INFO_PRINTF_BUFFER_SIZE,
-        // UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC,
-        // UR_DEVICE_INFO_PARENT_DEVICE,
-        // UR_DEVICE_INFO_PARTITION_PROPERTIES,
-        // UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES,
-        // UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,
-        // UR_DEVICE_INFO_PARTITION_TYPE,
-        // UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS,
-        // UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
-        // UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL,
-        // UR_DEVICE_INFO_USM_HOST_SUPPORT,
-        // UR_DEVICE_INFO_USM_DEVICE_SUPPORT,
-        // UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,
-        // UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,
-        // UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,
-        // UR_DEVICE_INFO_UUID,
-        // UR_DEVICE_INFO_PCI_ADDRESS,
-        // UR_DEVICE_INFO_GPU_EU_COUNT,
-        // UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,
-        // UR_DEVICE_INFO_GPU_EU_SLICES,
-        // UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,
-        // UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,
-        // UR_DEVICE_INFO_IMAGE_SRGB,
-        // UR_DEVICE_INFO_ATOMIC_64,
-        // UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,
-        // UR_DEVICE_INFO_BFLOAT16,
-        // UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES
-        ),
-    [](const ::testing::TestParamInfo<ur_device_info_t> &info) {
-        std::stringstream ss;
-        ss << info.param;
-        return ss.str();
-    });
+                             // UR_DEVICE_INFO_VENDOR_ID,
+                             // UR_DEVICE_INFO_DEVICE_ID,
+                             // UR_DEVICE_INFO_MAX_COMPUTE_UNITS,
+                             // UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,
+                             // UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
+                             // UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
+                             // UR_DEVICE_INFO_SINGLE_FP_CONFIG,
+                             // UR_DEVICE_INFO_HALF_FP_CONFIG,
+                             // UR_DEVICE_INFO_DOUBLE_FP_CONFIG,
+                             // UR_DEVICE_INFO_QUEUE_PROPERTIES,
+                             // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR,
+                             // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT,
+                             // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG,
+                             // UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE,
+                             // UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF,
+                             // UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY,
+                             // UR_DEVICE_INFO_MEMORY_CLOCK_RATE,
+                             // UR_DEVICE_INFO_ADDRESS_BITS,
+                             // UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,
+                             // UR_DEVICE_INFO_IMAGE_SUPPORTED,
+                             // UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS,
+                             // UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS,
+                             // UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS,
+                             // UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH,
+                             // UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT,
+                             // UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH,
+                             // UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT,
+                             // UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH,
+                             // UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE,
+                             // UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE,
+                             // UR_DEVICE_INFO_MAX_SAMPLERS,
+                             // UR_DEVICE_INFO_MAX_PARAMETER_SIZE,
+                             // UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN,
+                             // UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE,
+                             // UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE,
+                             // UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE,
+                             // UR_DEVICE_INFO_GLOBAL_MEM_SIZE,
+                             // UR_DEVICE_INFO_GLOBAL_MEM_FREE,
+                             // UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE,
+                             // UR_DEVICE_INFO_MAX_CONSTANT_ARGS,
+                             // UR_DEVICE_INFO_LOCAL_MEM_TYPE,
+                             // UR_DEVICE_INFO_LOCAL_MEM_SIZE,
+                             // UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT,
+                             // UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,
+                             // UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION,
+                             // UR_DEVICE_INFO_ENDIAN_LITTLE,
+                             // UR_DEVICE_INFO_AVAILABLE,
+                             // UR_DEVICE_INFO_COMPILER_AVAILABLE,
+                             // UR_DEVICE_INFO_LINKER_AVAILABLE,
+                             // UR_DEVICE_INFO_EXECUTION_CAPABILITIES,
+                             // UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,
+                             // UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES,
+                             // UR_DEVICE_INFO_BUILT_IN_KERNELS,
+                             // UR_DEVICE_INFO_PLATFORM,
+                             // UR_DEVICE_INFO_REFERENCE_COUNT,
+                             // UR_DEVICE_INFO_IL_VERSION,
+                             UR_DEVICE_INFO_NAME
+                             // UR_DEVICE_INFO_VENDOR,
+                             // UR_DEVICE_INFO_DRIVER_VERSION,
+                             // UR_DEVICE_INFO_PROFILE,
+                             // UR_DEVICE_INFO_VERSION,
+                             // UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION,
+                             // UR_DEVICE_INFO_EXTENSIONS,
+                             // UR_DEVICE_INFO_PRINTF_BUFFER_SIZE,
+                             // UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC,
+                             // UR_DEVICE_INFO_PARENT_DEVICE,
+                             // UR_DEVICE_INFO_PARTITION_PROPERTIES,
+                             // UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES,
+                             // UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,
+                             // UR_DEVICE_INFO_PARTITION_TYPE,
+                             // UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS,
+                             // UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
+                             // UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL,
+                             // UR_DEVICE_INFO_USM_HOST_SUPPORT,
+                             // UR_DEVICE_INFO_USM_DEVICE_SUPPORT,
+                             // UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,
+                             // UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,
+                             // UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,
+                             // UR_DEVICE_INFO_UUID,
+                             // UR_DEVICE_INFO_PCI_ADDRESS,
+                             // UR_DEVICE_INFO_GPU_EU_COUNT,
+                             // UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,
+                             // UR_DEVICE_INFO_GPU_EU_SLICES,
+                             // UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,
+                             // UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,
+                             // UR_DEVICE_INFO_IMAGE_SRGB,
+                             // UR_DEVICE_INFO_ATOMIC_64,
+                             // UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,
+                             // UR_DEVICE_INFO_BFLOAT16,
+                             // UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES
+                             ),
+                         [](const ::testing::TestParamInfo<ur_device_info_t> &info) {
+                             std::stringstream ss;
+                             ss << info.param;
+                             return ss.str();
+                         });
 
 TEST_P(urDeviceGetInfoTest, Success) {
     ur_device_info_t info_type = GetParam();
@@ -129,8 +125,7 @@ TEST_P(urDeviceGetInfoTest, Success) {
         ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, 0, nullptr, &size));
         ASSERT_NE(size, 0);
         void *info_data = alloca(size);
-        ASSERT_SUCCESS(
-            urDeviceGetInfo(device, info_type, size, info_data, nullptr));
+        ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, size, info_data, nullptr));
         ASSERT_NE(info_data, nullptr);
     }
 }

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -14,13 +14,11 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
 
 TEST_F(urDeviceGetNativeHandleTest, InvalidNullDeviceHandle) {
     for (auto device : devices) {
-        ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                         urDeviceGetNativeHandle(device, nullptr));
+        ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceGetNativeHandle(device, nullptr));
     }
 }
 
 TEST_F(urDeviceGetNativeHandleTest, InvalidNullNativeDeviceHandle) {
     ur_native_handle_t native_handle = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urDeviceGetNativeHandle(nullptr, &native_handle));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceGetNativeHandle(nullptr, &native_handle));
 }

--- a/test/conformance/device/urDevicePartition.cpp
+++ b/test/conformance/device/urDevicePartition.cpp
@@ -4,20 +4,16 @@
 
 using urDevicePartitionTest = uur::urAllDevicesTest;
 
-void getNumberComputeUnits(ur_device_handle_t_ *device,
-                           uint32_t &n_compute_units) {
+void getNumberComputeUnits(ur_device_handle_t_ *device, uint32_t &n_compute_units) {
 
-    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_COMPUTE_UNITS,
-                                   sizeof(n_compute_units), &n_compute_units,
-                                   nullptr));
+    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_COMPUTE_UNITS, sizeof(n_compute_units), &n_compute_units, nullptr));
     ASSERT_NE(n_compute_units, 0);
 }
 
 TEST_F(urDevicePartitionTest, PartitionEquallySuccess) {
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(device,
-                                            UR_DEVICE_PARTITION_EQUALLY)) {
+        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_EQUALLY)) {
             GTEST_SKIP();
         }
 
@@ -25,19 +21,15 @@ TEST_F(urDevicePartitionTest, PartitionEquallySuccess) {
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_compute_units));
 
         for (uint32_t i = 1; i < n_compute_units; ++i) {
-            ur_device_partition_property_t properties[] = {
-                UR_DEVICE_PARTITION_EQUALLY, i, 0};
+            ur_device_partition_property_t properties[] = {UR_DEVICE_PARTITION_EQUALLY, i, 0};
 
             // Get the number of devices that will be created
             uint32_t n_devices;
-            ASSERT_SUCCESS(
-                urDevicePartition(device, properties, 0, nullptr, &n_devices));
+            ASSERT_SUCCESS(urDevicePartition(device, properties, 0, nullptr, &n_devices));
             ASSERT_NE(n_devices, 0);
 
             std::vector<ur_device_handle_t> sub_devices(n_devices);
-            ASSERT_SUCCESS(urDevicePartition(
-                device, properties, static_cast<uint32_t>(sub_devices.size()),
-                sub_devices.data(), nullptr));
+            ASSERT_SUCCESS(urDevicePartition(device, properties, static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
                 ASSERT_SUCCESS(urDeviceRelease(sub_device));
@@ -50,21 +42,21 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
 
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(device,
-                                            UR_DEVICE_PARTITION_BY_COUNTS)) {
+        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_BY_COUNTS)) {
             GTEST_SKIP();
         }
 
         uint32_t n_cu_in_device = 0;
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_cu_in_device));
 
-        std::vector<ur_device_partition_property_t> properties = {
-            UR_DEVICE_PARTITION_BY_COUNTS};
+        std::vector<ur_device_partition_property_t> properties = {UR_DEVICE_PARTITION_BY_COUNTS};
 
-        enum class Combination { ONE, HALF, ALL_MINUS_ONE, ALL };
+        enum class Combination { ONE,
+                                 HALF,
+                                 ALL_MINUS_ONE,
+                                 ALL };
 
-        std::vector<Combination> combinations{Combination::ONE,
-                                              Combination::ALL};
+        std::vector<Combination> combinations{Combination::ONE, Combination::ALL};
 
         if (n_cu_in_device >= 2) {
             combinations.push_back(Combination::HALF);
@@ -81,8 +73,7 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
             }
             case Combination::HALF: {
                 n_cu_across_sub_devices = (n_cu_in_device / 2) * 2;
-                properties.insert(properties.end(),
-                                  {n_cu_in_device / 2, n_cu_in_device / 2, 0});
+                properties.insert(properties.end(), {n_cu_in_device / 2, n_cu_in_device / 2, 0});
                 break;
             }
             case Combination::ALL_MINUS_ONE: {
@@ -99,22 +90,18 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
 
             // Get the number of devices that will be created
             uint32_t n_devices;
-            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0,
-                                             nullptr, &n_devices));
+            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0, nullptr, &n_devices));
             ASSERT_EQ(n_devices, properties.size() - 2);
 
             std::vector<ur_device_handle_t> sub_devices(n_devices);
             ASSERT_SUCCESS(
-                urDevicePartition(device, properties.data(),
-                                  static_cast<uint32_t>(sub_devices.size()),
-                                  sub_devices.data(), nullptr));
+                urDevicePartition(device, properties.data(), static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
 
             uint32_t sum = 0;
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
                 uint32_t n_cu_in_sub_device;
-                ASSERT_NO_FATAL_FAILURE(
-                    getNumberComputeUnits(sub_device, n_cu_in_sub_device));
+                ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(sub_device, n_cu_in_sub_device));
                 sum += n_cu_in_sub_device;
                 ASSERT_SUCCESS(urDeviceRelease(sub_device));
             }
@@ -127,41 +114,34 @@ TEST_F(urDevicePartitionTest, PartitionByAffinityDomain) {
 
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(
-                device, UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN)) {
+        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN)) {
             GTEST_SKIP();
         }
 
         uint32_t n_compute_units = 0;
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_compute_units));
 
-        std::vector<ur_device_affinity_domain_flag_t> testFlags = {
-            UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
-            UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE};
+        std::vector<ur_device_affinity_domain_flag_t> testFlags = {UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
+                                                                   UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE};
 
         for (auto flag : testFlags) {
 
-            std::vector<ur_device_partition_property_t> properties = {
-                UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, flag, 0};
+            std::vector<ur_device_partition_property_t> properties = {UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, flag, 0};
 
             // Get the number of devices that will be created
             uint32_t n_devices;
-            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0,
-                                             nullptr, &n_devices));
+            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0, nullptr, &n_devices));
             ASSERT_NE(n_devices, 0);
 
             std::vector<ur_device_handle_t> sub_devices(n_devices);
             ASSERT_SUCCESS(
-                urDevicePartition(device, properties.data(),
-                                  static_cast<uint32_t>(sub_devices.size()),
-                                  sub_devices.data(), nullptr));
+                urDevicePartition(device, properties.data(), static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
 
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
 
                 ur_device_affinity_domain_flag_t type;
-                urDeviceGetInfo(sub_device, UR_DEVICE_INFO_PARTITION_TYPE,
-                                sizeof(type), &type, nullptr);
+                urDeviceGetInfo(sub_device, UR_DEVICE_INFO_PARTITION_TYPE, sizeof(type), &type, nullptr);
 
                 /* UR only supports splitting with the NUMA flag. So even if the
                  * NEXT_PARTITIONABLE flag is used, the result should always be

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -12,7 +12,4 @@ TEST_F(urDeviceReleaseTest, Success) {
 }
 
 // TODO - re-enable this test - #170
-TEST_F(urDeviceReleaseTest, InvalidNullHandle) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urDeviceRelease(nullptr));
-}
+TEST_F(urDeviceReleaseTest, InvalidNullHandle) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceRelease(nullptr)); }

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -12,7 +12,4 @@ TEST_F(urDeviceRetainTest, Success) {
     }
 }
 
-TEST_F(urDeviceRetainTest, InvalidNullHandle) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urDeviceRetain(nullptr));
-}
+TEST_F(urDeviceRetainTest, InvalidNullHandle) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceRetain(nullptr)); }

--- a/test/conformance/device/urDeviceSelectBinary.cpp
+++ b/test/conformance/device/urDeviceSelectBinary.cpp
@@ -10,12 +10,10 @@ TEST_F(urDeviceSelectBinaryTest, Success) {
     const char *binaries[] = {"binary A", "binary B"};
     uint32_t num_binaries = 2;
     for (auto device : devices) {
-        ASSERT_SUCCESS(urDeviceSelectBinary(device, (const uint8_t **)binaries,
-                                            num_binaries, nullptr));
+        ASSERT_SUCCESS(urDeviceSelectBinary(device, (const uint8_t **)binaries, num_binaries, nullptr));
     }
 }
 
 TEST_F(urDeviceSelectBinaryTest, InvalidNullHandle) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urDeviceSelectBinary(nullptr, nullptr, 0, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceSelectBinary(nullptr, nullptr, 0, nullptr));
 }

--- a/test/conformance/enqueue/rect_helpers.h
+++ b/test/conformance/enqueue/rect_helpers.h
@@ -23,8 +23,7 @@ struct test_parameters_t {
 };
 
 template <typename T>
-inline std::string
-printRectTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
+inline std::string printRectTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
     // ParamType will be std::tuple<ur_device_handle_t, test_parameters_t>
     const auto device_handle = std::get<0>(info.param);
     const auto platform_device_name = GetPlatformAndDeviceName(device_handle);
@@ -34,17 +33,13 @@ printRectTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
 
 // Performs host side equivalent of urEnqueueMemBufferReadRect,
 // urEnqueueMemBufferWriteRect and urEnqueueMemBufferCopyRect.
-inline void copyRect(std::vector<uint8_t> src, ur_rect_offset_t src_offset,
-                     ur_rect_offset_t dst_offset, ur_rect_region_t region,
-                     size_t src_row_pitch, size_t src_slice_pitch,
-                     size_t dst_row_pitch, size_t dst_slice_pitch,
+inline void copyRect(std::vector<uint8_t> src, ur_rect_offset_t src_offset, ur_rect_offset_t dst_offset, ur_rect_region_t region,
+                     size_t src_row_pitch, size_t src_slice_pitch, size_t dst_row_pitch, size_t dst_slice_pitch,
                      std::vector<uint8_t> &dst) {
-    const auto src_linear_offset = src_offset.x + src_offset.y * src_row_pitch +
-                                   src_offset.z * src_slice_pitch;
+    const auto src_linear_offset = src_offset.x + src_offset.y * src_row_pitch + src_offset.z * src_slice_pitch;
     const auto src_start = src.data() + src_linear_offset;
 
-    const auto dst_linear_offset = dst_offset.x + dst_offset.y * dst_row_pitch +
-                                   dst_offset.z * dst_slice_pitch;
+    const auto dst_linear_offset = dst_offset.x + dst_offset.y * dst_row_pitch + dst_offset.z * dst_slice_pitch;
     const auto dst_start = dst.data() + dst_linear_offset;
 
     for (unsigned k = 0; k < region.depth; ++k) {

--- a/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -5,14 +5,10 @@
 struct urEnqueueEventsWaitTest : uur::urMultiQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
-                                         nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                         nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0,
-                                               size, input.data(), 0, nullptr,
-                                               nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     }
 
     void TearDown() override {
@@ -37,27 +33,22 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitTest);
 TEST_P(urEnqueueEventsWaitTest, Success) {
     ur_event_handle_t event1 = nullptr;
     ur_event_handle_t waitEvent = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, &event1));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event1));
     ASSERT_SUCCESS(urEnqueueEventsWait(queue2, 1, &event1, &waitEvent));
     ASSERT_SUCCESS(urQueueFlush(queue1));
     ASSERT_SUCCESS(urQueueFlush(queue2));
     ASSERT_SUCCESS(urEventWait(1, &waitEvent));
 
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     ASSERT_EQ(input, output);
 
     ur_event_handle_t event2 = nullptr;
     input.assign(count, 420);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size,
-                                           input.data(), 0, nullptr, &event2));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size, input.data(), 0, nullptr, &event2));
     ASSERT_SUCCESS(urEventWait(1, &event2));
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, nullptr));
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     ASSERT_EQ(input, output);
     EXPECT_SUCCESS(urEventRelease(event1));
     EXPECT_SUCCESS(urEventRelease(waitEvent));
@@ -65,6 +56,5 @@ TEST_P(urEnqueueEventsWaitTest, Success) {
 }
 
 TEST_P(urEnqueueEventsWaitTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueEventsWait(nullptr, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueEventsWait(nullptr, 0, nullptr, nullptr));
 }

--- a/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -5,14 +5,10 @@
 struct urEnqueueEventsWaitWithBarrierTest : uur::urMultiQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
-                                         nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                         nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0,
-                                               size, input.data(), 0, nullptr,
-                                               nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     }
 
     void TearDown() override {
@@ -37,41 +33,32 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitWithBarrierTest);
 TEST_P(urEnqueueEventsWaitWithBarrierTest, Success) {
     ur_event_handle_t event1 = nullptr;
     ur_event_handle_t waitEvent = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, &event1));
-    EXPECT_SUCCESS(
-        urEnqueueEventsWaitWithBarrier(queue2, 1, &event1, &waitEvent));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event1));
+    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue2, 1, &event1, &waitEvent));
     EXPECT_SUCCESS(urQueueFlush(queue2));
     EXPECT_SUCCESS(urQueueFlush(queue1));
     EXPECT_SUCCESS(urEventWait(1, &waitEvent));
 
     std::vector<uint32_t> output(count, 1);
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     EXPECT_EQ(input, output);
     EXPECT_SUCCESS(urEventRelease(waitEvent));
     EXPECT_SUCCESS(urEventRelease(event1));
 
     ur_event_handle_t event2 = nullptr;
     input.assign(count, 420);
-    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
-    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, &event2));
-    EXPECT_SUCCESS(
-        urEnqueueEventsWaitWithBarrier(queue1, 1, &event2, &waitEvent));
+    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event2));
+    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue1, 1, &event2, &waitEvent));
     EXPECT_SUCCESS(urQueueFlush(queue2));
     EXPECT_SUCCESS(urQueueFlush(queue1));
     EXPECT_SUCCESS(urEventWait(1, &waitEvent));
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     EXPECT_SUCCESS(urEventRelease(waitEvent));
     EXPECT_SUCCESS(urEventRelease(event2));
     EXPECT_EQ(input, output);
 }
 
 TEST_P(urEnqueueEventsWaitWithBarrierTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueEventsWaitWithBarrier(nullptr, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueEventsWaitWithBarrier(nullptr, 0, nullptr, nullptr));
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -6,14 +6,10 @@
 struct urEnqueueMemBufferCopyTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
-                                         nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                         nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size,
-                                               input.data(), 0, nullptr,
-                                               nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     }
 
     void TearDown() override {
@@ -35,48 +31,38 @@ struct urEnqueueMemBufferCopyTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferCopyTest);
 
 TEST_P(urEnqueueMemBufferCopyTest, Success) {
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     ASSERT_EQ(input, output);
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullHandleQueue) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopy(nullptr, src_buffer, dst_buffer, 0,
-                                            0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(nullptr, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullHandleBufferSrc) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopy(queue, nullptr, dst_buffer, 0, 0,
-                                            size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(queue, nullptr, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullHandleBufferDst) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopy(queue, src_buffer, nullptr, 0, 0,
-                                            size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(queue, src_buffer, nullptr, 0, 0, size, 0, nullptr, nullptr));
 }
 
-using urEnqueueMemBufferCopyMultiDeviceTest =
-    uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferCopyMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
     // First queue does a fill.
     const uint32_t input = 42;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input,
-                                          sizeof(input), 0, size, 0, nullptr,
-                                          nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input, sizeof(input), 0, size, 0, nullptr, nullptr));
 
     // Then a copy.
     ur_mem_handle_t dst_buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                     nullptr, &dst_buffer));
-    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queues[0], buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queues[0], buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
 
     // Wait for the queue to finish executing.
     EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
@@ -87,13 +73,9 @@ TEST_F(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
-                                              output.data(), 0, nullptr,
-                                              nullptr));
+        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
         for (unsigned j = 0; j < count; ++j) {
-            EXPECT_EQ(input, output[j])
-                << "Result on queue " << i << " did not match at index " << j
-                << "!";
+            EXPECT_EQ(input, output[j]) << "Result on queue " << i << " did not match at index " << j << "!";
         }
     }
 

--- a/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -7,71 +7,56 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
     std::vector<uur::test_parameters_t> parameterizations;
 
 // Choose parameters so that we get good coverage and catch some edge cases.
-#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin,   \
-                         dst_origin, region, src_row_pitch, src_slice_pitch,   \
-                         dst_row_pitch, dst_slice_pitch)                       \
-    uur::test_parameters_t name{                                               \
-        #name,         src_buffer_size, dst_buffer_size, src_origin,           \
-        dst_origin,    region,          src_row_pitch,   src_slice_pitch,      \
-        dst_row_pitch, dst_slice_pitch};                                       \
-    parameterizations.push_back(name);                                         \
+#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin, dst_origin, region, src_row_pitch, src_slice_pitch, \
+                         dst_row_pitch, dst_slice_pitch)                                                                         \
+    uur::test_parameters_t name{#name, src_buffer_size, dst_buffer_size, src_origin, dst_origin,                                 \
+                                region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch};                         \
+    parameterizations.push_back(name);                                                                                           \
     (void)0
     // Tests that a 16x16x1 region can be read from a 16x16x1 device buffer at
     // offset {0,0,0} to a 16x16x1 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(copy_whole_buffer_2D, 256, 256,
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
+    PARAMETERIZATION(copy_whole_buffer_2D, 256, 256, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
                      (ur_rect_region_t{16, 16, 1}), 16, 256, 16, 256);
     // Tests that a 2x2x1 region can be read from a 4x4x1 device buffer at
     // offset {2,2,0} to a 8x4x1 host buffer at offset {4,2,0}.
-    PARAMETERIZATION(copy_non_zero_offsets_2D, 16, 32,
-                     (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
+    PARAMETERIZATION(copy_non_zero_offsets_2D, 16, 32, (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
                      (ur_rect_region_t{2, 2, 1}), 4, 16, 8, 32);
     // Tests that a 4x4x1 region can be read from a 4x4x16 device buffer at
     // offset {0,0,0} to a 8x4x16 host buffer at offset {4,0,0}.
-    PARAMETERIZATION(copy_different_buffer_sizes_2D, 256, 512,
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
+    PARAMETERIZATION(copy_different_buffer_sizes_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
                      (ur_rect_region_t{4, 4, 1}), 4, 16, 8, 32);
     // Tests that a 1x256x1 region can be read from a 1x256x1 device buffer at
     // offset {0,0,0} to a 2x256x1 host buffer at offset {1,0,0}.
-    PARAMETERIZATION(copy_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}),
-                     1, 256, 2, 512);
+    PARAMETERIZATION(copy_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}), 1,
+                     256, 2, 512);
     // Tests that a 256x1x1 region can be read from a 256x1x1 device buffer at
     // offset {0,0,0} to a 256x2x1 host buffer at offset {0,1,0}.
-    PARAMETERIZATION(copy_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}),
-                     256, 256, 256, 512);
+    PARAMETERIZATION(copy_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}), 256,
+                     256, 256, 512);
     // Tests that a 8x8x8 region can be read from a 8x8x8 device buffer at
     // offset {0,0,0} to a 8x8x8 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(copy_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}),
-                     8, 64, 8, 64);
+    PARAMETERIZATION(copy_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}), 8, 64, 8,
+                     64);
     // Tests that a 4x3x2 region can be read from a 8x8x8 device buffer at
     // offset {1,2,3} to a 8x8x8 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(copy_3d_with_offsets, 512, 512,
-                     (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}),
-                     (ur_rect_region_t{4, 3, 2}), 8, 64, 8, 64);
+    PARAMETERIZATION(copy_3d_with_offsets, 512, 512, (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 3, 2}),
+                     8, 64, 8, 64);
     // Tests that a 4x16x2 region can be read from a 8x32x1 device buffer at
     // offset {1,2,0} to a 8x32x4 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(copy_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}),
-                     (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}),
-                     8, 256, 8, 256);
+    PARAMETERIZATION(copy_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}), 8, 256,
+                     8, 256);
     // Tests that a 1x4x1 region can be read from a 8x16x4 device buffer at
     // offset {7,3,3} to a 2x8x1 host buffer at offset {1,3,0}.
-    PARAMETERIZATION(copy_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}),
-                     (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}),
-                     8, 128, 2, 16);
+    PARAMETERIZATION(copy_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}), (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}), 8, 128, 2,
+                     16);
 #undef PARAMETERIZATION
     return parameterizations;
 }
 
-struct urEnqueueMemBufferCopyRectTestWithParam
-    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+struct urEnqueueMemBufferCopyRectTestWithParam : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_TEST_SUITE_P(
-    urEnqueueMemBufferCopyRectTestWithParam,
-    testing::ValuesIn(generateParameterizations()),
-    uur::printRectTestString<urEnqueueMemBufferCopyRectTestWithParam>);
+UUR_TEST_SUITE_P(urEnqueueMemBufferCopyRectTestWithParam, testing::ValuesIn(generateParameterizations()),
+                 uur::printRectTestString<urEnqueueMemBufferCopyRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
     // Unpack the parameters.
@@ -87,45 +72,35 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
 
     // Create two buffers to copy between.
     ur_mem_handle_t src_buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     src_buffer_size, nullptr, &src_buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, src_buffer_size, nullptr, &src_buffer));
 
     // Fill src buffer with sequentially increasing values.
     std::vector<uint8_t> input(src_buffer_size, 0x0);
     std::iota(std::begin(input), std::end(input), 0x0);
     EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer,
-                                           /* is_blocking */ true, 0,
-                                           src_buffer_size, input.data(), 0,
-                                           nullptr, nullptr));
+                                           /* is_blocking */ true, 0, src_buffer_size, input.data(), 0, nullptr, nullptr));
 
     ur_mem_handle_t dst_buffer = nullptr;
-    EXPECT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     dst_buffer_size, nullptr, &dst_buffer));
+    EXPECT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, dst_buffer_size, nullptr, &dst_buffer));
 
     // Zero destination buffer to begin with since the write may not cover the
     // whole buffer.
     const uint8_t zero = 0x0;
-    EXPECT_SUCCESS(urEnqueueMemBufferFill(queue, dst_buffer, &zero,
-                                          sizeof(zero), 0, dst_buffer_size, 0,
-                                          nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferFill(queue, dst_buffer, &zero, sizeof(zero), 0, dst_buffer_size, 0, nullptr, nullptr));
 
     // Enqueue the rectangular copy between the buffers.
-    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(
-        queue, src_buffer, dst_buffer, src_buffer_origin, dst_buffer_origin,
-        region, src_buffer_row_pitch, src_buffer_slice_pitch,
-        dst_buffer_row_pitch, dst_buffer_slice_pitch, 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer, src_buffer_origin, dst_buffer_origin, region,
+                                              src_buffer_row_pitch, src_buffer_slice_pitch, dst_buffer_row_pitch, dst_buffer_slice_pitch, 0,
+                                              nullptr, nullptr));
 
     std::vector<uint8_t> output(dst_buffer_size, 0x0);
     EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer,
-                                          /* is_blocking */ true, 0,
-                                          dst_buffer_size, output.data(), 0,
-                                          nullptr, nullptr));
+                                          /* is_blocking */ true, 0, dst_buffer_size, output.data(), 0, nullptr, nullptr));
 
     // Do host side equivalent.
     std::vector<uint8_t> expected(dst_buffer_size, 0x0);
-    uur::copyRect(input, src_buffer_origin, dst_buffer_origin, region,
-                  src_buffer_row_pitch, src_buffer_slice_pitch,
-                  dst_buffer_row_pitch, dst_buffer_slice_pitch, expected);
+    uur::copyRect(input, src_buffer_origin, dst_buffer_origin, region, src_buffer_row_pitch, src_buffer_slice_pitch, dst_buffer_row_pitch,
+                  dst_buffer_slice_pitch, expected);
 
     // Verify the results.
     EXPECT_EQ(expected, output);
@@ -138,14 +113,10 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
 struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
-                                         nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                         nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size,
-                                               input.data(), 0, nullptr,
-                                               nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     }
 
     void TearDown() override {
@@ -171,10 +142,8 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleQueue) {
     ur_rect_offset_t src_origin{0, 0, 0};
     ur_rect_offset_t dst_origin{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopyRect(nullptr, src_buffer, dst_buffer,
-                                                src_origin, dst_origin,
-                                                src_region, size, size, size,
-                                                size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopyRect(nullptr, src_buffer, dst_buffer, src_origin, dst_origin, src_region, size, size, size, size,
+                                                0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferSrc) {
@@ -182,10 +151,8 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferSrc) {
     ur_rect_offset_t src_origin{0, 0, 0};
     ur_rect_offset_t dst_origin{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopyRect(queue, nullptr, dst_buffer,
-                                                src_origin, dst_origin,
-                                                src_region, size, size, size,
-                                                size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopyRect(queue, nullptr, dst_buffer, src_origin, dst_origin, src_region, size, size, size, size, 0,
+                                                nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferDst) {
@@ -193,30 +160,23 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferDst) {
     ur_rect_offset_t src_origin{0, 0, 0};
     ur_rect_offset_t dst_origin{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopyRect(queue, src_buffer, nullptr,
-                                                src_origin, dst_origin,
-                                                src_region, size, size, size,
-                                                size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopyRect(queue, src_buffer, nullptr, src_origin, dst_origin, src_region, size, size, size, size, 0,
+                                                nullptr, nullptr));
 }
 
-using urEnqueueMemBufferCopyRectMultiDeviceTest =
-    uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferCopyRectMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
     // First queue does a fill.
     const uint32_t input = 42;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input,
-                                          sizeof(input), 0, size, 0, nullptr,
-                                          nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input, sizeof(input), 0, size, 0, nullptr, nullptr));
 
     // Then a rectangular copy treating both buffers as 1024x1x1 1D buffers with
     // zero offsets.
     ur_mem_handle_t dst_buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                     nullptr, &dst_buffer));
-    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(
-        queues[0], buffer, dst_buffer, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size,
-        size, size, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(queues[0], buffer, dst_buffer, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size, size, size, size, 0,
+                                              nullptr, nullptr));
 
     // Wait for the queue to finish executing.
     EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
@@ -227,13 +187,9 @@ TEST_F(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
-                                              output.data(), 0, nullptr,
-                                              nullptr));
+        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
         for (unsigned j = 0; j < count; ++j) {
-            EXPECT_EQ(input, output[j])
-                << "Result on queue " << i << " did not match at index " << j
-                << "!";
+            EXPECT_EQ(input, output[j]) << "Result on queue " << i << " did not match at index " << j << "!";
         }
     }
 

--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -7,12 +7,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferFillTest);
 
 TEST_P(urEnqueueMemBufferFillTest, Success) {
     const uint32_t pattern = 0xdeadbeef;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern,
-                                          sizeof(pattern), 0, size, 0, nullptr,
-                                          nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern, sizeof(pattern), 0, size, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     for (unsigned i = 0; i < count; ++i) {
         ASSERT_EQ(output[i], pattern) << "Result mismatch at index: " << i;
     }
@@ -20,17 +17,13 @@ TEST_P(urEnqueueMemBufferFillTest, Success) {
 
 TEST_P(urEnqueueMemBufferFillTest, SuccessPartialFill) {
     const std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     const uint32_t pattern = 0xdeadbeef;
     const size_t partial_fill_size = size / 2;
     const size_t fill_count = count / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern,
-                                          sizeof(pattern), 0, partial_fill_size,
-                                          0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern, sizeof(pattern), 0, partial_fill_size, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     for (size_t i = 0; i < count - fill_count; ++i) {
         ASSERT_EQ(output[i], pattern) << "Result mismatch at index: " << i;
     }
@@ -42,17 +35,13 @@ TEST_P(urEnqueueMemBufferFillTest, SuccessPartialFill) {
 
 TEST_P(urEnqueueMemBufferFillTest, SuccessOffset) {
     const std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     const uint32_t pattern = 0xdeadbeef;
     const size_t offset_size = size / 2;
     const size_t offset_count = count / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern,
-                                          sizeof(pattern), offset_size,
-                                          offset_size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern, sizeof(pattern), offset_size, offset_size, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     for (size_t i = 0; i < offset_count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
     }
@@ -65,35 +54,26 @@ TEST_P(urEnqueueMemBufferFillTest, SuccessOffset) {
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullHandleQueue) {
     const uint32_t pattern = 0xdeadbeef;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferFill(nullptr, buffer, &pattern,
-                                            sizeof(pattern), 0, size, 0,
-                                            nullptr, nullptr));
+                     urEnqueueMemBufferFill(nullptr, buffer, &pattern, sizeof(pattern), 0, size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullHandleBuffer) {
     const uint32_t pattern = 0xdeadbeef;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferFill(queue, nullptr, &pattern,
-                                            sizeof(pattern), 0, size, 0,
-                                            nullptr, nullptr));
+                     urEnqueueMemBufferFill(queue, nullptr, &pattern, sizeof(pattern), 0, size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullHandlePointerPattern) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferFill(queue, buffer, nullptr,
-                                            sizeof(uint32_t), 0, size, 0,
-                                            nullptr, nullptr));
+                     urEnqueueMemBufferFill(queue, buffer, nullptr, sizeof(uint32_t), 0, size, 0, nullptr, nullptr));
 }
 
-using urEnqueueMemBufferFillMultiDeviceTest =
-    uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferFillMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
     // First queue does a fill.
     const uint32_t input = 42;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input,
-                                          sizeof(input), 0, size, 0, nullptr,
-                                          nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input, sizeof(input), 0, size, 0, nullptr, nullptr));
 
     // Wait for the queue to finish executing.
     EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
@@ -104,12 +84,9 @@ TEST_F(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        ASSERT_SUCCESS(urEnqueueMemBufferRead(
-            queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
         for (unsigned j = 0; j < count; ++j) {
-            ASSERT_EQ(input, output[j])
-                << "Result on queue " << i << " did not match at index " << j
-                << "!";
+            ASSERT_EQ(input, output[j]) << "Result on queue " << i << " did not match at index " << j << "!";
         }
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -7,13 +7,10 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferMapTest);
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessRead) {
     const std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     uint32_t *map = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ,
-                                         0, size, 0, nullptr, nullptr,
-                                         (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ, 0, size, 0, nullptr, nullptr, (void **)&map));
     for (unsigned i = 0; i < count; ++i) {
         ASSERT_EQ(map[i], 42) << "Result mismatch at index: " << i;
     }
@@ -21,20 +18,16 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessRead) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessWrite) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     uint32_t *map = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
-                                         0, size, 0, nullptr, nullptr,
-                                         (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, 0, size, 0, nullptr, nullptr, (void **)&map));
     for (unsigned i = 0; i < count; ++i) {
         map[i] = 42;
     }
     ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     for (unsigned i = 0; i < count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
     }
@@ -42,14 +35,12 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessWrite) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessOffset) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     uint32_t *map = nullptr;
     const size_t offset_size = size / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
-                                         offset_size, size - offset_size, 0,
-                                         nullptr, nullptr, (void **)&map));
+    ASSERT_SUCCESS(
+        urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, offset_size, size - offset_size, 0, nullptr, nullptr, (void **)&map));
 
     const size_t offset_count = count / 2;
     for (size_t i = 0; i < offset_count; ++i) {
@@ -58,8 +49,7 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessOffset) {
 
     ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
 
     for (size_t i = 0; i < offset_count; ++i) {
         ASSERT_EQ(output[i], 0) << "Result mismatch at index: " << i;
@@ -71,13 +61,10 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessOffset) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessPartialMap) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     uint32_t *map = nullptr;
     const size_t map_size = size / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
-                                         0, map_size, 0, nullptr, nullptr,
-                                         (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, 0, map_size, 0, nullptr, nullptr, (void **)&map));
 
     const size_t offset_count = count / 2;
     for (unsigned i = 0; i < offset_count; ++i) {
@@ -86,8 +73,7 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessPartialMap) {
 
     ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
 
     for (size_t i = 0; i < offset_count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
@@ -99,8 +85,7 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessPartialMap) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessMultiMaps) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     // Create two maps with non-overlapping ranges and write separate values
     // into each of them to check we can maintain multiple maps on the same
@@ -111,25 +96,19 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessMultiMaps) {
     const auto map_offset = size / 2;
     const auto map_count = count / 2;
 
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
-                                         0, map_size, 0, nullptr, nullptr,
-                                         (void **)&map_a));
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
-                                         map_offset, map_size, 0, nullptr,
-                                         nullptr, (void **)&map_b));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, 0, map_size, 0, nullptr, nullptr, (void **)&map_a));
+    ASSERT_SUCCESS(
+        urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, map_offset, map_size, 0, nullptr, nullptr, (void **)&map_b));
     for (size_t i = 0; i < map_count; ++i) {
         map_a[i] = 42;
     }
     for (size_t i = map_count; i < count; ++i) {
         map_a[i] = 24;
     }
-    ASSERT_SUCCESS(
-        urEnqueueMemUnmap(queue, buffer, map_a, 0, nullptr, nullptr));
-    ASSERT_SUCCESS(
-        urEnqueueMemUnmap(queue, buffer, map_b, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map_a, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map_b, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     for (size_t i = 0; i < map_count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
     }
@@ -140,46 +119,33 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessMultiMaps) {
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullHandleQueue) {
     uint32_t *map = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferMap(nullptr, buffer, true,
-                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                           0, size, 0, nullptr, nullptr,
-                                           (void **)&map));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemBufferMap(nullptr, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                                                                0, size, 0, nullptr, nullptr, (void **)&map));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullHandleBuffer) {
     uint32_t *map = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferMap(queue, nullptr, true,
-                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                           0, size, 0, nullptr, nullptr,
-                                           (void **)&map));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemBufferMap(queue, nullptr, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                                                                0, size, 0, nullptr, nullptr, (void **)&map));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidEnumerationMapFlags) {
     uint32_t *map = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urEnqueueMemBufferMap(queue, buffer, true,
-                                           UR_MAP_FLAG_FORCE_UINT32, 0, size, 0,
-                                           nullptr, nullptr, (void **)&map));
+                     urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_FORCE_UINT32, 0, size, 0, nullptr, nullptr, (void **)&map));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullPointerRetMap) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferMap(queue, buffer, true,
-                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                           0, size, 0, nullptr, nullptr,
-                                           nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                                                                 0, size, 0, nullptr, nullptr, nullptr));
 }
 
-using urEnqueueMemBufferMapMultiDeviceTest =
-    uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferMapMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferMapMultiDeviceTest, WriteMapDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     // Then the remaining queues map the buffer into some host memory. Since the
     // queues target different devices this checks that any devices memory has
@@ -187,15 +153,10 @@ TEST_F(urEnqueueMemBufferMapMultiDeviceTest, WriteMapDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         uint32_t *map = nullptr;
-        ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true,
-                                             UR_MAP_FLAG_READ, 0, size, 0,
-                                             nullptr, nullptr, (void **)&map));
+        ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ, 0, size, 0, nullptr, nullptr, (void **)&map));
         for (unsigned j = 0; j < count; ++j) {
-            ASSERT_EQ(input[j], map[j])
-                << "Result on queue " << i << " at index " << j
-                << " did not match!";
+            ASSERT_EQ(input[j], map[j]) << "Result on queue " << i << " at index " << j << " did not match!";
         }
-        ASSERT_SUCCESS(
-            urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -7,41 +7,33 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferReadTest);
 
 TEST_P(urEnqueueMemBufferReadTest, Success) {
     std::vector<uint32_t> output(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullHandleQueue) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferRead(nullptr, buffer, true, 0, size,
-                                            output.data(), 0, nullptr,
-                                            nullptr));
+                     urEnqueueMemBufferRead(nullptr, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullHandleBuffer) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferRead(queue, nullptr, true, 0, size,
-                                            output.data(), 0, nullptr,
-                                            nullptr));
+                     urEnqueueMemBufferRead(queue, nullptr, true, 0, size, output.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullPointerDst) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                            nullptr, 0, nullptr, nullptr));
+                     urEnqueueMemBufferRead(queue, buffer, true, 0, size, nullptr, 0, nullptr, nullptr));
 }
 
-using urEnqueueMemBufferReadMultiDeviceTest =
-    uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferReadMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     // Then the remaining queues do blocking reads from the buffer. Since the
     // queues target different devices this checks that any devices memory has
@@ -49,9 +41,7 @@ TEST_F(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        ASSERT_SUCCESS(urEnqueueMemBufferRead(
-            queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
-        ASSERT_EQ(input, output)
-            << "Result on queue " << i << " did not match!";
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        ASSERT_EQ(input, output) << "Result on queue " << i << " did not match!";
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -8,71 +8,56 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
     std::vector<uur::test_parameters_t> parameterizations;
 
 // Choose parameters so that we get good coverage and catch some edge cases.
-#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin,   \
-                         dst_origin, region, src_row_pitch, src_slice_pitch,   \
-                         dst_row_pitch, dst_slice_pitch)                       \
-    uur::test_parameters_t name{                                               \
-        #name,         src_buffer_size, dst_buffer_size, src_origin,           \
-        dst_origin,    region,          src_row_pitch,   src_slice_pitch,      \
-        dst_row_pitch, dst_slice_pitch};                                       \
-    parameterizations.push_back(name);                                         \
+#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin, dst_origin, region, src_row_pitch, src_slice_pitch, \
+                         dst_row_pitch, dst_slice_pitch)                                                                         \
+    uur::test_parameters_t name{#name, src_buffer_size, dst_buffer_size, src_origin, dst_origin,                                 \
+                                region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch};                         \
+    parameterizations.push_back(name);                                                                                           \
     (void)0
     // Tests that a 16x16x1 region can be read from a 16x16x1 device buffer at
     // offset {0,0,0} to a 16x16x1 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_whole_buffer_2D, 256, 256,
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
+    PARAMETERIZATION(write_whole_buffer_2D, 256, 256, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
                      (ur_rect_region_t{16, 16, 1}), 16, 256, 16, 256);
     // Tests that a 2x2x1 region can be read from a 4x4x1 device buffer at
     // offset {2,2,0} to a 8x4x1 host buffer at offset {4,2,0}.
-    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32,
-                     (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
+    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32, (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
                      (ur_rect_region_t{2, 2, 1}), 4, 16, 8, 32);
     // Tests that a 4x4x1 region can be read from a 4x4x16 device buffer at
     // offset {0,0,0} to a 8x4x16 host buffer at offset {4,0,0}.
-    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512,
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
+    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
                      (ur_rect_region_t{4, 4, 1}), 4, 16, 8, 32);
     // Tests that a 1x256x1 region can be read from a 1x256x1 device buffer at
     // offset {0,0,0} to a 2x256x1 host buffer at offset {1,0,0}.
-    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}),
-                     1, 256, 2, 512);
+    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}), 1,
+                     256, 2, 512);
     // Tests that a 256x1x1 region can be read from a 256x1x1 device buffer at
     // offset {0,0,0} to a 256x2x1 host buffer at offset {0,1,0}.
-    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}),
-                     256, 256, 256, 512);
+    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}), 256,
+                     256, 256, 512);
     // Tests that a 8x8x8 region can be read from a 8x8x8 device buffer at
     // offset {0,0,0} to a 8x8x8 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}),
-                     8, 64, 8, 64);
+    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}), 8, 64, 8,
+                     64);
     // Tests that a 4x3x2 region can be read from a 8x8x8 device buffer at
     // offset {1,2,3} to a 8x8x8 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_3d_with_offsets, 512, 512,
-                     (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}),
-                     (ur_rect_region_t{4, 3, 2}), 8, 64, 8, 64);
+    PARAMETERIZATION(write_3d_with_offsets, 512, 512, (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 3, 2}),
+                     8, 64, 8, 64);
     // Tests that a 4x16x2 region can be read from a 8x32x1 device buffer at
     // offset {1,2,0} to a 8x32x4 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}),
-                     (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}),
-                     8, 256, 8, 256);
+    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}), 8, 256,
+                     8, 256);
     // Tests that a 1x4x1 region can be read from a 8x16x4 device buffer at
     // offset {7,3,3} to a 2x8x1 host buffer at offset {1,3,0}.
-    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}),
-                     (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}),
-                     8, 128, 2, 16);
+    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}), (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}), 8, 128, 2,
+                     16);
 #undef PARAMETERIZATION
     return parameterizations;
 }
 
-struct urEnqueueMemBufferReadRectTestWithParam
-    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+struct urEnqueueMemBufferReadRectTestWithParam : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_TEST_SUITE_P(
-    urEnqueueMemBufferReadRectTestWithParam,
-    testing::ValuesIn(generateParameterizations()),
-    uur::printRectTestString<urEnqueueMemBufferReadRectTestWithParam>);
+UUR_TEST_SUITE_P(urEnqueueMemBufferReadRectTestWithParam, testing::ValuesIn(generateParameterizations()),
+                 uur::printRectTestString<urEnqueueMemBufferReadRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
     // Unpack the parameters.
@@ -88,26 +73,20 @@ TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
 
     // Create a buffer we will read from.
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
     // The input will just be sequentially increasing values.
     std::vector<uint8_t> input(buffer_size, 0x0);
     std::iota(std::begin(input), std::end(input), 0x0);
-    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* isBlocking */ true,
-                                           0, input.size(), input.data(), 0,
-                                           nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* isBlocking */ true, 0, input.size(), input.data(), 0, nullptr, nullptr));
 
     // Enqueue the rectangular read.
     std::vector<uint8_t> output(host_size, 0x0);
-    EXPECT_SUCCESS(urEnqueueMemBufferReadRect(
-        queue, buffer, /* isBlocking */ true, buffer_offset, host_offset,
-        region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
-        host_slice_pitch, output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferReadRect(queue, buffer, /* isBlocking */ true, buffer_offset, host_offset, region, buffer_row_pitch,
+                                              buffer_slice_pitch, host_row_pitch, host_slice_pitch, output.data(), 0, nullptr, nullptr));
 
     // Do host side equivalent.
     std::vector<uint8_t> expected(host_size, 0x0);
-    uur::copyRect(input, buffer_offset, host_offset, region, buffer_row_pitch,
-                  buffer_slice_pitch, host_row_pitch, host_slice_pitch,
+    uur::copyRect(input, buffer_offset, host_offset, region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch, host_slice_pitch,
                   expected);
 
     // Verify the results.
@@ -124,11 +103,9 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleQueue) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueMemBufferReadRect(nullptr, buffer, true, buffer_offset,
-                                   host_offset, region, size, size, size, size,
-                                   dst.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEnqueueMemBufferReadRect(nullptr, buffer, true, buffer_offset, host_offset, region, size, size, size, size,
+                                                dst.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleBuffer) {
@@ -136,11 +113,9 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleBuffer) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueMemBufferReadRect(queue, nullptr, true, buffer_offset,
-                                   host_offset, region, size, size, size, size,
-                                   dst.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEnqueueMemBufferReadRect(queue, nullptr, true, buffer_offset, host_offset, region, size, size, size, size,
+                                                dst.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPointerDst) {
@@ -149,24 +124,19 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPointerDst) {
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferReadRect(queue, buffer, true,
-                                                buffer_offset, host_offset,
-                                                region, size, size, size, size,
-                                                nullptr, 0, nullptr, nullptr));
+                     urEnqueueMemBufferReadRect(queue, buffer, true, buffer_offset, host_offset, region, size, size, size, size, nullptr, 0,
+                                                nullptr, nullptr));
 }
 
-using urEnqueueMemBufferReadRectMultiDeviceTest =
-    uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferReadRectMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest, WriteReadDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     // Then a rectangular write the buffer as 1024x1x1 1D.
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWriteRect(
-        queues[0], buffer, true, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size, size,
-        size, size, input.data(), 0, nullptr, nullptr));
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWriteRect(queues[0], buffer, true, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size, size, size, size,
+                                               input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 
     // Then the remaining queues do blocking reads from the buffer. Since the
     // queues target different devices this checks that any devices memory has
@@ -174,9 +144,7 @@ TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest, WriteReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        ASSERT_SUCCESS(urEnqueueMemBufferRead(
-            queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
-        ASSERT_EQ(input, output)
-            << "Result on queue " << i << " did not match!";
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        ASSERT_EQ(input, output) << "Result on queue " << i << " did not match!";
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -7,17 +7,14 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferWriteTest);
 
 TEST_P(urEnqueueMemBufferWriteTest, Success) {
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, SuccessWriteRead) {
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                           input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
-                                          output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
     for (size_t index = 0; index < count; index++) {
         ASSERT_EQ(input[index], output[index]);
     }
@@ -26,22 +23,17 @@ TEST_P(urEnqueueMemBufferWriteTest, SuccessWriteRead) {
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullHandleQueue) {
     std::vector<uint32_t> input(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferWrite(nullptr, buffer, true, 0, size,
-                                             input.data(), 0, nullptr,
-                                             nullptr));
+                     urEnqueueMemBufferWrite(nullptr, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullHandleBuffer) {
     std::vector<uint32_t> input(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferWrite(queue, nullptr, true, 0, size,
-                                             input.data(), 0, nullptr,
-                                             nullptr));
+                     urEnqueueMemBufferWrite(queue, nullptr, true, 0, size, input.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullPointerSrc) {
     std::vector<uint32_t> input(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
-                                             nullptr, 0, nullptr, nullptr));
+                     urEnqueueMemBufferWrite(queue, buffer, true, 0, size, nullptr, 0, nullptr, nullptr));
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -7,71 +7,56 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
     std::vector<uur::test_parameters_t> parameterizations;
 
 // Choose parameters so that we get good coverage and catch some edge cases.
-#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin,   \
-                         dst_origin, region, src_row_pitch, src_slice_pitch,   \
-                         dst_row_pitch, dst_slice_pitch)                       \
-    uur::test_parameters_t name{                                               \
-        #name,         src_buffer_size, dst_buffer_size, src_origin,           \
-        dst_origin,    region,          src_row_pitch,   src_slice_pitch,      \
-        dst_row_pitch, dst_slice_pitch};                                       \
-    parameterizations.push_back(name);                                         \
+#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin, dst_origin, region, src_row_pitch, src_slice_pitch, \
+                         dst_row_pitch, dst_slice_pitch)                                                                         \
+    uur::test_parameters_t name{#name, src_buffer_size, dst_buffer_size, src_origin, dst_origin,                                 \
+                                region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch};                         \
+    parameterizations.push_back(name);                                                                                           \
     (void)0
     // Tests that a 16x16x1 region can be written from a 16x16x1 host buffer at
     // offset {0,0,0} to a 16x16x1 device buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_whole_buffer_2D, 256, 256,
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
+    PARAMETERIZATION(write_whole_buffer_2D, 256, 256, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
                      (ur_rect_region_t{16, 16, 1}), 16, 256, 16, 256);
     // Tests that a 2x2x1 region can be written from a 4x4x1 host buffer at
     // offset {2,2,0} to a 8x4x1 device buffer at offset {4,2,0}.
-    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32,
-                     (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
+    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32, (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
                      (ur_rect_region_t{2, 2, 1}), 4, 16, 8, 32);
     // Tests that a 4x4x1 region can be written from a 4x4x16 host buffer at
     // offset {0,0,0} to a 8x4x16 device buffer at offset {4,0,0}.
-    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512,
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
+    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
                      (ur_rect_region_t{4, 4, 1}), 4, 16, 8, 32);
     // Tests that a 1x256x1 region can be written from a 1x256x1 host buffer at
     // offset {0,0,0} to a 2x256x1 device buffer at offset {1,0,0}.
-    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}),
-                     1, 256, 2, 512);
+    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}), 1,
+                     256, 2, 512);
     // Tests that a 256x1x1 region can be written from a 256x1x1 host buffer at
     // offset {0,0,0} to a 256x2x1 device buffer at offset {0,1,0}.
-    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}),
-                     256, 256, 256, 512);
+    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}), 256,
+                     256, 256, 512);
     // Tests that a 8x8x8 region can be written from a 8x8x8 host buffer at
     // offset {0,0,0} to a 8x8x8 device buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}),
-                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}),
-                     8, 64, 8, 64);
+    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}), 8, 64, 8,
+                     64);
     // Tests that a 4x3x2 region can be written from a 8x8x8 host buffer at
     // offset {1,2,3} to a 8x8x8 device buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_3d_with_offsets, 512, 512,
-                     (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}),
-                     (ur_rect_region_t{4, 3, 2}), 8, 64, 8, 64);
+    PARAMETERIZATION(write_3d_with_offsets, 512, 512, (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 3, 2}),
+                     8, 64, 8, 64);
     // Tests that a 4x16x2 region can be written from a 8x32x1 host buffer at
     // offset {1,2,0} to a 8x32x4 device buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}),
-                     (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}),
-                     8, 256, 8, 256);
+    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}), 8, 256,
+                     8, 256);
     // Tests that a 1x4x1 region can be written from a 8x16x4 host buffer at
     // offset {7,3,3} to a 2x8x1 device buffer at offset {1,3,0}.
-    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}),
-                     (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}),
-                     8, 128, 2, 16);
+    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}), (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}), 8, 128, 2,
+                     16);
 #undef PARAMETERIZATION
     return parameterizations;
 }
 
-struct urEnqueueMemBufferWriteRectTestWithParam
-    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+struct urEnqueueMemBufferWriteRectTestWithParam : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_TEST_SUITE_P(
-    urEnqueueMemBufferWriteRectTestWithParam,
-    testing::ValuesIn(generateParameterizations()),
-    uur::printRectTestString<urEnqueueMemBufferWriteRectTestWithParam>);
+UUR_TEST_SUITE_P(urEnqueueMemBufferWriteRectTestWithParam, testing::ValuesIn(generateParameterizations()),
+                 uur::printRectTestString<urEnqueueMemBufferWriteRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
     // Unpack the parameters.
@@ -87,33 +72,26 @@ TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
 
     // Create a buffer we will read from.
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
 
     // Zero it to begin with since the write may not cover the whole buffer.
     const uint8_t zero = 0x0;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &zero, sizeof(zero), 0,
-                                          buffer_size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &zero, sizeof(zero), 0, buffer_size, 0, nullptr, nullptr));
 
     // Create a host buffer of sequentially increasing values.
     std::vector<uint8_t> input(host_size, 0x0);
     std::iota(std::begin(input), std::end(input), 0x0);
 
     // Enqueue the rectangular write from that host buffer.
-    EXPECT_SUCCESS(urEnqueueMemBufferWriteRect(
-        queue, buffer, /* isBlocking */ true, buffer_origin, host_origin,
-        region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
-        host_slice_pitch, input.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferWriteRect(queue, buffer, /* isBlocking */ true, buffer_origin, host_origin, region, buffer_row_pitch,
+                                               buffer_slice_pitch, host_row_pitch, host_slice_pitch, input.data(), 0, nullptr, nullptr));
 
     std::vector<uint8_t> output(buffer_size, 0x0);
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, /* is_blocking */ true,
-                                          0, buffer_size, output.data(), 0,
-                                          nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, /* is_blocking */ true, 0, buffer_size, output.data(), 0, nullptr, nullptr));
 
     // Do host side equivalent.
     std::vector<uint8_t> expected(buffer_size, 0x0);
-    uur::copyRect(input, host_origin, buffer_origin, region, host_row_pitch,
-                  host_slice_pitch, buffer_row_pitch, buffer_slice_pitch,
+    uur::copyRect(input, host_origin, buffer_origin, region, host_row_pitch, host_slice_pitch, buffer_row_pitch, buffer_slice_pitch,
                   expected);
 
     // Verify the results.
@@ -131,11 +109,9 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleQueue) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueMemBufferWriteRect(nullptr, buffer, true, buffer_offset,
-                                    host_offset, region, size, size, size, size,
-                                    src.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEnqueueMemBufferWriteRect(nullptr, buffer, true, buffer_offset, host_offset, region, size, size, size, size,
+                                                 src.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleBuffer) {
@@ -143,11 +119,9 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleBuffer) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueMemBufferWriteRect(queue, nullptr, true, buffer_offset,
-                                    host_offset, region, size, size, size, size,
-                                    src.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEnqueueMemBufferWriteRect(queue, nullptr, true, buffer_offset, host_offset, region, size, size, size, size,
+                                                 src.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPointerSrc) {
@@ -156,8 +130,6 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPointerSrc) {
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferWriteRect(queue, buffer, true,
-                                                 buffer_offset, host_offset,
-                                                 region, size, size, size, size,
-                                                 nullptr, 0, nullptr, nullptr));
+                     urEnqueueMemBufferWriteRect(queue, buffer, true, buffer_offset, host_offset, region, size, size, size, size, nullptr,
+                                                 0, nullptr, nullptr));
 }

--- a/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -5,9 +5,8 @@
 struct urEnqueueMemUnmapTest : public uur::urMemBufferQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urMemBufferQueueTest::SetUp());
-        ASSERT_SUCCESS(urEnqueueMemBufferMap(
-            queue, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE, 0, size,
-            0, nullptr, nullptr, (void **)&map));
+        ASSERT_SUCCESS(
+            urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE, 0, size, 0, nullptr, nullptr, (void **)&map));
     };
 
     void TearDown() override { uur::urMemBufferQueueTest::TearDown(); }
@@ -16,24 +15,16 @@ struct urEnqueueMemUnmapTest : public uur::urMemBufferQueueTest {
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemUnmapTest);
 
-TEST_P(urEnqueueMemUnmapTest, Success) {
-    ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
-}
+TEST_P(urEnqueueMemUnmapTest, Success) { ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr)); }
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueMemUnmap(nullptr, buffer, map, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemUnmap(nullptr, buffer, map, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullHandleMem) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueMemUnmap(queue, nullptr, map, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemUnmap(queue, nullptr, map, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullPtrMap) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urEnqueueMemUnmap(queue, buffer, nullptr, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEnqueueMemUnmap(queue, buffer, nullptr, 0, nullptr, nullptr));
 }

--- a/test/conformance/enqueue/urEnqueueUSMMemset.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemset.cpp
@@ -8,17 +8,14 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMMemsetTest);
 TEST_P(urEnqueueUSMMemsetTest, Success) {
     bool host_usm{false};
     size_t size{sizeof(bool)};
-    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,
-                                   size, &host_usm, nullptr));
+    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_HOST_UNIFIED_MEMORY, size, &host_usm, nullptr));
 
     ur_event_handle_t event = nullptr;
     if (host_usm) { // Only test host USM if device supports it
         int *host_ptr{nullptr};
         ur_usm_mem_flags_t flags;
-        ASSERT_SUCCESS(urUSMHostAlloc(context, &flags, sizeof(int), 0,
-                                      reinterpret_cast<void **>(&host_ptr)));
-        ASSERT_SUCCESS(urEnqueueUSMMemset(queue, host_ptr, 0, sizeof(int), 0,
-                                          nullptr, &event));
+        ASSERT_SUCCESS(urUSMHostAlloc(context, &flags, sizeof(int), 0, reinterpret_cast<void **>(&host_ptr)));
+        ASSERT_SUCCESS(urEnqueueUSMMemset(queue, host_ptr, 0, sizeof(int), 0, nullptr, &event));
         EXPECT_SUCCESS(urQueueFlush(queue));
         ASSERT_SUCCESS(urEventWait(1, &event));
         EXPECT_SUCCESS(urEventRelease(event));
@@ -28,10 +25,8 @@ TEST_P(urEnqueueUSMMemsetTest, Success) {
 
     int *device_ptr{nullptr};
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0,
-                                    reinterpret_cast<void **>(&device_ptr)));
-    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, device_ptr, 1, sizeof(int), 0,
-                                      nullptr, &event));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, reinterpret_cast<void **>(&device_ptr)));
+    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, device_ptr, 1, sizeof(int), 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
     EXPECT_SUCCESS(urEventRelease(event));
@@ -43,28 +38,20 @@ TEST_P(urEnqueueUSMMemsetTest, Success) {
 TEST_P(urEnqueueUSMMemsetTest, InvalidNullQueueHandle) {
     int *ptr{nullptr};
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0,
-                                    reinterpret_cast<void **>(&ptr)));
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEnqueueUSMMemset(nullptr, ptr, 1, sizeof(int), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, reinterpret_cast<void **>(&ptr)));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueUSMMemset(nullptr, ptr, 1, sizeof(int), 0, nullptr, nullptr));
     ASSERT_SUCCESS(urUSMFree(context, ptr));
 }
 
 TEST_P(urEnqueueUSMMemsetTest, InvalidNullPtr) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueUSMMemset(queue, nullptr, 1, sizeof(int), 0,
-                                        nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEnqueueUSMMemset(queue, nullptr, 1, sizeof(int), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMMemsetTest, InvalidNullPtrEventWaitList) {
     int *ptr{nullptr};
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0,
-                                    reinterpret_cast<void **>(&ptr)));
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urEnqueueUSMMemset(queue, ptr, 1, sizeof(int), 1, nullptr, nullptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, reinterpret_cast<void **>(&ptr)));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEnqueueUSMMemset(queue, ptr, 1, sizeof(int), 1, nullptr, nullptr));
     ASSERT_SUCCESS(urUSMFree(context, ptr));
 }
 
@@ -72,7 +59,5 @@ TEST_P(urEnqueueUSMMemsetTest, InvalidMemObject) {
     // Random pointer which is not a usm allocation
     intptr_t address = 0xDEADBEEF;
     int *ptr = reinterpret_cast<int *>(address);
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_MEM_OBJECT,
-        urEnqueueUSMMemset(queue, ptr, 1, sizeof(int), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_MEM_OBJECT, urEnqueueUSMMemset(queue, ptr, 1, sizeof(int), 0, nullptr, nullptr));
 }

--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -15,17 +15,15 @@ namespace event {
  * - Execution Status: UR_EVENT_STATUS_COMPLETE
  * - Reference Count: 1
  */
-template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
+template <class T>
+struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_WRITE_ONLY,
-                                         size, nullptr, &buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &buffer));
 
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(this->queue, buffer, false, 0,
-                                               size, input.data(), 0, nullptr,
-                                               &event));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(this->queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
         ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
@@ -55,12 +53,10 @@ struct urEventReferenceTest : uur::urQueueTest {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
-                                         nullptr, &buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &buffer));
 
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(
-            queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
     }
 
     void TearDown() override {
@@ -72,8 +68,7 @@ struct urEventReferenceTest : uur::urQueueTest {
 
     bool checkEventReferenceCount(uint32_t expected_value) {
         uint32_t reference_count{};
-        urEventGetInfo(event, ur_event_info_t::UR_EVENT_INFO_REFERENCE_COUNT,
-                       sizeof(uint32_t), &reference_count, nullptr);
+        urEventGetInfo(event, ur_event_info_t::UR_EVENT_INFO_REFERENCE_COUNT, sizeof(uint32_t), &reference_count, nullptr);
         return reference_count == expected_value;
     }
 

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -12,8 +12,7 @@ TEST_P(urEventGetInfoTest, Success) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(
-        urEventGetInfo(event, info_type, size, data.data(), nullptr));
+    ASSERT_SUCCESS(urEventGetInfo(event, info_type, size, data.data(), nullptr));
 
     switch (info_type) {
     case UR_EVENT_INFO_COMMAND_QUEUE: {
@@ -22,8 +21,7 @@ TEST_P(urEventGetInfoTest, Success) {
         break;
     }
     case UR_EVENT_INFO_CONTEXT: {
-        auto returned_context =
-            reinterpret_cast<ur_context_handle_t>(data.data());
+        auto returned_context = reinterpret_cast<ur_context_handle_t>(data.data());
         ASSERT_EQ(context, returned_context);
         break;
     }
@@ -33,14 +31,12 @@ TEST_P(urEventGetInfoTest, Success) {
         break;
     }
     case UR_EVENT_INFO_COMMAND_EXECUTION_STATUS: {
-        auto returned_status =
-            reinterpret_cast<ur_event_status_t *>(data.data());
+        auto returned_status = reinterpret_cast<ur_event_status_t *>(data.data());
         ASSERT_EQ(UR_EVENT_STATUS_COMPLETE, *returned_status);
         break;
     }
     case UR_EVENT_INFO_REFERENCE_COUNT: {
-        auto returned_reference_count =
-            reinterpret_cast<uint32_t *>(data.data());
+        auto returned_reference_count = reinterpret_cast<uint32_t *>(data.data());
         ASSERT_EQ(1, *returned_reference_count);
         break;
     }
@@ -50,11 +46,8 @@ TEST_P(urEventGetInfoTest, Success) {
 }
 
 UUR_TEST_SUITE_P(urEventGetInfoTest,
-                 ::testing::Values(UR_EVENT_INFO_COMMAND_QUEUE,
-                                   UR_EVENT_INFO_CONTEXT,
-                                   UR_EVENT_INFO_COMMAND_TYPE,
-                                   UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
-                                   UR_EVENT_INFO_REFERENCE_COUNT),
+                 ::testing::Values(UR_EVENT_INFO_COMMAND_QUEUE, UR_EVENT_INFO_CONTEXT, UR_EVENT_INFO_COMMAND_TYPE,
+                                   UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, UR_EVENT_INFO_REFERENCE_COUNT),
                  uur::deviceTestWithParamPrinter<ur_event_info_t>);
 
 using urEventGetInfoNegativeTest = uur::event::urEventTest;
@@ -67,16 +60,12 @@ TEST_P(urEventGetInfoNegativeTest, InvalidNullHandle) {
     std::vector<uint8_t> data(size);
 
     /* Invalid hEvent */
-    ASSERT_EQ(
-        urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0, nullptr, &size),
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ(urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0, nullptr, &size), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventGetInfoNegativeTest, InvalidEnumeration) {
     size_t size;
-    ASSERT_EQ(
-        urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0, nullptr, &size),
-        UR_RESULT_ERROR_INVALID_ENUMERATION);
+    ASSERT_EQ(urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0, nullptr, &size), UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urEventGetInfoNegativeTest, InvalidValue) {
@@ -87,9 +76,7 @@ TEST_P(urEventGetInfoNegativeTest, InvalidValue) {
     std::vector<uint8_t> data(size);
 
     /* Invalid propValueSize */
-    ASSERT_EQ(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0, data.data(),
-                             nullptr),
-              UR_RESULT_ERROR_INVALID_VALUE);
+    ASSERT_EQ(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0, data.data(), nullptr), UR_RESULT_ERROR_INVALID_VALUE);
 }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetInfoNegativeTest);

--- a/test/conformance/event/urEventGetProfilingInfo.cpp
+++ b/test/conformance/event/urEventGetProfilingInfo.cpp
@@ -3,20 +3,17 @@
 
 #include "fixtures.h"
 
-using urEventGetProfilingInfoTest =
-    uur::event::urEventTestWithParam<ur_profiling_info_t>;
+using urEventGetProfilingInfoTest = uur::event::urEventTestWithParam<ur_profiling_info_t>;
 
 TEST_P(urEventGetProfilingInfoTest, Success) {
 
     ur_profiling_info_t info_type = getParam();
     size_t size;
-    ASSERT_SUCCESS(
-        urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
+    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, 8);
 
     std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(
-        urEventGetProfilingInfo(event, info_type, size, data.data(), nullptr));
+    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, size, data.data(), nullptr));
 
     if (sizeof(size_t) == size) {
         auto returned_value = reinterpret_cast<size_t *>(data.data());
@@ -25,9 +22,7 @@ TEST_P(urEventGetProfilingInfoTest, Success) {
 }
 
 UUR_TEST_SUITE_P(urEventGetProfilingInfoTest,
-                 ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED,
-                                   UR_PROFILING_INFO_COMMAND_SUBMIT,
-                                   UR_PROFILING_INFO_COMMAND_START,
+                 ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED, UR_PROFILING_INFO_COMMAND_SUBMIT, UR_PROFILING_INFO_COMMAND_START,
                                    UR_PROFILING_INFO_COMMAND_END),
                  uur::deviceTestWithParamPrinter<ur_profiling_info_t>);
 
@@ -36,35 +31,28 @@ using urEventGetProfilingInfoNegativeTest = uur::event::urEventTest;
 TEST_P(urEventGetProfilingInfoNegativeTest, InvalidNullHandle) {
     ur_profiling_info_t info_type = UR_PROFILING_INFO_COMMAND_QUEUED;
     size_t size;
-    ASSERT_SUCCESS(
-        urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
+    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
 
     /* Invalid hEvent */
-    ASSERT_EQ(urEventGetProfilingInfo(nullptr, info_type, 0, nullptr, &size),
-              UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ(urEventGetProfilingInfo(nullptr, info_type, 0, nullptr, &size), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventGetProfilingInfoNegativeTest, InvalidEnumeration) {
     size_t size;
-    ASSERT_EQ(urEventGetProfilingInfo(event, UR_PROFILING_INFO_FORCE_UINT32, 0,
-                                      nullptr, &size),
-              UR_RESULT_ERROR_INVALID_ENUMERATION);
+    ASSERT_EQ(urEventGetProfilingInfo(event, UR_PROFILING_INFO_FORCE_UINT32, 0, nullptr, &size), UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urEventGetProfilingInfoNegativeTest, InvalidValue) {
     ur_profiling_info_t info_type = UR_PROFILING_INFO_COMMAND_QUEUED;
     size_t size;
-    ASSERT_SUCCESS(
-        urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
+    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
 
     /* Invalid propValueSize */
-    ASSERT_EQ(
-        urEventGetProfilingInfo(event, info_type, 0, data.data(), nullptr),
-        UR_RESULT_ERROR_INVALID_VALUE);
+    ASSERT_EQ(urEventGetProfilingInfo(event, info_type, 0, data.data(), nullptr), UR_RESULT_ERROR_INVALID_VALUE);
 }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetProfilingInfoNegativeTest);

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -19,9 +19,7 @@ TEST_P(urEventReleaseTest, CheckReferenceCount) {
 
 using urEventReleaseNegativeTest = uur::urQueueTest;
 
-TEST_P(urEventReleaseNegativeTest, InvalidNullHandle) {
-    ASSERT_EQ(urEventRelease(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-}
+TEST_P(urEventReleaseNegativeTest, InvalidNullHandle) { ASSERT_EQ(urEventRelease(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE); }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseTest);
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseNegativeTest);

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -23,9 +23,7 @@ TEST_P(urEventRetainTest, CheckReferenceCount) {
 
 using urEventRetainNegativeTest = uur::urQueueTest;
 
-TEST_P(urEventRetainNegativeTest, InvalidNullHandle) {
-    ASSERT_EQ(urEventRetain(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-}
+TEST_P(urEventRetainNegativeTest, InvalidNullHandle) { ASSERT_EQ(urEventRetain(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE); }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainTest);
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainNegativeTest);

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -12,8 +12,7 @@ using urEventSetCallbackTest = uur::event::urEventReferenceTest;
 TEST_P(urEventSetCallbackTest, Success) {
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
-                             ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<bool *>(pUserData);
             *status = true;
@@ -21,9 +20,7 @@ TEST_P(urEventSetCallbackTest, Success) {
     };
 
     bool didRun = false;
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-        Callback::callback, &didRun));
+    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE, Callback::callback, &didRun));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ASSERT_SUCCESS(urEventRelease(event));
@@ -41,8 +38,7 @@ TEST_P(urEventSetCallbackTest, ValidateParameters) {
     };
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
-                             ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
 
             auto parameters = reinterpret_cast<CallbackParameters *>(pUserData);
             parameters->event = hEvent;
@@ -52,15 +48,13 @@ TEST_P(urEventSetCallbackTest, ValidateParameters) {
 
     CallbackParameters parameters{};
 
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-        Callback::callback, &parameters));
+    ASSERT_SUCCESS(
+        urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE, Callback::callback, &parameters));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ASSERT_SUCCESS(urEventRelease(event));
     ASSERT_EQ(event, parameters.event);
-    ASSERT_EQ(ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-              parameters.execStatus);
+    ASSERT_EQ(ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE, parameters.execStatus);
 }
 
 /**
@@ -76,8 +70,7 @@ TEST_P(urEventSetCallbackTest, AllStates) {
     };
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
-                             ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<CallbackStatus *>(pUserData);
             switch (execStatus) {
@@ -85,18 +78,15 @@ TEST_P(urEventSetCallbackTest, AllStates) {
                 status->queued = true;
                 break;
             }
-            case ur_execution_info_t::
-                UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED: {
+            case ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED: {
                 status->submitted = true;
                 break;
             }
-            case ur_execution_info_t::
-                UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING: {
+            case ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING: {
                 status->running = true;
                 break;
             }
-            case ur_execution_info_t::
-                UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE: {
+            case ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE: {
                 status->complete = true;
                 break;
             }
@@ -109,18 +99,10 @@ TEST_P(urEventSetCallbackTest, AllStates) {
 
     CallbackStatus status{};
 
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
-        Callback::callback, &status));
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED,
-        Callback::callback, &status));
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING,
-        Callback::callback, &status));
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-        Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED, Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED, Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING, Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE, Callback::callback, &status));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ASSERT_SUCCESS(urEventRelease(event));
@@ -140,8 +122,7 @@ TEST_P(urEventSetCallbackTest, EventAlreadyCompleted) {
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
-                             ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<bool *>(pUserData);
             *status = true;
@@ -150,9 +131,7 @@ TEST_P(urEventSetCallbackTest, EventAlreadyCompleted) {
 
     bool didRun = false;
 
-    ASSERT_SUCCESS(urEventSetCallback(
-        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-        Callback::callback, &didRun));
+    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE, Callback::callback, &didRun));
 
     ASSERT_SUCCESS(urEventRelease(event));
     ASSERT_TRUE(didRun);
@@ -163,28 +142,19 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventSetCallbackTest);
 /* Negative tests */
 using urEventSetCallbackNegativeTest = uur::event::urEventTest;
 
-void emptyCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
-                   void *pUserData) {}
+void emptyCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {}
 
 TEST_P(urEventSetCallbackNegativeTest, InvalidNullHandle) {
 
-    ASSERT_EQ(urEventSetCallback(
-                  nullptr,
-                  ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
-                  emptyCallback, nullptr),
+    ASSERT_EQ(urEventSetCallback(nullptr, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED, emptyCallback, nullptr),
               UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
-    ASSERT_EQ(urEventSetCallback(
-                  event,
-                  ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
-                  nullptr, nullptr),
+    ASSERT_EQ(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED, nullptr, nullptr),
               UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventSetCallbackNegativeTest, InvalidEnumeration) {
-    ASSERT_EQ(urEventSetCallback(
-                  event, ur_execution_info_t::UR_EXECUTION_INFO_FORCE_UINT32,
-                  emptyCallback, nullptr),
+    ASSERT_EQ(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_FORCE_UINT32, emptyCallback, nullptr),
               UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 

--- a/test/conformance/event/urEventWait.cpp
+++ b/test/conformance/event/urEventWait.cpp
@@ -6,14 +6,10 @@
 struct urEventWaitTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
-                                         nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
-                                         nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, false, 0,
-                                               size, input.data(), 0, nullptr,
-                                               &event));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, false, 0, size, input.data(), 0, nullptr, &event));
         ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
@@ -41,16 +37,13 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitTest);
 
 TEST_P(urEventWaitTest, Success) {
     ur_event_handle_t event1 = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
-                                          size, 0, nullptr, &event1));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event1));
     std::vector<uint32_t> output(count, 1);
     ur_event_handle_t event2 = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, false, 0, size,
-                                          output.data(), 0, nullptr, &event2));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, false, 0, size, output.data(), 0, nullptr, &event2));
     std::vector<ur_event_handle_t> events{event1, event2};
     EXPECT_SUCCESS(urQueueFlush(queue));
-    ASSERT_SUCCESS(
-        urEventWait(static_cast<uint32_t>(events.size()), events.data()));
+    ASSERT_SUCCESS(urEventWait(static_cast<uint32_t>(events.size()), events.data()));
     ASSERT_EQ(input, output);
 
     EXPECT_SUCCESS(urEventRelease(event1));
@@ -61,11 +54,8 @@ using urEventWaitNegativeTest = uur::urQueueTest;
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitNegativeTest);
 
-TEST_P(urEventWaitNegativeTest, ZeroSize) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE, urEventWait(0, nullptr));
-}
+TEST_P(urEventWaitNegativeTest, ZeroSize) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE, urEventWait(0, nullptr)); }
 
 TEST_P(urEventWaitNegativeTest, InvalidNullPointerEventList) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEventWait(1, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEventWait(1, nullptr));
 }

--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -7,64 +7,47 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateTest);
 
 TEST_P(urMemBufferCreateTest, Success) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096,
-                                     nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096, nullptr, &buffer));
     ASSERT_NE(nullptr, buffer);
     ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidNullHandleContext) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urMemBufferCreate(nullptr, UR_MEM_FLAG_READ_WRITE, 4096,
-                                       nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemBufferCreate(nullptr, UR_MEM_FLAG_READ_WRITE, 4096, nullptr, &buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidEnumerationFlags) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urMemBufferCreate(context, UR_MEM_FLAG_FORCE_UINT32, 4096,
-                                       nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urMemBufferCreate(context, UR_MEM_FLAG_FORCE_UINT32, 4096, nullptr, &buffer));
 }
 
-using urMemBufferCreateTestWithFlagsParam =
-    uur::urContextTestWithParam<ur_mem_flag_t>;
+using urMemBufferCreateTestWithFlagsParam = uur::urContextTestWithParam<ur_mem_flag_t>;
 
-using urMemBufferCreateWithHostPtrFlagsTest =
-    urMemBufferCreateTestWithFlagsParam;
+using urMemBufferCreateWithHostPtrFlagsTest = urMemBufferCreateTestWithFlagsParam;
 UUR_TEST_SUITE_P(urMemBufferCreateWithHostPtrFlagsTest,
-                 ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
-                                   UR_MEM_FLAG_ALLOC_HOST_POINTER,
-                                   UR_MEM_FLAG_USE_HOST_POINTER),
+                 ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER, UR_MEM_FLAG_ALLOC_HOST_POINTER, UR_MEM_FLAG_USE_HOST_POINTER),
                  uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferCreateWithHostPtrFlagsTest, InvalidHostPtr) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_HOST_PTR,
-        urMemBufferCreate(context, getParam(), 4096, nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_HOST_PTR, urMemBufferCreate(context, getParam(), 4096, nullptr, &buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidNullPointerBuffer) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096,
-                                       nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096, nullptr, nullptr));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidBufferSizeZero) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
-                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 0,
-                                       nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE, urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 0, nullptr, &buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidBufferSizeMax) {
     ur_mem_handle_t buffer = nullptr;
     uint64_t max_size = 0;
-    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,
-                                   sizeof(uint64_t), &max_size, nullptr));
+    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE, sizeof(uint64_t), &max_size, nullptr));
     ASSERT_NE(max_size, 0);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
-                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                       max_size + 1, nullptr, &buffer));
+                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, max_size + 1, nullptr, &buffer));
 }

--- a/test/conformance/memory/urMemBufferPartition.cpp
+++ b/test/conformance/memory/urMemBufferPartition.cpp
@@ -9,8 +9,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferPartitionTest);
 TEST_P(urMemBufferPartitionTest, Success) {
     ur_buffer_region_t region{0, 1024};
     ur_mem_handle_t partition = nullptr;
-    ASSERT_SUCCESS(urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
-                                        UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                        &partition));
+    ASSERT_SUCCESS(urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE, UR_BUFFER_CREATE_TYPE_REGION, &region, &partition));
     ASSERT_NE(partition, nullptr);
 }

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -4,8 +4,7 @@
 
 using urMemGetInfoTest = uur::urMemBufferTestWithParam<ur_mem_info_t>;
 
-UUR_TEST_SUITE_P(urMemGetInfoTest,
-                 ::testing::Values(UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT),
+UUR_TEST_SUITE_P(urMemGetInfoTest, ::testing::Values(UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT),
                  uur::deviceTestWithParamPrinter<ur_mem_info_t>);
 
 TEST_P(urMemGetInfoTest, Success) {

--- a/test/conformance/memory/urMemGetNativeHandle.cpp
+++ b/test/conformance/memory/urMemGetNativeHandle.cpp
@@ -14,11 +14,9 @@ TEST_P(urMemGetNativeHandleTest, Success) {
 
 TEST_P(urMemGetNativeHandleTest, InvalidNullHandleMem) {
     ur_native_handle_t phNativeMem;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urMemGetNativeHandle(nullptr, &phNativeMem));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemGetNativeHandle(nullptr, &phNativeMem));
 }
 
 TEST_P(urMemGetNativeHandleTest, InvalidNullPointerNativeMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urMemGetNativeHandle(buffer, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urMemGetNativeHandle(buffer, nullptr));
 }

--- a/test/conformance/memory/urMemRelease.cpp
+++ b/test/conformance/memory/urMemRelease.cpp
@@ -10,7 +10,4 @@ TEST_P(urMemReleaseTest, Success) {
     ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
-TEST_P(urMemReleaseTest, InvalidNullHandleMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urMemRelease(nullptr));
-}
+TEST_P(urMemReleaseTest, InvalidNullHandleMem) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemRelease(nullptr)); }

--- a/test/conformance/memory/urMemRetain.cpp
+++ b/test/conformance/memory/urMemRetain.cpp
@@ -10,6 +10,4 @@ TEST_P(urMemRetainTest, Success) {
     EXPECT_SUCCESS(urMemRelease(buffer));
 }
 
-TEST_P(urMemRetainTest, InvalidNullHandleMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemRetain(nullptr));
-}
+TEST_P(urMemRetainTest, InvalidNullHandleMem) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemRetain(nullptr)); }

--- a/test/conformance/platform/urInit.cpp
+++ b/test/conformance/platform/urInit.cpp
@@ -11,7 +11,6 @@ TEST(urInitTest, Success) {
 }
 
 TEST(urInitTest, ErrorInvalidEnumerationDeviceFlags) {
-    const ur_device_init_flags_t device_flags =
-        UR_DEVICE_INIT_FLAG_FORCE_UINT32;
+    const ur_device_init_flags_t device_flags = UR_DEVICE_INIT_FLAG_FORCE_UINT32;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urInit(device_flags));
 }

--- a/test/conformance/platform/urPlatformGet.cpp
+++ b/test/conformance/platform/urPlatformGet.cpp
@@ -20,6 +20,5 @@ TEST_F(urPlatformGetTest, InvalidNumEntries) {
     uint32_t count;
     ASSERT_SUCCESS(urPlatformGet(0, nullptr, &count));
     std::vector<ur_platform_handle_t> platforms(count);
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urPlatformGet(0, platforms.data(), nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE, urPlatformGet(0, platforms.data(), nullptr));
 }

--- a/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/test/conformance/platform/urPlatformGetInfo.cpp
@@ -4,30 +4,25 @@
 #include "fixtures.h"
 #include <cstring>
 
-struct urPlatformGetInfoTest
-    : uur::platform::urPlatformTest,
-      ::testing::WithParamInterface<ur_platform_info_t> {
+struct urPlatformGetInfoTest : uur::platform::urPlatformTest, ::testing::WithParamInterface<ur_platform_info_t> {
 
-    void SetUp() {
-        UUR_RETURN_ON_FATAL_FAILURE(uur::platform::urPlatformTest::SetUp());
-    }
+    void SetUp() { UUR_RETURN_ON_FATAL_FAILURE(uur::platform::urPlatformTest::SetUp()); }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    urPlatformGetInfo, urPlatformGetInfoTest,
-    ::testing::Values(UR_PLATFORM_INFO_NAME
-                      /*
+INSTANTIATE_TEST_SUITE_P(urPlatformGetInfo, urPlatformGetInfoTest,
+                         ::testing::Values(UR_PLATFORM_INFO_NAME
+                                           /*
                         UR_PLATFORM_INFO_VENDOR_NAME,
                         UR_PLATFORM_INFO_VERSION,
                         UR_PLATFORM_INFO_EXTENSIONS,
                         UR_PLATFORM_INFO_PROFILE
                       */
-                      ),
-    [](const ::testing::TestParamInfo<ur_platform_info_t> &info) {
-        std::stringstream ss;
-        ss << info.param;
-        return ss.str();
-    });
+                                           ),
+                         [](const ::testing::TestParamInfo<ur_platform_info_t> &info) {
+                             std::stringstream ss;
+                             ss << info.param;
+                             return ss.str();
+                         });
 
 TEST_P(urPlatformGetInfoTest, Success) {
     size_t size = 0;
@@ -35,20 +30,16 @@ TEST_P(urPlatformGetInfoTest, Success) {
     ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<char> name(size);
-    ASSERT_SUCCESS(
-        urPlatformGetInfo(platform, info_type, size, name.data(), nullptr));
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size, name.data(), nullptr));
     ASSERT_EQ(size, std::strlen(name.data()) + 1);
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidNullHandlePlatform) {
     size_t size = 0;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urPlatformGetInfo(nullptr, GetParam(), 0, nullptr, &size));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urPlatformGetInfo(nullptr, GetParam(), 0, nullptr, &size));
 }
 
 TEST_F(urPlatformGetInfoTest, InvalidEnumerationPlatformInfoType) {
     size_t size = 0;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urPlatformGetInfo(platform, UR_PLATFORM_INFO_FORCE_UINT32,
-                                       0, nullptr, &size));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urPlatformGetInfo(platform, UR_PLATFORM_INFO_FORCE_UINT32, 0, nullptr, &size));
 }

--- a/test/conformance/platform/urTearDown.cpp
+++ b/test/conformance/platform/urTearDown.cpp
@@ -14,6 +14,4 @@ TEST_F(urTearDownTest, Success) {
     ASSERT_SUCCESS(urTearDown(&tear_down_params));
 }
 
-TEST_F(urTearDownTest, InvalidNullPointerParams) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urTearDown(nullptr));
-}
+TEST_F(urTearDownTest, InvalidNullPointerParams) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urTearDown(nullptr)); }

--- a/test/conformance/queue/urQueueCreate.cpp
+++ b/test/conformance/queue/urQueueCreate.cpp
@@ -14,25 +14,20 @@ TEST_P(urQueueCreateTest, Success) {
 
 TEST_P(urQueueCreateTest, InvalidNullHandleContext) {
     ur_queue_handle_t queue = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueCreate(nullptr, device, 0, &queue));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueCreate(nullptr, device, 0, &queue));
 }
 
 TEST_P(urQueueCreateTest, InvalidNullHandleDevice) {
     ur_queue_handle_t queue = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueCreate(context, nullptr, 0, &queue));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueCreate(context, nullptr, 0, &queue));
 }
 
 TEST_P(urQueueCreateTest, InvalidEnumerationProps) {
     ur_queue_handle_t queue = nullptr;
-    ur_queue_property_t props[] = {UR_QUEUE_PROPERTIES_FLAGS,
-                                   UR_QUEUE_FLAG_FORCE_UINT32, 0};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urQueueCreate(context, device, props, &queue));
+    ur_queue_property_t props[] = {UR_QUEUE_PROPERTIES_FLAGS, UR_QUEUE_FLAG_FORCE_UINT32, 0};
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urQueueCreate(context, device, props, &queue));
 }
 
 TEST_P(urQueueCreateTest, InvalidNullPointerQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urQueueCreate(context, device, 0, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urQueueCreate(context, device, 0, nullptr));
 }

--- a/test/conformance/queue/urQueueFinish.cpp
+++ b/test/conformance/queue/urQueueFinish.cpp
@@ -8,25 +8,18 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFinishTest);
 TEST_P(urQueueFinishTest, Success) {
     constexpr size_t buffer_size = 1024;
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
 
     ur_event_handle_t event = nullptr;
     std::vector<uint8_t> data(buffer_size, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false,
-                                           0, 1024, data.data(), 0, nullptr,
-                                           &event));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false, 0, 1024, data.data(), 0, nullptr, &event));
 
     ASSERT_SUCCESS(urQueueFinish(queue));
 
     // check that enqueued commands have completed
     ur_event_status_t exec_status;
-    ASSERT_SUCCESS(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
-                                  sizeof(exec_status), &exec_status, nullptr));
+    ASSERT_SUCCESS(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, sizeof(exec_status), &exec_status, nullptr));
     ASSERT_EQ(exec_status, UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE);
 }
 
-TEST_P(urQueueFinishTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueFinish(nullptr));
-}
+TEST_P(urQueueFinishTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueFinish(nullptr)); }

--- a/test/conformance/queue/urQueueFlush.cpp
+++ b/test/conformance/queue/urQueueFlush.cpp
@@ -8,18 +8,12 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFlushTest);
 TEST_P(urQueueFlushTest, Success) {
     constexpr size_t buffer_size = 1024;
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
 
     std::vector<uint8_t> data(buffer_size, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false,
-                                           0, 1024, data.data(), 0, nullptr,
-                                           nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false, 0, 1024, data.data(), 0, nullptr, nullptr));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
 }
 
-TEST_P(urQueueFlushTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueFlush(nullptr));
-}
+TEST_P(urQueueFlushTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueFlush(nullptr)); }

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -5,11 +5,8 @@
 using urQueueGetInfoTest = uur::urQueueTestWithParam<ur_queue_info_t>;
 
 UUR_TEST_SUITE_P(urQueueGetInfoTest,
-                 ::testing::Values(UR_QUEUE_INFO_CONTEXT, UR_QUEUE_INFO_DEVICE,
-                                   UR_QUEUE_INFO_DEVICE_DEFAULT,
-                                   UR_QUEUE_INFO_PROPERTIES,
-                                   UR_QUEUE_INFO_REFERENCE_COUNT,
-                                   UR_QUEUE_INFO_SIZE),
+                 ::testing::Values(UR_QUEUE_INFO_CONTEXT, UR_QUEUE_INFO_DEVICE, UR_QUEUE_INFO_DEVICE_DEFAULT, UR_QUEUE_INFO_PROPERTIES,
+                                   UR_QUEUE_INFO_REFERENCE_COUNT, UR_QUEUE_INFO_SIZE),
                  uur::deviceTestWithParamPrinter<ur_queue_info_t>);
 
 TEST_P(urQueueGetInfoTest, Success) {
@@ -18,6 +15,5 @@ TEST_P(urQueueGetInfoTest, Success) {
     ASSERT_SUCCESS(urQueueGetInfo(queue, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(
-        urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
+    ASSERT_SUCCESS(urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
 }

--- a/test/conformance/queue/urQueueRelease.cpp
+++ b/test/conformance/queue/urQueueRelease.cpp
@@ -10,7 +10,4 @@ TEST_P(urQueueReleaseTest, Success) {
     ASSERT_SUCCESS(urQueueRelease(queue));
 }
 
-TEST_P(urQueueReleaseTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueRelease(nullptr));
-}
+TEST_P(urQueueReleaseTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueRelease(nullptr)); }

--- a/test/conformance/queue/urQueueRetain.cpp
+++ b/test/conformance/queue/urQueueRetain.cpp
@@ -10,7 +10,4 @@ TEST_P(urQueueRetainTest, Success) {
     EXPECT_SUCCESS(urQueueRelease(queue));
 }
 
-TEST_P(urQueueRetainTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueRetain(nullptr));
-}
+TEST_P(urQueueRetainTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueRetain(nullptr)); }

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -11,27 +11,23 @@ constexpr char ERROR_NO_ADAPTER[] = "Could not load adapter";
 
 PlatformEnvironment *PlatformEnvironment::instance = nullptr;
 
-std::ostream &operator<<(std::ostream &out,
-                         const ur_platform_handle_t &platform) {
+std::ostream &operator<<(std::ostream &out, const ur_platform_handle_t &platform) {
     size_t size;
     urPlatformGetInfo(platform, UR_PLATFORM_INFO_NAME, 0, nullptr, &size);
     std::vector<char> name(size);
-    urPlatformGetInfo(platform, UR_PLATFORM_INFO_NAME, size, name.data(),
-                      nullptr);
+    urPlatformGetInfo(platform, UR_PLATFORM_INFO_NAME, size, name.data(), nullptr);
     out << name.data();
     return out;
 }
 
-std::ostream &operator<<(std::ostream &out,
-                         const std::vector<ur_platform_handle_t> &platforms) {
+std::ostream &operator<<(std::ostream &out, const std::vector<ur_platform_handle_t> &platforms) {
     for (auto platform : platforms) {
         out << "\n  * \"" << platform << "\"";
     }
     return out;
 }
 
-uur::PlatformEnvironment::PlatformEnvironment(int argc, char **argv)
-    : platform_options{parsePlatformOptions(argc, argv)} {
+uur::PlatformEnvironment::PlatformEnvironment(int argc, char **argv) : platform_options{parsePlatformOptions(argc, argv)} {
     instance = this;
     ur_device_init_flags_t device_flags = 0;
     switch (urInit(device_flags)) {
@@ -77,14 +73,12 @@ uur::PlatformEnvironment::PlatformEnvironment(int argc, char **argv)
     } else {
         for (auto candidate : platforms) {
             size_t size;
-            if (urPlatformGetInfo(candidate, UR_PLATFORM_INFO_NAME, 0, nullptr,
-                                  &size)) {
+            if (urPlatformGetInfo(candidate, UR_PLATFORM_INFO_NAME, 0, nullptr, &size)) {
                 error = "urPlatformGetInfoFailed";
                 return;
             }
             std::vector<char> platform_name(size);
-            if (urPlatformGetInfo(candidate, UR_PLATFORM_INFO_NAME, size,
-                                  platform_name.data(), nullptr)) {
+            if (urPlatformGetInfo(candidate, UR_PLATFORM_INFO_NAME, size, platform_name.data(), nullptr)) {
                 error = "urPlatformGetInfo() failed";
                 return;
             }
@@ -126,18 +120,15 @@ void uur::PlatformEnvironment::TearDown() {
     }
 }
 
-PlatformEnvironment::PlatformOptions
-PlatformEnvironment::parsePlatformOptions(int argc, char **argv) {
+PlatformEnvironment::PlatformOptions PlatformEnvironment::parsePlatformOptions(int argc, char **argv) {
     PlatformOptions options;
     for (int argi = 1; argi < argc; ++argi) {
         const char *arg = argv[argi];
         if (!(std::strcmp(arg, "-h") && std::strcmp(arg, "--help"))) {
             // TODO - print help
             break;
-        } else if (std::strncmp(
-                       arg, "--platform=", sizeof("--platform=") - 1) == 0) {
-            options.platform_name =
-                std::string(&arg[std::strlen("--platform=")]);
+        } else if (std::strncmp(arg, "--platform=", sizeof("--platform=") - 1) == 0) {
+            options.platform_name = std::string(&arg[std::strlen("--platform=")]);
         }
     }
     return options;
@@ -145,8 +136,7 @@ PlatformEnvironment::parsePlatformOptions(int argc, char **argv) {
 
 DevicesEnvironment *DevicesEnvironment::instance = nullptr;
 
-DevicesEnvironment::DevicesEnvironment(int argc, char **argv)
-    : PlatformEnvironment(argc, argv) {
+DevicesEnvironment::DevicesEnvironment(int argc, char **argv) : PlatformEnvironment(argc, argv) {
     instance = this;
     if (!error.empty()) {
         return;
@@ -161,8 +151,7 @@ DevicesEnvironment::DevicesEnvironment(int argc, char **argv)
         return;
     }
     devices.resize(count);
-    if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, devices.data(),
-                    nullptr)) {
+    if (urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, devices.data(), nullptr)) {
         error = "urDeviceGet() failed to get devices.";
         return;
     }

--- a/test/conformance/testing/uur/checks.h
+++ b/test/conformance/testing/uur/checks.h
@@ -12,9 +12,7 @@ namespace uur {
 struct Result {
     Result(ur_result_t result) noexcept : value(result) {}
 
-    constexpr bool operator==(const Result &rhs) const noexcept {
-        return value == rhs.value;
-    }
+    constexpr bool operator==(const Result &rhs) const noexcept { return value == rhs.value; }
 
     ur_result_t value;
 };
@@ -26,9 +24,9 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
 
 inline std::ostream &operator<<(std::ostream &out, const ur_result_t &result) {
     switch (result) {
-#define CASE(VALUE)                                                            \
-    case VALUE:                                                                \
-        out << #VALUE;                                                         \
+#define CASE(VALUE)    \
+    case VALUE:        \
+        out << #VALUE; \
         break;
 
         CASE(UR_RESULT_SUCCESS)
@@ -110,28 +108,25 @@ inline std::ostream &operator<<(std::ostream &out, const ur_result_t &result) {
 } // namespace uur
 
 #ifndef ASSERT_EQ_RESULT
-#define ASSERT_EQ_RESULT(EXPECTED, ACTUAL)                                     \
-    ASSERT_EQ(uur::Result(EXPECTED), uur::Result(ACTUAL))
+#define ASSERT_EQ_RESULT(EXPECTED, ACTUAL) ASSERT_EQ(uur::Result(EXPECTED), uur::Result(ACTUAL))
 #endif
 #ifndef ASSERT_SUCCESS
 #define ASSERT_SUCCESS(ACTUAL) ASSERT_EQ_RESULT(UR_RESULT_SUCCESS, ACTUAL)
 #endif
 
 #ifndef EXPECT_EQ_RESULT
-#define EXPECT_EQ_RESULT(EXPECTED, ACTUAL)                                     \
-    EXPECT_EQ(uur::Result(EXPECTED), uur::Result(ACTUAL))
+#define EXPECT_EQ_RESULT(EXPECTED, ACTUAL) EXPECT_EQ(uur::Result(EXPECTED), uur::Result(ACTUAL))
 #endif
 #ifndef EXPECT_SUCCESS
 #define EXPECT_SUCCESS(ACTUAL) EXPECT_EQ_RESULT(UR_RESULT_SUCCESS, ACTUAL)
 #endif
 
-inline std::ostream &operator<<(std::ostream &out,
-                                const ur_device_info_t &info_type) {
+inline std::ostream &operator<<(std::ostream &out, const ur_device_info_t &info_type) {
     switch (info_type) {
 
-#define CASE(VALUE)                                                            \
-    case VALUE:                                                                \
-        out << #VALUE;                                                         \
+#define CASE(VALUE)    \
+    case VALUE:        \
+        out << #VALUE; \
         break;
 
         CASE(UR_DEVICE_INFO_TYPE)
@@ -240,13 +235,12 @@ inline std::ostream &operator<<(std::ostream &out,
     return out;
 }
 
-inline std::ostream &operator<<(std::ostream &out,
-                                const ur_platform_info_t &info) {
+inline std::ostream &operator<<(std::ostream &out, const ur_platform_info_t &info) {
 
     switch (info) {
-#define CASE(VALUE)                                                            \
-    case VALUE:                                                                \
-        out << #VALUE;                                                         \
+#define CASE(VALUE)    \
+    case VALUE:        \
+        out << #VALUE; \
         break;
         CASE(UR_PLATFORM_INFO_NAME)
         CASE(UR_PLATFORM_INFO_VENDOR_NAME)
@@ -262,12 +256,11 @@ inline std::ostream &operator<<(std::ostream &out,
     return out;
 }
 
-inline std::ostream &operator<<(std::ostream &out,
-                                const ur_queue_info_t &info) {
+inline std::ostream &operator<<(std::ostream &out, const ur_queue_info_t &info) {
     switch (info) {
-#define CASE(VALUE)                                                            \
-    case VALUE:                                                                \
-        out << #VALUE;                                                         \
+#define CASE(VALUE)    \
+    case VALUE:        \
+        out << #VALUE; \
         break;
 
         CASE(UR_QUEUE_INFO_CONTEXT)
@@ -288,9 +281,9 @@ inline std::ostream &operator<<(std::ostream &out,
 inline std::ostream &operator<<(std::ostream &out, const ur_mem_info_t &info) {
     switch (info) {
 
-#define CASE(name)                                                             \
-    case name:                                                                 \
-        out << #name;                                                          \
+#define CASE(name)    \
+    case name:        \
+        out << #name; \
         break;
 
         CASE(UR_MEM_INFO_SIZE)
@@ -306,9 +299,9 @@ inline std::ostream &operator<<(std::ostream &out, const ur_mem_info_t &info) {
 
 inline std::ostream &operator<<(std::ostream &out, const ur_mem_flag_t &flag) {
     switch (flag) {
-#define CASE(name)                                                             \
-    case name:                                                                 \
-        out << #name;                                                          \
+#define CASE(name)    \
+    case name:        \
+        out << #name; \
         break;
 
         CASE(UR_MEM_FLAG_READ_WRITE);
@@ -327,12 +320,11 @@ inline std::ostream &operator<<(std::ostream &out, const ur_mem_flag_t &flag) {
     return out;
 }
 
-inline std::ostream &operator<<(std::ostream &out,
-                                const ur_usm_alloc_info_t &info) {
+inline std::ostream &operator<<(std::ostream &out, const ur_usm_alloc_info_t &info) {
     switch (info) {
-#define CASE(name)                                                             \
-    case name:                                                                 \
-        out << #name;                                                          \
+#define CASE(name)    \
+    case name:        \
+        out << #name; \
         break;
 
         CASE(UR_USM_ALLOC_INFO_TYPE);
@@ -349,12 +341,11 @@ inline std::ostream &operator<<(std::ostream &out,
     return out;
 }
 
-inline std::ostream &operator<<(std::ostream &out,
-                                const ur_event_info_t &info) {
+inline std::ostream &operator<<(std::ostream &out, const ur_event_info_t &info) {
     switch (info) {
-#define CASE(name)                                                             \
-    case name:                                                                 \
-        out << #name;                                                          \
+#define CASE(name)    \
+    case name:        \
+        out << #name; \
         break;
 
         CASE(UR_EVENT_INFO_COMMAND_QUEUE);
@@ -372,12 +363,11 @@ inline std::ostream &operator<<(std::ostream &out,
     return out;
 }
 
-inline std::ostream &operator<<(std::ostream &out,
-                                const ur_profiling_info_t &info) {
+inline std::ostream &operator<<(std::ostream &out, const ur_profiling_info_t &info) {
     switch (info) {
-#define CASE(name)                                                             \
-    case name:                                                                 \
-        out << #name;                                                          \
+#define CASE(name)    \
+    case name:        \
+        out << #name; \
         break;
 
         CASE(UR_PROFILING_INFO_COMMAND_QUEUED);

--- a/test/conformance/testing/uur/environment.h
+++ b/test/conformance/testing/uur/environment.h
@@ -38,9 +38,7 @@ struct DevicesEnvironment : PlatformEnvironment {
     virtual void SetUp() override;
     virtual void TearDown() override;
 
-    inline const std::vector<ur_device_handle_t> &GetDevices() const {
-        return devices;
-    }
+    inline const std::vector<ur_device_handle_t> &GetDevices() const { return devices; }
 
     std::vector<ur_device_handle_t> devices;
     static DevicesEnvironment *instance;

--- a/test/conformance/testing/uur/utils.h
+++ b/test/conformance/testing/uur/utils.h
@@ -14,24 +14,19 @@ namespace uur {
 inline std::string GTestSanitizeString(const std::string &str) {
     auto str_cpy = str;
     std::replace_if(
-        str_cpy.begin(), str_cpy.end(), [](char c) { return !std::isalnum(c); },
-        '_');
+        str_cpy.begin(), str_cpy.end(), [](char c) { return !std::isalnum(c); }, '_');
     return str_cpy;
 }
 
-inline ur_platform_handle_t GetPlatform() {
-    return PlatformEnvironment::instance->platform;
-}
+inline ur_platform_handle_t GetPlatform() { return PlatformEnvironment::instance->platform; }
 
 inline std::string GetPlatformName(ur_platform_handle_t hPlatform) {
     size_t name_len = 0;
     urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_NAME, 0, nullptr, &name_len);
     std::string platform_name(name_len, '\0');
-    urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_NAME, name_len,
-                      &platform_name[0], nullptr);
+    urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_NAME, name_len, &platform_name[0], nullptr);
     platform_name.resize(platform_name.find_first_of('\0'));
-    return GTestSanitizeString(
-        std::string(platform_name.data(), platform_name.size()));
+    return GTestSanitizeString(std::string(platform_name.data(), platform_name.size()));
 }
 
 inline std::string GetDeviceName(ur_device_handle_t device) {

--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -9,13 +9,11 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMDeviceAllocTest);
 TEST_P(urUSMDeviceAllocTest, Success) {
     void *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(
-        urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, &ptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, &ptr));
     ASSERT_NE(ptr, nullptr);
 
     ur_event_handle_t event = nullptr;
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     ASSERT_SUCCESS(urUSMFree(context, ptr));
@@ -25,29 +23,21 @@ TEST_P(urUSMDeviceAllocTest, Success) {
 TEST_P(urUSMDeviceAllocTest, InvalidNullHandleContext) {
     void *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urUSMDeviceAlloc(nullptr, device, &flags, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urUSMDeviceAlloc(nullptr, device, &flags, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullHandleDevice) {
     ur_usm_mem_flags_t flags;
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_DEVICE,
-        urUSMDeviceAlloc(context, nullptr, &flags, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_DEVICE, urUSMDeviceAlloc(context, nullptr, &flags, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullPtrProps) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urUSMDeviceAlloc(context, device, nullptr, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urUSMDeviceAlloc(context, device, nullptr, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullPtrResult) {
     ur_usm_mem_flags_t flags;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, nullptr));
 }

--- a/test/conformance/usm/urUSMFree.cpp
+++ b/test/conformance/usm/urUSMFree.cpp
@@ -9,24 +9,16 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMFreeTest);
 TEST_P(urUSMFreeTest, Success) {
     void *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(
-        urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, &ptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &flags, sizeof(int), 0, &ptr));
 
     ur_event_handle_t event = nullptr;
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     ASSERT_NE(ptr, nullptr);
     ASSERT_SUCCESS(urUSMFree(context, ptr));
 }
 
-TEST_P(urUSMFreeTest, InvalidNullContext) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urUSMFree(nullptr, nullptr));
-}
+TEST_P(urUSMFreeTest, InvalidNullContext) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urUSMFree(nullptr, nullptr)); }
 
-TEST_P(urUSMFreeTest, InvalidNullPtrMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urUSMFree(context, nullptr));
-}
+TEST_P(urUSMFreeTest, InvalidNullPtrMem) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urUSMFree(context, nullptr)); }

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -3,25 +3,19 @@
 
 #include <uur/fixtures.h>
 
-using urUSMAllocInfoTest =
-    uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t>;
+using urUSMAllocInfoTest = uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t>;
 
 UUR_TEST_SUITE_P(urUSMAllocInfoTest,
-                 ::testing::Values(UR_USM_ALLOC_INFO_TYPE,
-                                   UR_USM_ALLOC_INFO_BASE_PTR,
-                                   UR_USM_ALLOC_INFO_SIZE,
-                                   UR_USM_ALLOC_INFO_DEVICE),
+                 ::testing::Values(UR_USM_ALLOC_INFO_TYPE, UR_USM_ALLOC_INFO_BASE_PTR, UR_USM_ALLOC_INFO_SIZE, UR_USM_ALLOC_INFO_DEVICE),
                  uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
 
 TEST_P(urUSMAllocInfoTest, Success) {
     size_t size = 0;
     auto alloc_info = getParam();
-    ASSERT_SUCCESS(
-        urUSMGetMemAllocInfo(context, ptr, alloc_info, 0, nullptr, &size));
+    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> info_data(size);
-    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size,
-                                        info_data.data(), nullptr));
+    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size, info_data.data(), nullptr));
 }
 
 using urUSMGetMemAllocInfoTest = uur::urUSMDeviceAllocTest;
@@ -30,23 +24,17 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMGetMemAllocInfoTest);
 TEST_P(urUSMGetMemAllocInfoTest, InvalidNullHandleContext) {
     ur_usm_type_t USMType;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urUSMGetMemAllocInfo(nullptr, ptr, UR_USM_ALLOC_INFO_TYPE,
-                                          sizeof(ur_usm_type_t), &USMType,
-                                          nullptr));
+                     urUSMGetMemAllocInfo(nullptr, ptr, UR_USM_ALLOC_INFO_TYPE, sizeof(ur_usm_type_t), &USMType, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidNullPointerMem) {
     ur_usm_type_t USMType;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urUSMGetMemAllocInfo(context, nullptr, UR_USM_ALLOC_INFO_TYPE,
-                             sizeof(ur_usm_type_t), &USMType, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urUSMGetMemAllocInfo(context, nullptr, UR_USM_ALLOC_INFO_TYPE, sizeof(ur_usm_type_t), &USMType, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidEnumeration) {
     ur_usm_type_t USMType;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_ENUMERATION,
-        urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_FORCE_UINT32,
-                             sizeof(ur_usm_type_t), &USMType, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
+                     urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_FORCE_UINT32, sizeof(ur_usm_type_t), &USMType, nullptr));
 }

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -10,29 +10,25 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMHostAllocTest);
 TEST_P(urUSMHostAllocTest, Success) {
     bool host_usm = false;
     size_t size = sizeof(bool);
-    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,
-                                   size, &host_usm, nullptr));
+    ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_HOST_UNIFIED_MEMORY, size, &host_usm, nullptr));
     if (!host_usm) { // Skip this test if device does not support Host USM
         GTEST_SKIP();
     }
 
     int *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(urUSMHostAlloc(context, &flags, sizeof(int), 0,
-                                  reinterpret_cast<void **>(&ptr)));
+    ASSERT_SUCCESS(urUSMHostAlloc(context, &flags, sizeof(int), 0, reinterpret_cast<void **>(&ptr)));
     ASSERT_NE(ptr, nullptr);
 
     // Set 0
     ur_event_handle_t event = nullptr;
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
     ASSERT_SUCCESS(urEventWait(1, &event));
     EXPECT_SUCCESS(urEventRelease(event));
     ASSERT_EQ(*ptr, 0);
 
     // Set 1, in all bytes of int
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemset(queue, ptr, 1, sizeof(int), 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, ptr, 1, sizeof(int), 0, nullptr, &event));
     ASSERT_SUCCESS(urEventWait(1, &event));
     EXPECT_SUCCESS(urEventRelease(event));
     // replicate it on host
@@ -46,18 +42,15 @@ TEST_P(urUSMHostAllocTest, Success) {
 TEST_P(urUSMHostAllocTest, InvalidNullHandleContext) {
     ur_usm_mem_flags_t flags;
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urUSMHostAlloc(nullptr, &flags, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urUSMHostAlloc(nullptr, &flags, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidNullPtrFlags) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urUSMHostAlloc(context, nullptr, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urUSMHostAlloc(context, nullptr, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidNullPtrResult) {
     ur_usm_mem_flags_t flags;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urUSMHostAlloc(context, &flags, sizeof(int), 0, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urUSMHostAlloc(context, &flags, sizeof(int), 0, nullptr));
 }

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -9,12 +9,10 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMSharedAllocTest);
 TEST_P(urUSMSharedAllocTest, Success) {
     void *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_SUCCESS(
-        urUSMSharedAlloc(context, device, &flags, sizeof(int), 0, &ptr));
+    ASSERT_SUCCESS(urUSMSharedAlloc(context, device, &flags, sizeof(int), 0, &ptr));
 
     ur_event_handle_t event = nullptr;
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMMemset(queue, ptr, 0, sizeof(int), 0, nullptr, &event));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     ASSERT_SUCCESS(urUSMFree(context, ptr));
@@ -24,29 +22,21 @@ TEST_P(urUSMSharedAllocTest, Success) {
 TEST_P(urUSMSharedAllocTest, InvalidNullHandleContext) {
     void *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urUSMSharedAlloc(nullptr, device, &flags, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urUSMSharedAlloc(nullptr, device, &flags, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidNullHandleDevice) {
     void *ptr = nullptr;
     ur_usm_mem_flags_t flags;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urUSMSharedAlloc(context, nullptr, &flags, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urUSMSharedAlloc(context, nullptr, &flags, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidNullPtrFlags) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urUSMDeviceAlloc(context, device, nullptr, sizeof(int), 0, &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urUSMDeviceAlloc(context, device, nullptr, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidNullPtrMem) {
     ur_usm_mem_flags_t flags;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urUSMSharedAlloc(context, device, &flags, sizeof(int), 0, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urUSMSharedAlloc(context, device, &flags, sizeof(int), 0, nullptr));
 }

--- a/test/layers/validation/fixtures.hpp
+++ b/test/layers/validation/fixtures.hpp
@@ -28,8 +28,7 @@ struct valPlatformsTest : urTest {
         ASSERT_EQ(urPlatformGet(0, nullptr, &count), UR_RESULT_SUCCESS);
         ASSERT_NE(count, 0);
         platforms.resize(count);
-        ASSERT_EQ(urPlatformGet(count, platforms.data(), nullptr),
-                  UR_RESULT_SUCCESS);
+        ASSERT_EQ(urPlatformGet(count, platforms.data(), nullptr), UR_RESULT_SUCCESS);
     }
 
     std::vector<ur_platform_handle_t> platforms;

--- a/test/layers/validation/parameters.cpp
+++ b/test/layers/validation/parameters.cpp
@@ -4,19 +4,16 @@
 #include "fixtures.hpp"
 
 TEST(valTest, urInit) {
-    const ur_device_init_flags_t device_flags =
-        UR_DEVICE_INIT_FLAG_FORCE_UINT32;
+    const ur_device_init_flags_t device_flags = UR_DEVICE_INIT_FLAG_FORCE_UINT32;
     ASSERT_EQ(UR_RESULT_ERROR_INVALID_ENUMERATION, urInit(device_flags));
 }
 
 TEST_F(valPlatformsTest, testUrPlatformGetApiVersion) {
     ur_api_version_t api_version = {};
 
-    ASSERT_EQ(urPlatformGetApiVersion(nullptr, &api_version),
-              UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ(urPlatformGetApiVersion(nullptr, &api_version), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
     for (auto p : platforms) {
-        ASSERT_EQ(urPlatformGetApiVersion(p, nullptr),
-                  UR_RESULT_ERROR_INVALID_NULL_POINTER);
+        ASSERT_EQ(urPlatformGetApiVersion(p, nullptr), UR_RESULT_ERROR_INVALID_NULL_POINTER);
     }
 }

--- a/test/unified_memory_allocation/common/helpers.h
+++ b/test/unified_memory_allocation/common/helpers.h
@@ -19,14 +19,11 @@ struct umaTest : ::testing::Test {
 namespace uma {
 
 auto wrapPoolUnique(uma_memory_pool_handle_t hPool) {
-    return std::unique_ptr<uma_memory_pool_t, decltype(&umaPoolDestroy)>(
-        hPool, &umaPoolDestroy);
+    return std::unique_ptr<uma_memory_pool_t, decltype(&umaPoolDestroy)>(hPool, &umaPoolDestroy);
 }
 
 auto wrapProviderUnique(uma_memory_provider_handle_t hProvider) {
-    return std::unique_ptr<uma_memory_provider_t,
-                           decltype(&umaMemoryProviderDestroy)>(
-        hProvider, &umaMemoryProviderDestroy);
+    return std::unique_ptr<uma_memory_provider_t, decltype(&umaMemoryProviderDestroy)>(hProvider, &umaMemoryProviderDestroy);
 }
 
 } // namespace uma

--- a/test/unified_memory_allocation/common/pool.h
+++ b/test/unified_memory_allocation/common/pool.h
@@ -11,8 +11,7 @@ extern "C" {
 #endif
 
 uma_memory_pool_handle_t nullPoolCreate();
-uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,
-                                         void (*trace)(const char *));
+uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool, void (*trace)(const char *));
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/common/provider.h
+++ b/test/unified_memory_allocation/common/provider.h
@@ -11,9 +11,7 @@ extern "C" {
 #endif
 
 uma_memory_provider_handle_t nullProviderCreate();
-uma_memory_provider_handle_t
-traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
-                    void (*trace)(const char *));
+uma_memory_provider_handle_t traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider, void (*trace)(const char *));
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/memoryPool.cpp
+++ b/test/unified_memory_allocation/memoryPool.cpp
@@ -12,8 +12,7 @@ TEST_F(umaTest, memoryPoolTrace) {
     auto trace = [](const char *name) { calls[name]++; };
 
     auto nullPool = uma::wrapPoolUnique(nullPoolCreate());
-    auto tracingPool =
-        uma::wrapPoolUnique(tracePoolCreate(nullPool.get(), trace));
+    auto tracingPool = uma::wrapPoolUnique(tracePoolCreate(nullPool.get(), trace));
 
     size_t call_count = 0;
 

--- a/test/unified_memory_allocation/memoryProvider.cpp
+++ b/test/unified_memory_allocation/memoryProvider.cpp
@@ -12,8 +12,7 @@ TEST_F(umaTest, memoryProviderTrace) {
     auto trace = [](const char *name) { calls[name]++; };
 
     auto nullProvider = uma::wrapProviderUnique(nullProviderCreate());
-    auto tracingProvider =
-        uma::wrapProviderUnique(traceProviderCreate(nullProvider.get(), trace));
+    auto tracingProvider = uma::wrapProviderUnique(traceProviderCreate(nullProvider.get(), trace));
 
     size_t call_count = 0;
 


### PR DESCRIPTION
This option is not idempotent, potentially causing issues when formatting multiple times.

Alternative to #263 
