### PR TITLE
[UR] Fix urUSMDeviceAlloc calls

### DIFF
--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -22,9 +22,9 @@ struct urEnqueueUSMMemcpy2DTestWithParam
 
         const size_t num_elements = pitch * height;
         ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, num_elements, 0, &pSrc));
+            urUSMDeviceAlloc(context, device, nullptr, nullptr, num_elements, 0, &pSrc));
         ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, num_elements, 0, &pDst));
+            urUSMDeviceAlloc(context, device, nullptr, nullptr, num_elements, 0, &pDst));
         ur_event_handle_t memset_event = nullptr;
         ASSERT_SUCCESS(urEnqueueUSMMemset2D(queue, pSrc, pitch, memset_value,
                                             width, height, 0, nullptr,


### PR DESCRIPTION
#305 Was not rebased when merging and wasn't up-to-date with the changes from #307 which changed the signature of `urUSMDeviceAlloc`.

This will fix the build.