### PR TITLE
Add UR_DEVICE_LOCAL_MEM_TYPE_NONE

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -491,8 +491,9 @@ class ur_device_mem_cache_type_t(c_int):
 ###############################################################################
 ## @brief Device local memory type
 class ur_device_local_mem_type_v(IntEnum):
-    LOCAL = 0                                       ## Dedicated local memory
-    GLOBAL = 1                                      ## Global memory
+    NONE = 0                                        ## No local memory support
+    LOCAL = 1                                       ## Dedicated local memory
+    GLOBAL = 2                                      ## Global memory
 
 class ur_device_local_mem_type_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -942,8 +942,9 @@ typedef enum ur_device_mem_cache_type_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device local memory type
 typedef enum ur_device_local_mem_type_t {
-    UR_DEVICE_LOCAL_MEM_TYPE_LOCAL = 0,  ///< Dedicated local memory
-    UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 1, ///< Global memory
+    UR_DEVICE_LOCAL_MEM_TYPE_NONE = 0,   ///< No local memory support
+    UR_DEVICE_LOCAL_MEM_TYPE_LOCAL = 1,  ///< Dedicated local memory
+    UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL = 2, ///< Global memory
     /// @cond
     UR_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -499,6 +499,8 @@ desc: "Device local memory type"
 class: $xDevice
 name: $x_device_local_mem_type_t
 etors:
+    - name: NONE
+      desc: "No local memory support"
     - name: LOCAL
       desc: "Dedicated local memory"
     - name: GLOBAL


### PR DESCRIPTION
Fixes #316 by adding `UR_DEVICE_LOCAL_MEM_TYPE_NONE` to the
`ur_device_local_mem_type_t` enum, this brings UR in line with the SYCL
and OpenCL specifications for the describing the local memory support a
device is capable of.
