### PR TITLE
Make array of devices passed to urContextCreate const

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -31,6 +31,7 @@ function(add_cppformat name)
                 --style=file
                 --i
                 ${ARGN}
+            COMMENT "Format CXX source files"
             )
     endif()
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -299,9 +299,9 @@ typedef struct ur_rect_region_t {
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
-    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4610,7 +4610,7 @@ typedef struct ur_platform_callbacks_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_context_create_params_t {
     uint32_t *pDeviceCount;
-    ur_device_handle_t **pphDevices;
+    const ur_device_handle_t **pphDevices;
     ur_context_handle_t **pphContext;
 } ur_context_create_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -88,7 +88,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetPlatformProcAddrTable_t)(
 /// @brief Function-pointer for urContextCreate
 typedef ur_result_t(UR_APICALL *ur_pfnContextCreate_t)(
     uint32_t,
-    ur_device_handle_t *,
+    const ur_device_handle_t *,
     ur_context_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -30,7 +30,7 @@ params:
       name: DeviceCount
       desc: |
             [in] the number of devices given in phDevices
-    - type: "$x_device_handle_t*"
+    - type: "const $x_device_handle_t*"
       name: phDevices
       desc: |
             [in][range(0, DeviceCount)] array of handle of devices.

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -14,9 +14,9 @@ namespace driver {
 /// @brief Intercept function for urContextCreate
 __urdlllocal ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
-    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -14,9 +14,9 @@ namespace validation_layer {
 /// @brief Intercept function for urContextCreate
 __urdlllocal ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
-    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = context.urDdiTable.Context.pfnCreate;
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -27,9 +27,9 @@ ur_mem_factory_t ur_mem_factory;
 /// @brief Intercept function for urContextCreate
 __urdlllocal ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
-    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -42,9 +42,9 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
-    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Context.pfnCreate;
     if (nullptr == pfnCreate) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -39,9 +39,9 @@
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,          ///< [in] the number of devices given in phDevices
-    ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
Add `const` to the `phDevices` argument of `urContextCreate` to match up
with PI/OpenCL and avoid unnecessary potential for `const_cast` in
adapter implementations.

Fixes #273
