### PR TITLE
Add ur_program_properties_t for program creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,14 +176,14 @@ install(
 set(API_JSON_FILE ${PROJECT_BINARY_DIR}/unified_runtime.json)
 
 # Generate source from the specification
-add_custom_target(generate-code
+add_custom_target(generate-code USES_TERMINAL
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
     COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE}
     COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
 )
 
 # Generate and format source from the specification
-add_custom_target(generate
+add_custom_target(generate USES_TERMINAL
     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target generate-code
     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target cppformat
 )

--- a/include/ur.py
+++ b/include/ur.py
@@ -205,6 +205,7 @@ class ur_result_t(c_int):
 ## @brief Defines structure types
 class ur_structure_type_v(IntEnum):
     IMAGE_DESC = 0                                  ## ::ur_image_desc_t
+    PROGRAM_PROPERTIES = 1                          ## ::ur_program_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -1035,6 +1036,55 @@ class ur_api_version_t(c_int):
 
 
 ###############################################################################
+## @brief Program metadata property type.
+class ur_program_metadata_type_v(IntEnum):
+    UINT32 = 0                                      ## type is a 32-bit integer.
+    UINT64 = 1                                      ## type is a 64-bit integer.
+    BYTE_ARRAY = 2                                  ## type is a byte array.
+    STRING = 3                                      ## type is a null-terminated string.
+
+class ur_program_metadata_type_t(c_int):
+    def __str__(self):
+        return str(ur_program_metadata_type_v(self.value))
+
+
+###############################################################################
+## @brief Program metadata value union.
+class ur_program_metadata_value_t(Structure):
+    _fields_ = [
+        ("data32", c_ulong),                                            ## [in] inline storage for the 32-bit data, type
+                                                                        ## ::UR_PROGRAM_METADATA_TYPE_UINT32.
+        ("data64", c_ulonglong),                                        ## [in] inline storage for the 64-bit data, type
+                                                                        ## ::UR_PROGRAM_METADATA_TYPE_UINT64.
+        ("pString", c_char_p),                                          ## [in] pointer to null-terminated string data, type
+                                                                        ## ::UR_PROGRAM_METADATA_TYPE_STRING.
+        ("pData", c_void_p)                                             ## [in] pointer to binary data, type
+                                                                        ## ::UR_PROGRAM_METADATA_TYPE_BYTE_ARRAY.
+    ]
+
+###############################################################################
+## @brief Program metadata property.
+class ur_program_metadata_t(Structure):
+    _fields_ = [
+        ("pName", c_char_p),                                            ## [in] null-terminated metadata name.
+        ("type", ur_program_metadata_type_t),                           ## [in] the type of metadata value.
+        ("size", c_size_t),                                             ## [in] size in bytes of the data pointed to by value.pData, or 0 when
+                                                                        ## value size is less than 64-bits and is stored directly in value.data.
+        ("value", ur_program_metadata_value_t)                          ## [in] the metadata value storage.
+    ]
+
+###############################################################################
+## @brief Program creation properties.
+class ur_program_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("count", c_ulong),                                             ## [in] the number of entries in pMetadatas, if count is greater than
+                                                                        ## zero then pMetadatas must not be null.
+        ("pMetadatas", POINTER(ur_program_metadata_t))                  ## [in][optional][range(0,count)] pointer to array of metadata entries.
+    ]
+
+###############################################################################
 ## @brief Get Program object information
 class ur_program_info_v(IntEnum):
     REFERENCE_COUNT = 0                             ## Program reference count info
@@ -1291,16 +1341,16 @@ class ur_event_dditable_t(Structure):
 ###############################################################################
 ## @brief Function-pointer for urProgramCreate
 if __use_win_types:
-    _urProgramCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_module_handle_t), c_char_p, POINTER(ur_program_handle_t) )
+    _urProgramCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_module_handle_t), c_char_p, POINTER(ur_program_properties_t), POINTER(ur_program_handle_t) )
 else:
-    _urProgramCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_module_handle_t), c_char_p, POINTER(ur_program_handle_t) )
+    _urProgramCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_module_handle_t), c_char_p, POINTER(ur_program_properties_t), POINTER(ur_program_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urProgramCreateWithBinary
 if __use_win_types:
-    _urProgramCreateWithBinary_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, POINTER(c_ubyte), POINTER(ur_program_handle_t) )
+    _urProgramCreateWithBinary_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, POINTER(c_ubyte), POINTER(ur_program_properties_t), POINTER(ur_program_handle_t) )
 else:
-    _urProgramCreateWithBinary_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, POINTER(c_ubyte), POINTER(ur_program_handle_t) )
+    _urProgramCreateWithBinary_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, POINTER(c_ubyte), POINTER(ur_program_properties_t), POINTER(ur_program_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urProgramRetain

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -258,6 +258,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnProgramCreate_t)(
     uint32_t,
     const ur_module_handle_t *,
     const char *,
+    const ur_program_properties_t *,
     ur_program_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -267,6 +268,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnProgramCreateWithBinary_t)(
     ur_device_handle_t,
     size_t,
     const uint8_t *,
+    const ur_program_properties_t *,
     ur_program_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/Doxyfile
+++ b/scripts/Doxyfile
@@ -740,7 +740,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -614,7 +614,7 @@ class ur_name_t(Structure):
     + `version` will be used to define the minimum API version in which the param will appear; `default="1.0"` This will also affect the order in which the param appears within the function.
   - if `class` is specified and the function is not `decl: static`, then the first param **must** be the handle associated with the class
 * A function may take the following optional sequence of scalars: {`analogue`}
-  - 'analogue` will be used as the function's remarks comment
+  - `analogue` will be used as the function's remarks comment
 * A function may take the following optional sequence of scalars or scalars to sequences: {`details`, `returns`}
   - `detail` will be used as the function's detailed comment
   - `return` will be used as the function's returns comment

--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -188,7 +188,7 @@ are a collection of modules that are linked together.
 
     // Create program from module
     ${x}_program_handle_t hProgram;
-    ${x}ProgramCreate(hContext, 1, &hModule, nullptr, hProgram);
+    ${x}ProgramCreate(hContext, 1, &hModule, nullptr, nullptr, hProgram);
 
 
 Kernels

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -271,6 +271,8 @@ name: $x_structure_type_t
 etors:
     - name: IMAGE_DESC
       desc: $x_image_desc_t
+    - name: PROGRAM_PROPERTIES
+      desc: $x_program_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -10,6 +10,68 @@ type: header
 desc: "Intel $OneApi Level-Zero Runtime APIs for Program"
 ordinal: "2"
 --- #--------------------------------------------------------------------------
+type: enum
+desc: "Program metadata property type."
+name: $x_program_metadata_type_t
+etors:
+    - name: UINT32
+      desc: "type is a 32-bit integer."
+    - name: UINT64
+      desc: "type is a 64-bit integer."
+    - name: BYTE_ARRAY
+      desc: "type is a byte array."
+    - name: STRING
+      desc: "type is a null-terminated string."
+--- #--------------------------------------------------------------------------
+type: union
+desc: "Program metadata value union."
+class: $xProgram
+name: $x_program_metadata_value_t
+members:
+    - type: uint32_t
+      name: data32
+      desc: "[in] inline storage for the 32-bit data, type $X_PROGRAM_METADATA_TYPE_UINT32."
+    - type: uint64_t
+      name: data64
+      desc: "[in] inline storage for the 64-bit data, type $X_PROGRAM_METADATA_TYPE_UINT64."
+    - type: char*
+      name: pString
+      desc: "[in] pointer to null-terminated string data, type $X_PROGRAM_METADATA_TYPE_STRING."
+    - type: void*
+      name: pData
+      desc: "[in] pointer to binary data, type $X_PROGRAM_METADATA_TYPE_BYTE_ARRAY."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Program metadata property."
+class: $xProgram
+name: $x_program_metadata_t
+members:
+    - type: char*
+      name: pName
+      desc: "[in] null-terminated metadata name."
+    - type: $x_program_metadata_type_t
+      name: type
+      desc: "[in] the type of metadata value."
+    - type: size_t
+      name: size
+      desc: "[in] size in bytes of the data pointed to by value.pData, or 0 when value size is less than 64-bits and is stored directly in value.data."
+    - type: $x_program_metadata_value_t
+      name: value
+      desc: "[in] the metadata value storage."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Program creation properties."
+class: $xProgram
+name: $x_program_properties_t
+base: $x_base_properties_t
+members:
+    - type: uint32_t
+      name: count
+      desc: "[in] the number of entries in pMetadatas, if count is greater than zero then pMetadatas must not be null."
+    - type: const $x_program_metadata_t*
+      name: pMetadatas
+      desc: "[in][optional][range(0,count)] pointer to array of metadata entries."
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create Program from input SPIR-V modules."
 class: $xProgram
@@ -33,12 +95,20 @@ params:
     - type: const char*
       name: pOptions
       desc: "[in][optional] pointer to linker options null-terminated string."
+    - type: const $x_program_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to program creation properties."
     - type: $x_program_handle_t*
       name: phProgram
       desc: "[out] pointer to handle of program object created."
+returns:
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER:
+        - "`NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`"
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`"
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Create program object from native binary."
+desc: "Create a program object from device native binary."
 class: $xProgram
 name: CreateWithBinary
 decl: static
@@ -60,9 +130,17 @@ params:
     - type: const uint8_t*
       name: pBinary
       desc: "[in] pointer to binary."
+    - type: const $x_program_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to program creation properties."
     - type: $x_program_handle_t*
       name: phProgram
       desc: "[out] pointer to handle of Program object created."
+returns:
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER:
+        - "`NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`"
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get a reference to the Program object."

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2585,18 +2585,19 @@ urGetLastResult(
 /// @brief Intercept function for urProgramCreate
 __urdlllocal ur_result_t UR_APICALL
 urProgramCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context instance
-    uint32_t count,                      ///< [in] number of module handles in module list.
-    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    uint32_t count,                             ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules,        ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                       ///< [in][optional] pointer to linker options null-terminated string.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Program.pfnCreate;
     if (nullptr != pfnCreate) {
-        result = pfnCreate(hContext, count, phModules, pOptions, phProgram);
+        result = pfnCreate(hContext, count, phModules, pOptions, pProperties, phProgram);
     } else {
         // generic implementation
         *phProgram = reinterpret_cast<ur_program_handle_t>(d_context.get());
@@ -2609,18 +2610,19 @@ urProgramCreate(
 /// @brief Intercept function for urProgramCreateWithBinary
 __urdlllocal ur_result_t UR_APICALL
 urProgramCreateWithBinary(
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
-    size_t size,                   ///< [in] size in bytes.
-    const uint8_t *pBinary,        ///< [in] pointer to binary.
-    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
+    size_t size,                                ///< [in] size in bytes.
+    const uint8_t *pBinary,                     ///< [in] pointer to binary.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithBinary = d_context.urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr != pfnCreateWithBinary) {
-        result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, phProgram);
+        result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
     } else {
         // generic implementation
         *phProgram = reinterpret_cast<ur_program_handle_t>(d_context.get());

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3395,11 +3395,12 @@ urGetLastResult(
 /// @brief Intercept function for urProgramCreate
 __urdlllocal ur_result_t UR_APICALL
 urProgramCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context instance
-    uint32_t count,                      ///< [in] number of module handles in module list.
-    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    uint32_t count,                             ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules,        ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                       ///< [in][optional] pointer to linker options null-terminated string.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreate = context.urDdiTable.Program.pfnCreate;
 
@@ -3419,20 +3420,29 @@ urProgramCreate(
         if (NULL == phProgram) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    return pfnCreate(hContext, count, phModules, pOptions, phProgram);
+    return pfnCreate(hContext, count, phModules, pOptions, pProperties, phProgram);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
 __urdlllocal ur_result_t UR_APICALL
 urProgramCreateWithBinary(
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
-    size_t size,                   ///< [in] size in bytes.
-    const uint8_t *pBinary,        ///< [in] pointer to binary.
-    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
+    size_t size,                                ///< [in] size in bytes.
+    const uint8_t *pBinary,                     ///< [in] pointer to binary.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
 ) {
     auto pfnCreateWithBinary = context.urDdiTable.Program.pfnCreateWithBinary;
 
@@ -3456,9 +3466,17 @@ urProgramCreateWithBinary(
         if (NULL == phProgram) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, phProgram);
+    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3965,11 +3965,12 @@ urGetLastResult(
 /// @brief Intercept function for urProgramCreate
 __urdlllocal ur_result_t UR_APICALL
 urProgramCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context instance
-    uint32_t count,                      ///< [in] number of module handles in module list.
-    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    uint32_t count,                             ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules,        ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                       ///< [in][optional] pointer to linker options null-terminated string.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3990,7 +3991,7 @@ urProgramCreate(
     }
 
     // forward to device-platform
-    result = pfnCreate(hContext, count, phModules, pOptions, phProgram);
+    result = pfnCreate(hContext, count, phModules, pOptions, pProperties, phProgram);
     delete[] phModulesLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -4012,11 +4013,12 @@ urProgramCreate(
 /// @brief Intercept function for urProgramCreateWithBinary
 __urdlllocal ur_result_t UR_APICALL
 urProgramCreateWithBinary(
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
-    size_t size,                   ///< [in] size in bytes.
-    const uint8_t *pBinary,        ///< [in] pointer to binary.
-    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
+    size_t size,                                ///< [in] size in bytes.
+    const uint8_t *pBinary,                     ///< [in] pointer to binary.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4034,7 +4036,7 @@ urProgramCreateWithBinary(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, phProgram);
+    result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3881,24 +3881,28 @@ urGetLastResult(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phModules`
 ///         + `NULL == phProgram`
+///         + `NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`
 ur_result_t UR_APICALL
 urProgramCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context instance
-    uint32_t count,                      ///< [in] number of module handles in module list.
-    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    uint32_t count,                             ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules,        ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                       ///< [in][optional] pointer to linker options null-terminated string.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Program.pfnCreate;
     if (nullptr == pfnCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreate(hContext, count, phModules, pOptions, phProgram);
+    return pfnCreate(hContext, count, phModules, pOptions, pProperties, phProgram);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Create program object from native binary.
+/// @brief Create a program object from device native binary.
 ///
 /// @details
 ///     - The application may call this function from simultaneous threads.
@@ -3917,20 +3921,24 @@ urProgramCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pBinary`
 ///         + `NULL == phProgram`
+///         + `NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`
 ur_result_t UR_APICALL
 urProgramCreateWithBinary(
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
-    size_t size,                   ///< [in] size in bytes.
-    const uint8_t *pBinary,        ///< [in] pointer to binary.
-    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
+    size_t size,                                ///< [in] size in bytes.
+    const uint8_t *pBinary,                     ///< [in] pointer to binary.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
 ) {
     auto pfnCreateWithBinary = ur_lib::context->urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr == pfnCreateWithBinary) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, phProgram);
+    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3470,20 +3470,24 @@ urGetLastResult(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phModules`
 ///         + `NULL == phProgram`
+///         + `NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`
 ur_result_t UR_APICALL
 urProgramCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context instance
-    uint32_t count,                      ///< [in] number of module handles in module list.
-    const ur_module_handle_t *phModules, ///< [in][range(0, count)] pointer to array of modules.
-    const char *pOptions,                ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram       ///< [out] pointer to handle of program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    uint32_t count,                             ///< [in] number of module handles in module list.
+    const ur_module_handle_t *phModules,        ///< [in][range(0, count)] pointer to array of modules.
+    const char *pOptions,                       ///< [in][optional] pointer to linker options null-terminated string.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Create program object from native binary.
+/// @brief Create a program object from device native binary.
 ///
 /// @details
 ///     - The application may call this function from simultaneous threads.
@@ -3502,13 +3506,17 @@ urProgramCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pBinary`
 ///         + `NULL == phProgram`
+///         + `NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`
 ur_result_t UR_APICALL
 urProgramCreateWithBinary(
-    ur_context_handle_t hContext,  ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,    ///< [in] handle to device associated with binary.
-    size_t size,                   ///< [in] size in bytes.
-    const uint8_t *pBinary,        ///< [in] pointer to binary.
-    ur_program_handle_t *phProgram ///< [out] pointer to handle of Program object created.
+    ur_context_handle_t hContext,               ///< [in] handle of the context instance
+    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
+    size_t size,                                ///< [in] size in bytes.
+    const uint8_t *pBinary,                     ///< [in] pointer to binary.
+    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
The new `ur_program_properties_t` struct allows the provision of
additional metadata to be passed into the
`urProgramCreate`/`urProgramCreateWithBinary` entry points.
Additionally, it supports `stype` and `pNext` which enable extending
program creation without breaking ABI.

Fixes #95
