### PR TITLE
Remove a requirement for type: struct

### DIFF
--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -464,7 +464,7 @@ class ur_name_flags_v(IntEnum):
       - `in,out` is used for members that are both read and write; typically this is used for pointers to other data structures that contain both read and write members
     + `desc` may include one the following annotations: {`"[optional]"`}
       - `optional` is used for members that are pointers where it is legal for the value to be `nullptr`
-    + `type` must be an ISO-C standard identifier; except it may **not** be a `handle_t`
+    + `type` must be an ISO-C standard identifier
     + `name` must be a unique ISO-C standard identifier
   - A member may take the following optional scalar field: {`init`, `version`}
     + `init` will be used to initialize the C++ struct|union member's value

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -259,9 +259,6 @@ def _validate_doc(f, d, tags, line_num):
             if not annotation:
                 raise Exception(prefix+"'desc' must start with {'[in]', '[out]', '[in,out]'}")
 
-            if type_traits.is_handle(item['type']):
-                raise Exception(prefix+"'type' must not be '*_handle_t': %s"%item['type'])
-
             if item['type'].endswith("flag_t"):
                 raise Exception(prefix+"'type' must not be '*_flag_t': %s"%item['type'])
 


### PR DESCRIPTION
That disallows member to be 'handle_t'.

I'd like to create an opaque handle: `ur_usm_pool_handle_t` and have it as a member in `ur_usm_desc_t` in: https://github.com/oneapi-src/unified-runtime/pull/264.

@jandres742 said that this requirement: `It is just to avoid having in a struct handles, which by the moment we use this struct, might not be defined` so, in my opinion it should be safe to lift this requirement as long as we make sure that the handle is defined.

If you see some other problems with this change, I can just leave the `void*` as the type of pool handle or pass `ur_usm_pool_handle_t` as a separate argument to allocation function, but I think having everything in the desc struct is a better option.