### PR TITLE
Exclude `<ENUM>_FORCE_UINT32` from Doxygen

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -217,7 +217,9 @@ typedef enum ur_result_t {
     UR_RESULT_ERROR_ADAPTER_SPECIFIC = 68,                ///< An adapter specific warning/error has been reported and can be
                                                           ///< retrieved via the urGetLastResult entry point.
     UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                 ///< Unknown or internal error
+    /// @cond
     UR_RESULT_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_result_t;
 
@@ -225,7 +227,9 @@ typedef enum ur_result_t {
 /// @brief Defines structure types
 typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_IMAGE_DESC = 0, ///< ::ur_image_desc_t
+    /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_structure_type_t;
 
@@ -342,7 +346,9 @@ typedef enum ur_context_info_t {
                                               ///< supported.
     UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT = 5, ///< [bool] to indicate if the ::urEnqueueUSMMemset2D entrypoint is
                                               ///< supported.
+    /// @cond
     UR_CONTEXT_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_context_info_t;
 
@@ -1062,7 +1068,9 @@ typedef uint32_t ur_map_flags_t;
 typedef enum ur_map_flag_t {
     UR_MAP_FLAG_READ = UR_BIT(0),  ///< Map for read access
     UR_MAP_FLAG_WRITE = UR_BIT(1), ///< Map for write access
+    /// @cond
     UR_MAP_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_map_flag_t;
 
@@ -1071,7 +1079,9 @@ typedef enum ur_map_flag_t {
 typedef uint32_t ur_usm_migration_flags_t;
 typedef enum ur_usm_migration_flag_t {
     UR_USM_MIGRATION_FLAG_DEFAULT = UR_BIT(0), ///< Default migration TODO: Add more enums!
+    /// @cond
     UR_USM_MIGRATION_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_usm_migration_flag_t;
 
@@ -1262,7 +1272,9 @@ urEnqueueUSMPrefetch(
 /// @brief USM memory advice
 typedef enum ur_mem_advice_t {
     UR_MEM_ADVICE_DEFAULT = 0, ///< The USM memory advice is default
+    /// @cond
     UR_MEM_ADVICE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_mem_advice_t;
 
@@ -1484,7 +1496,9 @@ typedef enum ur_command_t {
     UR_COMMAND_USM_MEMCPY_2D = 23,                ///< Event created by ::urEnqueueUSMMemcpy2D
     UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 24, ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
     UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 25,  ///< Event created by ::urEnqueueDeviceGlobalVariableRead
+    /// @cond
     UR_COMMAND_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_command_t;
 
@@ -1495,7 +1509,9 @@ typedef enum ur_event_status_t {
     UR_EVENT_STATUS_RUNNING = 1,   ///< Command is running
     UR_EVENT_STATUS_SUBMITTED = 2, ///< Command is submitted
     UR_EVENT_STATUS_QUEUED = 3,    ///< Command is queued
+    /// @cond
     UR_EVENT_STATUS_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_event_status_t;
 
@@ -1507,7 +1523,9 @@ typedef enum ur_event_info_t {
     UR_EVENT_INFO_COMMAND_TYPE = 2,             ///< [::ur_command_t] Command type information of an event object
     UR_EVENT_INFO_COMMAND_EXECUTION_STATUS = 3, ///< [::ur_event_status_t] Command execution status of an event object
     UR_EVENT_INFO_REFERENCE_COUNT = 4,          ///< [uint32_t] Reference count of an event object
+    /// @cond
     UR_EVENT_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_event_info_t;
 
@@ -1522,7 +1540,9 @@ typedef enum ur_profiling_info_t {
                                           ///< starts execution
     UR_PROFILING_INFO_COMMAND_END = 3,    ///< A 64-bit value of current device counter in nanoseconds when the event
                                           ///< has finished execution
+    /// @cond
     UR_PROFILING_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_profiling_info_t;
 
@@ -1712,7 +1732,9 @@ typedef enum ur_execution_info_t {
     UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED = 2, ///< Indicates that the event has been submitted by the host to the device.
     UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED = 3,    ///< Indicates that the event has been queued, this is the initial state of
                                                     ///< events.
+    /// @cond
     UR_EXECUTION_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_execution_info_t;
 
@@ -1773,7 +1795,9 @@ typedef enum ur_mem_flag_t {
                                                      ///< the memory object
     UR_MEM_FLAG_ALLOC_HOST_POINTER = UR_BIT(4),      ///< Allocate memory object from host accessible memory
     UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER = UR_BIT(5), ///< Allocate memory and copy the data from host pointer pointed memory
+    /// @cond
     UR_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_mem_flag_t;
 
@@ -1787,7 +1811,9 @@ typedef enum ur_mem_type_t {
     UR_MEM_TYPE_IMAGE1D = 4,        ///< 1D image object
     UR_MEM_TYPE_IMAGE1D_ARRAY = 5,  ///< 1D image array object
     UR_MEM_TYPE_IMAGE1D_BUFFER = 6, ///< 1D image buffer object
+    /// @cond
     UR_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_mem_type_t;
 
@@ -1796,7 +1822,9 @@ typedef enum ur_mem_type_t {
 typedef enum ur_mem_info_t {
     UR_MEM_INFO_SIZE = 0,    ///< size_t: actual size of of memory object in bytes
     UR_MEM_INFO_CONTEXT = 1, ///< ::ur_context_handle_t: context in which the memory object was created
+    /// @cond
     UR_MEM_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_mem_info_t;
 
@@ -1817,7 +1845,9 @@ typedef enum ur_image_channel_order_t {
     UR_IMAGE_CHANNEL_ORDER_RGX = 11,      ///< channel order RGx
     UR_IMAGE_CHANNEL_ORDER_RGBX = 12,     ///< channel order RGBx
     UR_IMAGE_CHANNEL_ORDER_SRGBA = 13,    ///< channel order sRGBA
+    /// @cond
     UR_IMAGE_CHANNEL_ORDER_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_image_channel_order_t;
 
@@ -1839,7 +1869,9 @@ typedef enum ur_image_channel_type_t {
     UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32 = 12, ///< channel type unsigned int32
     UR_IMAGE_CHANNEL_TYPE_HALF_FLOAT = 13,     ///< channel type half float
     UR_IMAGE_CHANNEL_TYPE_FLOAT = 14,          ///< channel type float
+    /// @cond
     UR_IMAGE_CHANNEL_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_image_channel_type_t;
 
@@ -1853,7 +1885,9 @@ typedef enum ur_image_info_t {
     UR_IMAGE_INFO_WIDTH = 4,        ///< size_t: image width
     UR_IMAGE_INFO_HEIGHT = 5,       ///< size_t: image height
     UR_IMAGE_INFO_DEPTH = 6,        ///< size_t: image depth
+    /// @cond
     UR_IMAGE_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_image_info_t;
 
@@ -2012,7 +2046,9 @@ typedef struct ur_buffer_region_t {
 /// @brief Buffer creation type
 typedef enum ur_buffer_create_type_t {
     UR_BUFFER_CREATE_TYPE_REGION = 0, ///< buffer create type is region
+    /// @cond
     UR_BUFFER_CREATE_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_buffer_create_type_t;
 
@@ -2200,7 +2236,9 @@ typedef enum ur_queue_info_t {
     UR_QUEUE_INFO_PROPERTIES = 3,      ///< Queue properties info
     UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< Queue reference count
     UR_QUEUE_INFO_SIZE = 5,            ///< Queue size info
+    /// @cond
     UR_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_queue_info_t;
 
@@ -2215,7 +2253,9 @@ typedef enum ur_queue_flag_t {
     UR_QUEUE_FLAG_DISCARD_EVENTS = UR_BIT(4),                ///< Events will be discarded
     UR_QUEUE_FLAG_PRIORITY_LOW = UR_BIT(5),                  ///< Low priority queue
     UR_QUEUE_FLAG_PRIORITY_HIGH = UR_BIT(6),                 ///< High priority queue
+    /// @cond
     UR_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_queue_flag_t;
 
@@ -2228,7 +2268,9 @@ typedef intptr_t ur_queue_property_t;
 typedef enum ur_queue_properties_t {
     UR_QUEUE_PROPERTIES_FLAGS = -1,         ///< [::ur_queue_flags_t]: the bitfield of queue flags
     UR_QUEUE_PROPERTIES_COMPUTE_INDEX = -2, ///< [uint32_t]: the queue index
+    /// @cond
     UR_QUEUE_PROPERTIES_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_queue_properties_t;
 
@@ -2473,7 +2515,9 @@ typedef enum ur_sampler_info_t {
     UR_SAMPLER_INFO_MIP_FILTER_MODE = 5,   ///< Sampler MIP filter mode setting
     UR_SAMPLER_INFO_LOD_MIN = 6,           ///< Sampler LOD Min value
     UR_SAMPLER_INFO_LOD_MAX = 7,           ///< Sampler LOD Max value
+    /// @cond
     UR_SAMPLER_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_sampler_info_t;
 
@@ -2483,7 +2527,9 @@ typedef enum ur_sampler_properties_t {
     UR_SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0, ///< Sampler normalized coordinates
     UR_SAMPLER_PROPERTIES_ADDRESSING_MODE = 1,   ///< Sampler addressing mode
     UR_SAMPLER_PROPERTIES_FILTER_MODE = 2,       ///< Sampler filter mode
+    /// @cond
     UR_SAMPLER_PROPERTIES_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_sampler_properties_t;
 
@@ -2499,7 +2545,9 @@ typedef enum ur_sampler_addressing_mode_t {
     UR_SAMPLER_ADDRESSING_MODE_CLAMP = 2,           ///< Clamp
     UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE = 3,   ///< Clamp to edge
     UR_SAMPLER_ADDRESSING_MODE_NONE = 4,            ///< None
+    /// @cond
     UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_sampler_addressing_mode_t;
 
@@ -2676,7 +2724,9 @@ urSamplerCreateWithNativeHandle(
 typedef uint32_t ur_usm_mem_flags_t;
 typedef enum ur_usm_mem_flag_t {
     UR_USM_MEM_FLAG_ALLOC_FLAGS_INTEL = UR_BIT(0), ///< The USM memory allocation is from Intel USM
+    /// @cond
     UR_USM_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_usm_mem_flag_t;
 
@@ -2687,7 +2737,9 @@ typedef enum ur_usm_type_t {
     UR_USM_TYPE_HOST = 1,   ///< Host USM type
     UR_USM_TYPE_DEVICE = 2, ///< Device USM type
     UR_USM_TYPE_SHARED = 3, ///< Shared USM type
+    /// @cond
     UR_USM_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_usm_type_t;
 
@@ -2698,7 +2750,9 @@ typedef enum ur_usm_alloc_info_t {
     UR_USM_ALLOC_INFO_BASE_PTR = 1, ///< Memory allocation base pointer info
     UR_USM_ALLOC_INFO_SIZE = 2,     ///< Memory allocation size info
     UR_USM_ALLOC_INFO_DEVICE = 3,   ///< Memory allocation device info
+    /// @cond
     UR_USM_ALLOC_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_usm_alloc_info_t;
 
@@ -2847,7 +2901,9 @@ typedef enum ur_device_type_t {
     UR_DEVICE_TYPE_FPGA = 5,    ///< Field Programmable Gate Array
     UR_DEVICE_TYPE_MCA = 6,     ///< Memory Copy Accelerator
     UR_DEVICE_TYPE_VPU = 7,     ///< Vision Processing Unit
+    /// @cond
     UR_DEVICE_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_type_t;
 
@@ -3014,7 +3070,9 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 100,             ///< uint32_t: Returns 1 if the device doesn't have a notion of a
                                                                 ///< queue index. Otherwise, returns the number of queue indices that are
                                                                 ///< available for this device.
+    /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_info_t;
 
@@ -3112,7 +3170,9 @@ typedef enum ur_device_partition_t {
     UR_DEVICE_PARTITION_BY_COUNTS_LIST_END = 0x0,    ///< End of by counts list
     UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN = 0x1088, ///< Partition by affinity domain
     UR_DEVICE_PARTITION_BY_CSLICE = 0x1089,          ///< Partition by c-slice
+    /// @cond
     UR_DEVICE_PARTITION_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_partition_t;
 
@@ -3200,7 +3260,9 @@ typedef enum ur_fp_capability_flag_t {
     UR_FP_CAPABILITY_FLAG_INF_NAN = UR_BIT(4),                       ///< Support INF to NAN
     UR_FP_CAPABILITY_FLAG_DENORM = UR_BIT(5),                        ///< Support denorm
     UR_FP_CAPABILITY_FLAG_FMA = UR_BIT(6),                           ///< Support FMA
+    /// @cond
     UR_FP_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_fp_capability_flag_t;
 
@@ -3210,7 +3272,9 @@ typedef enum ur_device_mem_cache_type_t {
     UR_DEVICE_MEM_CACHE_TYPE_NONE = 0,             ///< Has none cache
     UR_DEVICE_MEM_CACHE_TYPE_READ_ONLY_CACHE = 1,  ///< Has read only cache
     UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE = 2, ///< Has read write cache
+    /// @cond
     UR_DEVICE_MEM_CACHE_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_mem_cache_type_t;
 
@@ -3219,7 +3283,9 @@ typedef enum ur_device_mem_cache_type_t {
 typedef enum ur_device_local_mem_type_t {
     UR_DEVICE_LOCAL_MEM_TYPE_LOCAL = 0,  ///< Dedicated local memory
     UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 1, ///< Global memory
+    /// @cond
     UR_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_local_mem_type_t;
 
@@ -3229,7 +3295,9 @@ typedef uint32_t ur_device_exec_capability_flags_t;
 typedef enum ur_device_exec_capability_flag_t {
     UR_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL = UR_BIT(0),        ///< Support kernel execution
     UR_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL = UR_BIT(1), ///< Support native kernel execution
+    /// @cond
     UR_DEVICE_EXEC_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_exec_capability_flag_t;
 
@@ -3239,7 +3307,9 @@ typedef uint32_t ur_device_affinity_domain_flags_t;
 typedef enum ur_device_affinity_domain_flag_t {
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),               ///< By NUMA
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1), ///< BY next partitionable
+    /// @cond
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_affinity_domain_flag_t;
 
@@ -3330,7 +3400,9 @@ typedef enum ur_memory_order_capability_flag_t {
     UR_MEMORY_ORDER_CAPABILITY_FLAG_RELEASE = UR_BIT(2), ///< Release memory ordering
     UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQ_REL = UR_BIT(3), ///< Acquire/release memory ordering
     UR_MEMORY_ORDER_CAPABILITY_FLAG_SEQ_CST = UR_BIT(4), ///< Sequentially consistent memory ordering
+    /// @cond
     UR_MEMORY_ORDER_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_memory_order_capability_flag_t;
 
@@ -3343,7 +3415,9 @@ typedef enum ur_memory_scope_capability_flag_t {
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_GROUP = UR_BIT(2), ///< Work group scope
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_DEVICE = UR_BIT(3),     ///< Device scope
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_SYSTEM = UR_BIT(4),     ///< System scope
+    /// @cond
     UR_MEMORY_SCOPE_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_memory_scope_capability_flag_t;
 
@@ -3437,7 +3511,9 @@ typedef enum ur_kernel_info_t {
     UR_KERNEL_INFO_CONTEXT = 3,         ///< Return Context object associated with Kernel
     UR_KERNEL_INFO_PROGRAM = 4,         ///< Return Program object associated with Kernel
     UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< Return Kernel attributes, return type char[]
+    /// @cond
     UR_KERNEL_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_kernel_info_t;
 
@@ -3453,7 +3529,9 @@ typedef enum ur_kernel_group_info_t {
                                                                  ///< size_t
     UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,                   ///< Return minimum amount of private memory in bytes used by each work
                                                                  ///< item in the Kernel, return type size_t
+    /// @cond
     UR_KERNEL_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_kernel_group_info_t;
 
@@ -3465,7 +3543,9 @@ typedef enum ur_kernel_sub_group_info_t {
     UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2, ///< Return number of SubGroup required by the source code, return type
                                                          ///< uint32_t
     UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3,   ///< Return SubGroup size required by Intel, return type uint32_t
+    /// @cond
     UR_KERNEL_SUB_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_kernel_sub_group_info_t;
 
@@ -3475,7 +3555,9 @@ typedef enum ur_kernel_exec_info_t {
     UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0, ///< Kernel might access data through USM pointer, type bool_t*
     UR_KERNEL_EXEC_INFO_USM_PTRS = 1,            ///< Provide an explicit list of USM pointers that the kernel will access,
                                                  ///< type void*[].
+    /// @cond
     UR_KERNEL_EXEC_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_kernel_exec_info_t;
 
@@ -3950,7 +4032,9 @@ typedef enum ur_platform_info_t {
                                       ///< size of the info needs to be dynamically queried.
     UR_PLATFORM_INFO_PROFILE = 5,     ///< [char*] The string denoting profile of the platform. The size of the
                                       ///< info needs to be dynamically queried.
+    /// @cond
     UR_PLATFORM_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_platform_info_t;
 
@@ -3994,7 +4078,9 @@ urPlatformGetInfo(
 typedef enum ur_api_version_t {
     UR_API_VERSION_0_9 = UR_MAKE_VERSION(0, 9),     ///< version 0.9
     UR_API_VERSION_CURRENT = UR_MAKE_VERSION(0, 9), ///< latest known version
+    /// @cond
     UR_API_VERSION_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_api_version_t;
 
@@ -4264,7 +4350,9 @@ typedef enum ur_program_info_t {
     UR_PROGRAM_INFO_NUM_KERNELS = 7,     ///< Number of kernels in Program, return type size_t
     UR_PROGRAM_INFO_KERNEL_NAMES = 8,    ///< Return a semi-colon separated list of kernel names in Program, return
                                          ///< type char[]
+    /// @cond
     UR_PROGRAM_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_program_info_t;
 
@@ -4303,7 +4391,9 @@ typedef enum ur_program_build_status_t {
     UR_PROGRAM_BUILD_STATUS_ERROR = 1,       ///< Program build error
     UR_PROGRAM_BUILD_STATUS_SUCCESS = 2,     ///< Program build success
     UR_PROGRAM_BUILD_STATUS_IN_PROGRESS = 3, ///< Program build in progress
+    /// @cond
     UR_PROGRAM_BUILD_STATUS_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_program_build_status_t;
 
@@ -4314,7 +4404,9 @@ typedef enum ur_program_binary_type_t {
     UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT = 1, ///< Program binary is compiled object
     UR_PROGRAM_BINARY_TYPE_LIBRARY = 2,         ///< Program binary is library object
     UR_PROGRAM_BINARY_TYPE_EXECUTABLE = 3,      ///< Program binary is executable
+    /// @cond
     UR_PROGRAM_BINARY_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_program_binary_type_t;
 
@@ -4325,7 +4417,9 @@ typedef enum ur_program_build_info_t {
     UR_PROGRAM_BUILD_INFO_OPTIONS = 1,     ///< Program build options, return type char[]
     UR_PROGRAM_BUILD_INFO_LOG = 2,         ///< Program build log, return type char[]
     UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3, ///< Program binary type, return type ::ur_program_binary_type_t
+    /// @cond
     UR_PROGRAM_BUILD_INFO_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_program_build_info_t;
 
@@ -4441,7 +4535,9 @@ urProgramCreateWithNativeHandle(
 typedef uint32_t ur_device_init_flags_t;
 typedef enum ur_device_init_flag_t {
     UR_DEVICE_INIT_FLAG_GPU = UR_BIT(0), ///< initialize GPU device drivers
+    /// @cond
     UR_DEVICE_INIT_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
 
 } ur_device_init_flag_t;
 

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -596,7 +596,11 @@ def make_etor_lines(namespace, tags, obj, py=False, meta=None):
             prologue = ""
 
     if not py:
-        lines.append("%sFORCE_UINT32 = 0x7fffffff"%make_enum_name(namespace, tags, obj)[:-1].upper())
+        lines += [
+            "/// @cond",
+            "%sFORCE_UINT32 = 0x7fffffff"%make_enum_name(namespace, tags, obj)[:-1].upper(),
+            "/// @endcond",
+        ]
 
     return lines
 


### PR DESCRIPTION
Enums generated in C or C++ files include an `<ENUM>_FORCE_UINT32`
enumeration to force the compiler to use the equivalent of `uint32_t`
for the underlying type. Unfortunately, this also made its way into the
Doxygen and therefore the generated HTML specification. This patch
unconditionally excludes the `<ENUM>_FORCE_UINT32` enumeration from the
Doxygen and thus also from the HTML specification.
