### PR TITLE
[uma] memory tracking provider

### DIFF
--- a/source/common/unified_memory_allocation/CMakeLists.txt
+++ b/source/common/unified_memory_allocation/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(UMA_SOURCES
     src/memory_pool.c
     src/memory_provider.c
+    src/memory_tracker.cpp
 )
 
 if(UMA_BUILD_SHARED_LIBRARY)

--- a/source/common/unified_memory_allocation/include/uma/memory_pool.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool.h
@@ -10,7 +10,7 @@
 #define UMA_MEMORY_POOL_H 1
 
 #include <uma/base.h>
-#include <uma/memory_pool_ops.h>
+#include <uma/memory_provider.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,13 +18,19 @@ extern "C" {
 
 typedef struct uma_memory_pool_t *uma_memory_pool_handle_t;
 
+struct uma_memory_pool_ops_t;
+
 ///
 /// \brief Creates new memory pool
 /// \param ops instance of uma_memory_pool_ops_t
+/// \param providers array of memory providers that will be used for coarse-grain allocations. Should contain at least one memory provider.
+/// \param numProvider number of elements in the providers array
 /// \param params pointer to pool-specific parameters
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params,
+enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops,
+                                uma_memory_provider_handle_t *providers,
+                                size_t numProviders, void *params,
                                 uma_memory_pool_handle_t *hPool);
 
 ///
@@ -88,6 +94,12 @@ size_t umaPoolMallocUsableSize(uma_memory_pool_handle_t hPool, void *ptr);
 void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr);
 
 ///
+/// \brief Frees the memory space pointed by ptr if it belongs to UMA pool, does nothing otherwise
+/// \param ptr pointer to the allocated memory
+///
+void umaFree(void *ptr);
+
+///
 /// \brief Retrieve string representation of the underlying pool specific
 ///        result reported by the last API that returned
 ///        UMA_RESULT_ERROR_POOL_SPECIFIC or NULL ptr (in case of allocation
@@ -110,6 +122,12 @@ void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr);
 ///         returned indicates that the adapter specific result is an error.
 enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
                                        const char **ppMessage);
+
+///
+/// \brief Retrieve memory pool associated with a given ptr.
+/// \param ptr pointer to memory belonging to a memory pool
+/// \return handle to a memory pool that contains ptr or NULL if pointer does not belong to any UMA pool
+uma_memory_pool_handle_t umaPoolByPtr(const void *ptr);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_pool_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool_ops.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-/// This structure comprises function pointers used by corresponding  umaPool*
+/// \brief This structure comprises function pointers used by corresponding  umaPool*
 /// calls. Each memory pool implementation should initialize all function
 /// pointers.
 struct uma_memory_pool_ops_t {
@@ -25,11 +25,15 @@ struct uma_memory_pool_ops_t {
 
     ///
     /// \brief Intializes memory pool
+    /// \param providers array of memory providers that will be used for coarse-grain allocations. Should contain at least one memory provider.
+    /// \param numProvider number of elements in the providers array
     /// \param params pool-specific params
     /// \param pool returns pointer to the pool
     /// \return UMA_RESULT_SUCCESS on success or appropriate error code on
     /// failure
-    enum uma_result_t (*initialize)(void *params, void **pool);
+    enum uma_result_t (*initialize)(uma_memory_provider_handle_t *providers,
+                                    size_t numProviders, void *params,
+                                    void **pool);
 
     ///
     /// \brief Finalizes memory pool

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -41,7 +41,7 @@ void umaMemoryProviderDestroy(uma_memory_provider_handle_t hProvider);
 /// \param hProvider handle to the memory provider
 /// \param size number of bytes to allocate
 /// \param alignment alignment of the allocation
-/// \param ptr returns pointer to the allocated memory
+/// \param ptr will be updated with pointer to the allocated memory
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
 enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,

--- a/source/common/unified_memory_allocation/src/memory_pool.c
+++ b/source/common/unified_memory_allocation/src/memory_pool.c
@@ -6,18 +6,43 @@
  *
  */
 
+#include "memory_tracker.h"
 #include <uma/memory_pool.h>
+#include <uma/memory_pool_ops.h>
 
 #include <assert.h>
 #include <stdlib.h>
 
 struct uma_memory_pool_t {
-    struct uma_memory_pool_ops_t ops;
     void *pool_priv;
+    struct uma_memory_pool_ops_t ops;
+
+    // Holds array of memory providers. All providers are wrapped
+    // by memory tracking providers (owned and released by UMA).
+    uma_memory_provider_handle_t *providers;
+
+    size_t numProviders;
 };
 
-enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params,
+static void
+destroyMemoryProviderWrappers(uma_memory_provider_handle_t *providers,
+                              size_t numProviders) {
+    for (size_t i = 0; i < numProviders; i++) {
+        umaMemoryProviderDestroy(providers[i]);
+    }
+
+    free(providers);
+}
+
+enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops,
+                                uma_memory_provider_handle_t *providers,
+                                size_t numProviders, void *params,
                                 uma_memory_pool_handle_t *hPool) {
+    if (!numProviders || !providers) {
+        return UMA_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    enum uma_result_t ret = UMA_RESULT_SUCCESS;
     uma_memory_pool_handle_t pool = malloc(sizeof(struct uma_memory_pool_t));
     if (!pool) {
         return UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY;
@@ -25,24 +50,47 @@ enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params,
 
     assert(ops->version == UMA_VERSION_CURRENT);
 
-    pool->ops = *ops;
-
-    void *pool_priv;
-    enum uma_result_t ret = ops->initialize(params, &pool_priv);
-    if (ret != UMA_RESULT_SUCCESS) {
-        free(pool);
-        return ret;
+    pool->providers =
+        calloc(numProviders, sizeof(uma_memory_provider_handle_t));
+    if (!pool->providers) {
+        ret = UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+        goto err_providers_alloc;
     }
 
-    pool->pool_priv = pool_priv;
+    size_t providerInd = 0;
+    pool->numProviders = numProviders;
+
+    // Wrap each provider with memory tracking provider.
+    for (providerInd = 0; providerInd < numProviders; providerInd++) {
+        ret = umaTrackingMemoryProviderCreate(providers[providerInd], pool,
+                                              &pool->providers[providerInd]);
+        if (ret != UMA_RESULT_SUCCESS) {
+            goto err_providers_init;
+        }
+    }
+
+    pool->ops = *ops;
+    ret = ops->initialize(pool->providers, pool->numProviders, params,
+                          &pool->pool_priv);
+    if (ret != UMA_RESULT_SUCCESS) {
+        goto err_pool_init;
+    }
 
     *hPool = pool;
-
     return UMA_RESULT_SUCCESS;
+
+err_pool_init:
+err_providers_init:
+    destroyMemoryProviderWrappers(pool->providers, providerInd);
+err_providers_alloc:
+    free(pool);
+
+    return ret;
 }
 
 void umaPoolDestroy(uma_memory_pool_handle_t hPool) {
     hPool->ops.finalize(hPool->pool_priv);
+    destroyMemoryProviderWrappers(hPool->providers, hPool->numProviders);
     free(hPool);
 }
 
@@ -71,7 +119,18 @@ void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr) {
     hPool->ops.free(hPool->pool_priv, ptr);
 }
 
+void umaFree(void *ptr) {
+    uma_memory_pool_handle_t hPool = umaPoolByPtr(ptr);
+    if (hPool) {
+        umaPoolFree(hPool, ptr);
+    }
+}
+
 enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
                                        const char **ppMessage) {
     return hPool->ops.get_last_result(hPool->pool_priv, ppMessage);
+}
+
+uma_memory_pool_handle_t umaPoolByPtr(const void *ptr) {
+    return umaMemoryTrackerGetPool(umaMemoryTrackerGet(), ptr);
 }

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -1,0 +1,188 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+#include "memory_tracker.h"
+#include <uma/memory_provider.h>
+#include <uma/memory_provider_ops.h>
+
+#include <map>
+#include <mutex>
+#include <shared_mutex>
+
+// TODO: reimplement in C and optimize...
+struct uma_memory_tracker_t {
+    enum uma_result_t add(void *pool, const void *ptr, size_t size) {
+        std::unique_lock<std::shared_mutex> lock(mtx);
+
+        if (size == 0) {
+            return UMA_RESULT_SUCCESS;
+        }
+
+        auto ret =
+            map.try_emplace(reinterpret_cast<uintptr_t>(ptr), size, pool);
+        return ret.second ? UMA_RESULT_SUCCESS : UMA_RESULT_ERROR_UNKNOWN;
+    }
+
+    enum uma_result_t remove(const void *ptr, size_t size) {
+        std::unique_lock<std::shared_mutex> lock(mtx);
+
+        map.erase(reinterpret_cast<uintptr_t>(ptr));
+
+        // TODO: handle removing part of the range
+        (void)size;
+
+        return UMA_RESULT_SUCCESS;
+    }
+
+    void *find(const void *ptr) {
+        std::shared_lock<std::shared_mutex> lock(mtx);
+
+        auto intptr = reinterpret_cast<uintptr_t>(ptr);
+        auto it = map.upper_bound(intptr);
+        if (it == map.begin()) {
+            return nullptr;
+        }
+
+        --it;
+
+        auto address = it->first;
+        auto size = it->second.first;
+        auto pool = it->second.second;
+
+        if (intptr >= address && intptr < address + size) {
+            return pool;
+        }
+
+        return nullptr;
+    }
+
+  private:
+    std::shared_mutex mtx;
+    std::map<uintptr_t, std::pair<size_t, void *>> map;
+};
+
+static enum uma_result_t
+umaMemoryTrackerAdd(uma_memory_tracker_handle_t hTracker, void *pool,
+                    const void *ptr, size_t size) {
+    return hTracker->add(pool, ptr, size);
+}
+
+static enum uma_result_t
+umaMemoryTrackerRemove(uma_memory_tracker_handle_t hTracker, const void *ptr,
+                       size_t size) {
+    return hTracker->remove(ptr, size);
+}
+
+extern "C" {
+
+uma_memory_tracker_handle_t umaMemoryTrackerGet() {
+    static uma_memory_tracker_t tracker;
+    return &tracker;
+}
+
+void *umaMemoryTrackerGetPool(uma_memory_tracker_handle_t hTracker,
+                              const void *ptr) {
+    return hTracker->find(ptr);
+}
+
+struct uma_tracking_memory_provider_t {
+    uma_memory_provider_handle_t hUpstream;
+    uma_memory_tracker_handle_t hTracker;
+    uma_memory_pool_handle_t pool;
+};
+
+typedef struct uma_tracking_memory_provider_t uma_tracking_memory_provider_t;
+
+static enum uma_result_t trackingAlloc(void *hProvider, size_t size,
+                                       size_t alignment, void **ptr) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)hProvider;
+    enum uma_result_t ret = UMA_RESULT_SUCCESS;
+
+    ret = umaMemoryProviderAlloc(p->hUpstream, size, alignment, ptr);
+    if (ret != UMA_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    ret = umaMemoryTrackerAdd(p->hTracker, p->pool, *ptr, size);
+    if (ret != UMA_RESULT_SUCCESS && p->hUpstream) {
+        if (umaMemoryProviderFree(p->hUpstream, *ptr, size)) {
+            // TODO: LOG
+        }
+    }
+
+    return ret;
+}
+
+static enum uma_result_t trackingFree(void *hProvider, void *ptr, size_t size) {
+    enum uma_result_t ret;
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)hProvider;
+
+    // umaMemoryTrackerRemove should be called before umaMemoryProviderFree
+    // to avoid a race condition. If the order would be different, other thread
+    // could allocate the memory at address `ptr` before a call to umaMemoryTrackerRemove
+    // resulting in inconsistent state.
+    ret = umaMemoryTrackerRemove(p->hTracker, ptr, size);
+    if (ret != UMA_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    ret = umaMemoryProviderFree(p->hUpstream, ptr, size);
+    if (ret != UMA_RESULT_SUCCESS) {
+        if (umaMemoryTrackerAdd(p->hTracker, p->pool, ptr, size) !=
+            UMA_RESULT_SUCCESS) {
+            // TODO: LOG
+        }
+        return ret;
+    }
+
+    return ret;
+}
+
+static enum uma_result_t trackingInitialize(void *params, void **ret) {
+    uma_tracking_memory_provider_t *provider =
+        (uma_tracking_memory_provider_t *)malloc(
+            sizeof(uma_tracking_memory_provider_t));
+    if (!provider) {
+        return UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    *provider = *((uma_tracking_memory_provider_t *)params);
+    *ret = provider;
+    return UMA_RESULT_SUCCESS;
+}
+
+static void trackingFinalize(void *provider) { free(provider); }
+
+static enum uma_result_t trackingGetLastResult(void *provider,
+                                               const char **msg) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderGetLastResult(p->hUpstream, msg);
+}
+
+enum uma_result_t umaTrackingMemoryProviderCreate(
+    uma_memory_provider_handle_t hUpstream, uma_memory_pool_handle_t hPool,
+    uma_memory_provider_handle_t *hTrackingProvider) {
+    uma_tracking_memory_provider_t params;
+    params.hUpstream = hUpstream, params.hTracker = umaMemoryTrackerGet(),
+    params.pool = hPool;
+
+    struct uma_memory_provider_ops_t trackingMemoryProviderOps;
+    trackingMemoryProviderOps.version = UMA_VERSION_CURRENT;
+    trackingMemoryProviderOps.initialize = trackingInitialize;
+    trackingMemoryProviderOps.finalize = trackingFinalize;
+    trackingMemoryProviderOps.alloc = trackingAlloc;
+    trackingMemoryProviderOps.free = trackingFree;
+    trackingMemoryProviderOps.get_last_result = trackingGetLastResult;
+
+    return umaMemoryProviderCreate(&trackingMemoryProviderOps, &params,
+                                   hTrackingProvider);
+}
+}

--- a/source/common/unified_memory_allocation/src/memory_tracker.h
+++ b/source/common/unified_memory_allocation/src/memory_tracker.h
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+#ifndef UMA_MEMORY_TRACKER_INTERNAL_H
+#define UMA_MEMORY_TRACKER_INTERNAL_H 1
+
+#include <uma/base.h>
+#include <uma/memory_pool.h>
+#include <uma/memory_provider.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct uma_memory_tracker_t *uma_memory_tracker_handle_t;
+
+uma_memory_tracker_handle_t umaMemoryTrackerGet();
+void *umaMemoryTrackerGetPool(uma_memory_tracker_handle_t hTracker,
+                              const void *ptr);
+
+// Creates a memory provider that tracks each allocation/deallocation through uma_memory_tracker_handle_t and
+// forwards all requests to hUpstream memory Provider. hUpstream liftime should be managed by the user of this function.
+enum uma_result_t umaTrackingMemoryProviderCreate(
+    uma_memory_provider_handle_t hUpstream, uma_memory_pool_handle_t hPool,
+    uma_memory_provider_handle_t *hTrackingProvider);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UMA_MEMORY_TRACKER_INTERNAL_H */

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -32,7 +32,7 @@ static enum uma_result_t nullFree(void *provider, void *ptr, size_t size) {
     return UMA_RESULT_SUCCESS;
 }
 
-enum uma_result_t nullGetLastResult(void *provider, const char **ppMsg) {
+static enum uma_result_t nullGetLastResult(void *provider, const char **ppMsg) {
     (void)provider;
     (void)ppMsg;
     return UMA_RESULT_SUCCESS;
@@ -87,7 +87,8 @@ static enum uma_result_t traceFree(void *provider, void *ptr, size_t size) {
     return umaMemoryProviderFree(traceProvider->hUpstreamProvider, ptr, size);
 }
 
-enum uma_result_t traceGetLastResult(void *provider, const char **ppMsg) {
+static enum uma_result_t traceGetLastResult(void *provider,
+                                            const char **ppMsg) {
     struct traceParams *traceProvider = (struct traceParams *)provider;
 
     traceProvider->trace("get_last_result");

--- a/test/unified_memory_allocation/memoryPool.hpp
+++ b/test/unified_memory_allocation/memoryPool.hpp
@@ -5,24 +5,46 @@
 
 #include <cstring>
 #include <functional>
+#include <random>
 
 #ifndef UMA_TEST_MEMORY_POOL_OPS_HPP
 #define UMA_TEST_MEMORY_POOL_OPS_HPP
 
-struct umaPoolTest
-    : uma_test::test,
-      ::testing::WithParamInterface<
-          std::function<std::pair<uma_result_t, uma::pool_unique_handle_t>()>> {
+struct umaPoolTest : uma_test::test,
+                     ::testing::WithParamInterface<
+                         std::function<uma::pool_unique_handle_t(void)>> {
     umaPoolTest() : pool(nullptr, nullptr) {}
     void SetUp() {
         test::SetUp();
-        auto [res, pool] = this->GetParam()();
-        EXPECT_EQ(res, UMA_RESULT_SUCCESS);
-        EXPECT_NE(pool, nullptr);
-        this->pool = std::move(pool);
+        this->pool = makePool();
     }
+
     void TearDown() override { test::TearDown(); }
+
+    uma::pool_unique_handle_t makePool() {
+        auto pool = this->GetParam()();
+        EXPECT_NE(pool, nullptr);
+        return pool;
+    }
+
     uma::pool_unique_handle_t pool;
+};
+
+struct umaMultiPoolTest : umaPoolTest {
+    static constexpr auto numPools = 16;
+
+    void SetUp() {
+        umaPoolTest::SetUp();
+
+        pools.emplace_back(std::move(pool));
+        for (size_t i = 1; i < numPools; i++) {
+            pools.emplace_back(makePool());
+        }
+    }
+
+    void TearDown() override { umaPoolTest::TearDown(); }
+
+    std::vector<uma::pool_unique_handle_t> pools;
 };
 
 TEST_P(umaPoolTest, allocFree) {
@@ -49,6 +71,44 @@ TEST_P(umaPoolTest, pow2AlignedAlloc) {
         ASSERT_TRUE(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
         std::memset(ptr, 0, allocSize);
         umaPoolFree(pool.get(), ptr);
+    }
+}
+
+// TODO: add similar tests for realloc/aligned_alloc, etc.
+// TODO: add multithreaded tests
+TEST_P(umaMultiPoolTest, memoryTracking) {
+    static constexpr int allocSizes[] = {1,  2,  4,  8,   16,   20,
+                                         32, 40, 64, 128, 1024, 4096};
+    static constexpr auto nAllocs = 256;
+
+    std::mt19937_64 g(0);
+    std::uniform_int_distribution allocSizesDist(
+        0, static_cast<int>(std::size(allocSizes) - 1));
+    std::uniform_int_distribution poolsDist(0,
+                                            static_cast<int>(pools.size() - 1));
+
+    std::vector<std::tuple<void *, size_t, uma_memory_pool_handle_t>> ptrs;
+    for (size_t i = 0; i < nAllocs; i++) {
+        auto &pool = pools[poolsDist(g)];
+        auto size = allocSizes[allocSizesDist(g)];
+
+        auto *ptr = umaPoolMalloc(pool.get(), size);
+        ASSERT_NE(ptr, nullptr);
+
+        ptrs.emplace_back(ptr, size, pool.get());
+    }
+
+    for (auto [ptr, size, expectedPool] : ptrs) {
+        auto pool = umaPoolByPtr(ptr);
+        ASSERT_EQ(pool, expectedPool);
+
+        pool = umaPoolByPtr(reinterpret_cast<void *>(
+            reinterpret_cast<intptr_t>(ptr) + size - 1));
+        ASSERT_EQ(pool, expectedPool);
+    }
+
+    for (auto [ptr, _1, _2] : ptrs) {
+        umaFree(ptr);
     }
 }
 

--- a/test/unified_memory_allocation/memoryPoolAPI.cpp
+++ b/test/unified_memory_allocation/memoryPoolAPI.cpp
@@ -4,6 +4,8 @@
 
 #include "pool.h"
 #include "pool.hpp"
+#include "provider.h"
+#include "provider.hpp"
 
 #include "memoryPool.hpp"
 
@@ -13,52 +15,149 @@
 using uma_test::test;
 
 TEST_F(test, memoryPoolTrace) {
-    static std::unordered_map<std::string, size_t> calls;
-    auto trace = [](const char *name) { calls[name]++; };
+    static std::unordered_map<std::string, size_t> poolCalls;
+    static std::unordered_map<std::string, size_t> providerCalls;
+    auto tracePool = [](const char *name) { poolCalls[name]++; };
+    auto traceProvider = [](const char *name) { providerCalls[name]++; };
 
-    auto nullPool = uma_test::wrapPoolUnique(nullPoolCreate());
+    auto nullProvider = uma_test::wrapProviderUnique(nullProviderCreate());
+    auto tracingProvider = uma_test::wrapProviderUnique(
+        traceProviderCreate(nullProvider.get(), traceProvider));
+    auto provider = tracingProvider.get();
+
+    auto [ret, proxyPool] =
+        uma::poolMakeUnique<uma_test::proxy_pool>(&provider, 1);
+    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
+
     auto tracingPool =
-        uma_test::wrapPoolUnique(tracePoolCreate(nullPool.get(), trace));
+        uma_test::wrapPoolUnique(tracePoolCreate(proxyPool.get(), tracePool));
 
-    size_t call_count = 0;
+    size_t pool_call_count = 0;
+    size_t provider_call_count = 0;
 
     umaPoolMalloc(tracingPool.get(), 0);
-    ASSERT_EQ(calls["malloc"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(poolCalls["malloc"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
+
+    ASSERT_EQ(providerCalls["alloc"], 1);
+    ASSERT_EQ(providerCalls.size(), ++provider_call_count);
 
     umaPoolFree(tracingPool.get(), nullptr);
-    ASSERT_EQ(calls["free"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(poolCalls["free"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
+
+    ASSERT_EQ(providerCalls["free"], 1);
+    ASSERT_EQ(providerCalls.size(), ++provider_call_count);
 
     umaPoolCalloc(tracingPool.get(), 0, 0);
-    ASSERT_EQ(calls["calloc"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(poolCalls["calloc"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
+
+    ASSERT_EQ(providerCalls["alloc"], 2);
+    ASSERT_EQ(providerCalls.size(), provider_call_count);
 
     umaPoolRealloc(tracingPool.get(), nullptr, 0);
-    ASSERT_EQ(calls["realloc"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(poolCalls["realloc"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
+
+    ASSERT_EQ(providerCalls.size(), provider_call_count);
 
     umaPoolAlignedMalloc(tracingPool.get(), 0, 0);
-    ASSERT_EQ(calls["aligned_malloc"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(poolCalls["aligned_malloc"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
+
+    ASSERT_EQ(providerCalls["alloc"], 3);
+    ASSERT_EQ(providerCalls.size(), provider_call_count);
 
     umaPoolMallocUsableSize(tracingPool.get(), nullptr);
-    ASSERT_EQ(calls["malloc_usable_size"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(poolCalls["malloc_usable_size"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
-    enum uma_result_t ret = umaPoolGetLastResult(tracingPool.get(), nullptr);
+    ASSERT_EQ(providerCalls.size(), provider_call_count);
+
+    ret = umaPoolGetLastResult(tracingPool.get(), nullptr);
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
-    ASSERT_EQ(calls["get_last_result"], 1);
-    ASSERT_EQ(calls.size(), ++call_count);
+
+    ASSERT_EQ(poolCalls["get_last_result"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
+
+    ASSERT_EQ(providerCalls["get_last_result"], 1);
+    ASSERT_EQ(providerCalls.size(), ++provider_call_count);
 }
 
+TEST_F(test, memoryPoolWithCustomProviders) {
+    uma_memory_provider_handle_t providers[] = {nullProviderCreate(),
+                                                nullProviderCreate()};
+
+    struct pool : public uma_test::pool_base {
+        uma_result_t initialize(uma_memory_provider_handle_t *providers,
+                                size_t numProviders) noexcept {
+            EXPECT_NE(providers, nullptr);
+            EXPECT_EQ(numProviders, 2);
+            return UMA_RESULT_SUCCESS;
+        }
+    };
+
+    auto ret = uma::poolMakeUnique<pool>(providers, 2);
+    ASSERT_EQ(ret.first, UMA_RESULT_SUCCESS);
+    ASSERT_NE(ret.second, nullptr);
+
+    for (auto &provider : providers) {
+        umaMemoryProviderDestroy(provider);
+    }
+}
+
+template <typename Pool>
+static auto
+makePool(std::function<uma::provider_unique_handle_t()> makeProvider) {
+    auto providerUnique = makeProvider();
+    uma_memory_provider_handle_t provider = providerUnique.get();
+    auto pool = uma::poolMakeUnique<Pool>(&provider, 1).second;
+    auto dtor = [provider =
+                     providerUnique.release()](uma_memory_pool_handle_t hPool) {
+        umaPoolDestroy(hPool);
+        umaMemoryProviderDestroy(provider);
+    };
+    return uma::pool_unique_handle_t(pool.release(), std::move(dtor));
+}
+
+INSTANTIATE_TEST_SUITE_P(mallocPoolTest, umaPoolTest, ::testing::Values([] {
+                             return makePool<uma_test::malloc_pool>([] {
+                                 return uma_test::wrapProviderUnique(
+                                     nullProviderCreate());
+                             });
+                         }));
+
 INSTANTIATE_TEST_SUITE_P(
-    mallocPoolTest, umaPoolTest, ::testing::Values([] {
-        return uma::poolMakeUnique<uma_test::malloc_pool>();
+    mallocProviderPoolTest, umaPoolTest, ::testing::Values([] {
+        return makePool<uma_test::proxy_pool>([] {
+            return uma::memoryProviderMakeUnique<uma_test::provider_malloc>()
+                .second;
+        });
     }));
 
-//////////////////////////// Negative test cases
-///////////////////////////////////
+INSTANTIATE_TEST_SUITE_P(
+    mallocMultiPoolTest, umaMultiPoolTest, ::testing::Values([] {
+        return makePool<uma_test::proxy_pool>([] {
+            return uma::memoryProviderMakeUnique<uma_test::provider_malloc>()
+                .second;
+        });
+    }));
+
+////////////////// Negative test cases /////////////////
+
+TEST_F(test, memoryPoolInvalidProvidersNullptr) {
+    auto ret = uma::poolMakeUnique<uma_test::pool_base>(nullptr, 1);
+    ASSERT_EQ(ret.first, UMA_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(test, memoryPoolInvalidProvidersNum) {
+    auto nullProvider = uma_test::wrapProviderUnique(nullProviderCreate());
+    uma_memory_provider_handle_t providers[] = {nullProvider.get()};
+
+    auto ret = uma::poolMakeUnique<uma_test::pool_base>(providers, 0);
+    ASSERT_EQ(ret.first, UMA_RESULT_ERROR_INVALID_ARGUMENT);
+}
 
 struct poolInitializeTest : uma_test::test,
                             ::testing::WithParamInterface<uma_result_t> {};
@@ -72,12 +171,17 @@ INSTANTIATE_TEST_SUITE_P(
                       UMA_RESULT_ERROR_UNKNOWN));
 
 TEST_P(poolInitializeTest, errorPropagation) {
+    auto nullProvider = uma_test::wrapProviderUnique(nullProviderCreate());
+    uma_memory_provider_handle_t providers[] = {nullProvider.get()};
+
     struct pool : public uma_test::pool_base {
-        uma_result_t initialize(uma_result_t errorToReturn) noexcept {
+        uma_result_t initialize(uma_memory_provider_handle_t *providers,
+                                size_t numProviders,
+                                uma_result_t errorToReturn) noexcept {
             return errorToReturn;
         }
     };
-    auto ret = uma::poolMakeUnique<pool>(this->GetParam());
+    auto ret = uma::poolMakeUnique<pool>(providers, 1, this->GetParam());
     ASSERT_EQ(ret.first, this->GetParam());
     ASSERT_EQ(ret.second, nullptr);
 }


### PR DESCRIPTION
This PR adds a `umaPoolByPtr` function. It's implemented on top of (internal) memoryTracker.

This PR also requires users to pass all memory providers to memory pool through `providers` array parameter in initialize method. This allows UMA to wrap each provider and register all allocations/deallocations.

