### PR TITLE
Make names in urEnqueueMemImageWrite align with other APIs

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4451,8 +4451,8 @@ urEnqueueMemImageWrite(
     ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
     ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                               ///< image
-    size_t inputRowPitch,                     ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
     void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6835,8 +6835,8 @@ typedef struct ur_enqueue_mem_image_write_params_t {
     bool *pblockingWrite;
     ur_rect_offset_t *porigin;
     ur_rect_region_t *pregion;
-    size_t *pinputRowPitch;
-    size_t *pinputSlicePitch;
+    size_t *prowPitch;
+    size_t *pslicePitch;
     void **ppSrc;
     uint32_t *pnumEventsInWaitList;
     const ur_event_handle_t **pphEventWaitList;

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -619,10 +619,10 @@ params:
       name: region
       desc: "[in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D image"
     - type: size_t
-      name: inputRowPitch
+      name: rowPitch
       desc: "[in] length of each row in bytes"
     - type: size_t
-      name: inputSlicePitch
+      name: slicePitch
       desc: "[in] length of each 2D slice of the 3D image"
     - type: void*
       name: pSrc

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2459,8 +2459,8 @@ urEnqueueMemImageWrite(
     ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
     ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                               ///< image
-    size_t inputRowPitch,                     ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
     void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -2475,7 +2475,7 @@ urEnqueueMemImageWrite(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageWrite = d_context.urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr != pfnMemImageWrite) {
-        result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3203,8 +3203,8 @@ urEnqueueMemImageWrite(
     ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
     ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                               ///< image
-    size_t inputRowPitch,                     ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
     void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -3242,7 +3242,7 @@ urEnqueueMemImageWrite(
         }
     }
 
-    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3680,8 +3680,8 @@ urEnqueueMemImageWrite(
     ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
     ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                               ///< image
-    size_t inputRowPitch,                     ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
     void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -3713,7 +3713,7 @@ urEnqueueMemImageWrite(
     }
 
     // forward to device-platform
-    result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3823,8 +3823,8 @@ urEnqueueMemImageWrite(
     ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
     ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                               ///< image
-    size_t inputRowPitch,                     ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
     void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -3839,7 +3839,7 @@ urEnqueueMemImageWrite(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, inputRowPitch, inputSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3403,8 +3403,8 @@ urEnqueueMemImageWrite(
     ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
     ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
                                               ///< image
-    size_t inputRowPitch,                     ///< [in] length of each row in bytes
-    size_t inputSlicePitch,                   ///< [in] length of each 2D slice of the 3D image
+    size_t rowPitch,                          ///< [in] length of each row in bytes
+    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
     void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
     uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of


### PR DESCRIPTION
Change inputRowPitch and inputSlicePitch be rowPitch and slicePitch as in other APIs.