### PR TITLE
[ur] CTS release/retain tests increment reference counts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,5 +4,4 @@ BasedOnStyle:  LLVM
 IndentWidth:   4
 InsertBraces: true
 ReflowComments: false
-ColumnLimit: 0
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ BasedOnStyle:  LLVM
 IndentWidth:   4
 InsertBraces: true
 ReflowComments: false
+ColumnLimit: 80
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -4,5 +4,5 @@ BasedOnStyle:  LLVM
 IndentWidth:   4
 InsertBraces: true
 ReflowComments: false
-ColumnLimit: 80
+ColumnLimit: 0
 ...

--- a/include/ur.py
+++ b/include/ur.py
@@ -249,9 +249,10 @@ class ur_rect_region_t(Structure):
 ###############################################################################
 ## @brief Supported context info
 class ur_context_info_v(IntEnum):
-    NUM_DEVICES = 1                                 ## [uint32_t] The number of the devices in the context
-    DEVICES = 2                                     ## [::ur_context_handle_t...] The array of the device handles in the
+    NUM_DEVICES = 0                                 ## [uint32_t] The number of the devices in the context
+    DEVICES = 1                                     ## [::ur_context_handle_t...] The array of the device handles in the
                                                     ## context
+    REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the context object.
     USM_MEMCPY2D_SUPPORT = 3                        ## [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
                                                     ## supported.
     USM_FILL2D_SUPPORT = 4                          ## [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is

--- a/include/ur.py
+++ b/include/ur.py
@@ -253,6 +253,9 @@ class ur_context_info_v(IntEnum):
     DEVICES = 1                                     ## [::ur_context_handle_t...] The array of the device handles in the
                                                     ## context
     REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the context object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
     USM_MEMCPY2D_SUPPORT = 3                        ## [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
                                                     ## supported.
     USM_FILL2D_SUPPORT = 4                          ## [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is
@@ -357,7 +360,10 @@ class ur_event_info_v(IntEnum):
     CONTEXT = 1                                     ## [::ur_context_handle_t] Context information of an event object
     COMMAND_TYPE = 2                                ## [::ur_command_t] Command type information of an event object
     COMMAND_EXECUTION_STATUS = 3                    ## [::ur_event_status_t] Command execution status of an event object
-    REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of an event object
+    REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of the event object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
 
 class ur_event_info_t(c_int):
     def __str__(self):
@@ -556,14 +562,15 @@ class ur_buffer_create_type_t(c_int):
 ###############################################################################
 ## @brief Query queue info
 class ur_queue_info_v(IntEnum):
-    CONTEXT = 0                                     ## ::ur_queue_handle_t: context associated with this queue.
-    DEVICE = 1                                      ## ::ur_device_handle_t: device associated with this queue.
-    DEVICE_DEFAULT = 2                              ## ::ur_queue_handle_t: the current default queue of the underlying
-                                                    ## device.
-    PROPERTIES = 3                                  ## ::ur_queue_flags_t: the properties associated with
-                                                    ## ::UR_QUEUE_PROPERTIES_FLAGS.
-    REFERENCE_COUNT = 4                             ## Queue reference count
-    SIZE = 5                                        ## uint32_t: The size of the queue
+    CONTEXT = 0                                     ## Queue context info
+    DEVICE = 1                                      ## Queue device info
+    DEVICE_DEFAULT = 2                              ## Queue device default info
+    PROPERTIES = 3                                  ## Queue properties info
+    REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of the queue object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
+    SIZE = 5                                        ## Queue size info
 
 class ur_queue_info_t(c_int):
     def __str__(self):
@@ -605,7 +612,10 @@ class ur_queue_properties_t(c_int):
 ###############################################################################
 ## @brief Get sample object information
 class ur_sampler_info_v(IntEnum):
-    REFERENCE_COUNT = 0                             ## Sampler reference count info
+    REFERENCE_COUNT = 0                             ## [uint32_t] Reference count of the sampler object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
     CONTEXT = 1                                     ## Sampler context info
     NORMALIZED_COORDS = 2                           ## Sampler normalized coordindate setting
     ADDRESSING_MODE = 3                             ## Sampler addressing mode setting
@@ -777,7 +787,10 @@ class ur_device_info_v(IntEnum):
     QUEUE_ON_HOST_PROPERTIES = 61                   ## ::ur_queue_flags_t: host queue property bit-field
     BUILT_IN_KERNELS = 62                           ## char[]: a semi-colon separated list of built-in kernels
     PLATFORM = 63                                   ## ::ur_platform_handle_t: the platform associated with the device
-    REFERENCE_COUNT = 64                            ## uint32_t: reference count
+    REFERENCE_COUNT = 64                            ## [uint32_t] Reference count of the device object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
     IL_VERSION = 65                                 ## char[]: IL version
     NAME = 66                                       ## char[]: Device name
     VENDOR = 67                                     ## char[]: Device vendor
@@ -942,7 +955,10 @@ class ur_memory_scope_capability_flags_t(c_int):
 class ur_kernel_info_v(IntEnum):
     FUNCTION_NAME = 0                               ## Return Kernel function name, return type char[]
     NUM_ARGS = 1                                    ## Return Kernel number of arguments
-    REFERENCE_COUNT = 2                             ## Return Kernel reference count
+    REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the kernel object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
     CONTEXT = 3                                     ## Return Context object associated with Kernel
     PROGRAM = 4                                     ## Return Program object associated with Kernel
     ATTRIBUTES = 5                                  ## Return Kernel attributes, return type char[]
@@ -1090,7 +1106,10 @@ class ur_program_properties_t(Structure):
 ###############################################################################
 ## @brief Get Program object information
 class ur_program_info_v(IntEnum):
-    REFERENCE_COUNT = 0                             ## Program reference count info
+    REFERENCE_COUNT = 0                             ## [uint32_t] Reference count of the program object.
+                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## It is unsuitable for general use in applications. This feature is
+                                                    ## provided for identifying memory leaks.
     CONTEXT = 1                                     ## Program context info
     NUM_DEVICES = 2                                 ## Return number of devices associated with Program
     DEVICES = 3                                     ## Return list of devices associated with Program, return type

--- a/include/ur.py
+++ b/include/ur.py
@@ -562,15 +562,17 @@ class ur_buffer_create_type_t(c_int):
 ###############################################################################
 ## @brief Query queue info
 class ur_queue_info_v(IntEnum):
-    CONTEXT = 0                                     ## Queue context info
-    DEVICE = 1                                      ## Queue device info
-    DEVICE_DEFAULT = 2                              ## Queue device default info
-    PROPERTIES = 3                                  ## Queue properties info
+    CONTEXT = 0                                     ## ::ur_queue_handle_t: context associated with this queue.
+    DEVICE = 1                                      ## ::ur_device_handle_t: device associated with this queue.
+    DEVICE_DEFAULT = 2                              ## ::ur_queue_handle_t: the current default queue of the underlying
+                                                    ## device.
+    PROPERTIES = 3                                  ## ::ur_queue_flags_t: the properties associated with
+                                                    ## ::UR_QUEUE_PROPERTIES_FLAGS.
     REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of the queue object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    SIZE = 5                                        ## Queue size info
+    SIZE = 5                                        ## uint32_t: The size of the queue
 
 class ur_queue_info_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -339,9 +339,10 @@ urContextRetain(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported context info
 typedef enum ur_context_info_t {
-    UR_CONTEXT_INFO_NUM_DEVICES = 1,          ///< [uint32_t] The number of the devices in the context
-    UR_CONTEXT_INFO_DEVICES = 2,              ///< [::ur_context_handle_t...] The array of the device handles in the
+    UR_CONTEXT_INFO_NUM_DEVICES = 0,          ///< [uint32_t] The number of the devices in the context
+    UR_CONTEXT_INFO_DEVICES = 1,              ///< [::ur_context_handle_t...] The array of the device handles in the
                                               ///< context
+    UR_CONTEXT_INFO_REFERENCE_COUNT = 2,      ///< [uint32_t] Reference count of the context object.
     UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT = 3, ///< [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
                                               ///< supported.
     UR_CONTEXT_INFO_USM_FILL2D_SUPPORT = 4,   ///< [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -343,6 +343,9 @@ typedef enum ur_context_info_t {
     UR_CONTEXT_INFO_DEVICES = 1,              ///< [::ur_context_handle_t...] The array of the device handles in the
                                               ///< context
     UR_CONTEXT_INFO_REFERENCE_COUNT = 2,      ///< [uint32_t] Reference count of the context object.
+                                              ///< The reference count returned should be considered immediately stale.
+                                              ///< It is unsuitable for general use in applications. This feature is
+                                              ///< provided for identifying memory leaks.
     UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT = 3, ///< [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
                                               ///< supported.
     UR_CONTEXT_INFO_USM_FILL2D_SUPPORT = 4,   ///< [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is
@@ -1617,7 +1620,10 @@ typedef enum ur_event_info_t {
     UR_EVENT_INFO_CONTEXT = 1,                  ///< [::ur_context_handle_t] Context information of an event object
     UR_EVENT_INFO_COMMAND_TYPE = 2,             ///< [::ur_command_t] Command type information of an event object
     UR_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3, ///< [::ur_event_status_t] Command execution status of an event object
-    UR_EVENT_INFO_REFERENCE_COUNT = 4,          ///< [uint32_t] Reference count of an event object
+    UR_EVENT_INFO_REFERENCE_COUNT = 4,          ///< [uint32_t] Reference count of the event object.
+                                                ///< The reference count returned should be considered immediately stale.
+                                                ///< It is unsuitable for general use in applications. This feature is
+                                                ///< provided for identifying memory leaks.
     /// @cond
     UR_EVENT_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2325,14 +2331,15 @@ urTearDown(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query queue info
 typedef enum ur_queue_info_t {
-    UR_QUEUE_INFO_CONTEXT = 0,         ///< ::ur_queue_handle_t: context associated with this queue.
-    UR_QUEUE_INFO_DEVICE = 1,          ///< ::ur_device_handle_t: device associated with this queue.
-    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< ::ur_queue_handle_t: the current default queue of the underlying
-                                       ///< device.
-    UR_QUEUE_INFO_PROPERTIES = 3,      ///< ::ur_queue_flags_t: the properties associated with
-                                       ///< ::UR_QUEUE_PROPERTIES_FLAGS.
-    UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< Queue reference count
-    UR_QUEUE_INFO_SIZE = 5,            ///< uint32_t: The size of the queue
+    UR_QUEUE_INFO_CONTEXT = 0,         ///< Queue context info
+    UR_QUEUE_INFO_DEVICE = 1,          ///< Queue device info
+    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< Queue device default info
+    UR_QUEUE_INFO_PROPERTIES = 3,      ///< Queue properties info
+    UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< [uint32_t] Reference count of the queue object.
+                                       ///< The reference count returned should be considered immediately stale.
+                                       ///< It is unsuitable for general use in applications. This feature is
+                                       ///< provided for identifying memory leaks.
+    UR_QUEUE_INFO_SIZE = 5,            ///< Queue size info
     /// @cond
     UR_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2604,7 +2611,10 @@ urQueueFlush(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get sample object information
 typedef enum ur_sampler_info_t {
-    UR_SAMPLER_INFO_REFERENCE_COUNT = 0,   ///< Sampler reference count info
+    UR_SAMPLER_INFO_REFERENCE_COUNT = 0,   ///< [uint32_t] Reference count of the sampler object.
+                                           ///< The reference count returned should be considered immediately stale.
+                                           ///< It is unsuitable for general use in applications. This feature is
+                                           ///< provided for identifying memory leaks.
     UR_SAMPLER_INFO_CONTEXT = 1,           ///< Sampler context info
     UR_SAMPLER_INFO_NORMALIZED_COORDS = 2, ///< Sampler normalized coordindate setting
     UR_SAMPLER_INFO_ADDRESSING_MODE = 3,   ///< Sampler addressing mode setting
@@ -3121,7 +3131,10 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,               ///< ::ur_queue_flags_t: host queue property bit-field
     UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< char[]: a semi-colon separated list of built-in kernels
     UR_DEVICE_INFO_PLATFORM = 63,                               ///< ::ur_platform_handle_t: the platform associated with the device
-    UR_DEVICE_INFO_REFERENCE_COUNT = 64,                        ///< uint32_t: reference count
+    UR_DEVICE_INFO_REFERENCE_COUNT = 64,                        ///< [uint32_t] Reference count of the device object.
+                                                                ///< The reference count returned should be considered immediately stale.
+                                                                ///< It is unsuitable for general use in applications. This feature is
+                                                                ///< provided for identifying memory leaks.
     UR_DEVICE_INFO_IL_VERSION = 65,                             ///< char[]: IL version
     UR_DEVICE_INFO_NAME = 66,                                   ///< char[]: Device name
     UR_DEVICE_INFO_VENDOR = 67,                                 ///< char[]: Device vendor
@@ -3604,7 +3617,10 @@ urKernelSetArgLocal(
 typedef enum ur_kernel_info_t {
     UR_KERNEL_INFO_FUNCTION_NAME = 0,   ///< Return Kernel function name, return type char[]
     UR_KERNEL_INFO_NUM_ARGS = 1,        ///< Return Kernel number of arguments
-    UR_KERNEL_INFO_REFERENCE_COUNT = 2, ///< Return Kernel reference count
+    UR_KERNEL_INFO_REFERENCE_COUNT = 2, ///< [uint32_t] Reference count of the kernel object.
+                                        ///< The reference count returned should be considered immediately stale.
+                                        ///< It is unsuitable for general use in applications. This feature is
+                                        ///< provided for identifying memory leaks.
     UR_KERNEL_INFO_CONTEXT = 3,         ///< Return Context object associated with Kernel
     UR_KERNEL_INFO_PROGRAM = 4,         ///< Return Program object associated with Kernel
     UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< Return Kernel attributes, return type char[]
@@ -4492,7 +4508,10 @@ urProgramGetFunctionPointer(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object information
 typedef enum ur_program_info_t {
-    UR_PROGRAM_INFO_REFERENCE_COUNT = 0, ///< Program reference count info
+    UR_PROGRAM_INFO_REFERENCE_COUNT = 0, ///< [uint32_t] Reference count of the program object.
+                                         ///< The reference count returned should be considered immediately stale.
+                                         ///< It is unsuitable for general use in applications. This feature is
+                                         ///< provided for identifying memory leaks.
     UR_PROGRAM_INFO_CONTEXT = 1,         ///< Program context info
     UR_PROGRAM_INFO_NUM_DEVICES = 2,     ///< Return number of devices associated with Program
     UR_PROGRAM_INFO_DEVICES = 3,         ///< Return list of devices associated with Program, return type

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2331,15 +2331,17 @@ urTearDown(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query queue info
 typedef enum ur_queue_info_t {
-    UR_QUEUE_INFO_CONTEXT = 0,         ///< Queue context info
-    UR_QUEUE_INFO_DEVICE = 1,          ///< Queue device info
-    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< Queue device default info
-    UR_QUEUE_INFO_PROPERTIES = 3,      ///< Queue properties info
+    UR_QUEUE_INFO_CONTEXT = 0,         ///< ::ur_queue_handle_t: context associated with this queue.
+    UR_QUEUE_INFO_DEVICE = 1,          ///< ::ur_device_handle_t: device associated with this queue.
+    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< ::ur_queue_handle_t: the current default queue of the underlying
+                                       ///< device.
+    UR_QUEUE_INFO_PROPERTIES = 3,      ///< ::ur_queue_flags_t: the properties associated with
+                                       ///< ::UR_QUEUE_PROPERTIES_FLAGS.
     UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< [uint32_t] Reference count of the queue object.
                                        ///< The reference count returned should be considered immediately stale.
                                        ///< It is unsuitable for general use in applications. This feature is
                                        ///< provided for identifying memory leaks.
-    UR_QUEUE_INFO_SIZE = 5,            ///< Queue size info
+    UR_QUEUE_INFO_SIZE = 5,            ///< uint32_t: The size of the queue
     /// @cond
     UR_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -69,7 +69,10 @@ etors:
     - name: DEVICES
       desc: "[$x_context_handle_t...] The array of the device handles in the context"
     - name: REFERENCE_COUNT
-      desc: "[uint32_t] Reference count of the context object."
+      desc: |
+            [uint32_t] Reference count of the context object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: USM_MEMCPY2D_SUPPORT
       desc: "[bool] to indicate if the $xEnqueueUSMMemcpy2D entrypoint is supported."
     - name: USM_FILL2D_SUPPORT

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -65,19 +65,16 @@ class: $xContext
 name: $x_context_info_t
 etors:
     - name: NUM_DEVICES
-      value: "1"
       desc: "[uint32_t] The number of the devices in the context"
     - name: DEVICES
-      value: "2"
       desc: "[$x_context_handle_t...] The array of the device handles in the context"
+    - name: REFERENCE_COUNT
+      desc: "[uint32_t] Reference count of the context object."
     - name: USM_MEMCPY2D_SUPPORT
-      value: "3"
       desc: "[bool] to indicate if the $xEnqueueUSMMemcpy2D entrypoint is supported."
     - name: USM_FILL2D_SUPPORT
-      value: "4"
       desc: "[bool] to indicate if the $xEnqueueUSMFill2D entrypoint is supported."
     - name: USM_MEMSET2D_SUPPORT
-      value: "5"
       desc: "[bool] to indicate if the $xEnqueueUSMMemset2D entrypoint is supported."
 --- #--------------------------------------------------------------------------
 type: function

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -206,7 +206,10 @@ etors:
     - name: PLATFORM
       desc: "$x_platform_handle_t: the platform associated with the device"
     - name: REFERENCE_COUNT
-      desc: "uint32_t: reference count"
+      desc: |
+            [uint32_t] Reference count of the device object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: IL_VERSION
       desc: "char[]: IL version"
     - name: NAME

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -98,7 +98,10 @@ etors:
     - name: COMMAND_EXECUTION_STATUS
       desc: "[$x_event_status_t] Command execution status of an event object"
     - name: REFERENCE_COUNT
-      desc: "[uint32_t] Reference count of an event object"
+      desc: |
+            [uint32_t] Reference count of the event object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Profiling query information type"

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -86,7 +86,10 @@ etors:
     - name: NUM_ARGS
       desc: "Return Kernel number of arguments"
     - name: REFERENCE_COUNT
-      desc: "Return Kernel reference count"
+      desc: |
+            [uint32_t] Reference count of the kernel object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: CONTEXT
       desc: "Return Context object associated with Kernel"
     - name: PROGRAM

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -215,7 +215,10 @@ class: $xProgram
 name: $x_program_info_t
 etors:
     - name: REFERENCE_COUNT
-      desc: "Program reference count info"
+      desc: |
+            [uint32_t] Reference count of the program object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: CONTEXT
       desc: "Program context info"
     - name: NUM_DEVICES

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -24,7 +24,10 @@ etors:
     - name: PROPERTIES
       desc: "$x_queue_flags_t: the properties associated with $X_QUEUE_PROPERTIES_FLAGS."
     - name: REFERENCE_COUNT
-      desc: "Queue reference count"
+      desc: |
+            [uint32_t] Reference count of the queue object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: SIZE
       desc: "uint32_t: The size of the queue"
 --- #--------------------------------------------------------------------------

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -16,7 +16,10 @@ class: $xSampler
 name: $x_sampler_info_t
 etors:
     - name: REFERENCE_COUNT
-      desc: "Sampler reference count info"
+      desc: |
+            [uint32_t] Reference count of the sampler object.
+            The reference count returned should be considered immediately stale. 
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: CONTEXT
       desc: "Sampler context info"
     - name: NORMALIZED_COORDS

--- a/test/conformance/context/urContextRelease.cpp
+++ b/test/conformance/context/urContextRelease.cpp
@@ -8,7 +8,19 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextReleaseTest);
 
 TEST_P(urContextReleaseTest, Success) {
     ASSERT_SUCCESS(urContextRetain(context));
+
+    const auto prevRefCount = uur::urContextGetReferenceCount(context);
+    ASSERT_TRUE(prevRefCount.second);
+
     ASSERT_SUCCESS(urContextRelease(context));
+
+    const auto refCount = uur::urContextGetReferenceCount(context);
+    ASSERT_TRUE(refCount.second);
+
+    ASSERT_EQ(prevRefCount.first + 1, refCount.first);
 }
 
-TEST_P(urContextReleaseTest, InvalidNullHandleContext) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urContextRelease(nullptr)); }
+TEST_P(urContextReleaseTest, InvalidNullHandleContext) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urContextRelease(nullptr));
+}

--- a/test/conformance/context/urContextRelease.cpp
+++ b/test/conformance/context/urContextRelease.cpp
@@ -9,15 +9,15 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextReleaseTest);
 TEST_P(urContextReleaseTest, Success) {
     ASSERT_SUCCESS(urContextRetain(context));
 
-    const auto prevRefCount = uur::urContextGetReferenceCount(context);
-    ASSERT_TRUE(prevRefCount.second);
+    const auto prevRefCount = uur::GetObjectReferenceCount(context);
+    ASSERT_TRUE(prevRefCount.has_value());
 
     ASSERT_SUCCESS(urContextRelease(context));
 
-    const auto refCount = uur::urContextGetReferenceCount(context);
-    ASSERT_TRUE(refCount.second);
+    const auto refCount = uur::GetObjectReferenceCount(context);
+    ASSERT_TRUE(refCount.has_value());
 
-    ASSERT_GT(prevRefCount.first, refCount.first);
+    ASSERT_GT(prevRefCount.value(), refCount.value());
 }
 
 TEST_P(urContextReleaseTest, InvalidNullHandleContext) {

--- a/test/conformance/context/urContextRelease.cpp
+++ b/test/conformance/context/urContextRelease.cpp
@@ -17,7 +17,7 @@ TEST_P(urContextReleaseTest, Success) {
     const auto refCount = uur::urContextGetReferenceCount(context);
     ASSERT_TRUE(refCount.second);
 
-    ASSERT_EQ(prevRefCount.first + 1, refCount.first);
+    ASSERT_GT(prevRefCount.first, refCount.first);
 }
 
 TEST_P(urContextReleaseTest, InvalidNullHandleContext) {

--- a/test/conformance/context/urContextRetain.cpp
+++ b/test/conformance/context/urContextRetain.cpp
@@ -7,8 +7,20 @@ using urContextRetainTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextRetainTest);
 
 TEST_P(urContextRetainTest, Success) {
+    const auto prevRefCount = uur::urContextGetReferenceCount(context);
+    ASSERT_TRUE(prevRefCount.second);
+
     ASSERT_SUCCESS(urContextRetain(context));
+
+    const auto refCount = uur::urContextGetReferenceCount(context);
+    ASSERT_TRUE(refCount.second);
+
+    ASSERT_EQ(prevRefCount.first + 1, refCount.first);
+
     EXPECT_SUCCESS(urContextRelease(context));
 }
 
-TEST_P(urContextRetainTest, InvalidNullHandleContext) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urContextRetain(nullptr)); }
+TEST_P(urContextRetainTest, InvalidNullHandleContext) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urContextRetain(nullptr));
+}

--- a/test/conformance/context/urContextRetain.cpp
+++ b/test/conformance/context/urContextRetain.cpp
@@ -15,7 +15,7 @@ TEST_P(urContextRetainTest, Success) {
     const auto refCount = uur::urContextGetReferenceCount(context);
     ASSERT_TRUE(refCount.second);
 
-    ASSERT_EQ(prevRefCount.first + 1, refCount.first);
+    ASSERT_LT(prevRefCount.first, refCount.first);
 
     EXPECT_SUCCESS(urContextRelease(context));
 }

--- a/test/conformance/context/urContextRetain.cpp
+++ b/test/conformance/context/urContextRetain.cpp
@@ -7,15 +7,15 @@ using urContextRetainTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextRetainTest);
 
 TEST_P(urContextRetainTest, Success) {
-    const auto prevRefCount = uur::urContextGetReferenceCount(context);
-    ASSERT_TRUE(prevRefCount.second);
+    const auto prevRefCount = uur::GetObjectReferenceCount(context);
+    ASSERT_TRUE(prevRefCount.has_value());
 
     ASSERT_SUCCESS(urContextRetain(context));
 
-    const auto refCount = uur::urContextGetReferenceCount(context);
-    ASSERT_TRUE(refCount.second);
+    const auto refCount = uur::GetObjectReferenceCount(context);
+    ASSERT_TRUE(refCount.has_value());
 
-    ASSERT_LT(prevRefCount.first, refCount.first);
+    ASSERT_LT(prevRefCount.value(), refCount.value());
 
     EXPECT_SUCCESS(urContextRelease(context));
 }

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -16,7 +16,7 @@ TEST_F(urDeviceReleaseTest, Success) {
         const auto refCount = uur::urDeviceGetReferenceCount(device);
         ASSERT_TRUE(refCount.second);
 
-        ASSERT_EQ(prevRefCount.first - 1, refCount.first);
+        ASSERT_GT(prevRefCount.first, refCount.first);
     }
 }
 

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -8,15 +8,15 @@ TEST_F(urDeviceReleaseTest, Success) {
     for (auto device : devices) {
         ASSERT_SUCCESS(urDeviceRetain(device));
 
-        const auto prevRefCount = uur::urDeviceGetReferenceCount(device);
-        ASSERT_TRUE(prevRefCount.second);
+        const auto prevRefCount = uur::GetObjectReferenceCount(device);
+        ASSERT_TRUE(prevRefCount.has_value());
 
         EXPECT_SUCCESS(urDeviceRelease(device));
 
-        const auto refCount = uur::urDeviceGetReferenceCount(device);
-        ASSERT_TRUE(refCount.second);
+        const auto refCount = uur::GetObjectReferenceCount(device);
+        ASSERT_TRUE(refCount.has_value());
 
-        ASSERT_GT(prevRefCount.first, refCount.first);
+        ASSERT_GT(prevRefCount.value(), refCount.value());
     }
 }
 

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -7,7 +7,16 @@ struct urDeviceReleaseTest : uur::urAllDevicesTest {};
 TEST_F(urDeviceReleaseTest, Success) {
     for (auto device : devices) {
         ASSERT_SUCCESS(urDeviceRetain(device));
+
+        const auto prevRefCount = uur::urDeviceGetReferenceCount(device);
+        ASSERT_TRUE(prevRefCount.second);
+
         EXPECT_SUCCESS(urDeviceRelease(device));
+
+        const auto refCount = uur::urDeviceGetReferenceCount(device);
+        ASSERT_TRUE(refCount.second);
+
+        ASSERT_EQ(prevRefCount.first - 1, refCount.first);
     }
 }
 

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -7,15 +7,15 @@ using urDeviceRetainTest = uur::urAllDevicesTest;
 
 TEST_F(urDeviceRetainTest, Success) {
     for (auto device : devices) {
-        const auto prevRefCount = uur::urDeviceGetReferenceCount(device);
-        ASSERT_TRUE(prevRefCount.second);
+        const auto prevRefCount = uur::GetObjectReferenceCount(device);
+        ASSERT_TRUE(prevRefCount.has_value());
 
         ASSERT_SUCCESS(urDeviceRetain(device));
 
-        const auto refCount = uur::urDeviceGetReferenceCount(device);
-        ASSERT_TRUE(refCount.second);
+        const auto refCount = uur::GetObjectReferenceCount(device);
+        ASSERT_TRUE(refCount.has_value());
 
-        ASSERT_LT(prevRefCount.first, refCount.first);
+        ASSERT_LT(prevRefCount.value(), refCount.value());
 
         EXPECT_SUCCESS(urDeviceRelease(device));
     }

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -15,7 +15,7 @@ TEST_F(urDeviceRetainTest, Success) {
         const auto refCount = uur::urDeviceGetReferenceCount(device);
         ASSERT_TRUE(refCount.second);
 
-        ASSERT_EQ(prevRefCount.first + 1, refCount.first);
+        ASSERT_LT(prevRefCount.first, refCount.first);
 
         EXPECT_SUCCESS(urDeviceRelease(device));
     }

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -7,9 +7,21 @@ using urDeviceRetainTest = uur::urAllDevicesTest;
 
 TEST_F(urDeviceRetainTest, Success) {
     for (auto device : devices) {
+        const auto prevRefCount = uur::urDeviceGetReferenceCount(device);
+        ASSERT_TRUE(prevRefCount.second);
+
         ASSERT_SUCCESS(urDeviceRetain(device));
+
+        const auto refCount = uur::urDeviceGetReferenceCount(device);
+        ASSERT_TRUE(refCount.second);
+
+        ASSERT_EQ(prevRefCount.first + 1, refCount.first);
+
         EXPECT_SUCCESS(urDeviceRelease(device));
     }
 }
 
-TEST_F(urDeviceRetainTest, InvalidNullHandle) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceRetain(nullptr)); }
+TEST_F(urDeviceRetainTest, InvalidNullHandle) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urDeviceRetain(nullptr));
+}

--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -15,7 +15,8 @@ namespace event {
  * - Execution Status: UR_EVENT_STATUS_COMPLETE
  * - Reference Count: 1
  */
-template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
+template <class T>
+struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());

--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -15,15 +15,17 @@ namespace event {
  * - Execution Status: UR_EVENT_STATUS_COMPLETE
  * - Reference Count: 1
  */
-template <class T>
-struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
+template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_WRITE_ONLY,
+                                         size, nullptr, &buffer));
 
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(this->queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(this->queue, buffer, false, 0,
+                                               size, input.data(), 0, nullptr,
+                                               &event));
         ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
@@ -53,10 +55,12 @@ struct urEventReferenceTest : uur::urQueueTest {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &buffer));
 
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(
+            queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
     }
 
     void TearDown() override {
@@ -64,12 +68,6 @@ struct urEventReferenceTest : uur::urQueueTest {
             EXPECT_SUCCESS(urMemRelease(buffer));
         }
         urQueueTest::TearDown();
-    }
-
-    bool checkEventReferenceCount(uint32_t expected_value) {
-        uint32_t reference_count{};
-        urEventGetInfo(event, ur_event_info_t::UR_EVENT_INFO_REFERENCE_COUNT, sizeof(uint32_t), &reference_count, nullptr);
-        return reference_count == expected_value;
     }
 
     const size_t count = 1024;

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -3,25 +3,25 @@
 
 #include "fixtures.h"
 
-using urEventReleaseTest = uur::event::urEventReferenceTest;
-
-/* Check that urEventRelease returns Success */
-TEST_P(urEventReleaseTest, Success) { ASSERT_SUCCESS(urEventRelease(event)); }
-
-/* Check that urEventRelease decrements the reference count*/
-TEST_P(urEventReleaseTest, CheckReferenceCount) {
-    ASSERT_SUCCESS(urEventRetain(event));
-    ASSERT_TRUE(checkEventReferenceCount(2));
-    ASSERT_SUCCESS(urEventRelease(event));
-    ASSERT_TRUE(checkEventReferenceCount(1));
-    ASSERT_SUCCESS(urEventRelease(event));
-}
-
-using urEventReleaseNegativeTest = uur::urQueueTest;
-
-TEST_P(urEventReleaseNegativeTest, InvalidNullHandle) {
-    ASSERT_EQ_RESULT(urEventRelease(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-}
+using urEventReleaseTest = uur::event::urEventTest;
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseTest);
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseNegativeTest);
+
+TEST_P(urEventReleaseTest, Success) {
+    ASSERT_SUCCESS(urEventRetain(event));
+
+    const auto prevRefCount = uur::urEventGetReferenceCount(event);
+    ASSERT_TRUE(prevRefCount.second);
+
+    ASSERT_SUCCESS(urEventRelease(event));
+
+    const auto refCount = uur::urEventGetReferenceCount(event);
+    ASSERT_TRUE(refCount.second);
+
+    ASSERT_GT(prevRefCount.first, refCount.first);
+}
+
+TEST(urEventReleaseTest, InvalidNullHandle) {
+    ASSERT_EQ_RESULT(urEventRelease(nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -10,15 +10,15 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseTest);
 TEST_P(urEventReleaseTest, Success) {
     ASSERT_SUCCESS(urEventRetain(event));
 
-    const auto prevRefCount = uur::urEventGetReferenceCount(event);
-    ASSERT_TRUE(prevRefCount.second);
+    const auto prevRefCount = uur::GetObjectReferenceCount(event);
+    ASSERT_TRUE(prevRefCount.has_value());
 
     ASSERT_SUCCESS(urEventRelease(event));
 
-    const auto refCount = uur::urEventGetReferenceCount(event);
-    ASSERT_TRUE(refCount.second);
+    const auto refCount = uur::GetObjectReferenceCount(event);
+    ASSERT_TRUE(refCount.has_value());
 
-    ASSERT_GT(prevRefCount.first, refCount.first);
+    ASSERT_GT(prevRefCount.value(), refCount.value());
 }
 
 TEST_P(urEventReleaseTest, InvalidNullHandle) {

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -21,7 +21,7 @@ TEST_P(urEventReleaseTest, Success) {
     ASSERT_GT(prevRefCount.first, refCount.first);
 }
 
-TEST(urEventReleaseTest, InvalidNullHandle) {
+TEST_P(urEventReleaseTest, InvalidNullHandle) {
     ASSERT_EQ_RESULT(urEventRelease(nullptr),
                      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -7,15 +7,15 @@ using urEventRetainTest = uur::event::urEventTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainTest);
 
 TEST_P(urEventRetainTest, Success) {
-    const auto prevRefCount = uur::urEventGetReferenceCount(event);
-    ASSERT_TRUE(prevRefCount.second);
+    const auto prevRefCount = uur::GetObjectReferenceCount(event);
+    ASSERT_TRUE(prevRefCount.has_value());
 
     ASSERT_SUCCESS(urEventRetain(event));
 
-    const auto refCount = uur::urEventGetReferenceCount(event);
-    ASSERT_TRUE(refCount.second);
+    const auto refCount = uur::GetObjectReferenceCount(event);
+    ASSERT_TRUE(refCount.has_value());
 
-    ASSERT_LT(prevRefCount.first, refCount.first);
+    ASSERT_LT(prevRefCount.value(), refCount.value());
 
     ASSERT_SUCCESS(urEventRelease(event));
 }

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -3,29 +3,24 @@
 
 #include "fixtures.h"
 
-using urEventRetainTest = uur::event::urEventReferenceTest;
-
-/* Check that urEventRetain returns Success */
-TEST_P(urEventRetainTest, Success) {
-    ASSERT_SUCCESS(urEventRetain(event));
-    ASSERT_SUCCESS(urEventRelease(event));
-    ASSERT_SUCCESS(urEventRelease(event));
-}
-
-/* Check that urEventRetain increments the reference count */
-TEST_P(urEventRetainTest, CheckReferenceCount) {
-    ASSERT_TRUE(checkEventReferenceCount(1));
-    ASSERT_SUCCESS(urEventRetain(event));
-    ASSERT_TRUE(checkEventReferenceCount(2));
-    ASSERT_SUCCESS(urEventRelease(event));
-    ASSERT_SUCCESS(urEventRelease(event));
-}
-
-using urEventRetainNegativeTest = uur::urQueueTest;
-
-TEST_P(urEventRetainNegativeTest, InvalidNullHandle) {
-    ASSERT_EQ_RESULT(urEventRetain(nullptr), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-}
-
+using urEventRetainTest = uur::event::urEventTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainTest);
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainNegativeTest);
+
+TEST_P(urEventRetainTest, Success) {
+    const auto prevRefCount = uur::urEventGetReferenceCount(event);
+    ASSERT_TRUE(prevRefCount.second);
+
+    ASSERT_SUCCESS(urEventRetain(event));
+
+    const auto refCount = uur::urEventGetReferenceCount(event);
+    ASSERT_TRUE(refCount.second);
+
+    ASSERT_LT(prevRefCount.first, refCount.first);
+
+    ASSERT_SUCCESS(urEventRelease(event));
+}
+
+TEST(urEventRetainTest, InvalidNullHandle) {
+    ASSERT_EQ_RESULT(urEventRetain(nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -20,7 +20,7 @@ TEST_P(urEventRetainTest, Success) {
     ASSERT_SUCCESS(urEventRelease(event));
 }
 
-TEST(urEventRetainTest, InvalidNullHandle) {
+TEST_P(urEventRetainTest, InvalidNullHandle) {
     ASSERT_EQ_RESULT(urEventRetain(nullptr),
                      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }

--- a/test/conformance/queue/urQueueRelease.cpp
+++ b/test/conformance/queue/urQueueRelease.cpp
@@ -7,7 +7,19 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueReleaseTest);
 
 TEST_P(urQueueReleaseTest, Success) {
     ASSERT_SUCCESS(urQueueRetain(queue));
+
+    const auto prevRefCount = uur::urQueueGetReferenceCount(queue);
+    ASSERT_TRUE(prevRefCount.second);
+
     ASSERT_SUCCESS(urQueueRelease(queue));
+
+    const auto refCount = uur::urQueueGetReferenceCount(queue);
+    ASSERT_TRUE(refCount.second);
+
+    ASSERT_GT(prevRefCount.first, refCount.first);
 }
 
-TEST_P(urQueueReleaseTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueRelease(nullptr)); }
+TEST_P(urQueueReleaseTest, InvalidNullHandleQueue) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urQueueRelease(nullptr));
+}

--- a/test/conformance/queue/urQueueRelease.cpp
+++ b/test/conformance/queue/urQueueRelease.cpp
@@ -8,15 +8,15 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueReleaseTest);
 TEST_P(urQueueReleaseTest, Success) {
     ASSERT_SUCCESS(urQueueRetain(queue));
 
-    const auto prevRefCount = uur::urQueueGetReferenceCount(queue);
-    ASSERT_TRUE(prevRefCount.second);
+    const auto prevRefCount = uur::GetObjectReferenceCount(queue);
+    ASSERT_TRUE(prevRefCount.has_value());
 
     ASSERT_SUCCESS(urQueueRelease(queue));
 
-    const auto refCount = uur::urQueueGetReferenceCount(queue);
-    ASSERT_TRUE(refCount.second);
+    const auto refCount = uur::GetObjectReferenceCount(queue);
+    ASSERT_TRUE(refCount.has_value());
 
-    ASSERT_GT(prevRefCount.first, refCount.first);
+    ASSERT_GT(prevRefCount.value(), refCount.value());
 }
 
 TEST_P(urQueueReleaseTest, InvalidNullHandleQueue) {

--- a/test/conformance/queue/urQueueRetain.cpp
+++ b/test/conformance/queue/urQueueRetain.cpp
@@ -6,15 +6,15 @@ using urQueueRetainTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueRetainTest);
 
 TEST_P(urQueueRetainTest, Success) {
-    const auto prevRefCount = uur::urQueueGetReferenceCount(queue);
-    ASSERT_TRUE(prevRefCount.second);
+    const auto prevRefCount = uur::GetObjectReferenceCount(queue);
+    ASSERT_TRUE(prevRefCount.has_value());
 
     ASSERT_SUCCESS(urQueueRetain(queue));
 
-    const auto refCount = uur::urQueueGetReferenceCount(queue);
-    ASSERT_TRUE(refCount.second);
+    const auto refCount = uur::GetObjectReferenceCount(queue);
+    ASSERT_TRUE(refCount.has_value());
 
-    ASSERT_LT(prevRefCount.first, refCount.first);
+    ASSERT_LT(prevRefCount.value(), refCount.value());
 
     EXPECT_SUCCESS(urQueueRelease(queue));
 }

--- a/test/conformance/queue/urQueueRetain.cpp
+++ b/test/conformance/queue/urQueueRetain.cpp
@@ -6,8 +6,20 @@ using urQueueRetainTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueRetainTest);
 
 TEST_P(urQueueRetainTest, Success) {
+    const auto prevRefCount = uur::urQueueGetReferenceCount(queue);
+    ASSERT_TRUE(prevRefCount.second);
+
     ASSERT_SUCCESS(urQueueRetain(queue));
+
+    const auto refCount = uur::urQueueGetReferenceCount(queue);
+    ASSERT_TRUE(refCount.second);
+
+    ASSERT_LT(prevRefCount.first, refCount.first);
+
     EXPECT_SUCCESS(urQueueRelease(queue));
 }
 
-TEST_P(urQueueRetainTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueRetain(nullptr)); }
+TEST_P(urQueueRetainTest, InvalidNullHandleQueue) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urQueueRetain(nullptr));
+}

--- a/test/conformance/testing/uur/utils.h
+++ b/test/conformance/testing/uur/utils.h
@@ -14,19 +14,24 @@ namespace uur {
 inline std::string GTestSanitizeString(const std::string &str) {
     auto str_cpy = str;
     std::replace_if(
-        str_cpy.begin(), str_cpy.end(), [](char c) { return !std::isalnum(c); }, '_');
+        str_cpy.begin(), str_cpy.end(), [](char c) { return !std::isalnum(c); },
+        '_');
     return str_cpy;
 }
 
-inline ur_platform_handle_t GetPlatform() { return PlatformEnvironment::instance->platform; }
+inline ur_platform_handle_t GetPlatform() {
+    return PlatformEnvironment::instance->platform;
+}
 
 inline std::string GetPlatformName(ur_platform_handle_t hPlatform) {
     size_t name_len = 0;
     urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_NAME, 0, nullptr, &name_len);
     std::string platform_name(name_len, '\0');
-    urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_NAME, name_len, &platform_name[0], nullptr);
+    urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_NAME, name_len,
+                      &platform_name[0], nullptr);
     platform_name.resize(platform_name.find_first_of('\0'));
-    return GTestSanitizeString(std::string(platform_name.data(), platform_name.size()));
+    return GTestSanitizeString(
+        std::string(platform_name.data(), platform_name.size()));
 }
 
 inline std::string GetDeviceName(ur_device_handle_t device) {
@@ -40,6 +45,16 @@ inline std::string GetDeviceName(ur_device_handle_t device) {
 
 inline std::string GetPlatformAndDeviceName(ur_device_handle_t device) {
     return GetPlatformName(GetPlatform()) + "__" + GetDeviceName(device);
+}
+
+inline std::pair<uint32_t, bool>
+urContextGetReferenceCount(ur_context_handle_t context) {
+    uint32_t refCount = 0;
+    if (urContextGetInfo(context, UR_CONTEXT_INFO_REFERENCE_COUNT,
+                         sizeof(uint32_t), &refCount, nullptr)) {
+        return {0, false};
+    }
+    return {refCount, true};
 }
 
 } // namespace uur

--- a/test/conformance/testing/uur/utils.h
+++ b/test/conformance/testing/uur/utils.h
@@ -4,6 +4,7 @@
 #ifndef UR_CONFORMANCE_INCLUDE_UTILS_H_INCLUDED
 #define UR_CONFORMANCE_INCLUDE_UTILS_H_INCLUDED
 
+#include <optional>
 #include <string>
 #include <uur/environment.h>
 
@@ -47,44 +48,84 @@ inline std::string GetPlatformAndDeviceName(ur_device_handle_t device) {
     return GetPlatformName(GetPlatform()) + "__" + GetDeviceName(device);
 }
 
-inline std::pair<uint32_t, bool>
-urContextGetReferenceCount(ur_context_handle_t context) {
-    uint32_t refCount = 0;
-    if (urContextGetInfo(context, UR_CONTEXT_INFO_REFERENCE_COUNT,
-                         sizeof(uint32_t), &refCount, nullptr)) {
-        return {0, false};
+template <class T, class ObjectTy, class InfoTy, class Callable>
+std::optional<T> GetInfo(ObjectTy object, InfoTy info, Callable cb) {
+    size_t infoSize = 0;
+    if (cb(object, info, 0, nullptr, &infoSize)) {
+        return std::nullopt;
     }
-    return {refCount, true};
+    if (infoSize == 0 || infoSize != sizeof(T)) {
+        return std::nullopt;
+    }
+    T queryValue{};
+    if (cb(object, info, sizeof(T), &queryValue, nullptr)) {
+        return std::nullopt;
+    }
+    return queryValue;
 }
 
-inline std::pair<uint32_t, bool>
-urDeviceGetReferenceCount(ur_device_handle_t device) {
-    uint32_t refCount = 0;
-    if (urDeviceGetInfo(device, UR_DEVICE_INFO_REFERENCE_COUNT,
-                        sizeof(uint32_t), &refCount, 0)) {
-        return {0, false};
-    }
-    return {refCount, true};
-}
+template <class T>
+auto GetContextInfo = [](ur_context_handle_t context, ur_context_info_t info) {
+    return GetInfo<T>(context, info, urContextGetInfo);
+};
 
-inline std::pair<uint32_t, bool>
-urEventGetReferenceCount(ur_event_handle_t event) {
-    int32_t refCount = 0;
-    if (urEventGetInfo(event, UR_EVENT_INFO_REFERENCE_COUNT, sizeof(uint32_t),
-                       &refCount, 0)) {
-        return {0, false};
-    }
-    return {refCount, true};
-}
+template <class T>
+auto GetDeviceInfo = [](ur_device_handle_t device, ur_device_info_t info) {
+    return GetInfo<T>(device, info, urDeviceGetInfo);
+};
 
-inline std::pair<uint32_t, bool>
-urQueueGetReferenceCount(ur_queue_handle_t queue) {
-    uint32_t refCount = 0;
-    if (urQueueGetInfo(queue, UR_QUEUE_INFO_REFERENCE_COUNT, sizeof(uint32_t),
-                       &refCount, nullptr)) {
-        return {0, false};
+template <class T>
+auto GetEventInfo = [](ur_event_handle_t event, ur_event_info_t info) {
+    return GetInfo<T>(event, info, urEventGetInfo);
+};
+
+template <class T>
+auto GetQueueInfo = [](ur_queue_handle_t queue, ur_queue_info_t info) {
+    return GetInfo<T>(queue, info, urQueueGetInfo);
+};
+
+template <class T>
+auto GetSamplerInfo = [](ur_sampler_handle_t sampler, ur_sampler_info_t info) {
+    return GetInfo<T>(sampler, info, urSamplerGetInfo);
+};
+
+template <class T>
+auto GetKernelInfo = [](ur_kernel_handle_t kernel, ur_kernel_info_t info) {
+    return GetInfo<T>(kernel, info, urKernelGetInfo);
+};
+
+template <class T>
+auto GetProgramInfo = [](ur_program_handle_t program, ur_program_info_t info) {
+    return GetInfo<T>(program, info, urProgramGetInfo);
+};
+
+template <class T>
+std::optional<uint32_t> GetObjectReferenceCount(T object) {
+    if constexpr (std::is_same_v<T, ur_context_handle_t>) {
+        return GetContextInfo<uint32_t>(object,
+                                        UR_CONTEXT_INFO_REFERENCE_COUNT);
     }
-    return {refCount, true};
+    if constexpr (std::is_same_v<T, ur_device_handle_t>) {
+        return GetDeviceInfo<uint32_t>(object, UR_DEVICE_INFO_REFERENCE_COUNT);
+    }
+    if constexpr (std::is_same_v<T, ur_event_handle_t>) {
+        return GetEventInfo<uint32_t>(object, UR_EVENT_INFO_REFERENCE_COUNT);
+    }
+    if constexpr (std::is_same_v<T, ur_queue_handle_t>) {
+        return GetQueueInfo<uint32_t>(object, UR_QUEUE_INFO_REFERENCE_COUNT);
+    }
+    if constexpr (std::is_same_v<T, ur_sampler_handle_t>) {
+        return GetSamplerInfo<uint32_t>(object,
+                                        UR_SAMPLER_INFO_REFERENCE_COUNT);
+    }
+    if constexpr (std::is_same_v<T, ur_kernel_handle_t>) {
+        return GetKernelInfo<uint32_t>(object, UR_KERNEL_INFO_REFERENCE_COUNT);
+    }
+    if constexpr (std::is_same_v<T, ur_program_handle_t>) {
+        return GetProgramInfo<uint32_t>(object,
+                                        UR_PROGRAM_INFO_REFERENCE_COUNT);
+    }
+    return std::nullopt;
 }
 
 } // namespace uur

--- a/test/conformance/testing/uur/utils.h
+++ b/test/conformance/testing/uur/utils.h
@@ -68,6 +68,16 @@ urDeviceGetReferenceCount(ur_device_handle_t device) {
 }
 
 inline std::pair<uint32_t, bool>
+urEventGetReferenceCount(ur_event_handle_t event) {
+    int32_t refCount = 0;
+    if (urEventGetInfo(event, UR_EVENT_INFO_REFERENCE_COUNT, sizeof(uint32_t),
+                       &refCount, 0)) {
+        return {0, false};
+    }
+    return {refCount, true};
+}
+
+inline std::pair<uint32_t, bool>
 urQueueGetReferenceCount(ur_queue_handle_t queue) {
     uint32_t refCount = 0;
     if (urQueueGetInfo(queue, UR_QUEUE_INFO_REFERENCE_COUNT, sizeof(uint32_t),

--- a/test/conformance/testing/uur/utils.h
+++ b/test/conformance/testing/uur/utils.h
@@ -67,6 +67,16 @@ urDeviceGetReferenceCount(ur_device_handle_t device) {
     return {refCount, true};
 }
 
+inline std::pair<uint32_t, bool>
+urQueueGetReferenceCount(ur_queue_handle_t queue) {
+    uint32_t refCount = 0;
+    if (urQueueGetInfo(queue, UR_QUEUE_INFO_REFERENCE_COUNT, sizeof(uint32_t),
+                       &refCount, nullptr)) {
+        return {0, false};
+    }
+    return {refCount, true};
+}
+
 } // namespace uur
 
 #endif // UR_CONFORMANCE_INCLUDE_UTILS_H_INCLUDED

--- a/test/conformance/testing/uur/utils.h
+++ b/test/conformance/testing/uur/utils.h
@@ -57,6 +57,16 @@ urContextGetReferenceCount(ur_context_handle_t context) {
     return {refCount, true};
 }
 
+inline std::pair<uint32_t, bool>
+urDeviceGetReferenceCount(ur_device_handle_t device) {
+    uint32_t refCount = 0;
+    if (urDeviceGetInfo(device, UR_DEVICE_INFO_REFERENCE_COUNT,
+                        sizeof(uint32_t), &refCount, 0)) {
+        return {0, false};
+    }
+    return {refCount, true};
+}
+
 } // namespace uur
 
 #endif // UR_CONFORMANCE_INCLUDE_UTILS_H_INCLUDED


### PR DESCRIPTION
`urRetain*` and `urRelease*` entry-points should increase and decrease the reference count of an object respectivelly. We have getInfo queries that can query the reference count from each object. These queries have the caveat that their value cannot be used reliably, especially in a multithreaded context. However, they are useful in a testing scenario where we disallow multithreading and assert that the reference count has changed after a release/retain call. 

This PR:
* Extends object lifetime testing and asserts that the reference count has changed after each release/retain call
* Clarifies the spec that `REFERENCE_COUNT` queries cannot be used reliably in an application context, especially a multithreaded one.

Closes #248 