### PR TITLE
[ur] Complete Native Handle Tests

### DIFF
--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -1,2 +1,14 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: MIT
+
+#include <uur/fixtures.h>
+
+using urEventCreateWithNativeHandleTest = uur::urContextTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
+
+TEST_P(urEventCreateWithNativeHandleTest, InvalidNullHandleNativeEvent) {
+    ur_event_handle_t event = nullptr;
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEventCreateWithNativeHandle(nullptr, context, &event));
+}


### PR DESCRIPTION
Since we don't have a `native_handle` the only valid test we can write is for when we have a `nullptr` native handle. This PR adds the same test to `event`. `device`, `context`, `memory`, `queue` were completed previously. 

This Closes #222 & #224 