### PR TITLE
[uma] fix empty prototypes in uma c tests

### DIFF
--- a/test/unified_memory_allocation/common/pool.c
+++ b/test/unified_memory_allocation/common/pool.c
@@ -62,7 +62,7 @@ enum uma_result_t nullGetLastResult(void *pool, const char** ppMsg) {
     return UMA_RESULT_SUCCESS;
 }
 
-uma_memory_pool_handle_t nullPoolCreate() {
+uma_memory_pool_handle_t nullPoolCreate(void) {
     struct uma_memory_pool_ops_t ops = {
         .version = UMA_VERSION_CURRENT,
         .initialize = nullInitialize,

--- a/test/unified_memory_allocation/common/pool.h
+++ b/test/unified_memory_allocation/common/pool.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-uma_memory_pool_handle_t nullPoolCreate();
+uma_memory_pool_handle_t nullPoolCreate(void);
 uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool, void (*trace)(const char *));
 
 #if defined(__cplusplus)

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -39,7 +39,7 @@ enum uma_result_t nullGetLastResult(void *provider, const char** ppMsg) {
     return UMA_RESULT_SUCCESS;
 }
 
-uma_memory_provider_handle_t nullProviderCreate() {
+uma_memory_provider_handle_t nullProviderCreate(void) {
     struct uma_memory_provider_ops_t ops = {
         .version = UMA_VERSION_CURRENT,
         .initialize = nullInitialize,

--- a/test/unified_memory_allocation/common/provider.h
+++ b/test/unified_memory_allocation/common/provider.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-uma_memory_provider_handle_t nullProviderCreate();
+uma_memory_provider_handle_t nullProviderCreate(void);
 uma_memory_provider_handle_t traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider, void (*trace)(const char *));
 
 #if defined(__cplusplus)


### PR DESCRIPTION
showed up on clang after enabling -Wpedantic