### PR TITLE
[uma] fix leaks in create methods

### DIFF
--- a/source/common/unified_memory_allocation/src/memory_pool.c
+++ b/source/common/unified_memory_allocation/src/memory_pool.c
@@ -30,6 +30,7 @@ enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params,
     void *pool_priv;
     enum uma_result_t ret = ops->initialize(params, &pool_priv);
     if (ret != UMA_RESULT_SUCCESS) {
+        free(pool);
         return ret;
     }
 

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -32,6 +32,7 @@ umaMemoryProviderCreate(struct uma_memory_provider_ops_t *ops, void *params,
     void *provider_priv;
     enum uma_result_t ret = ops->initialize(params, &provider_priv);
     if (ret != UMA_RESULT_SUCCESS) {
+        free(provider);
         return ret;
     }
 


### PR DESCRIPTION
I've added simple tests for initialization in: https://github.com/oneapi-src/unified-runtime/pull/322 but we might want to someday enable valgrind for those.