### PR TITLE
[ur] Remove semicolon from extern C

### DIFF
--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -288,5 +288,5 @@ ${tbl['export']['name']}(
 %endfor
 
 #if defined(__cplusplus)
-};
+}
 #endif

--- a/scripts/templates/nullddi.cpp.mako
+++ b/scripts/templates/nullddi.cpp.mako
@@ -115,5 +115,5 @@ ${tbl['export']['name']}(
 
 %endfor
 #if defined(__cplusplus)
-};
+}
 #endif

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -3401,5 +3401,5 @@ urGetDeviceProcAddrTable(
 }
 
 #if defined(__cplusplus)
-};
+}
 #endif

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -5295,5 +5295,5 @@ urGetDeviceProcAddrTable(
 }
 
 #if defined(__cplusplus)
-};
+}
 #endif


### PR DESCRIPTION
The `-Wpedantic` option was added to the UR build - when building I get the following error.


```
[build] ../source/drivers/null/ur_nullddi.cpp:3404:2: error: extra ‘;’ [-Werror=pedantic]
[build]  3404 | };
```

This additional semicolon is unnecessary for `extern "C" {}` construct so I have removed it.