### PR TITLE
[UR] `urDeviceSelectBinary` spec changes 

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -209,6 +209,7 @@ class ur_structure_type_v(IntEnum):
     USM_DESC = 7                                    ## ::ur_usm_desc_t
     USM_POOL_DESC = 8                               ## ::ur_usm_pool_desc_t
     USM_POOL_LIMITS_DESC = 9                        ## ::ur_usm_pool_limits_desc_t
+    DEVICE_BINARY = 10                              ## ::ur_device_binary_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -292,6 +293,61 @@ class ur_api_version_t(c_int):
     def __str__(self):
         return str(ur_api_version_v(self.value))
 
+
+###############################################################################
+## @brief Target identification strings for
+##        ::ur_device_binary_t.pDeviceTargetSpec 
+##        A device type represented by a particular target triple requires
+##        specific 
+##        binary images. We need to map the image type onto the device target triple
+UR_DEVICE_BINARY_TARGET_UNKNOWN = "<unknown>"
+
+###############################################################################
+## @brief SPIR-V 32-bit image <-> "spir", 32-bit OpenCL device
+UR_DEVICE_BINARY_TARGET_SPIRV32 = "spir"
+
+###############################################################################
+## @brief SPIR-V 64-bit image <-> "spir64", 64-bit OpenCL device
+UR_DEVICE_BINARY_TARGET_SPIRV64 = "spir64"
+
+###############################################################################
+## @brief Device-specific binary images produced from SPIR-V 64-bit <-> various 
+##        "spir64_*" triples for specific 64-bit OpenCL CPU devices
+UR_DEVICE_BINARY_TARGET_SPIRV64_X86_64 = "spir64_x86_64"
+
+###############################################################################
+## @brief Generic GPU device (64-bit OpenCL)
+UR_DEVICE_BINARY_TARGET_SPIRV64_GEN = "spir64_gen"
+
+###############################################################################
+## @brief 64-bit OpenCL FPGA device
+UR_DEVICE_BINARY_TARGET_SPIRV64_FPGA = "spir64_fpga"
+
+###############################################################################
+## @brief PTX 64-bit image <-> "nvptx64", 64-bit NVIDIA PTX device
+UR_DEVICE_BINARY_TARGET_NVPTX64 = "nvptx64"
+
+###############################################################################
+## @brief AMD GCN
+UR_DEVICE_BINARY_TARGET_AMDGCN = "amdgcn"
+
+###############################################################################
+## @brief Device Binary Type
+class ur_device_binary_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_DEVICE_BINARY
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("pDeviceTargetSpec", c_char_p)                                 ## [in] null-terminated string representation of the device's target architecture.
+                                                                        ## For example: 
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_UNKNOWN
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_SPIRV32
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_SPIRV64
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_SPIRV64_X86_64
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_SPIRV64_GEN
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_SPIRV64_FPGA
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_NVPTX64
+                                                                        ## + ::UR_DEVICE_BINARY_TARGET_AMDGCN
+    ]
 
 ###############################################################################
 ## @brief Supported device types
@@ -2385,9 +2441,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urDeviceSelectBinary
 if __use_win_types:
-    _urDeviceSelectBinary_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(POINTER(c_ubyte)), c_ulong, POINTER(c_ulong) )
+    _urDeviceSelectBinary_t = WINFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_binary_t), c_ulong, POINTER(c_ulong) )
 else:
-    _urDeviceSelectBinary_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(POINTER(c_ubyte)), c_ulong, POINTER(c_ulong) )
+    _urDeviceSelectBinary_t = CFUNCTYPE( ur_result_t, ur_device_handle_t, POINTER(ur_device_binary_t), c_ulong, POINTER(c_ulong) )
 
 ###############################################################################
 ## @brief Function-pointer for urDeviceGetNativeHandle

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2830,6 +2830,16 @@ typedef struct ur_specialization_constant_info_t {
 ///     - Any spec constants set with this entry point will apply only to
 ///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
 ///
+/// @details
+///     - `hProgram` must have been created with the ::urProgramCreateWithIL
+///       entry point.
+///     - Any spec constants set with this entry point will apply only to
+///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
+///
+/// @remarks
+///   _Analogues_
+///     - **clSetProgramSpecializationConstant**
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1331,7 +1331,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnDevicePartition_t)(
 /// @brief Function-pointer for urDeviceSelectBinary
 typedef ur_result_t(UR_APICALL *ur_pfnDeviceSelectBinary_t)(
     ur_device_handle_t,
-    const uint8_t **,
+    const ur_device_binary_t *,
     uint32_t,
     uint32_t *);
 

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -282,6 +282,8 @@ etors:
       desc: $x_usm_pool_desc_t
     - name: USM_POOL_LIMITS_DESC
       desc: $x_usm_pool_limits_desc_t
+    - name: DEVICE_BINARY
+      desc: "$x_device_binary_t"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -11,6 +11,73 @@ type: header
 desc: "Intel $OneApi Unified Runtime APIs for Device"
 ordinal: "2"
 --- #--------------------------------------------------------------------------
+type: macro
+desc: |
+      Target identification strings for $x_device_binary_t.pDeviceTargetSpec 
+      A device type represented by a particular target triple requires specific 
+      binary images. We need to map the image type onto the device target triple
+name: "$X_DEVICE_BINARY_TARGET_UNKNOWN"
+value: "\"<unknown>\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: |
+     SPIR-V 32-bit image <-> "spir", 32-bit OpenCL device
+name: "$X_DEVICE_BINARY_TARGET_SPIRV32"
+value: "\"spir\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: |
+      SPIR-V 64-bit image <-> "spir64", 64-bit OpenCL device
+name: "$X_DEVICE_BINARY_TARGET_SPIRV64"
+value: "\"spir64\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: |
+      Device-specific binary images produced from SPIR-V 64-bit <-> various 
+      "spir64_*" triples for specific 64-bit OpenCL CPU devices
+name: "$X_DEVICE_BINARY_TARGET_SPIRV64_X86_64"
+value: "\"spir64_x86_64\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Generic GPU device (64-bit OpenCL)"
+name: "$X_DEVICE_BINARY_TARGET_SPIRV64_GEN"
+value: "\"spir64_gen\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "64-bit OpenCL FPGA device"
+name: "$X_DEVICE_BINARY_TARGET_SPIRV64_FPGA"
+value: "\"spir64_fpga\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: |
+      PTX 64-bit image <-> "nvptx64", 64-bit NVIDIA PTX device
+name: "$X_DEVICE_BINARY_TARGET_NVPTX64"
+value: "\"nvptx64\""
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "AMD GCN"
+name: "$X_DEVICE_BINARY_TARGET_AMDGCN"
+value: "\"amdgcn\""
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Device Binary Type"
+name: $x_device_binary_t
+base: $x_base_desc_t
+members:
+    - type: const char*
+      name: pDeviceTargetSpec
+      desc: |
+            [in] null-terminated string representation of the device's target architecture.
+            For example: 
+            + $X_DEVICE_BINARY_TARGET_UNKNOWN
+            + $X_DEVICE_BINARY_TARGET_SPIRV32
+            + $X_DEVICE_BINARY_TARGET_SPIRV64
+            + $X_DEVICE_BINARY_TARGET_SPIRV64_X86_64
+            + $X_DEVICE_BINARY_TARGET_SPIRV64_GEN
+            + $X_DEVICE_BINARY_TARGET_SPIRV64_FPGA
+            + $X_DEVICE_BINARY_TARGET_NVPTX64
+            + $X_DEVICE_BINARY_TARGET_AMDGCN
+--- #--------------------------------------------------------------------------
 type: enum
 desc: "Supported device types"
 class: $xDevice
@@ -440,8 +507,8 @@ params:
       name: hDevice
       desc: |
             [in] handle of the device to select binary for.
-    - type: "const uint8_t**"
-      name: ppBinaries
+    - type: "const $x_device_binary_t*"
+      name: pBinaries
       desc: |
             [in] the array of binaries to select from.
     - type: "uint32_t"
@@ -453,9 +520,10 @@ params:
       name: pSelectedBinary
       desc: |
             [out] the index of the selected binary in the input array of binaries.
-            If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+            If a suitable binary was not found the function returns $X_RESULT_ERROR_INVALID_BINARY.
 returns:
-    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_SIZE:
+      - "`NumBinaries == 0`"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "FP capabilities"

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -448,13 +448,13 @@ members:
 type: function
 desc: "Set an array of specialization constants on a Program."
 class: $xProgram
-name: SetSpecializationConstant
-ordinal: "7"
-analogue:
-    - "**clSetProgramSpecializationConstant**"
+name: SetSpecializationConstants
 details:
+    - "The application may call this function from simultaneous threads for the same device."
+    - "The implementation of this function should be thread-safe."
     - "`hProgram` must have been created with the $xProgramCreateWithIL entry point."
     - "Any spec constants set with this entry point will apply only to subsequent calls to $xProgramBuild or $xProgramCompile."
+ordinal: "7"
 params:
     - type: $x_program_handle_t
       name: hProgram

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -448,13 +448,13 @@ members:
 type: function
 desc: "Set an array of specialization constants on a Program."
 class: $xProgram
-name: SetSpecializationConstants
+name: SetSpecializationConstant
+ordinal: "7"
+analogue:
+    - "**clSetProgramSpecializationConstant**"
 details:
-    - "The application may call this function from simultaneous threads for the same device."
-    - "The implementation of this function should be thread-safe."
     - "`hProgram` must have been created with the $xProgramCreateWithIL entry point."
     - "Any spec constants set with this entry point will apply only to subsequent calls to $xProgramBuild or $xProgramCompile."
-ordinal: "7"
 params:
     - type: $x_program_handle_t
       name: hProgram

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -329,13 +329,14 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
-    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    const ur_device_binary_t
+        *pBinaries,       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
         pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    ///< If a suitable binary was not found the function returns ::UR_RESULT_ERROR_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -343,7 +344,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     auto pfnSelectBinary = d_context.urDdiTable.Device.pfnSelectBinary;
     if (nullptr != pfnSelectBinary) {
         result =
-            pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+            pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
     } else {
         // generic implementation
     }

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -392,13 +392,14 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
-    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    const ur_device_binary_t
+        *pBinaries,       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
         pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    ///< If a suitable binary was not found the function returns ::UR_RESULT_ERROR_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
 
@@ -406,13 +407,13 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_select_binary_params_t params = {&hDevice, &ppBinaries,
+    ur_device_select_binary_params_t params = {&hDevice, &pBinaries,
                                                &NumBinaries, &pSelectedBinary};
     uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_SELECT_BINARY,
                                              "urDeviceSelectBinary", &params);
 
     ur_result_t result =
-        pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+        pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
 
     context.notify_end(UR_FUNCTION_DEVICE_SELECT_BINARY, "urDeviceSelectBinary",
                        &params, &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -367,13 +367,14 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
-    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    const ur_device_binary_t
+        *pBinaries,       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
         pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    ///< If a suitable binary was not found the function returns ::UR_RESULT_ERROR_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
 
@@ -386,16 +387,20 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == ppBinaries) {
+        if (NULL == pBinaries) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
         if (NULL == pSelectedBinary) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (NumBinaries == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    return pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+    return pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -481,13 +481,14 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
-    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    const ur_device_binary_t
+        *pBinaries,       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
         pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    ///< If a suitable binary was not found the function returns ::UR_RESULT_ERROR_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -502,7 +503,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+    result = pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
 
     return result;
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2142,6 +2142,16 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///     - Any spec constants set with this entry point will apply only to
 ///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
 ///
+/// @details
+///     - `hProgram` must have been created with the ::urProgramCreateWithIL
+///       entry point.
+///     - Any spec constants set with this entry point will apply only to
+///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
+///
+/// @remarks
+///   _Analogues_
+///     - **clSetProgramSpecializationConstant**
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -512,26 +512,28 @@ ur_result_t UR_APICALL urDevicePartition(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == ppBinaries`
+///         + `NULL == pBinaries`
 ///         + `NULL == pSelectedBinary`
-///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `NumBinaries == 0`
 ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
-    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    const ur_device_binary_t
+        *pBinaries,       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
         pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    ///< If a suitable binary was not found the function returns ::UR_RESULT_ERROR_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = ur_lib::context->urDdiTable.Device.pfnSelectBinary;
     if (nullptr == pfnSelectBinary) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+    return pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2141,16 +2143,6 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///       entry point.
 ///     - Any spec constants set with this entry point will apply only to
 ///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
-///
-/// @details
-///     - `hProgram` must have been created with the ::urProgramCreateWithIL
-///       entry point.
-///     - Any spec constants set with this entry point will apply only to
-///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
-///
-/// @remarks
-///   _Analogues_
-///     - **clSetProgramSpecializationConstant**
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -443,19 +443,21 @@ ur_result_t UR_APICALL urDevicePartition(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == ppBinaries`
+///         + `NULL == pBinaries`
 ///         + `NULL == pSelectedBinary`
-///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `NumBinaries == 0`
 ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
-    const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
+    const ur_device_binary_t
+        *pBinaries,       ///< [in] the array of binaries to select from.
     uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
                           ///< Must greater than or equal to zero otherwise
                           ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
     uint32_t *
         pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
-    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    ///< If a suitable binary was not found the function returns ::UR_RESULT_ERROR_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1876,16 +1878,6 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///       entry point.
 ///     - Any spec constants set with this entry point will apply only to
 ///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
-///
-/// @details
-///     - `hProgram` must have been created with the ::urProgramCreateWithIL
-///       entry point.
-///     - Any spec constants set with this entry point will apply only to
-///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
-///
-/// @remarks
-///   _Analogues_
-///     - **clSetProgramSpecializationConstant**
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1877,6 +1877,16 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///     - Any spec constants set with this entry point will apply only to
 ///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
 ///
+/// @details
+///     - `hProgram` must have been created with the ::urProgramCreateWithIL
+///       entry point.
+///     - Any spec constants set with this entry point will apply only to
+///       subsequent calls to ::urProgramBuild or ::urProgramCompile.
+///
+/// @remarks
+///   _Analogues_
+///     - **clSetProgramSpecializationConstant**
+///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED

--- a/test/conformance/device/urDeviceSelectBinary.cpp
+++ b/test/conformance/device/urDeviceSelectBinary.cpp
@@ -1,26 +1,36 @@
 // Copyright (C) 2022-2023 Intel Corporation
 // SPDX-License-Identifier: MIT
 #include <uur/fixtures.h>
-
 using urDeviceSelectBinaryTest = uur::urAllDevicesTest;
 
-// TODO - Replace with valid UR binaries. - See #171
-static const char *binaries[] = {"binary A", "binary B"};
-static const uint32_t binaries_length = 2;
+static constexpr ur_device_binary_t binaries[] = {
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr, UR_DEVICE_BINARY_TARGET_UNKNOWN},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr, UR_DEVICE_BINARY_TARGET_SPIRV32},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr, UR_DEVICE_BINARY_TARGET_SPIRV64},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr,
+     UR_DEVICE_BINARY_TARGET_SPIRV64_X86_64},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr,
+     UR_DEVICE_BINARY_TARGET_SPIRV64_GEN},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr,
+     UR_DEVICE_BINARY_TARGET_SPIRV64_FPGA},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr, UR_DEVICE_BINARY_TARGET_NVPTX64},
+    {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr, UR_DEVICE_BINARY_TARGET_AMDGCN}};
+static constexpr uint32_t binaries_length =
+    sizeof(binaries) / sizeof(ur_device_binary_t);
 
 TEST_F(urDeviceSelectBinaryTest, Success) {
     for (auto device : devices) {
         uint32_t selected_binary = binaries_length; // invalid index
-        ASSERT_SUCCESS(urDeviceSelectBinary(device, (const uint8_t **)binaries,
-                                            binaries_length, &selected_binary));
-        ASSERT_LT(selected_binary, 2);
+        ASSERT_SUCCESS(urDeviceSelectBinary(device, binaries, binaries_length,
+                                            &selected_binary));
+        ASSERT_LT(selected_binary, binaries_length);
     }
 }
 
 TEST_F(urDeviceSelectBinaryTest, InvalidNullHandleDevice) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urDeviceSelectBinary(nullptr, (const uint8_t **)binaries,
-                                          binaries_length, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urDeviceSelectBinary(nullptr, binaries, binaries_length, nullptr));
 }
 
 TEST_F(urDeviceSelectBinaryTest, InvalidNullPointerBinaries) {
@@ -34,19 +44,17 @@ TEST_F(urDeviceSelectBinaryTest, InvalidNullPointerBinaries) {
 
 TEST_F(urDeviceSelectBinaryTest, InvalidNullPointerSelectedBinary) {
     for (auto device : devices) {
-        ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                         urDeviceSelectBinary(device,
-                                              (const uint8_t **)binaries,
-                                              binaries_length, nullptr));
+        ASSERT_EQ_RESULT(
+            UR_RESULT_ERROR_INVALID_NULL_POINTER,
+            urDeviceSelectBinary(device, binaries, binaries_length, nullptr));
     }
 }
 
 TEST_F(urDeviceSelectBinaryTest, InvalidValueNumBinaries) {
     for (auto device : devices) {
         uint32_t selected_binary;
-        ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
-                         urDeviceSelectBinary(device,
-                                              (const uint8_t **)binaries, 0,
-                                              &selected_binary));
+        ASSERT_EQ_RESULT(
+            UR_RESULT_ERROR_INVALID_VALUE,
+            urDeviceSelectBinary(device, binaries, 0, &selected_binary));
     }
 }


### PR DESCRIPTION
PI uses a `pi_device_binary` type which includes a bunch of additional metadata that is used by the program manager in SYCL. However the only place where this binary struct is used is with the `urDeviceSelectBinary` entry point. Every implemented plugin selects the correct device binary by comparing the correct `DeviceTargetSpec` within the plugin. The extra complexity inherited in PI from the program manager is unnecessary for UR and has been removed. I have left the option of extending this struct with the `ur_base_desc_t` class.

Closes #252 
Closes #118 
Closes #171 
Closes #114 
