### PR TITLE
Add ur_context_properties_t for context creation

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -205,11 +205,12 @@ class ur_result_t(c_int):
 ###############################################################################
 ## @brief Defines structure types
 class ur_structure_type_v(IntEnum):
-    IMAGE_DESC = 0                                  ## ::ur_image_desc_t
-    PROGRAM_PROPERTIES = 1                          ## ::ur_program_properties_t
-    USM_DESC = 2                                    ## ::ur_usm_desc_t
-    USM_POOL_DESC = 3                               ## ::ur_usm_pool_desc_t
-    USM_POOL_LIMITS_DESC = 4                        ## ::ur_usm_pool_limits_desc_t
+    CONTEXT_PROPERTIES = 0                          ## ::ur_context_properties_t
+    IMAGE_DESC = 1                                  ## ::ur_image_desc_t
+    PROGRAM_PROPERTIES = 2                          ## ::ur_program_properties_t
+    USM_DESC = 3                                    ## ::ur_usm_desc_t
+    USM_POOL_DESC = 4                               ## ::ur_usm_pool_desc_t
+    USM_POOL_LIMITS_DESC = 5                        ## ::ur_usm_pool_limits_desc_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -549,6 +550,26 @@ class ur_memory_scope_capability_flags_t(c_int):
 
 
 ###############################################################################
+## @brief Context property type
+class ur_context_flags_v(IntEnum):
+    TBD = UR_BIT(0)                                 ## reserved for future use
+
+class ur_context_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Context creation properties
+class ur_context_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("flags", ur_context_flags_t)                                   ## [in] context creation flags.
+    ]
+
+###############################################################################
 ## @brief Supported context info
 class ur_context_info_v(IntEnum):
     NUM_DEVICES = 0                                 ## [uint32_t] The number of the devices in the context
@@ -697,7 +718,7 @@ class ur_image_format_t(Structure):
 ## @brief Image descriptor type.
 class ur_image_desc_t(Structure):
     _fields_ = [
-        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_IMAGE_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("type", ur_mem_type_t),                                        ## [in] memory object type
         ("width", c_size_t),                                            ## [in] image width
@@ -859,7 +880,7 @@ class ur_usm_pool_handle_t(c_void_p):
 ## @brief USM allocation descriptor type
 class ur_usm_desc_t(Structure):
     _fields_ = [
-        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("flags", ur_usm_mem_flags_t),                                  ## [in] memory allocation flags
         ("hints", ur_mem_advice_t)                                      ## [in] Memory advice hints
@@ -869,7 +890,7 @@ class ur_usm_desc_t(Structure):
 ## @brief USM pool descriptor type
 class ur_usm_pool_desc_t(Structure):
     _fields_ = [
-        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_POOL_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("flags", ur_usm_pool_flags_t)                                  ## [in] memory allocation flags
     ]
@@ -878,7 +899,8 @@ class ur_usm_pool_desc_t(Structure):
 ## @brief USM pool limits descriptor type
 class ur_usm_pool_limits_desc_t(Structure):
     _fields_ = [
-        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("maxPoolSize", c_size_t),                                      ## [in] Maximum size of a memory pool
         ("maxPoolableSize", c_size_t),                                  ## [in] Allocations up to this limit will be subject to pooling
@@ -936,7 +958,8 @@ class ur_program_metadata_t(Structure):
 ## @brief Program creation properties.
 class ur_program_properties_t(Structure):
     _fields_ = [
-        ("stype", ur_structure_type_t),                                 ## [in] type of this structure
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES
         ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
         ("count", c_ulong),                                             ## [in] the number of entries in pMetadatas, if count is greater than
                                                                         ## zero then pMetadatas must not be null.
@@ -1296,9 +1319,9 @@ class ur_platform_dditable_t(Structure):
 ###############################################################################
 ## @brief Function-pointer for urContextCreate
 if __use_win_types:
-    _urContextCreate_t = WINFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_handle_t) )
+    _urContextCreate_t = WINFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_properties_t), POINTER(ur_context_handle_t) )
 else:
-    _urContextCreate_t = CFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_handle_t) )
+    _urContextCreate_t = CFUNCTYPE( ur_result_t, c_ulong, POINTER(ur_device_handle_t), POINTER(ur_context_properties_t), POINTER(ur_context_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urContextRetain

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -228,11 +228,12 @@ typedef enum ur_result_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
 typedef enum ur_structure_type_t {
-    UR_STRUCTURE_TYPE_IMAGE_DESC = 0,           ///< ::ur_image_desc_t
-    UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES = 1,   ///< ::ur_program_properties_t
-    UR_STRUCTURE_TYPE_USM_DESC = 2,             ///< ::ur_usm_desc_t
-    UR_STRUCTURE_TYPE_USM_POOL_DESC = 3,        ///< ::ur_usm_pool_desc_t
-    UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 4, ///< ::ur_usm_pool_limits_desc_t
+    UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES = 0,   ///< ::ur_context_properties_t
+    UR_STRUCTURE_TYPE_IMAGE_DESC = 1,           ///< ::ur_image_desc_t
+    UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES = 2,   ///< ::ur_program_properties_t
+    UR_STRUCTURE_TYPE_USM_DESC = 3,             ///< ::ur_usm_desc_t
+    UR_STRUCTURE_TYPE_USM_POOL_DESC = 4,        ///< ::ur_usm_pool_desc_t
+    UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 5, ///< ::ur_usm_pool_limits_desc_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1089,6 +1090,27 @@ typedef enum ur_memory_scope_capability_flag_t {
 #pragma region context
 #endif
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Context property type
+typedef uint32_t ur_context_flags_t;
+typedef enum ur_context_flag_t {
+    UR_CONTEXT_FLAG_TBD = UR_BIT(0), ///< reserved for future use
+    /// @cond
+    UR_CONTEXT_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_context_flag_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Context creation properties
+typedef struct ur_context_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    ur_context_flags_t flags;  ///< [in] context creation flags.
+
+} ur_context_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Creates a context with the given devices.
 ///
 /// @details
@@ -1117,9 +1139,10 @@ typedef enum ur_memory_scope_capability_flag_t {
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1434,7 +1457,7 @@ typedef struct ur_image_format_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image descriptor type.
 typedef struct ur_image_desc_t {
-    ur_structure_type_t stype; ///< [in] type of this structure
+    ur_structure_type_t stype; ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_IMAGE_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_mem_type_t type;        ///< [in] memory object type
     size_t width;              ///< [in] image width
@@ -2035,7 +2058,7 @@ typedef struct ur_usm_pool_handle_t_ *ur_usm_pool_handle_t;
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocation descriptor type
 typedef struct ur_usm_desc_t {
-    ur_structure_type_t stype; ///< [in] type of this structure
+    ur_structure_type_t stype; ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_usm_mem_flags_t flags;  ///< [in] memory allocation flags
     ur_mem_advice_t hints;     ///< [in] Memory advice hints
@@ -2045,7 +2068,7 @@ typedef struct ur_usm_desc_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM pool descriptor type
 typedef struct ur_usm_pool_desc_t {
-    ur_structure_type_t stype; ///< [in] type of this structure
+    ur_structure_type_t stype; ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_POOL_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_usm_pool_flags_t flags; ///< [in] memory allocation flags
 
@@ -2054,7 +2077,8 @@ typedef struct ur_usm_pool_desc_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM pool limits descriptor type
 typedef struct ur_usm_pool_limits_desc_t {
-    ur_structure_type_t stype; ///< [in] type of this structure
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     size_t maxPoolSize;        ///< [in] Maximum size of a memory pool
     size_t maxPoolableSize;    ///< [in] Allocations up to this limit will be subject to pooling
@@ -2482,7 +2506,8 @@ typedef struct ur_program_metadata_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program creation properties.
 typedef struct ur_program_properties_t {
-    ur_structure_type_t stype;               ///< [in] type of this structure
+    ur_structure_type_t stype;               ///< [in] type of this structure, must be
+                                             ///< ::UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES
     void *pNext;                             ///< [in,out][optional] pointer to extension-specific structure
     uint32_t count;                          ///< [in] the number of entries in pMetadatas, if count is greater than
                                              ///< zero then pMetadatas must not be null.
@@ -5087,6 +5112,7 @@ typedef struct ur_platform_callbacks_t {
 typedef struct ur_context_create_params_t {
     uint32_t *pDeviceCount;
     const ur_device_handle_t **pphDevices;
+    const ur_context_properties_t **ppProperties;
     ur_context_handle_t **pphContext;
 } ur_context_create_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -89,6 +89,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetPlatformProcAddrTable_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnContextCreate_t)(
     uint32_t,
     const ur_device_handle_t *,
+    const ur_context_properties_t *,
     ur_context_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -155,7 +155,7 @@ events, and programs are explicitly created against a context. A trivial work wi
 
     // Create a context
     ${x}_context_handle_t hContext;
-    ${x}ContextCreate(1, &hDevice, &hContext);
+    ${x}ContextCreate(1, &hDevice, nullptr, &hContext);
 
     // Operations on this context
     // ...

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -269,6 +269,8 @@ type: enum
 desc: "Defines structure types"
 name: $x_structure_type_t
 etors:
+    - name: CONTEXT_PROPERTIES
+      desc: $x_context_properties_t
     - name: IMAGE_DESC
       desc: $x_image_desc_t
     - name: PROGRAM_PROPERTIES

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -10,6 +10,23 @@ type: header
 desc: "Intel $OneApi Unified Runtime APIs for Context"
 ordinal: "3"
 --- #--------------------------------------------------------------------------
+type: enum
+desc: "Context property type"
+name: $x_context_flags_t
+etors:
+    - name: TBD
+      desc: "reserved for future use"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Context creation properties"
+class: $xProgram
+name: $x_context_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_context_flags_t
+      name: flags
+      desc: "[in] context creation flags."
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Creates a context with the given devices."
 class: $xContext
@@ -34,6 +51,10 @@ params:
       name: phDevices
       desc: |
             [in][range(0, DeviceCount)] array of handle of devices.
+    - type: const $x_context_properties_t*
+      name: pProperties
+      desc: |
+            [in][optional] pointer to context creation properties.
     - type: $x_context_handle_t*
       name: phContext
       desc: "[out] pointer to handle of context object created"

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -634,7 +634,7 @@ def _inline_base(obj, meta):
                 m = copy.deepcopy(m)
                 if m['name'] == "stype":
                     m['init'] = re.sub(r"(\$[a-z]+)(\w+)_t", r"\1_STRUCTURE_TYPE\2", obj['name']).upper()
-
+                    m['desc'] += ', must be %s' % m['init']
                 obj['members'].insert(i, m)
     return obj
 

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -408,16 +408,17 @@ urDeviceGetGlobalTimestamps(
 /// @brief Intercept function for urContextCreate
 __urdlllocal ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Context.pfnCreate;
     if (nullptr != pfnCreate) {
-        result = pfnCreate(DeviceCount, phDevices, phContext);
+        result = pfnCreate(DeviceCount, phDevices, pProperties, phContext);
     } else {
         // generic implementation
         *phContext = reinterpret_cast<ur_context_handle_t>(d_context.get());

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -478,9 +478,10 @@ urDeviceGetGlobalTimestamps(
 /// @brief Intercept function for urContextCreate
 __urdlllocal ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = context.urDdiTable.Context.pfnCreate;
 
@@ -498,7 +499,7 @@ urContextCreate(
         }
     }
 
-    return pfnCreate(DeviceCount, phDevices, phContext);
+    return pfnCreate(DeviceCount, phDevices, pProperties, phContext);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -598,9 +598,10 @@ urDeviceGetGlobalTimestamps(
 /// @brief Intercept function for urContextCreate
 __urdlllocal ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -618,7 +619,7 @@ urContextCreate(
     }
 
     // forward to device-platform
-    result = pfnCreate(DeviceCount, phDevices, phContext);
+    result = pfnCreate(DeviceCount, phDevices, pProperties, phContext);
     delete[] phDevicesLocal;
 
     if (UR_RESULT_SUCCESS != result) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -654,16 +654,17 @@ urDeviceGetGlobalTimestamps(
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Context.pfnCreate;
     if (nullptr == pfnCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreate(DeviceCount, phDevices, phContext);
+    return pfnCreate(DeviceCount, phDevices, pProperties, phContext);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -574,9 +574,10 @@ urDeviceGetGlobalTimestamps(
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
 ur_result_t UR_APICALL
 urContextCreate(
-    uint32_t DeviceCount,                ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
-    ur_context_handle_t *phContext       ///< [out] pointer to handle of context object created
+    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/conformance/context/urContextCreate.cpp
+++ b/test/conformance/context/urContextCreate.cpp
@@ -9,19 +9,29 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateTest);
 
 TEST_P(urContextCreateTest, Success) {
     ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, &context));
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
+    ASSERT_NE(nullptr, context);
+    ASSERT_SUCCESS(urContextRelease(context));
+}
+
+TEST_P(urContextCreateTest, SuccessWithProperties) {
+    ur_context_properties_t properties{UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES};
+    ur_context_handle_t context = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, &properties, &context));
     ASSERT_NE(nullptr, context);
     ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(urContextCreateTest, InvalidNullPointerDevices) {
     ur_context_handle_t context = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urContextCreate(1, nullptr, &context));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urContextCreate(1, nullptr, nullptr, &context));
 }
 
 TEST_P(urContextCreateTest, InvalidNullPointerContext) {
     auto device = GetParam();
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urContextCreate(1, &device, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urContextCreate(1, &device, nullptr, nullptr));
 }
 
 using urContextCreateMultiDeviceTest = uur::urAllDevicesTest;
@@ -30,7 +40,8 @@ TEST_F(urContextCreateMultiDeviceTest, Success) {
         GTEST_SKIP();
     }
     ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(static_cast<uint32_t>(devices.size()), devices.data(), &context));
+    ASSERT_SUCCESS(urContextCreate(static_cast<uint32_t>(devices.size()),
+                                   devices.data(), nullptr, &context));
     ASSERT_NE(nullptr, context);
     ASSERT_SUCCESS(urContextRelease(context));
 }

--- a/test/conformance/context/urContextSetExtendedDeleter.cpp
+++ b/test/conformance/context/urContextSetExtendedDeleter.cpp
@@ -9,7 +9,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextSetExtendedDeleterTest);
 
 TEST_P(urContextSetExtendedDeleterTest, Success) {
     ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, &context));
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
     ASSERT_NE(context, nullptr);
 
     bool called = false;
@@ -28,7 +28,7 @@ TEST_P(urContextSetExtendedDeleterTest, InvalidNullHandleContext) {
 
 TEST_P(urContextSetExtendedDeleterTest, InvalidNullPointerDeleter) {
     ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, &context));
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
     ASSERT_NE(context, nullptr);
 
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,

--- a/test/conformance/testing/uur/fixtures.h
+++ b/test/conformance/testing/uur/fixtures.h
@@ -122,7 +122,7 @@ struct urDeviceTestWithParam
 struct urContextTest : urDeviceTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urDeviceTest::SetUp());
-        ASSERT_SUCCESS(urContextCreate(1, &device, &context));
+        ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
         ASSERT_NE(context, nullptr);
     }
 
@@ -169,7 +169,7 @@ template <class T>
 struct urContextTestWithParam : urDeviceTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urDeviceTestWithParam<T>::SetUp());
-        ASSERT_SUCCESS(urContextCreate(1, &this->device, &context));
+        ASSERT_SUCCESS(urContextCreate(1, &this->device, nullptr, &context));
     }
 
     void TearDown() override {
@@ -261,7 +261,7 @@ struct urMultiDeviceContextTest : urPlatformTest {
             GTEST_SKIP();
         }
         ASSERT_SUCCESS(urContextCreate(static_cast<uint32_t>(devices.size()),
-                                       devices.data(), &context));
+                                       devices.data(), nullptr, &context));
     }
 
     void TearDown() override {


### PR DESCRIPTION
Introduce the `ur_context_properties_t` struct to enable extending the
creation of context beyond the defaults. As there are currently no
context properties, the `ur_context_flags_t` in also introduced as a
placeholder which creation flags can be added to in future.

Fixes #97
