### PR TITLE
[ur] use explicit function pointers

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -460,7 +460,7 @@ urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Context's extended deleter callback function with user data.
-typedef void(ur_context_extended_deleter_t)(
+typedef void (*ur_context_extended_deleter_t)(
     void *pUserData ///< [in][out] pointer to data to be passed to callback
 );
 
@@ -1834,7 +1834,7 @@ typedef enum ur_execution_info_t {
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event callback function that can be registered by the application.
-typedef void(ur_event_callback_t)(
+typedef void (*ur_event_callback_t)(
     ur_event_handle_t hEvent,       ///< [in] handle to event
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     void *pUserData                 ///< [in][out] pointer to data to be passed to callback
@@ -3949,7 +3949,7 @@ urKernelCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief callback function for urModuleCreate
-typedef void(ur_modulecreate_callback_t)(
+typedef void (*ur_modulecreate_callback_t)(
     ur_module_handle_t hModule, ///< [in] handle of Module object created.
     void *pParams               ///< [in][out] pointer to user data to be passed to callback.
 );

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -73,7 +73,7 @@ extern "C" {
 typedef ${th.subt(n, tags, obj['value'])} ${th.make_type_name(n, tags, obj)};
 ## FPTR TYPEDEF ###############################################################
 %elif re.match(r"fptr_typedef", obj['type']):
-typedef ${th.subt(n, tags, obj['return'])} (${th.make_func_name(n, tags, obj)})(
+typedef ${th.subt(n, tags, obj['return'])} (*${th.make_func_name(n, tags, obj)})(
 %if 'params' in obj:
 %for line in th.make_param_lines(n, tags, obj):
     ${line}

--- a/test/conformance/context/urContextSetExtendedDeleter.cpp
+++ b/test/conformance/context/urContextSetExtendedDeleter.cpp
@@ -13,7 +13,7 @@ TEST_P(urContextSetExtendedDeleterTest, Success) {
     ASSERT_NE(context, nullptr);
 
     bool called = false;
-    ur_context_extended_deleter_t *deleter = [](void *userdata) { *static_cast<bool *>(userdata) = true; };
+    ur_context_extended_deleter_t deleter = [](void *userdata) { *static_cast<bool *>(userdata) = true; };
 
     ASSERT_SUCCESS(urContextSetExtendedDeleter(context, deleter, &called));
     ASSERT_SUCCESS(urContextRelease(context));
@@ -21,7 +21,7 @@ TEST_P(urContextSetExtendedDeleterTest, Success) {
 }
 
 TEST_P(urContextSetExtendedDeleterTest, InvalidNullHandleContext) {
-    ur_context_extended_deleter_t *deleter = [](void *) {};
+    ur_context_extended_deleter_t deleter = [](void *) {};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urContextSetExtendedDeleter(nullptr, deleter, nullptr));
 }


### PR DESCRIPTION
UR spec defined 'fptr' as function types instead of actual pointers.
This is fine for function parameters but made it difficult to populate
params structs (e.g., `params.pfnNotify = &notify` didn't work).

> A function designator is an expression that has function type. Except when it is the
> operand of the *sizeof operator* or the unary *&* operator, a function designator with
> type "function returning type" is converted to an expression that has type "pointer to
> function returning type".
> C11 6.3.2.1-4