### PR TITLE
Set required C++ standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ include(helpers)
 
 find_package(Python3 COMPONENTS Interpreter)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 # Build Options
 option(UR_DEVELOPER_MODE "enable developer checks, treats warnings as errors" OFF)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tools can be acquired via instructions in [third_party](/third_party/README.md).
 ## Building
 
 Requirements:
-- C++ compiler with C++14 support
+- C++ compiler with C++17 support
 - cmake >= 3.14.0
 - clang-format-15.0 (can be installed with `python -m pip install clang-format`)
 


### PR DESCRIPTION
This is consistent with intel/llvm: https://github.com/intel/llvm/blob/6761f0ef372a0e54b970d85241808339e9bcf077/llvm/docs/CMake.rst#L279