### PR TITLE
[ur] Enable better formating for tests

### DIFF
--- a/examples/collector/collector.cpp
+++ b/examples/collector/collector.cpp
@@ -25,14 +25,17 @@
 #include "ur_api.h"
 #include "xpti/xpti_trace_framework.h"
 
-constexpr uint16_t TRACE_FN_BEGIN = static_cast<uint16_t>(xpti::trace_point_type_t::function_with_args_begin);
-constexpr uint16_t TRACE_FN_END = static_cast<uint16_t>(xpti::trace_point_type_t::function_with_args_end);
+constexpr uint16_t TRACE_FN_BEGIN =
+    static_cast<uint16_t>(xpti::trace_point_type_t::function_with_args_begin);
+constexpr uint16_t TRACE_FN_END =
+    static_cast<uint16_t>(xpti::trace_point_type_t::function_with_args_end);
 constexpr std::string_view UR_STREAM_NAME = "ur";
 
 /**
  * @brief Formats the function parameters and arguments for urInit
  */
-std::ostream &operator<<(std::ostream &os, const struct ur_init_params_t *params) {
+std::ostream &operator<<(std::ostream &os,
+                         const struct ur_init_params_t *params) {
     os << ".device_flags = ";
     if (*params->pdevice_flags & UR_DEVICE_INIT_FLAG_GPU) {
         os << "UR_DEVICE_INIT_FLAG_GPU";
@@ -48,14 +51,15 @@ std::ostream &operator<<(std::ostream &os, const struct ur_init_params_t *params
  * This example only implements a handler for one function, `urInit`, but it's
  * trivial to expand it to support more.
  */
-static std::unordered_map<std::string_view,
-                          std::function<void(const xpti::function_with_args_t *, std::ostream &)>>
-    handlers =
-        {
-            {"urInit", [](const xpti::function_with_args_t *fn_args, std::ostream &os) {
-                 auto params = static_cast<const struct ur_init_params_t *>(fn_args->args_data);
-                 os << params;
-             }}};
+static std::unordered_map<
+    std::string_view,
+    std::function<void(const xpti::function_with_args_t *, std::ostream &)>>
+    handlers = {{"urInit", [](const xpti::function_with_args_t *fn_args,
+                              std::ostream &os) {
+                     auto params = static_cast<const struct ur_init_params_t *>(
+                         fn_args->args_data);
+                     os << params;
+                 }}};
 
 /**
  * @brief Tracing callback invoked by the dispatcher on every event.
@@ -74,7 +78,8 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type,
     auto *args = static_cast<const xpti::function_with_args_t *>(user_data);
     std::ostringstream out;
     if (trace_type == TRACE_FN_BEGIN) {
-        out << "function_with_args_begin(" << instance << ") - " << args->function_name << "(";
+        out << "function_with_args_begin(" << instance << ") - "
+            << args->function_name << "(";
         auto it = handlers.find(args->function_name);
         if (it == handlers.end()) {
             out << "unimplemented";
@@ -84,7 +89,9 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type,
         out << ");";
     } else if (trace_type == TRACE_FN_END) {
         auto result = static_cast<const ur_result_t *>(args->ret_data);
-        out << "function_with_args_end(" << instance << ") - " << args->function_name << "(...) -> ur_result_t(" << *result << ");";
+        out << "function_with_args_end(" << instance << ") - "
+            << args->function_name << "(...) -> ur_result_t(" << *result
+            << ");";
     } else {
         out << "unsupported trace type";
     }
@@ -105,12 +112,18 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
                                      const char *version_str,
                                      const char *stream_name) {
     if (!stream_name || std::string_view(stream_name) != UR_STREAM_NAME) {
-        std::cout << "Invalid stream name: " << stream_name << ". Expected " << UR_STREAM_NAME << ". Aborting." << std::endl;
+        std::cout << "Invalid stream name: " << stream_name << ". Expected "
+                  << UR_STREAM_NAME << ". Aborting." << std::endl;
         return;
     }
 
-    if (UR_MAKE_VERSION(major_version, minor_version) != UR_API_VERSION_CURRENT) {
-        std::cout << "Invalid stream version: " << major_version << "." << minor_version << ". Expected " << UR_MAJOR_VERSION(UR_API_VERSION_CURRENT) << "." << UR_MINOR_VERSION(UR_API_VERSION_CURRENT) << ". Aborting." << std::endl;
+    if (UR_MAKE_VERSION(major_version, minor_version) !=
+        UR_API_VERSION_CURRENT) {
+        std::cout << "Invalid stream version: " << major_version << "."
+                  << minor_version << ". Expected "
+                  << UR_MAJOR_VERSION(UR_API_VERSION_CURRENT) << "."
+                  << UR_MINOR_VERSION(UR_API_VERSION_CURRENT) << ". Aborting."
+                  << std::endl;
         return;
     }
 
@@ -130,6 +143,5 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
  *
  * Can be used to cleanup state or resources.
  */
-XPTI_CALLBACK_API void xptiTraceFinish(const char *stream_name) {
-    /* noop */
+XPTI_CALLBACK_API void xptiTraceFinish(const char *stream_name) { /* noop */
 }

--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -29,14 +29,16 @@ int main(int argc, char *argv[]) {
 
     status = urPlatformGet(1, nullptr, &platformCount);
     if (status != UR_RESULT_SUCCESS) {
-        std::cout << "urPlatformGet failed with return code: " << status << std::endl;
+        std::cout << "urPlatformGet failed with return code: " << status
+                  << std::endl;
         goto out;
     }
 
     platforms.resize(platformCount);
     status = urPlatformGet(platformCount, platforms.data(), nullptr);
     if (status != UR_RESULT_SUCCESS) {
-        std::cout << "urPlatformGet failed with return code: " << status << std::endl;
+        std::cout << "urPlatformGet failed with return code: " << status
+                  << std::endl;
         goto out;
     }
 
@@ -44,36 +46,47 @@ int main(int argc, char *argv[]) {
         ur_api_version_t api_version = {};
         status = urPlatformGetApiVersion(p, &api_version);
         if (status != UR_RESULT_SUCCESS) {
-            std::cout << "urPlatformGetApiVersion failed with return code: " << status << std::endl;
+            std::cout << "urPlatformGetApiVersion failed with return code: "
+                      << status << std::endl;
             goto out;
         }
-        std::cout << "API version: " << UR_MAJOR_VERSION(api_version) << "." << UR_MINOR_VERSION(api_version) << std::endl;
+        std::cout << "API version: " << UR_MAJOR_VERSION(api_version) << "."
+                  << UR_MINOR_VERSION(api_version) << std::endl;
 
         uint32_t deviceCount = 0;
         status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, 0, nullptr, &deviceCount);
         if (status != UR_RESULT_SUCCESS) {
-            std::cout << "urDeviceGet failed with return code: " << status << std::endl;
+            std::cout << "urDeviceGet failed with return code: " << status
+                      << std::endl;
             goto out;
         }
 
         std::vector<ur_device_handle_t> devices(deviceCount);
-        status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, deviceCount, devices.data(), nullptr);
+        status = urDeviceGet(p, UR_DEVICE_TYPE_GPU, deviceCount, devices.data(),
+                             nullptr);
         if (status != UR_RESULT_SUCCESS) {
-            std::cout << "urDeviceGet failed with return code: " << status << std::endl;
+            std::cout << "urDeviceGet failed with return code: " << status
+                      << std::endl;
             goto out;
         }
         for (auto d : devices) {
             ur_device_type_t device_type;
-            status = urDeviceGetInfo(d, UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t), static_cast<void *>(&device_type), nullptr);
+            status = urDeviceGetInfo(
+                d, UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t),
+                static_cast<void *>(&device_type), nullptr);
             if (status != UR_RESULT_SUCCESS) {
-                std::cout << "urDeviceGetInfo failed with return code: " << status << std::endl;
+                std::cout << "urDeviceGetInfo failed with return code: "
+                          << status << std::endl;
                 goto out;
             }
             static const size_t DEVICE_NAME_MAX_LEN = 1024;
             char device_name[DEVICE_NAME_MAX_LEN] = {0};
-            status = urDeviceGetInfo(d, UR_DEVICE_INFO_NAME, DEVICE_NAME_MAX_LEN - 1, static_cast<void *>(&device_name), nullptr);
+            status =
+                urDeviceGetInfo(d, UR_DEVICE_INFO_NAME, DEVICE_NAME_MAX_LEN - 1,
+                                static_cast<void *>(&device_name), nullptr);
             if (status != UR_RESULT_SUCCESS) {
-                std::cout << "urDeviceGetInfo failed with return code: " << status << std::endl;
+                std::cout << "urDeviceGetInfo failed with return code: "
+                          << status << std::endl;
                 goto out;
             }
             if (device_type == UR_DEVICE_TYPE_GPU) {

--- a/include/.clang-format
+++ b/include/.clang-format
@@ -4,4 +4,5 @@ BasedOnStyle:  LLVM
 IndentWidth:   4
 InsertBraces: true
 ReflowComments: false
+ColumnLimit: 0
 ...

--- a/source/common/logger/ur_level.hpp
+++ b/source/common/logger/ur_level.hpp
@@ -9,11 +9,7 @@
 
 namespace logger {
 
-enum class Level { DEBUG,
-                   INFO,
-                   WARN,
-                   ERR,
-                   QUIET };
+enum class Level { DEBUG, INFO, WARN, ERR, QUIET };
 
 inline constexpr auto level_to_str(Level level) {
     switch (level) {

--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -19,9 +19,7 @@ inline Logger &get_logger(std::string name = "common") {
     return logger;
 }
 
-inline void init(std::string name) {
-    get_logger(name);
-}
+inline void init(std::string name) { get_logger(name); }
 
 template <typename... Args>
 inline void debug(const char *format, Args &&...args) {
@@ -45,7 +43,9 @@ inline void error(const char *format, Args &&...args) {
 
 inline void setLevel(logger::Level level) { get_logger().setLevel(level); }
 
-inline void setFlushLevel(logger::Level level) { get_logger().setFlushLevel(level); }
+inline void setFlushLevel(logger::Level level) {
+    get_logger().setFlushLevel(level);
+}
 
 /// @brief Create an instance of the logger with parameters obtained from the respective
 ///        environment variable or with default configuration if the env var is empty,
@@ -102,10 +102,13 @@ inline Logger create_logger(std::string logger_name) {
             values = kv->second;
         }
 
-        sink = values.size() == 2 ? sink_from_str(logger_name, values[0], values[1])
-                                  : sink_from_str(logger_name, values[0]);
+        sink = values.size() == 2
+                   ? sink_from_str(logger_name, values[0], values[1])
+                   : sink_from_str(logger_name, values[0]);
     } catch (const std::invalid_argument &e) {
-        std::cerr << "Error when creating a logger instance from environment variable" << e.what();
+        std::cerr
+            << "Error when creating a logger instance from environment variable"
+            << e.what();
         return Logger(std::make_unique<logger::StderrSink>(logger_name));
     }
     sink->setFlushLevel(flush_level);

--- a/source/common/logger/ur_logger_details.hpp
+++ b/source/common/logger/ur_logger_details.hpp
@@ -43,13 +43,11 @@ class Logger {
         this->sink->setFlushLevel(level);
     }
 
-    template <typename... Args>
-    void debug(const char *format, Args &&...args) {
+    template <typename... Args> void debug(const char *format, Args &&...args) {
         log(logger::Level::DEBUG, format, std::forward<Args>(args)...);
     }
 
-    template <typename... Args>
-    void info(const char *format, Args &&...args) {
+    template <typename... Args> void info(const char *format, Args &&...args) {
         log(logger::Level::INFO, format, std::forward<Args>(args)...);
     }
 
@@ -58,8 +56,7 @@ class Logger {
         log(logger::Level::WARN, format, std::forward<Args>(args)...);
     }
 
-    template <typename... Args>
-    void error(const char *format, Args &&...args) {
+    template <typename... Args> void error(const char *format, Args &&...args) {
         log(logger::Level::ERR, format, std::forward<Args>(args)...);
     }
 

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -30,7 +30,9 @@ class Sink {
     std::ostream *ostream;
     logger::Level flush_level;
 
-    Sink(std::string logger_name) : logger_name(logger_name) { flush_level = logger::Level::ERR; }
+    Sink(std::string logger_name) : logger_name(logger_name) {
+        flush_level = logger::Level::ERR;
+    }
 
   private:
     std::string logger_name;
@@ -45,20 +47,21 @@ class Sink {
                 if (*(++fmt) == '{') {
                     *ostream << *fmt++;
                 } else {
-                    throw std::runtime_error("No arguments provided and braces not escaped!");
+                    throw std::runtime_error(
+                        "No arguments provided and braces not escaped!");
                 }
             } else if (*fmt == '}') {
                 if (*(++fmt) == '}') {
                     *ostream << *fmt++;
                 } else {
-                    throw std::runtime_error("Closing curly brace not escaped!");
+                    throw std::runtime_error(
+                        "Closing curly brace not escaped!");
                 }
             }
         }
     }
 
-    template <typename Arg>
-    void format(const char *fmt, Arg &&arg) {
+    template <typename Arg> void format(const char *fmt, Arg &&arg) {
         while (*fmt != '\0') {
             while (*fmt != '{' && *fmt != '}' && *fmt != '\0') {
                 *ostream << *fmt++;
@@ -77,7 +80,8 @@ class Sink {
                 if (*(++fmt) == '}') {
                     *ostream << *fmt++;
                 } else {
-                    throw std::runtime_error("Closing curly brace not escaped!");
+                    throw std::runtime_error(
+                        "Closing curly brace not escaped!");
                 }
             }
         }
@@ -104,7 +108,8 @@ class Sink {
                 if (*(++fmt) == '}') {
                     *ostream << *fmt++;
                 } else {
-                    throw std::runtime_error("Closing curly brace not escaped!");
+                    throw std::runtime_error(
+                        "Closing curly brace not escaped!");
                 }
             }
         }
@@ -115,9 +120,12 @@ class Sink {
 
 class StdoutSink : public Sink {
   public:
-    StdoutSink(std::string logger_name) : Sink(logger_name) { this->ostream = &std::cout; }
+    StdoutSink(std::string logger_name) : Sink(logger_name) {
+        this->ostream = &std::cout;
+    }
 
-    StdoutSink(std::string logger_name, Level flush_lvl) : StdoutSink(logger_name) {
+    StdoutSink(std::string logger_name, Level flush_lvl)
+        : StdoutSink(logger_name) {
         this->flush_level = flush_lvl;
     }
 
@@ -126,9 +134,12 @@ class StdoutSink : public Sink {
 
 class StderrSink : public Sink {
   public:
-    StderrSink(std::string logger_name) : Sink(logger_name) { this->ostream = &std::cerr; }
+    StderrSink(std::string logger_name) : Sink(logger_name) {
+        this->ostream = &std::cerr;
+    }
 
-    StderrSink(std::string logger_name, Level flush_lvl) : StderrSink(logger_name) {
+    StderrSink(std::string logger_name, Level flush_lvl)
+        : StderrSink(logger_name) {
         this->flush_level = flush_lvl;
     }
 
@@ -137,7 +148,8 @@ class StderrSink : public Sink {
 
 class FileSink : public Sink {
   public:
-    FileSink(std::string logger_name, std::string file_path) : Sink(logger_name) {
+    FileSink(std::string logger_name, std::string file_path)
+        : Sink(logger_name) {
         ofstream = std::ofstream(file_path, std::ofstream::out);
         if (ofstream.rdstate() != std::ofstream::goodbit) {
             throw std::invalid_argument(
@@ -147,7 +159,8 @@ class FileSink : public Sink {
         this->ostream = &ofstream;
     }
 
-    FileSink(std::string logger_name, std::string file_path, Level flush_lvl) : FileSink(logger_name, file_path) {
+    FileSink(std::string logger_name, std::string file_path, Level flush_lvl)
+        : FileSink(logger_name, file_path) {
         this->flush_level = flush_lvl;
     }
 
@@ -155,13 +168,16 @@ class FileSink : public Sink {
     std::ofstream ofstream;
 };
 
-inline std::unique_ptr<Sink> sink_from_str(std::string logger_name, std::string name, std::string file_path = "") {
+inline std::unique_ptr<Sink> sink_from_str(std::string logger_name,
+                                           std::string name,
+                                           std::string file_path = "") {
     if (name == "stdout") {
         return std::make_unique<logger::StdoutSink>(logger_name);
     } else if (name == "stderr") {
         return std::make_unique<logger::StderrSink>(logger_name);
     } else if (name == "file" && !file_path.empty()) {
-        return std::make_unique<logger::FileSink>(logger_name, file_path.c_str());
+        return std::make_unique<logger::FileSink>(logger_name,
+                                                  file_path.c_str());
     }
 
     throw std::invalid_argument(

--- a/source/common/unified_memory_allocation/include/uma/base.h
+++ b/source/common/unified_memory_allocation/include/uma/base.h
@@ -17,7 +17,8 @@ extern "C" {
 #endif
 
 /// \brief Generates generic 'UMA' API versions
-#define UMA_MAKE_VERSION(_major, _minor) ((_major << 16) | (_minor & 0x0000ffff))
+#define UMA_MAKE_VERSION(_major, _minor)                                       \
+    ((_major << 16) | (_minor & 0x0000ffff))
 
 /// \brief Extracts 'UMA' API major version
 #define UMA_MAJOR_VERSION(_ver) (_ver >> 16)
@@ -30,13 +31,17 @@ extern "C" {
 
 /// \brief Operation results
 enum uma_result_t {
-    UMA_RESULT_SUCCESS = 0,                        ///< Success
-    UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY = 1,       ///< Insufficient host memory to satisfy call,
-    UMA_RESULT_ERROR_POOL_SPECIFIC = 2,            ///< A pool specific warning/error has been reported and can be
-                                                   ///< Retrieved via the umaPoolGetLastResult entry point.
-    UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC = 3, ///< A provider specific warning/error has been reported and can be
-                                                   ///< Retrieved via the umaMemoryProviderGetLastResult entry point.
-    UMA_RESULT_ERROR_INVALID_ARGUMENT = 4,         ///< Generic error code for invalid arguments
+    UMA_RESULT_SUCCESS = 0, ///< Success
+    UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY =
+        1, ///< Insufficient host memory to satisfy call,
+    UMA_RESULT_ERROR_POOL_SPECIFIC =
+        2, ///< A pool specific warning/error has been reported and can be
+           ///< Retrieved via the umaPoolGetLastResult entry point.
+    UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC =
+        3, ///< A provider specific warning/error has been reported and can be
+           ///< Retrieved via the umaMemoryProviderGetLastResult entry point.
+    UMA_RESULT_ERROR_INVALID_ARGUMENT =
+        4, ///< Generic error code for invalid arguments
 
     UMA_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
 };

--- a/source/common/unified_memory_allocation/include/uma/memory_pool.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool.h
@@ -24,7 +24,8 @@ typedef struct uma_memory_pool_t *uma_memory_pool_handle_t;
 /// \param params pointer to pool-specific parameters
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params, uma_memory_pool_handle_t *hPool);
+enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops, void *params,
+                                uma_memory_pool_handle_t *hPool);
 
 ///
 /// \brief Destroys memory pool
@@ -48,7 +49,8 @@ void *umaPoolMalloc(uma_memory_pool_handle_t hPool, size_t size);
 /// \param alignment alignment of the allocation
 /// \return Pointer to the allocated memory
 ///
-void *umaPoolAlignedMalloc(uma_memory_pool_handle_t hPool, size_t size, size_t alignment);
+void *umaPoolAlignedMalloc(uma_memory_pool_handle_t hPool, size_t size,
+                           size_t alignment);
 
 ///
 /// \brief Allocates memory of the specified hPool for an array of num elements
@@ -106,7 +108,8 @@ void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr);
 /// \return UMA_RESULT_SUCCESS if the result being
 ///         reported is to be considered a warning. Any other result code
 ///         returned indicates that the adapter specific result is an error.
-enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool, const char **ppMessage);
+enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
+                                       const char **ppMessage);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -24,7 +24,9 @@ typedef struct uma_memory_provider_t *uma_memory_provider_handle_t;
 /// \param params pointer to provider-specific parameters
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t umaMemoryProviderCreate(struct uma_memory_provider_ops_t *ops, void *params, uma_memory_provider_handle_t *hProvider);
+enum uma_result_t
+umaMemoryProviderCreate(struct uma_memory_provider_ops_t *ops, void *params,
+                        uma_memory_provider_handle_t *hProvider);
 
 ///
 /// \brief Destroys memory provider
@@ -42,7 +44,9 @@ void umaMemoryProviderDestroy(uma_memory_provider_handle_t hProvider);
 /// \param ptr returns pointer to the allocated memory
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
 ///
-enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider, size_t size, size_t alignment, void **ptr);
+enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,
+                                         size_t size, size_t alignment,
+                                         void **ptr);
 
 ///
 /// \brief Frees the memory space pointed by ptr from the memory provider
@@ -50,7 +54,8 @@ enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,
 /// \param ptr pointer to the allocated memory
 /// \param size size of the allocation
 ///
-enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider, void *ptr, size_t size);
+enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
+                                        void *ptr, size_t size);
 
 ///
 /// \brief Retrieve string representation of the underlying provider specific
@@ -73,7 +78,9 @@ enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider, 
 /// \return UMA_RESULT_SUCCESS if the result being reported is to be considered
 ///         a warning. Any other result code returned indicates that the
 ///         adapter specific result is an error.
-enum uma_result_t umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider, const char **ppMessage);
+enum uma_result_t
+umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
+                               const char **ppMessage);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -37,9 +37,11 @@ struct uma_memory_provider_ops_t {
     void (*finalize)(void *pool);
 
     /// Refer to memory_provider.h for description of those functions
-    enum uma_result_t (*alloc)(void *provider, size_t size, size_t alignment, void **ptr);
+    enum uma_result_t (*alloc)(void *provider, size_t size, size_t alignment,
+                               void **ptr);
     enum uma_result_t (*free)(void *provider, void *ptr, size_t size);
-    enum uma_result_t (*get_last_result)(void *provider, const char **ppMessage);
+    enum uma_result_t (*get_last_result)(void *provider,
+                                         const char **ppMessage);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_memory_allocation/src/memory_pool.c
+++ b/source/common/unified_memory_allocation/src/memory_pool.c
@@ -71,7 +71,7 @@ void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr) {
     hPool->ops.free(hPool->pool_priv, ptr);
 }
 
-enum uma_result_t
-umaPoolGetLastResult(uma_memory_pool_handle_t hPool, const char **ppMessage) {
+enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
+                                       const char **ppMessage) {
     return hPool->ops.get_last_result(hPool->pool_priv, ppMessage);
 }

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -60,6 +60,7 @@ enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
 }
 
 enum uma_result_t
-umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider, const char **ppMessage) {
+umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
+                               const char **ppMessage) {
     return hProvider->ops.get_last_result(hProvider->provider_priv, ppMessage);
 }

--- a/source/common/ur_singleton.hpp
+++ b/source/common/ur_singleton.hpp
@@ -15,11 +15,11 @@
 
 //////////////////////////////////////////////////////////////////////////
 /// a abstract factory for creation of singleton objects
-template <typename singleton_tn, typename key_tn>
-class singleton_factory_t {
+template <typename singleton_tn, typename key_tn> class singleton_factory_t {
   protected:
     using singleton_t = singleton_tn;
-    using key_t = typename std::conditional<std::is_pointer<key_tn>::value, size_t, key_tn>::type;
+    using key_t = typename std::conditional<std::is_pointer<key_tn>::value,
+                                            size_t, key_tn>::type;
 
     using ptr_t = std::unique_ptr<singleton_t>;
     using map_t = std::unordered_map<key_t, ptr_t>;
@@ -29,8 +29,9 @@ class singleton_factory_t {
 
     //////////////////////////////////////////////////////////////////////////
     /// extract the key from parameter list and if necessary, convert type
-    template <typename... Ts>
-    key_t getKey(key_tn key, Ts &&...params) { return reinterpret_cast<key_t>(key); }
+    template <typename... Ts> key_t getKey(key_tn key, Ts &&...params) {
+        return reinterpret_cast<key_t>(key);
+    }
 
   public:
     //////////////////////////////////////////////////////////////////////////
@@ -43,8 +44,7 @@ class singleton_factory_t {
     /// if no instance exists, then creates a new instance
     /// the params are forwarded to the ctor of the singleton
     /// the first parameter must be the unique identifier of the instance
-    template <typename... Ts>
-    singleton_tn *getInstance(Ts &&...params) {
+    template <typename... Ts> singleton_tn *getInstance(Ts &&...params) {
         auto key = getKey(std::forward<Ts>(params)...);
 
         if (key == 0) { // No zero keys allowed in map
@@ -55,7 +55,8 @@ class singleton_factory_t {
         auto iter = map.find(key);
 
         if (map.end() == iter) {
-            auto ptr = std::make_unique<singleton_t>(std::forward<Ts>(params)...);
+            auto ptr =
+                std::make_unique<singleton_t>(std::forward<Ts>(params)...);
             iter = map.emplace(key, std::move(ptr)).first;
         }
         return iter->second.get();

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -45,8 +45,8 @@
 #define MAKE_LIBRARY_NAME(NAME, VERSION) NAME ".dll"
 #define MAKE_LAYER_NAME(NAME) NAME ".dll"
 #define LOAD_DRIVER_LIBRARY(NAME) LoadLibraryExA(NAME, nullptr, 0)
-#define FREE_DRIVER_LIBRARY(LIB) \
-    if (LIB)                     \
+#define FREE_DRIVER_LIBRARY(LIB)                                               \
+    if (LIB)                                                                   \
     FreeLibrary(LIB)
 #define GET_FUNCTION_PTR(LIB, FUNC_NAME) GetProcAddress(LIB, FUNC_NAME)
 #define string_copy_s strncpy_s
@@ -54,14 +54,16 @@
 #include <dlfcn.h>
 #define HMODULE void *
 #define MAKE_LIBRARY_NAME(NAME, VERSION) "lib" NAME ".so." VERSION
-#define MAKE_LAYER_NAME(NAME) "lib" NAME ".so." L0_VALIDATION_LAYER_SUPPORTED_VERSION
+#define MAKE_LAYER_NAME(NAME)                                                  \
+    "lib" NAME ".so." L0_VALIDATION_LAYER_SUPPORTED_VERSION
 #if defined(SANITIZER_ANY)
 #define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY | RTLD_LOCAL)
 #else
-#define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND)
+#define LOAD_DRIVER_LIBRARY(NAME)                                              \
+    dlopen(NAME, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND)
 #endif
-#define FREE_DRIVER_LIBRARY(LIB) \
-    if (LIB)                     \
+#define FREE_DRIVER_LIBRARY(LIB)                                               \
+    if (LIB)                                                                   \
     dlclose(LIB)
 #define GET_FUNCTION_PTR(LIB, FUNC_NAME) dlsym(LIB, FUNC_NAME)
 #define string_copy_s strncpy
@@ -130,7 +132,8 @@ static void throw_wrong_format_vec(const char *env_var_name) {
 static void throw_wrong_format_map(const char *env_var_name) {
     std::stringstream ex_ss;
     ex_ss << "Wrong format of the " << env_var_name << " environment variable!"
-          << " Proper format is: ENV_VAR=\"param_1:value_1,value_2;param_2:value_1";
+          << " Proper format is: "
+             "ENV_VAR=\"param_1:value_1,value_2;param_2:value_1";
     throw std::invalid_argument(ex_ss.str());
 }
 
@@ -145,7 +148,8 @@ static void throw_wrong_format_map(const char *env_var_name) {
 /// @return std::optional with a possible vector of strings containing parsed values
 ///         and std::nullopt when the environment variable is not set or is empty
 /// @throws std::invalid_argument() when the parsed environment variable has wrong format
-inline std::optional<std::vector<std::string>> getenv_to_vec(const char *env_var_name) {
+inline std::optional<std::vector<std::string>>
+getenv_to_vec(const char *env_var_name) {
     char values_delim = ',';
 
     auto env_var = ur_getenv(env_var_name);
@@ -153,7 +157,8 @@ inline std::optional<std::vector<std::string>> getenv_to_vec(const char *env_var
         return std::nullopt;
     }
 
-    if (env_var->find(':') == std::string::npos && env_var->find(';') == std::string::npos) {
+    if (env_var->find(':') == std::string::npos &&
+        env_var->find(';') == std::string::npos) {
         std::stringstream values_ss(*env_var);
         std::string value;
         std::vector<std::string> values_vec;
@@ -217,7 +222,9 @@ inline std::optional<EnvVarMap> getenv_to_map(const char *env_var_name) {
 
         std::getline(kv_ss, key, key_value_delim);
         std::getline(kv_ss, values);
-        if (key.empty() || values.empty() || values.find(':') != std::string::npos || map.find(key) != map.end()) {
+        if (key.empty() || values.empty() ||
+            values.find(':') != std::string::npos ||
+            map.find(key) != map.end()) {
             throw_wrong_format_map(env_var_name);
         }
 

--- a/source/drivers/null/ur_null.cpp
+++ b/source/drivers/null/ur_null.cpp
@@ -16,7 +16,9 @@ context_t d_context;
 //////////////////////////////////////////////////////////////////////////
 context_t::context_t() {
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGet = [](uint32_t NumEntries, ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
+    urDdiTable.Platform.pfnGet = [](uint32_t NumEntries,
+                                    ur_platform_handle_t *phPlatforms,
+                                    uint32_t *pNumPlatforms) {
         if (phPlatforms != nullptr && NumEntries != 1) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
@@ -30,103 +32,113 @@ context_t::context_t() {
     };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGetApiVersion = [](ur_platform_handle_t, ur_api_version_t *version) {
+    urDdiTable.Platform.pfnGetApiVersion = [](ur_platform_handle_t,
+                                              ur_api_version_t *version) {
         *version = d_context.version;
         return UR_RESULT_SUCCESS;
     };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGetInfo = [](ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType, size_t Size,
-                                        void *pPlatformInfo, size_t *pSizeRet) {
-        if (!hPlatform) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
+    urDdiTable.Platform.pfnGetInfo =
+        [](ur_platform_handle_t hPlatform, ur_platform_info_t PlatformInfoType,
+           size_t Size, void *pPlatformInfo, size_t *pSizeRet) {
+            if (!hPlatform) {
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+            }
 
-        switch (PlatformInfoType) {
-        case UR_PLATFORM_INFO_NAME: {
-            const char null_platform_name[] = "UR_PLATFORM_NULL";
-            if (pSizeRet) {
-                *pSizeRet = sizeof(null_platform_name);
-            }
-            if (pPlatformInfo && Size != sizeof(null_platform_name)) {
-                return UR_RESULT_ERROR_INVALID_SIZE;
-            }
-            if (pPlatformInfo) {
+            switch (PlatformInfoType) {
+            case UR_PLATFORM_INFO_NAME: {
+                const char null_platform_name[] = "UR_PLATFORM_NULL";
+                if (pSizeRet) {
+                    *pSizeRet = sizeof(null_platform_name);
+                }
+                if (pPlatformInfo && Size != sizeof(null_platform_name)) {
+                    return UR_RESULT_ERROR_INVALID_SIZE;
+                }
+                if (pPlatformInfo) {
 #if defined(_WIN32)
-                strncpy_s(reinterpret_cast<char *>(pPlatformInfo), Size, null_platform_name, sizeof(null_platform_name));
+                    strncpy_s(reinterpret_cast<char *>(pPlatformInfo), Size,
+                              null_platform_name, sizeof(null_platform_name));
 #else
-                strncpy(reinterpret_cast<char *>(pPlatformInfo), null_platform_name, Size);
+                    strncpy(reinterpret_cast<char *>(pPlatformInfo),
+                            null_platform_name, Size);
 #endif
+                }
+            } break;
+
+            default:
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
             }
-        } break;
 
-        default:
-            return UR_RESULT_ERROR_INVALID_ENUMERATION;
-        }
-
-        return UR_RESULT_SUCCESS;
-    };
+            return UR_RESULT_SUCCESS;
+        };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Device.pfnGet = [](ur_platform_handle_t hPlatform, ur_device_type_t DevicesType, uint32_t NumEntries,
-                                  ur_device_handle_t *phDevices, uint32_t *pNumDevices) {
-        (void)DevicesType;
-        if (hPlatform == nullptr) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-        if (UR_DEVICE_TYPE_VPU < DevicesType) {
-            return UR_RESULT_ERROR_INVALID_ENUMERATION;
-        }
-        if (phDevices != nullptr && NumEntries != 1) {
-            return UR_RESULT_ERROR_INVALID_SIZE;
-        }
-        if (pNumDevices != nullptr) {
-            *pNumDevices = 1;
-        }
-        if (nullptr != phDevices) {
-            *reinterpret_cast<void **>(phDevices) = d_context.get();
-        }
-        return UR_RESULT_SUCCESS;
-    };
+    urDdiTable.Device.pfnGet =
+        [](ur_platform_handle_t hPlatform, ur_device_type_t DevicesType,
+           uint32_t NumEntries, ur_device_handle_t *phDevices,
+           uint32_t *pNumDevices) {
+            (void)DevicesType;
+            if (hPlatform == nullptr) {
+                return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+            }
+            if (UR_DEVICE_TYPE_VPU < DevicesType) {
+                return UR_RESULT_ERROR_INVALID_ENUMERATION;
+            }
+            if (phDevices != nullptr && NumEntries != 1) {
+                return UR_RESULT_ERROR_INVALID_SIZE;
+            }
+            if (pNumDevices != nullptr) {
+                *pNumDevices = 1;
+            }
+            if (nullptr != phDevices) {
+                *reinterpret_cast<void **>(phDevices) = d_context.get();
+            }
+            return UR_RESULT_SUCCESS;
+        };
 
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Device.pfnGetInfo = [](ur_device_handle_t hDevice, ur_device_info_t infoType, size_t propSize, void *pDeviceInfo,
-                                      size_t *pPropSizeRet) {
-        switch (infoType) {
-        case UR_DEVICE_INFO_TYPE:
-            if (pDeviceInfo && propSize != sizeof(ur_device_type_t)) {
-                return UR_RESULT_ERROR_INVALID_SIZE;
-            }
+    urDdiTable.Device.pfnGetInfo =
+        [](ur_device_handle_t hDevice, ur_device_info_t infoType,
+           size_t propSize, void *pDeviceInfo, size_t *pPropSizeRet) {
+            switch (infoType) {
+            case UR_DEVICE_INFO_TYPE:
+                if (pDeviceInfo && propSize != sizeof(ur_device_type_t)) {
+                    return UR_RESULT_ERROR_INVALID_SIZE;
+                }
 
-            if (pDeviceInfo != nullptr) {
-                *reinterpret_cast<ur_device_type_t *>(pDeviceInfo) = UR_DEVICE_TYPE_GPU;
-            }
-            if (pPropSizeRet != nullptr) {
-                *pPropSizeRet = sizeof(ur_device_type_t);
-            }
-            break;
+                if (pDeviceInfo != nullptr) {
+                    *reinterpret_cast<ur_device_type_t *>(pDeviceInfo) =
+                        UR_DEVICE_TYPE_GPU;
+                }
+                if (pPropSizeRet != nullptr) {
+                    *pPropSizeRet = sizeof(ur_device_type_t);
+                }
+                break;
 
-        case UR_DEVICE_INFO_NAME: {
-            char deviceName[] = "Null Device";
-            if (pDeviceInfo && propSize < sizeof(deviceName)) {
-                return UR_RESULT_ERROR_INVALID_SIZE;
-            }
-            if (pDeviceInfo != nullptr) {
+            case UR_DEVICE_INFO_NAME: {
+                char deviceName[] = "Null Device";
+                if (pDeviceInfo && propSize < sizeof(deviceName)) {
+                    return UR_RESULT_ERROR_INVALID_SIZE;
+                }
+                if (pDeviceInfo != nullptr) {
 #if defined(_WIN32)
-                strncpy_s(reinterpret_cast<char *>(pDeviceInfo), propSize, deviceName, sizeof(deviceName));
+                    strncpy_s(reinterpret_cast<char *>(pDeviceInfo), propSize,
+                              deviceName, sizeof(deviceName));
 #else
-                strncpy(reinterpret_cast<char *>(pDeviceInfo), deviceName, propSize);
+                    strncpy(reinterpret_cast<char *>(pDeviceInfo), deviceName,
+                            propSize);
 #endif
-            }
-            if (pPropSizeRet != nullptr) {
-                *pPropSizeRet = sizeof(deviceName);
-            }
-        } break;
+                }
+                if (pPropSizeRet != nullptr) {
+                    *pPropSizeRet = sizeof(deviceName);
+                }
+            } break;
 
-        default:
-            return UR_RESULT_ERROR_INVALID_ARGUMENT;
-        }
-        return UR_RESULT_SUCCESS;
-    };
+            default:
+                return UR_RESULT_ERROR_INVALID_ARGUMENT;
+            }
+            return UR_RESULT_SUCCESS;
+        };
 }
 } // namespace driver

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -12,10 +12,9 @@
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL
-urInit(
+__urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -32,8 +31,7 @@ urInit(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL
-urTearDown(
+__urdlllocal ur_result_t UR_APICALL urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -51,16 +49,18 @@ urTearDown(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGet(
-    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
-                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                       ///< will be returned.
-    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                       ///< If NumEntries is less than the number of platforms available, then
-                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -71,7 +71,8 @@ urPlatformGet(
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phPlatforms) && (i < NumEntries); ++i) {
-            phPlatforms[i] = reinterpret_cast<ur_platform_handle_t>(d_context.get());
+            phPlatforms[i] =
+                reinterpret_cast<ur_platform_handle_t>(d_context.get());
         }
     }
 
@@ -80,23 +81,24 @@ urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Platform.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+        result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
+                            pSizeRet);
     } else {
         // generic implementation
     }
@@ -106,8 +108,7 @@ urPlatformGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -126,10 +127,10 @@ urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -139,7 +140,8 @@ urPlatformGetNativeHandle(
         result = pfnGetNativeHandle(hPlatform, phNativePlatform);
     } else {
         // generic implementation
-        *phNativePlatform = reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativePlatform =
+            reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -147,15 +149,17 @@ urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
     } else {
@@ -168,11 +172,11 @@ urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL
-urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -189,30 +193,33 @@ urGetLastResult(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
-                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                    ///< will be returned.
-    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                    ///< If NumEntries is less than the number of devices available, then
-                                    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
-                                    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGet = d_context.urDdiTable.Device.pfnGet;
     if (nullptr != pfnGet) {
-        result = pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
+        result =
+            pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phDevices) && (i < NumEntries); ++i) {
-            phDevices[i] = reinterpret_cast<ur_device_handle_t>(d_context.get());
+            phDevices[i] =
+                reinterpret_cast<ur_device_handle_t>(d_context.get());
         }
     }
 
@@ -221,24 +228,25 @@ urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return the info
-                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Device.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+        result =
+            pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -248,9 +256,9 @@ urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRetain(
-    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+    ur_device_handle_t
+        hDevice ///< [in] handle of the device to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -267,8 +275,7 @@ urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -286,27 +293,31 @@ urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL
-urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices, ///< [in] the number of sub-devices.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnPartition = d_context.urDdiTable.Device.pfnPartition;
     if (nullptr != pfnPartition) {
-        result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
+        result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
+                              pNumDevicesRet);
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phSubDevices) && (i < NumDevices); ++i) {
-            phSubDevices[i] = reinterpret_cast<ur_device_handle_t>(d_context.get());
+            phSubDevices[i] =
+                reinterpret_cast<ur_device_handle_t>(d_context.get());
         }
     }
 
@@ -315,22 +326,24 @@ urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL
-urDeviceSelectBinary(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
-                                ///< Must greater than or equal to zero otherwise
-                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
-                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
+                          ///< Must greater than or equal to zero otherwise
+                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSelectBinary = d_context.urDdiTable.Device.pfnSelectBinary;
     if (nullptr != pfnSelectBinary) {
-        result = pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+        result =
+            pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
     } else {
         // generic implementation
     }
@@ -340,10 +353,10 @@ urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,        ///< [in] handle of the device.
-    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ///< [in] handle of the device.
+    ur_native_handle_t
+        *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -361,16 +374,17 @@ urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t
+        *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Device.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
     } else {
@@ -383,20 +397,23 @@ urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                                ///< correlates with the Host's global timestamp value
-    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
-                                ///< correlates with the Device's global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnGetGlobalTimestamps = d_context.urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps =
+        d_context.urDdiTable.Device.pfnGetGlobalTimestamps;
     if (nullptr != pfnGetGlobalTimestamps) {
-        result = pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
+        result =
+            pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
     } else {
         // generic implementation
     }
@@ -406,12 +423,14 @@ urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL
-urContextCreate(
-    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
-    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
-    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL urContextCreate(
+    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t
+        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *
+        pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t
+        *phContext ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -429,9 +448,9 @@ urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL
-urContextRetain(
-    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urContextRetain(
+    ur_context_handle_t
+        hContext ///< [in] handle of the context to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -448,8 +467,7 @@ urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL
-urContextRelease(
+__urdlllocal ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -467,24 +485,26 @@ urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Context.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
+        result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
+                            pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -494,10 +514,10 @@ urContextGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -507,7 +527,8 @@ urContextGetNativeHandle(
         result = pfnGetNativeHandle(hContext, phNativeContext);
     } else {
         // generic implementation
-        *phNativeContext = reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativeContext =
+            reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -515,15 +536,17 @@ urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Context.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeContext, phContext);
     } else {
@@ -536,16 +559,18 @@ urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL
-urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,             ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_context_extended_deleter_t
+        pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnSetExtendedDeleter = d_context.urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter =
+        d_context.urDdiTable.Context.pfnSetExtendedDeleter;
     if (nullptr != pfnSetExtendedDeleter) {
         result = pfnSetExtendedDeleter(hContext, pfnDeleter, pUserData);
     } else {
@@ -557,21 +582,22 @@ urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemImageCreate(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    void *pHost,                           ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    void *pHost,           ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageCreate = d_context.urDdiTable.Mem.pfnImageCreate;
     if (nullptr != pfnImageCreate) {
-        result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
+        result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc,
+                                pHost, phMem);
     } else {
         // generic implementation
         *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());
@@ -582,13 +608,13 @@ urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
-    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
-    void *pHost,                  ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    size_t size, ///< [in] size in bytes of the memory object to be allocated
+    void *pHost, ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t
+        *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -606,8 +632,7 @@ urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL
-urMemRetain(
+__urdlllocal ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -625,8 +650,7 @@ urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL
-urMemRelease(
+__urdlllocal ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -644,20 +668,23 @@ urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t
+        hBuffer,          ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
-    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *
+        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnBufferPartition = d_context.urDdiTable.Mem.pfnBufferPartition;
     if (nullptr != pfnBufferPartition) {
-        result = pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
+        result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
+                                    pBufferCreateInfo, phMem);
     } else {
         // generic implementation
         *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());
@@ -668,10 +695,10 @@ urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemGetNativeHandle(
-    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
-    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -689,16 +716,17 @@ urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of the mem object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Mem.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeMem, hContext, phMem);
     } else {
@@ -711,23 +739,26 @@ urMemCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+    ur_mem_handle_t
+        hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Mem.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+        result =
+            pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -737,23 +768,25 @@ urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageGetInfo = d_context.urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr != pfnImageGetInfo) {
-        result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+        result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
+                                 pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -763,12 +796,13 @@ urMemImageGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_property_t
+        *pProps, ///< [in] specifies a list of sampler property names and their
+                 ///< corresponding values.
+    ur_sampler_handle_t
+        *phSampler ///< [out] pointer to handle of sampler object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -786,9 +820,9 @@ urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRetain(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -805,9 +839,9 @@ urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRelease(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -824,20 +858,22 @@ urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
-    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
+    size_t *
+        pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Sampler.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+        result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
+                            pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -847,10 +883,10 @@ urSamplerGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -860,7 +896,8 @@ urSamplerGetNativeHandle(
         result = pfnGetNativeHandle(hSampler, phNativeSampler);
     } else {
         // generic implementation
-        *phNativeSampler = reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativeSampler =
+            reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -868,16 +905,18 @@ urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
     } else {
@@ -890,17 +929,19 @@ urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM host memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -917,25 +958,28 @@ urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM device memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnDeviceAlloc = d_context.urDdiTable.USM.pfnDeviceAlloc;
     if (nullptr != pfnDeviceAlloc) {
-        result = pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+        result = pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align,
+                                ppMem);
     } else {
         // generic implementation
     }
@@ -945,25 +989,28 @@ urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object.
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM shared memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object.
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnSharedAlloc = d_context.urDdiTable.USM.pfnSharedAlloc;
     if (nullptr != pfnSharedAlloc) {
-        result = pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+        result = pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align,
+                                ppMem);
     } else {
         // generic implementation
     }
@@ -973,8 +1020,7 @@ urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL
-urUSMFree(
+__urdlllocal ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -993,21 +1039,24 @@ urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL
-urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t
+        propName, ///< [in] the name of the USM allocation property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue, ///< [out][optional] value of the USM allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetMemAllocInfo = d_context.urDdiTable.USM.pfnGetMemAllocInfo;
     if (nullptr != pfnGetMemAllocInfo) {
-        result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+        result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
+                                    pPropValue, pPropValueSizeRet);
     } else {
         // generic implementation
     }
@@ -1017,12 +1066,12 @@ urUSMGetMemAllocInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolCreate(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_usm_pool_desc_t *pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
-                                   ///< ::ur_usm_pool_limits_desc_t
-    ur_usm_pool_handle_t *ppPool   ///< [out] pointer to USM memory pool
+__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_pool_desc_t *
+        pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
+                   ///< ::ur_usm_pool_limits_desc_t
+    ur_usm_pool_handle_t *ppPool ///< [out] pointer to USM memory pool
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1040,8 +1089,7 @@ urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolDestroy
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolDestroy(
+__urdlllocal ur_result_t UR_APICALL urUSMPoolDestroy(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_handle_t pPool    ///< [in] pointer to USM memory pool
 ) {
@@ -1060,13 +1108,14 @@ urUSMPoolDestroy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithIL(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    const void *pIL,                            ///< [in] pointer to IL binary.
-    size_t length,                              ///< [in] length of `pIL` in bytes.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const void *pIL,              ///< [in] pointer to IL binary.
+    size_t length,                ///< [in] length of `pIL` in bytes.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1084,21 +1133,24 @@ urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithBinary(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
-    size_t size,                                ///< [in] size in bytes.
-    const uint8_t *pBinary,                     ///< [in] pointer to binary.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_device_handle_t
+        hDevice,            ///< [in] handle to device associated with binary.
+    size_t size,            ///< [in] size in bytes.
+    const uint8_t *pBinary, ///< [in] pointer to binary.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreateWithBinary = d_context.urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr != pfnCreateWithBinary) {
-        result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
+        result = pfnCreateWithBinary(hContext, hDevice, size, pBinary,
+                                     pProperties, phProgram);
     } else {
         // generic implementation
         *phProgram = reinterpret_cast<ur_program_handle_t>(d_context.get());
@@ -1109,11 +1161,11 @@ urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL
-urProgramBuild(
+__urdlllocal ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1130,11 +1182,12 @@ urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL
-urProgramCompile(
+__urdlllocal ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    ur_program_handle_t hProgram, ///< [in][out] handle of the program to compile.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    ur_program_handle_t
+        hProgram, ///< [in][out] handle of the program to compile.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1151,13 +1204,15 @@ urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL
-urProgramLink(
-    ur_context_handle_t hContext,          ///< [in] handle of the context instance.
-    uint32_t count,                        ///< [in] number of program handles in `phPrograms`.
-    const ur_program_handle_t *phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
-    const char *pOptions,                  ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram         ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramLink(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance.
+    uint32_t count, ///< [in] number of program handles in `phPrograms`.
+    const ur_program_handle_t *
+        phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1175,8 +1230,7 @@ urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL
-urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1194,8 +1248,7 @@ urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL
-urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1213,21 +1266,26 @@ urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
-                                  ///< The program must already be built to the specified device, or
-                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
-    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program to search for function in.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnGetFunctionPointer = d_context.urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer =
+        d_context.urDdiTable.Program.pfnGetFunctionPointer;
     if (nullptr != pfnGetFunctionPointer) {
-        result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
+        result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
+                                       ppFunctionPointer);
     } else {
         // generic implementation
     }
@@ -1237,24 +1295,26 @@ urProgramGetFunctionPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName,   ///< [in] name of the Program property to query
-    size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
-                                  ///< If propSize is not equal to or greater than the real number of bytes
-                                  ///< needed to return
-                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+    ur_program_info_t propName, ///< [in] name of the Program property to query
+    size_t propSize,            ///< [in] the size of the Program property.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Program.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+        result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo,
+                            pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1264,25 +1324,28 @@ urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
-    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
-    size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
-                                      ///< If propSize is not equal to or greater than the real number of bytes
-                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
-    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
-                                      ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
+    ur_program_build_info_t
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetBuildInfo = d_context.urDdiTable.Program.pfnGetBuildInfo;
     if (nullptr != pfnGetBuildInfo) {
-        result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+        result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize,
+                                 pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1292,17 +1355,18 @@ urProgramGetBuildInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in][range(0, count)] array of specialization constant value
-                                                            ///< descriptions
+__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in][range(0, count)] array of specialization constant value
+                       ///< descriptions
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnSetSpecializationConstants = d_context.urDdiTable.Program.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        d_context.urDdiTable.Program.pfnSetSpecializationConstants;
     if (nullptr != pfnSetSpecializationConstants) {
         result = pfnSetSpecializationConstants(hProgram, count, pSpecConstants);
     } else {
@@ -1314,10 +1378,10 @@ urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1327,7 +1391,8 @@ urProgramGetNativeHandle(
         result = pfnGetNativeHandle(hProgram, phNativeProgram);
     } else {
         // generic implementation
-        *phNativeProgram = reinterpret_cast<ur_native_handle_t>(d_context.get());
+        *phNativeProgram =
+            reinterpret_cast<ur_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -1335,16 +1400,18 @@ urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Program.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
     } else {
@@ -1357,11 +1424,11 @@ urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to handle of kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1379,12 +1446,12 @@ urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,             ///< [in] size of argument type
-    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void
+        *pArgValue ///< [in] argument value represented as matching arg type.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1401,11 +1468,11 @@ urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1422,25 +1489,27 @@ urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return
-                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
-                                ///< queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Kernel.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+        result =
+            pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1450,23 +1519,26 @@ urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
-    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                     ///< property.
-    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
-                                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_group_info_t
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetGroupInfo = d_context.urDdiTable.Kernel.pfnGetGroupInfo;
     if (nullptr != pfnGetGroupInfo) {
-        result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+        result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize,
+                                 pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1476,23 +1548,26 @@ urKernelGetGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
-    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                         ///< property.
-    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
-                                         ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetSubGroupInfo = d_context.urDdiTable.Kernel.pfnGetSubGroupInfo;
     if (nullptr != pfnGetSubGroupInfo) {
-        result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+        result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
+                                    pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1502,8 +1577,7 @@ urKernelGetSubGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL
-urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1521,8 +1595,7 @@ urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL
-urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1540,12 +1613,12 @@ urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
-                                ///< value. If null then argument value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1562,13 +1635,13 @@ urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                    ///< property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1585,10 +1658,9 @@ urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
-    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1606,11 +1678,10 @@ urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1627,16 +1698,17 @@ urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in] array of specialization constant value descriptions
+__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in] array of specialization constant value descriptions
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnSetSpecializationConstants = d_context.urDdiTable.Kernel.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        d_context.urDdiTable.Kernel.pfnSetSpecializationConstants;
     if (nullptr != pfnSetSpecializationConstants) {
         result = pfnSetSpecializationConstants(hKernel, count, pSpecConstants);
     } else {
@@ -1648,10 +1720,10 @@ urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
-    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_native_handle_t
+        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1669,16 +1741,17 @@ urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to the handle of the kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeKernel, hContext, phKernel);
     } else {
@@ -1691,20 +1764,22 @@ urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
-    size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out][optional] value of the queue property
+    size_t *
+        pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Queue.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+        result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
+                            pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1714,17 +1789,18 @@ urQueueGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_queue_property_t *
+        pProps, ///< [in][optional] specifies a list of queue properties and their
+                ///< corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1742,8 +1818,7 @@ urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL
-urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1761,8 +1836,7 @@ urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL
-urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1780,10 +1854,10 @@ urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
-    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_native_handle_t
+        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1801,16 +1875,17 @@ urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to the handle of the queue object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Queue.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeQueue, hContext, phQueue);
     } else {
@@ -1823,8 +1898,7 @@ urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL
-urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1842,8 +1916,7 @@ urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL
-urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1861,20 +1934,21 @@ urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize, ///< [in] size in bytes of the event property value
+    void *pPropValue,     ///< [out][optional] value of the event property
+    size_t
+        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Event.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+        result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
+                            pPropValueSizeRet);
     } else {
         // generic implementation
     }
@@ -1884,21 +1958,24 @@ urEventGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,     ///< [in] handle of the event object
-    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
-                                  ///< propValue
+__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_profiling_info_t
+        propName, ///< [in] the name of the profiling property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the profiling property value
+    void *pPropValue,  ///< [out][optional] value of the profiling property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetProfilingInfo = d_context.urDdiTable.Event.pfnGetProfilingInfo;
     if (nullptr != pfnGetProfilingInfo) {
-        result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+        result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
+                                     pPropValue, pPropValueSizeRet);
     } else {
         // generic implementation
     }
@@ -1908,11 +1985,11 @@ urEventGetProfilingInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL
-urEventWait(
-    uint32_t numEvents,                      ///< [in] number of events in the event list
-    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                             ///< completion
+__urdlllocal ur_result_t UR_APICALL urEventWait(
+    uint32_t numEvents, ///< [in] number of events in the event list
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1929,8 +2006,7 @@ urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL
-urEventRetain(
+__urdlllocal ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1948,8 +2024,7 @@ urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL
-urEventRelease(
+__urdlllocal ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1967,10 +2042,10 @@ urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventGetNativeHandle(
-    ur_event_handle_t hEvent,         ///< [in] handle of the event.
-    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ///< [in] handle of the event.
+    ur_native_handle_t
+        *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1988,16 +2063,17 @@ urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t
+        *phEvent ///< [out] pointer to the handle of the event object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateWithNativeHandle = d_context.urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        d_context.urDdiTable.Event.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
         result = pfnCreateWithNativeHandle(hNativeEvent, hContext, phEvent);
     } else {
@@ -2010,12 +2086,12 @@ urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL
-urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2032,36 +2108,43 @@ urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
-    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                              ///< work-group work-items
-    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< offset used to calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< number of global work-items in workDim that will execute the kernel
-                                              ///< function
-    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
-                                              ///< specify the number of local work-items forming a work-group that will
-                                              ///< execute the kernel function.
-                                              ///< If nullptr, the runtime implementation will choose the work-group
-                                              ///< size.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnKernelLaunch = d_context.urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr != pfnKernelLaunch) {
-        result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
+                                 pGlobalWorkSize, pLocalWorkSize,
+                                 numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2074,24 +2157,26 @@ urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnEventsWait = d_context.urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr != pfnEventsWait) {
-        result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList,
+                               phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2104,24 +2189,27 @@ urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnEventsWaitWithBarrier = d_context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier =
+        d_context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr != pfnEventsWaitWithBarrier) {
-        result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
+                                          phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2134,28 +2222,31 @@ urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being read
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being read
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferRead = d_context.urDdiTable.Enqueue.pfnMemBufferRead;
     if (nullptr != pfnMemBufferRead) {
-        result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+        result =
+            pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
+                             numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2168,28 +2259,33 @@ urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being written
-    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being written
+    const void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferWrite = d_context.urDdiTable.Enqueue.pfnMemBufferWrite;
     if (nullptr != pfnMemBufferWrite) {
-        result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size,
+                                   pSrc, numEventsInWaitList, phEventWaitList,
+                                   phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2202,35 +2298,45 @@ urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< dst
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by dst
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemBufferReadRect = d_context.urDdiTable.Enqueue.pfnMemBufferReadRect;
+    auto pfnMemBufferReadRect =
+        d_context.urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr != pfnMemBufferReadRect) {
-        result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferReadRect(
+            hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
+            bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
+            pDst, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2243,36 +2349,48 @@ urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
-                                              ///< written
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< src
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by src
-    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
+    void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemBufferWriteRect = d_context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect =
+        d_context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr != pfnMemBufferWriteRect) {
-        result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferWriteRect(
+            hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region,
+            bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
+            pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2285,28 +2403,31 @@ urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                              ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
+    size_t size,      ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferCopy = d_context.urDdiTable.Enqueue.pfnMemBufferCopy;
     if (nullptr != pfnMemBufferCopy) {
-        result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
+                                  dstOffset, size, numEventsInWaitList,
+                                  phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2319,32 +2440,42 @@ urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t
+        region, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemBufferCopyRect = d_context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
+    auto pfnMemBufferCopyRect =
+        d_context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr != pfnMemBufferCopyRect) {
-        result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferCopyRect(
+            hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region,
+            srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+            numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2357,28 +2488,31 @@ urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    const void *pPattern,                     ///< [in] pointer to the fill pattern
-    size_t patternSize,                       ///< [in] size in bytes of the pattern
-    size_t offset,                            ///< [in] offset into the buffer
-    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    const void *pPattern,     ///< [in] pointer to the fill pattern
+    size_t patternSize,       ///< [in] size in bytes of the pattern
+    size_t offset,            ///< [in] offset into the buffer
+    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferFill = d_context.urDdiTable.Enqueue.pfnMemBufferFill;
     if (nullptr != pfnMemBufferFill) {
-        result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize,
+                                  offset, size, numEventsInWaitList,
+                                  phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2391,31 +2525,36 @@ urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pDst, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageRead = d_context.urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr != pfnMemImageRead) {
-        result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
+                                 rowPitch, slicePitch, pDst,
+                                 numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2428,31 +2567,37 @@ urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pSrc, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageWrite = d_context.urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr != pfnMemImageWrite) {
-        result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemImageWrite(
+            hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch,
+            pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2465,31 +2610,37 @@ urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                              ///< image
-    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                              ///< or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemImageCopy = d_context.urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr != pfnMemImageCopy) {
-        result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin,
+                                 dstOrigin, region, numEventsInWaitList,
+                                 phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2502,30 +2653,33 @@ urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
-    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
-                                              ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
+    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,   ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [out][optional] return an event object that identifies this particular
+                 ///< command instance.
+    void **ppRetMap ///< [out] return mapped pointer.  TODO: move it before
+                    ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferMap = d_context.urDdiTable.Enqueue.pfnMemBufferMap;
     if (nullptr != pfnMemBufferMap) {
-        result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
+        result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset,
+                                 size, numEventsInWaitList, phEventWaitList,
+                                 phEvent, ppRetMap);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2538,25 +2692,28 @@ urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr,                         ///< [in] mapped host address
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t
+        hMem,         ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr, ///< [in] mapped host address
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemUnmap = d_context.urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr != pfnMemUnmap) {
-        result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
+                             phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2569,28 +2726,33 @@ urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    void *ptr,                                ///< [in] pointer to USM memory object
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t size,                              ///< [in] size in bytes to be set. Must be a multiple of patternSize.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    void *ptr,                ///< [in] pointer to USM memory object
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        size, ///< [in] size in bytes to be set. Must be a multiple of patternSize.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMFill = d_context.urDdiTable.Enqueue.pfnUSMFill;
     if (nullptr != pfnUSMFill) {
-        result = pfnUSMFill(hQueue, ptr, patternSize, pPattern, size, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMFill(hQueue, ptr, patternSize, pPattern, size,
+                            numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2603,27 +2765,29 @@ urEnqueueUSMFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking copy
-    void *pDst,                               ///< [in] pointer to the destination USM memory object
-    const void *pSrc,                         ///< [in] pointer to the source USM memory object
-    size_t size,                              ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool blocking,            ///< [in] blocking or non-blocking copy
+    void *pDst,       ///< [in] pointer to the destination USM memory object
+    const void *pSrc, ///< [in] pointer to the source USM memory object
+    size_t size,      ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemcpy = d_context.urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr != pfnUSMMemcpy) {
-        result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size,
+                              numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2636,26 +2800,28 @@ urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    const void *pMem,                         ///< [in] pointer to the USM memory object
-    size_t size,                              ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
+    const void *pMem,               ///< [in] pointer to the USM memory object
+    size_t size,                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMPrefetch = d_context.urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr != pfnUSMPrefetch) {
-        result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
+                                phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2668,14 +2834,14 @@ urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    const void *pMem,          ///< [in] pointer to the USM memory object
-    size_t size,               ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
-                               ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    const void *pMem,         ///< [in] pointer to the USM memory object
+    size_t size,              ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,   ///< [in] USM memory advice
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2695,31 +2861,38 @@ urEnqueueUSMMemAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    void *pMem,                               ///< [in] pointer to memory to be filled.
-    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                             ///< [in] the width in bytes of each row to fill. Must be a multiple of
-                                              ///< patternSize.
-    size_t height,                            ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    void *pMem,               ///< [in] pointer to memory to be filled.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        width, ///< [in] the width in bytes of each row to fill. Must be a multiple of
+               ///< patternSize.
+    size_t height,                ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMFill2D = d_context.urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr != pfnUSMFill2D) {
-        result = pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+        result =
+            pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
+                         height, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2732,30 +2905,35 @@ urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    bool blocking,                            ///< [in] indicates if this operation should block the host.
-    void *pDst,                               ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
-    const void *pSrc,                         ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
-    size_t width,                             ///< [in] the width in bytes of each row to be copied.
-    size_t height,                            ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    bool blocking, ///< [in] indicates if this operation should block the host.
+    void *pDst,    ///< [in] pointer to memory where data will be copied.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
+    const void *pSrc, ///< [in] pointer to memory to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMMemcpy2D = d_context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr != pfnUSMMemcpy2D) {
-        result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc,
+                                srcPitch, width, height, numEventsInWaitList,
+                                phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2768,29 +2946,36 @@ urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                       ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite, ///< [in] indicates if this operation should block.
+    size_t count,       ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc, ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnDeviceGlobalVariableWrite = d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite =
+        d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr != pfnDeviceGlobalVariableWrite) {
-        result = pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnDeviceGlobalVariableWrite(
+            hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
+            numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2803,29 +2988,36 @@ urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                        ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst,                               ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingRead, ///< [in] indicates if this operation should block.
+    size_t count,      ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnDeviceGlobalVariableRead = d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead =
+        d_context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr != pfnDeviceGlobalVariableRead) {
-        result = pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnDeviceGlobalVariableRead(
+            hQueue, hProgram, name, blockingRead, count, offset, pDst,
+            numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2850,10 +3042,10 @@ extern "C" {
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetGlobalProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_global_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -2882,10 +3074,10 @@ urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetContextProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_context_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -2907,7 +3099,8 @@ urGetContextProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urContextGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urContextCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urContextCreateWithNativeHandle;
 
     pDdiTable->pfnSetExtendedDeleter = driver::urContextSetExtendedDeleter;
 
@@ -2922,10 +3115,10 @@ urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetEnqueueProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_enqueue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -2941,7 +3134,8 @@ urGetEnqueueProcAddrTable(
 
     pDdiTable->pfnEventsWait = driver::urEnqueueEventsWait;
 
-    pDdiTable->pfnEventsWaitWithBarrier = driver::urEnqueueEventsWaitWithBarrier;
+    pDdiTable->pfnEventsWaitWithBarrier =
+        driver::urEnqueueEventsWaitWithBarrier;
 
     pDdiTable->pfnMemBufferRead = driver::urEnqueueMemBufferRead;
 
@@ -2979,9 +3173,11 @@ urGetEnqueueProcAddrTable(
 
     pDdiTable->pfnUSMMemcpy2D = driver::urEnqueueUSMMemcpy2D;
 
-    pDdiTable->pfnDeviceGlobalVariableWrite = driver::urEnqueueDeviceGlobalVariableWrite;
+    pDdiTable->pfnDeviceGlobalVariableWrite =
+        driver::urEnqueueDeviceGlobalVariableWrite;
 
-    pDdiTable->pfnDeviceGlobalVariableRead = driver::urEnqueueDeviceGlobalVariableRead;
+    pDdiTable->pfnDeviceGlobalVariableRead =
+        driver::urEnqueueDeviceGlobalVariableRead;
 
     return result;
 }
@@ -2994,10 +3190,10 @@ urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetEventProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_event_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3021,7 +3217,8 @@ urGetEventProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urEventGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urEventCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urEventCreateWithNativeHandle;
 
     pDdiTable->pfnSetCallback = driver::urEventSetCallback;
 
@@ -3036,10 +3233,10 @@ urGetEventProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetKernelProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_kernel_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3065,7 +3262,8 @@ urGetKernelProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urKernelGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urKernelCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urKernelCreateWithNativeHandle;
 
     pDdiTable->pfnSetArgValue = driver::urKernelSetArgValue;
 
@@ -3079,7 +3277,8 @@ urGetKernelProcAddrTable(
 
     pDdiTable->pfnSetArgMemObj = driver::urKernelSetArgMemObj;
 
-    pDdiTable->pfnSetSpecializationConstants = driver::urKernelSetSpecializationConstants;
+    pDdiTable->pfnSetSpecializationConstants =
+        driver::urKernelSetSpecializationConstants;
 
     return result;
 }
@@ -3092,10 +3291,10 @@ urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetMemProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_mem_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3136,10 +3335,10 @@ urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetPlatformProcAddrTable(
-    ur_api_version_t version,         ///< [in] API version requested
-    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_platform_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3157,7 +3356,8 @@ urGetPlatformProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urPlatformGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urPlatformCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urPlatformCreateWithNativeHandle;
 
     pDdiTable->pfnGetApiVersion = driver::urPlatformGetApiVersion;
 
@@ -3172,10 +3372,10 @@ urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetProgramProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_program_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3207,11 +3407,13 @@ urGetProgramProcAddrTable(
 
     pDdiTable->pfnGetBuildInfo = driver::urProgramGetBuildInfo;
 
-    pDdiTable->pfnSetSpecializationConstants = driver::urProgramSetSpecializationConstants;
+    pDdiTable->pfnSetSpecializationConstants =
+        driver::urProgramSetSpecializationConstants;
 
     pDdiTable->pfnGetNativeHandle = driver::urProgramGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urProgramCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urProgramCreateWithNativeHandle;
 
     return result;
 }
@@ -3224,10 +3426,10 @@ urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetQueueProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_queue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3249,7 +3451,8 @@ urGetQueueProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urQueueGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urQueueCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urQueueCreateWithNativeHandle;
 
     pDdiTable->pfnFinish = driver::urQueueFinish;
 
@@ -3266,10 +3469,10 @@ urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetSamplerProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_sampler_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3291,7 +3494,8 @@ urGetSamplerProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urSamplerGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urSamplerCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urSamplerCreateWithNativeHandle;
 
     return result;
 }
@@ -3304,10 +3508,10 @@ urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetUSMProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3344,10 +3548,10 @@ urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetDeviceProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_device_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (nullptr == pDdiTable) {
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
@@ -3373,7 +3577,8 @@ urGetDeviceProcAddrTable(
 
     pDdiTable->pfnGetNativeHandle = driver::urDeviceGetNativeHandle;
 
-    pDdiTable->pfnCreateWithNativeHandle = driver::urDeviceCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        driver::urDeviceCreateWithNativeHandle;
 
     pDdiTable->pfnGetGlobalTimestamps = driver::urDeviceGetGlobalTimestamps;
 

--- a/source/loader/layers/tracing/ur_tracing_layer.cpp
+++ b/source/loader/layers/tracing/ur_tracing_layer.cpp
@@ -28,26 +28,30 @@ context_t::context_t() {
     call_stream_id = xptiRegisterStream(CALL_STREAM_NAME);
     std::ostringstream streamv;
     streamv << STREAM_VER_MAJOR << "." << STREAM_VER_MINOR;
-    xptiInitialize(CALL_STREAM_NAME, STREAM_VER_MAJOR, STREAM_VER_MINOR, streamv.str().data());
+    xptiInitialize(CALL_STREAM_NAME, STREAM_VER_MAJOR, STREAM_VER_MINOR,
+                   streamv.str().data());
 }
 
-bool context_t::isEnabled() {
-    return xptiTraceEnabled();
-}
+bool context_t::isEnabled() { return xptiTraceEnabled(); }
 
-void context_t::notify(uint16_t trace_type, uint32_t id, const char *name, void *args, ur_result_t *resultp, uint64_t instance) {
+void context_t::notify(uint16_t trace_type, uint32_t id, const char *name,
+                       void *args, ur_result_t *resultp, uint64_t instance) {
     xpti::function_with_args_t payload{id, name, args, resultp, nullptr};
-    xptiNotifySubscribers(call_stream_id, trace_type, nullptr, nullptr, instance, &payload);
+    xptiNotifySubscribers(call_stream_id, trace_type, nullptr, nullptr,
+                          instance, &payload);
 }
 
 uint64_t context_t::notify_begin(uint32_t id, const char *name, void *args) {
     uint64_t instance = xptiGetUniqueId();
-    notify((uint16_t)xpti::trace_point_type_t::function_with_args_begin, id, name, args, nullptr, instance);
+    notify((uint16_t)xpti::trace_point_type_t::function_with_args_begin, id,
+           name, args, nullptr, instance);
     return instance;
 }
 
-void context_t::notify_end(uint32_t id, const char *name, void *args, ur_result_t *resultp, uint64_t instance) {
-    notify((uint16_t)xpti::trace_point_type_t::function_with_args_end, id, name, args, resultp, instance);
+void context_t::notify_end(uint32_t id, const char *name, void *args,
+                           ur_result_t *resultp, uint64_t instance) {
+    notify((uint16_t)xpti::trace_point_type_t::function_with_args_end, id, name,
+           args, resultp, instance);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/layers/tracing/ur_tracing_layer.hpp
+++ b/source/loader/layers/tracing/ur_tracing_layer.hpp
@@ -29,10 +29,12 @@ class __urdlllocal context_t : public proxy_layer_context_t {
     bool isEnabled();
     ur_result_t init(ur_dditable_t *dditable);
     uint64_t notify_begin(uint32_t id, const char *name, void *args);
-    void notify_end(uint32_t id, const char *name, void *args, ur_result_t *resultp, uint64_t instance);
+    void notify_end(uint32_t id, const char *name, void *args,
+                    ur_result_t *resultp, uint64_t instance);
 
   private:
-    void notify(uint16_t trace_type, uint32_t id, const char *name, void *args, ur_result_t *resultp, uint64_t instance);
+    void notify(uint16_t trace_type, uint32_t id, const char *name, void *args,
+                ur_result_t *resultp, uint64_t instance);
     uint8_t call_stream_id;
 };
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -15,10 +15,9 @@
 namespace tracing_layer {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL
-urInit(
+__urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     auto pfnInit = context.urDdiTable.Global.pfnInit;
 
@@ -27,7 +26,8 @@ urInit(
     }
 
     ur_init_params_t params = {&device_flags};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_INIT, "urInit", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_INIT, "urInit", &params);
 
     ur_result_t result = pfnInit(device_flags);
 
@@ -38,8 +38,7 @@ urInit(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL
-urTearDown(
+__urdlllocal ur_result_t UR_APICALL urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     auto pfnTearDown = context.urDdiTable.Global.pfnTearDown;
@@ -49,27 +48,31 @@ urTearDown(
     }
 
     ur_tear_down_params_t params = {&pParams};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_TEAR_DOWN, "urTearDown", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_TEAR_DOWN, "urTearDown", &params);
 
     ur_result_t result = pfnTearDown(pParams);
 
-    context.notify_end(UR_FUNCTION_TEAR_DOWN, "urTearDown", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_TEAR_DOWN, "urTearDown", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGet(
-    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
-                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                       ///< will be returned.
-    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                       ///< If NumEntries is less than the number of platforms available, then
-                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = context.urDdiTable.Platform.pfnGet;
 
@@ -77,28 +80,31 @@ urPlatformGet(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_get_params_t params = {&NumEntries, &phPlatforms, &pNumPlatforms};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET, "urPlatformGet", &params);
+    ur_platform_get_params_t params = {&NumEntries, &phPlatforms,
+                                       &pNumPlatforms};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET,
+                                             "urPlatformGet", &params);
 
     ur_result_t result = pfnGet(NumEntries, phPlatforms, pNumPlatforms);
 
-    context.notify_end(UR_FUNCTION_PLATFORM_GET, "urPlatformGet", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PLATFORM_GET, "urPlatformGet", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Platform.pfnGetInfo;
 
@@ -106,20 +112,23 @@ urPlatformGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_get_info_params_t params = {&hPlatform, &PlatformInfoType, &Size, &pPlatformInfo, &pSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET_INFO, "urPlatformGetInfo", &params);
+    ur_platform_get_info_params_t params = {&hPlatform, &PlatformInfoType,
+                                            &Size, &pPlatformInfo, &pSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET_INFO,
+                                             "urPlatformGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
 
-    context.notify_end(UR_FUNCTION_PLATFORM_GET_INFO, "urPlatformGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PLATFORM_GET_INFO, "urPlatformGetInfo",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -130,21 +139,24 @@ urPlatformGetApiVersion(
     }
 
     ur_platform_get_api_version_params_t params = {&hDriver, &pVersion};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET_API_VERSION, "urPlatformGetApiVersion", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PLATFORM_GET_API_VERSION,
+                             "urPlatformGetApiVersion", &params);
 
     ur_result_t result = pfnGetApiVersion(hDriver, pVersion);
 
-    context.notify_end(UR_FUNCTION_PLATFORM_GET_API_VERSION, "urPlatformGetApiVersion", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PLATFORM_GET_API_VERSION,
+                       "urPlatformGetApiVersion", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Platform.pfnGetNativeHandle;
 
@@ -152,46 +164,57 @@ urPlatformGetNativeHandle(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_get_native_handle_params_t params = {&hPlatform, &phNativePlatform};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE, "urPlatformGetNativeHandle", &params);
+    ur_platform_get_native_handle_params_t params = {&hPlatform,
+                                                     &phNativePlatform};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE,
+                             "urPlatformGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hPlatform, phNativePlatform);
 
-    context.notify_end(UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE, "urPlatformGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE,
+                       "urPlatformGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Platform.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_create_with_native_handle_params_t params = {&hNativePlatform, &phPlatform};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE, "urPlatformCreateWithNativeHandle", &params);
+    ur_platform_create_with_native_handle_params_t params = {&hNativePlatform,
+                                                             &phPlatform};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE,
+                             "urPlatformCreateWithNativeHandle", &params);
 
     ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
 
-    context.notify_end(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE, "urPlatformCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE,
+                       "urPlatformCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL
-urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     auto pfnGetLastResult = context.urDdiTable.Global.pfnGetLastResult;
 
@@ -200,30 +223,33 @@ urGetLastResult(
     }
 
     ur_get_last_result_params_t params = {&hPlatform, &ppMessage};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_GET_LAST_RESULT, "urGetLastResult", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_GET_LAST_RESULT,
+                                             "urGetLastResult", &params);
 
     ur_result_t result = pfnGetLastResult(hPlatform, ppMessage);
 
-    context.notify_end(UR_FUNCTION_GET_LAST_RESULT, "urGetLastResult", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_GET_LAST_RESULT, "urGetLastResult", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
-                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                    ///< will be returned.
-    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                    ///< If NumEntries is less than the number of devices available, then
-                                    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
-                                    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = context.urDdiTable.Device.pfnGet;
 
@@ -231,29 +257,33 @@ urDeviceGet(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_get_params_t params = {&hPlatform, &DeviceType, &NumEntries, &phDevices, &pNumDevices};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_GET, "urDeviceGet", &params);
+    ur_device_get_params_t params = {&hPlatform, &DeviceType, &NumEntries,
+                                     &phDevices, &pNumDevices};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_DEVICE_GET, "urDeviceGet", &params);
 
-    ur_result_t result = pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
+    ur_result_t result =
+        pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
 
-    context.notify_end(UR_FUNCTION_DEVICE_GET, "urDeviceGet", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_GET, "urDeviceGet", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return the info
-                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
 
@@ -261,21 +291,25 @@ urDeviceGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_get_info_params_t params = {&hDevice, &infoType, &propSize, &pDeviceInfo, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_GET_INFO, "urDeviceGetInfo", &params);
+    ur_device_get_info_params_t params = {&hDevice, &infoType, &propSize,
+                                          &pDeviceInfo, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_GET_INFO,
+                                             "urDeviceGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_DEVICE_GET_INFO, "urDeviceGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_GET_INFO, "urDeviceGetInfo", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRetain(
-    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+    ur_device_handle_t
+        hDevice ///< [in] handle of the device to get a reference of.
 ) {
     auto pfnRetain = context.urDdiTable.Device.pfnRetain;
 
@@ -284,19 +318,20 @@ urDeviceRetain(
     }
 
     ur_device_retain_params_t params = {&hDevice};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_RETAIN, "urDeviceRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_RETAIN,
+                                             "urDeviceRetain", &params);
 
     ur_result_t result = pfnRetain(hDevice);
 
-    context.notify_end(UR_FUNCTION_DEVICE_RETAIN, "urDeviceRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_RETAIN, "urDeviceRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     auto pfnRelease = context.urDdiTable.Device.pfnRelease;
@@ -306,27 +341,31 @@ urDeviceRelease(
     }
 
     ur_device_release_params_t params = {&hDevice};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_RELEASE, "urDeviceRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_RELEASE,
+                                             "urDeviceRelease", &params);
 
     ur_result_t result = pfnRelease(hDevice);
 
-    context.notify_end(UR_FUNCTION_DEVICE_RELEASE, "urDeviceRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_RELEASE, "urDeviceRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL
-urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices, ///< [in] the number of sub-devices.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = context.urDdiTable.Device.pfnPartition;
 
@@ -334,27 +373,32 @@ urDevicePartition(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_partition_params_t params = {&hDevice, &pProperties, &NumDevices, &phSubDevices, &pNumDevicesRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_PARTITION, "urDevicePartition", &params);
+    ur_device_partition_params_t params = {&hDevice, &pProperties, &NumDevices,
+                                           &phSubDevices, &pNumDevicesRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_PARTITION,
+                                             "urDevicePartition", &params);
 
-    ur_result_t result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
+    ur_result_t result = pfnPartition(hDevice, pProperties, NumDevices,
+                                      phSubDevices, pNumDevicesRet);
 
-    context.notify_end(UR_FUNCTION_DEVICE_PARTITION, "urDevicePartition", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_PARTITION, "urDevicePartition",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL
-urDeviceSelectBinary(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
-                                ///< Must greater than or equal to zero otherwise
-                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
-                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
+                          ///< Must greater than or equal to zero otherwise
+                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
 
@@ -362,22 +406,26 @@ urDeviceSelectBinary(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_select_binary_params_t params = {&hDevice, &ppBinaries, &NumBinaries, &pSelectedBinary};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_SELECT_BINARY, "urDeviceSelectBinary", &params);
+    ur_device_select_binary_params_t params = {&hDevice, &ppBinaries,
+                                               &NumBinaries, &pSelectedBinary};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_SELECT_BINARY,
+                                             "urDeviceSelectBinary", &params);
 
-    ur_result_t result = pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
+    ur_result_t result =
+        pfnSelectBinary(hDevice, ppBinaries, NumBinaries, pSelectedBinary);
 
-    context.notify_end(UR_FUNCTION_DEVICE_SELECT_BINARY, "urDeviceSelectBinary", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_SELECT_BINARY, "urDeviceSelectBinary",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,        ///< [in] handle of the device.
-    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ///< [in] handle of the device.
+    ur_native_handle_t
+        *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Device.pfnGetNativeHandle;
 
@@ -386,73 +434,93 @@ urDeviceGetNativeHandle(
     }
 
     ur_device_get_native_handle_params_t params = {&hDevice, &phNativeDevice};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, "urDeviceGetNativeHandle", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE,
+                             "urDeviceGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hDevice, phNativeDevice);
 
-    context.notify_end(UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, "urDeviceGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE,
+                       "urDeviceGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t
+        *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Device.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_create_with_native_handle_params_t params = {&hNativeDevice, &hPlatform, &phDevice};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE, "urDeviceCreateWithNativeHandle", &params);
+    ur_device_create_with_native_handle_params_t params = {
+        &hNativeDevice, &hPlatform, &phDevice};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE,
+                             "urDeviceCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
 
-    context.notify_end(UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE, "urDeviceCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE,
+                       "urDeviceCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                                ///< correlates with the Host's global timestamp value
-    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
-                                ///< correlates with the Device's global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
-    auto pfnGetGlobalTimestamps = context.urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps =
+        context.urDdiTable.Device.pfnGetGlobalTimestamps;
 
     if (nullptr == pfnGetGlobalTimestamps) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_get_global_timestamps_params_t params = {&hDevice, &pDeviceTimestamp, &pHostTimestamp};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS, "urDeviceGetGlobalTimestamps", &params);
+    ur_device_get_global_timestamps_params_t params = {
+        &hDevice, &pDeviceTimestamp, &pHostTimestamp};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS,
+                             "urDeviceGetGlobalTimestamps", &params);
 
-    ur_result_t result = pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
+    ur_result_t result =
+        pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
 
-    context.notify_end(UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS, "urDeviceGetGlobalTimestamps", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS,
+                       "urDeviceGetGlobalTimestamps", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL
-urContextCreate(
-    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
-    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
-    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL urContextCreate(
+    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t
+        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *
+        pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t
+        *phContext ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = context.urDdiTable.Context.pfnCreate;
 
@@ -460,21 +528,25 @@ urContextCreate(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_context_create_params_t params = {&DeviceCount, &phDevices, &pProperties, &phContext};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_CREATE, "urContextCreate", &params);
+    ur_context_create_params_t params = {&DeviceCount, &phDevices, &pProperties,
+                                         &phContext};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_CREATE,
+                                             "urContextCreate", &params);
 
-    ur_result_t result = pfnCreate(DeviceCount, phDevices, pProperties, phContext);
+    ur_result_t result =
+        pfnCreate(DeviceCount, phDevices, pProperties, phContext);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_CREATE, "urContextCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_CREATE, "urContextCreate", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL
-urContextRetain(
-    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urContextRetain(
+    ur_context_handle_t
+        hContext ///< [in] handle of the context to get a reference of.
 ) {
     auto pfnRetain = context.urDdiTable.Context.pfnRetain;
 
@@ -483,19 +555,20 @@ urContextRetain(
     }
 
     ur_context_retain_params_t params = {&hContext};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_RETAIN, "urContextRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_RETAIN,
+                                             "urContextRetain", &params);
 
     ur_result_t result = pfnRetain(hContext);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_RETAIN, "urContextRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_RETAIN, "urContextRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL
-urContextRelease(
+__urdlllocal ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     auto pfnRelease = context.urDdiTable.Context.pfnRelease;
@@ -505,28 +578,31 @@ urContextRelease(
     }
 
     ur_context_release_params_t params = {&hContext};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_RELEASE, "urContextRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_RELEASE,
+                                             "urContextRelease", &params);
 
     ur_result_t result = pfnRelease(hContext);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_RELEASE, "urContextRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_RELEASE, "urContextRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
 
@@ -534,22 +610,26 @@ urContextGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_context_get_info_params_t params = {&hContext, &ContextInfoType, &propSize, &pContextInfo, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_GET_INFO, "urContextGetInfo", &params);
+    ur_context_get_info_params_t params = {
+        &hContext, &ContextInfoType, &propSize, &pContextInfo, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_GET_INFO,
+                                             "urContextGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
+    ur_result_t result = pfnGetInfo(hContext, ContextInfoType, propSize,
+                                    pContextInfo, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_GET_INFO, "urContextGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_GET_INFO, "urContextGetInfo",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Context.pfnGetNativeHandle;
 
@@ -557,73 +637,91 @@ urContextGetNativeHandle(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_context_get_native_handle_params_t params = {&hContext, &phNativeContext};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE, "urContextGetNativeHandle", &params);
+    ur_context_get_native_handle_params_t params = {&hContext,
+                                                    &phNativeContext};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE,
+                             "urContextGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hContext, phNativeContext);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE, "urContextGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE,
+                       "urContextGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Context.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_context_create_with_native_handle_params_t params = {&hNativeContext, &phContext};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE, "urContextCreateWithNativeHandle", &params);
+    ur_context_create_with_native_handle_params_t params = {&hNativeContext,
+                                                            &phContext};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE,
+                             "urContextCreateWithNativeHandle", &params);
 
     ur_result_t result = pfnCreateWithNativeHandle(hNativeContext, phContext);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE, "urContextCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE,
+                       "urContextCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL
-urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,             ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_context_extended_deleter_t
+        pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
-    auto pfnSetExtendedDeleter = context.urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter =
+        context.urDdiTable.Context.pfnSetExtendedDeleter;
 
     if (nullptr == pfnSetExtendedDeleter) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_context_set_extended_deleter_params_t params = {&hContext, &pfnDeleter, &pUserData};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER, "urContextSetExtendedDeleter", &params);
+    ur_context_set_extended_deleter_params_t params = {&hContext, &pfnDeleter,
+                                                       &pUserData};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER,
+                             "urContextSetExtendedDeleter", &params);
 
     ur_result_t result = pfnSetExtendedDeleter(hContext, pfnDeleter, pUserData);
 
-    context.notify_end(UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER, "urContextSetExtendedDeleter", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER,
+                       "urContextSetExtendedDeleter", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemImageCreate(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    void *pHost,                           ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    void *pHost,           ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
 ) {
     auto pfnImageCreate = context.urDdiTable.Mem.pfnImageCreate;
 
@@ -631,25 +729,29 @@ urMemImageCreate(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_image_create_params_t params = {&hContext, &flags, &pImageFormat, &pImageDesc, &pHost, &phMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_IMAGE_CREATE, "urMemImageCreate", &params);
+    ur_mem_image_create_params_t params = {&hContext,   &flags, &pImageFormat,
+                                           &pImageDesc, &pHost, &phMem};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_IMAGE_CREATE,
+                                             "urMemImageCreate", &params);
 
-    ur_result_t result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
+    ur_result_t result =
+        pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
 
-    context.notify_end(UR_FUNCTION_MEM_IMAGE_CREATE, "urMemImageCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_IMAGE_CREATE, "urMemImageCreate",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
-    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
-    void *pHost,                  ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    size_t size, ///< [in] size in bytes of the memory object to be allocated
+    void *pHost, ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t
+        *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
     auto pfnBufferCreate = context.urDdiTable.Mem.pfnBufferCreate;
 
@@ -657,20 +759,23 @@ urMemBufferCreate(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_buffer_create_params_t params = {&hContext, &flags, &size, &pHost, &phBuffer};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_BUFFER_CREATE, "urMemBufferCreate", &params);
+    ur_mem_buffer_create_params_t params = {&hContext, &flags, &size, &pHost,
+                                            &phBuffer};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_BUFFER_CREATE,
+                                             "urMemBufferCreate", &params);
 
-    ur_result_t result = pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
+    ur_result_t result =
+        pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
 
-    context.notify_end(UR_FUNCTION_MEM_BUFFER_CREATE, "urMemBufferCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_BUFFER_CREATE, "urMemBufferCreate",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL
-urMemRetain(
+__urdlllocal ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Mem.pfnRetain;
@@ -680,19 +785,20 @@ urMemRetain(
     }
 
     ur_mem_retain_params_t params = {&hMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_RETAIN, "urMemRetain", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_MEM_RETAIN, "urMemRetain", &params);
 
     ur_result_t result = pfnRetain(hMem);
 
-    context.notify_end(UR_FUNCTION_MEM_RETAIN, "urMemRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_RETAIN, "urMemRetain", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL
-urMemRelease(
+__urdlllocal ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     auto pfnRelease = context.urDdiTable.Mem.pfnRelease;
@@ -702,24 +808,28 @@ urMemRelease(
     }
 
     ur_mem_release_params_t params = {&hMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_RELEASE, "urMemRelease", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_MEM_RELEASE, "urMemRelease", &params);
 
     ur_result_t result = pfnRelease(hMem);
 
-    context.notify_end(UR_FUNCTION_MEM_RELEASE, "urMemRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_RELEASE, "urMemRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t
+        hBuffer,          ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
-    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *
+        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
     auto pfnBufferPartition = context.urDdiTable.Mem.pfnBufferPartition;
 
@@ -727,22 +837,26 @@ urMemBufferPartition(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_buffer_partition_params_t params = {&hBuffer, &flags, &bufferCreateType, &pBufferCreateInfo, &phMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_BUFFER_PARTITION, "urMemBufferPartition", &params);
+    ur_mem_buffer_partition_params_t params = {
+        &hBuffer, &flags, &bufferCreateType, &pBufferCreateInfo, &phMem};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_BUFFER_PARTITION,
+                                             "urMemBufferPartition", &params);
 
-    ur_result_t result = pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
+    ur_result_t result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
+                                            pBufferCreateInfo, phMem);
 
-    context.notify_end(UR_FUNCTION_MEM_BUFFER_PARTITION, "urMemBufferPartition", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_BUFFER_PARTITION, "urMemBufferPartition",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemGetNativeHandle(
-    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
-    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Mem.pfnGetNativeHandle;
 
@@ -751,51 +865,61 @@ urMemGetNativeHandle(
     }
 
     ur_mem_get_native_handle_params_t params = {&hMem, &phNativeMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_GET_NATIVE_HANDLE, "urMemGetNativeHandle", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
+                                             "urMemGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hMem, phNativeMem);
 
-    context.notify_end(UR_FUNCTION_MEM_GET_NATIVE_HANDLE, "urMemGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
+                       "urMemGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of the mem object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Mem.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_create_with_native_handle_params_t params = {&hNativeMem, &hContext, &phMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_CREATE_WITH_NATIVE_HANDLE, "urMemCreateWithNativeHandle", &params);
+    ur_mem_create_with_native_handle_params_t params = {&hNativeMem, &hContext,
+                                                        &phMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_MEM_CREATE_WITH_NATIVE_HANDLE,
+                             "urMemCreateWithNativeHandle", &params);
 
     ur_result_t result = pfnCreateWithNativeHandle(hNativeMem, hContext, phMem);
 
-    context.notify_end(UR_FUNCTION_MEM_CREATE_WITH_NATIVE_HANDLE, "urMemCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_CREATE_WITH_NATIVE_HANDLE,
+                       "urMemCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+    ur_mem_handle_t
+        hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
 
@@ -803,28 +927,33 @@ urMemGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_get_info_params_t params = {&hMemory, &MemInfoType, &propSize, &pMemInfo, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params);
+    ur_mem_get_info_params_t params = {&hMemory, &MemInfoType, &propSize,
+                                       &pMemInfo, &pPropSizeRet};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
 
@@ -832,24 +961,29 @@ urMemImageGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_image_get_info_params_t params = {&hMemory, &ImgInfoType, &propSize, &pImgInfo, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_IMAGE_GET_INFO, "urMemImageGetInfo", &params);
+    ur_mem_image_get_info_params_t params = {&hMemory, &ImgInfoType, &propSize,
+                                             &pImgInfo, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_IMAGE_GET_INFO,
+                                             "urMemImageGetInfo", &params);
 
-    ur_result_t result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_MEM_IMAGE_GET_INFO, "urMemImageGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_MEM_IMAGE_GET_INFO, "urMemImageGetInfo",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_property_t
+        *pProps, ///< [in] specifies a list of sampler property names and their
+                 ///< corresponding values.
+    ur_sampler_handle_t
+        *phSampler ///< [out] pointer to handle of sampler object created
 ) {
     auto pfnCreate = context.urDdiTable.Sampler.pfnCreate;
 
@@ -858,20 +992,22 @@ urSamplerCreate(
     }
 
     ur_sampler_create_params_t params = {&hContext, &pProps, &phSampler};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_CREATE, "urSamplerCreate", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_CREATE,
+                                             "urSamplerCreate", &params);
 
     ur_result_t result = pfnCreate(hContext, pProps, phSampler);
 
-    context.notify_end(UR_FUNCTION_SAMPLER_CREATE, "urSamplerCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_SAMPLER_CREATE, "urSamplerCreate", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRetain(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Sampler.pfnRetain;
 
@@ -880,20 +1016,22 @@ urSamplerRetain(
     }
 
     ur_sampler_retain_params_t params = {&hSampler};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_RETAIN, "urSamplerRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_RETAIN,
+                                             "urSamplerRetain", &params);
 
     ur_result_t result = pfnRetain(hSampler);
 
-    context.notify_end(UR_FUNCTION_SAMPLER_RETAIN, "urSamplerRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_SAMPLER_RETAIN, "urSamplerRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRelease(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to release
 ) {
     auto pfnRelease = context.urDdiTable.Sampler.pfnRelease;
 
@@ -902,24 +1040,27 @@ urSamplerRelease(
     }
 
     ur_sampler_release_params_t params = {&hSampler};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_RELEASE, "urSamplerRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_RELEASE,
+                                             "urSamplerRelease", &params);
 
     ur_result_t result = pfnRelease(hSampler);
 
-    context.notify_end(UR_FUNCTION_SAMPLER_RELEASE, "urSamplerRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_SAMPLER_RELEASE, "urSamplerRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
-    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
+    size_t *
+        pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     auto pfnGetInfo = context.urDdiTable.Sampler.pfnGetInfo;
 
@@ -927,22 +1068,26 @@ urSamplerGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_sampler_get_info_params_t params = {&hSampler, &propName, &propValueSize, &pPropValue, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_GET_INFO, "urSamplerGetInfo", &params);
+    ur_sampler_get_info_params_t params = {&hSampler, &propName, &propValueSize,
+                                           &pPropValue, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_GET_INFO,
+                                             "urSamplerGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_SAMPLER_GET_INFO, "urSamplerGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_SAMPLER_GET_INFO, "urSamplerGetInfo",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Sampler.pfnGetNativeHandle;
 
@@ -950,53 +1095,67 @@ urSamplerGetNativeHandle(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_sampler_get_native_handle_params_t params = {&hSampler, &phNativeSampler};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE, "urSamplerGetNativeHandle", &params);
+    ur_sampler_get_native_handle_params_t params = {&hSampler,
+                                                    &phNativeSampler};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE,
+                             "urSamplerGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hSampler, phNativeSampler);
 
-    context.notify_end(UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE, "urSamplerGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE,
+                       "urSamplerGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_sampler_create_with_native_handle_params_t params = {&hNativeSampler, &hContext, &phSampler};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE, "urSamplerCreateWithNativeHandle", &params);
+    ur_sampler_create_with_native_handle_params_t params = {
+        &hNativeSampler, &hContext, &phSampler};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE,
+                             "urSamplerCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
 
-    context.notify_end(UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE, "urSamplerCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE,
+                       "urSamplerCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM host memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = context.urDdiTable.USM.pfnHostAlloc;
 
@@ -1004,30 +1163,36 @@ urUSMHostAlloc(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_usm_host_alloc_params_t params = {&hContext, &pUSMDesc, &pool, &size, &align, &ppMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_HOST_ALLOC, "urUSMHostAlloc", &params);
+    ur_usm_host_alloc_params_t params = {&hContext, &pUSMDesc, &pool,
+                                         &size,     &align,    &ppMem};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_HOST_ALLOC,
+                                             "urUSMHostAlloc", &params);
 
-    ur_result_t result = pfnHostAlloc(hContext, pUSMDesc, pool, size, align, ppMem);
+    ur_result_t result =
+        pfnHostAlloc(hContext, pUSMDesc, pool, size, align, ppMem);
 
-    context.notify_end(UR_FUNCTION_USM_HOST_ALLOC, "urUSMHostAlloc", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_HOST_ALLOC, "urUSMHostAlloc", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM device memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = context.urDdiTable.USM.pfnDeviceAlloc;
 
@@ -1035,30 +1200,36 @@ urUSMDeviceAlloc(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_usm_device_alloc_params_t params = {&hContext, &hDevice, &pUSMDesc, &pool, &size, &align, &ppMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_DEVICE_ALLOC, "urUSMDeviceAlloc", &params);
+    ur_usm_device_alloc_params_t params = {
+        &hContext, &hDevice, &pUSMDesc, &pool, &size, &align, &ppMem};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_DEVICE_ALLOC,
+                                             "urUSMDeviceAlloc", &params);
 
-    ur_result_t result = pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    ur_result_t result =
+        pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
 
-    context.notify_end(UR_FUNCTION_USM_DEVICE_ALLOC, "urUSMDeviceAlloc", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_DEVICE_ALLOC, "urUSMDeviceAlloc",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object.
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM shared memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object.
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = context.urDdiTable.USM.pfnSharedAlloc;
 
@@ -1066,20 +1237,23 @@ urUSMSharedAlloc(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_usm_shared_alloc_params_t params = {&hContext, &hDevice, &pUSMDesc, &pool, &size, &align, &ppMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_SHARED_ALLOC, "urUSMSharedAlloc", &params);
+    ur_usm_shared_alloc_params_t params = {
+        &hContext, &hDevice, &pUSMDesc, &pool, &size, &align, &ppMem};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_SHARED_ALLOC,
+                                             "urUSMSharedAlloc", &params);
 
-    ur_result_t result = pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    ur_result_t result =
+        pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
 
-    context.notify_end(UR_FUNCTION_USM_SHARED_ALLOC, "urUSMSharedAlloc", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_SHARED_ALLOC, "urUSMSharedAlloc",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL
-urUSMFree(
+__urdlllocal ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1090,25 +1264,29 @@ urUSMFree(
     }
 
     ur_usm_free_params_t params = {&hContext, &pMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_FREE, "urUSMFree", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_USM_FREE, "urUSMFree", &params);
 
     ur_result_t result = pfnFree(hContext, pMem);
 
-    context.notify_end(UR_FUNCTION_USM_FREE, "urUSMFree", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_FREE, "urUSMFree", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL
-urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t
+        propName, ///< [in] the name of the USM allocation property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue, ///< [out][optional] value of the USM allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo = context.urDdiTable.USM.pfnGetMemAllocInfo;
 
@@ -1116,24 +1294,29 @@ urUSMGetMemAllocInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_usm_get_mem_alloc_info_params_t params = {&hContext, &pMem, &propName, &propValueSize, &pPropValue, &pPropValueSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, "urUSMGetMemAllocInfo", &params);
+    ur_usm_get_mem_alloc_info_params_t params = {
+        &hContext,      &pMem,       &propName,
+        &propValueSize, &pPropValue, &pPropValueSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO,
+                                             "urUSMGetMemAllocInfo", &params);
 
-    ur_result_t result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetMemAllocInfo(
+        hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
 
-    context.notify_end(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, "urUSMGetMemAllocInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO,
+                       "urUSMGetMemAllocInfo", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolCreate(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_usm_pool_desc_t *pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
-                                   ///< ::ur_usm_pool_limits_desc_t
-    ur_usm_pool_handle_t *ppPool   ///< [out] pointer to USM memory pool
+__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_pool_desc_t *
+        pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
+                   ///< ::ur_usm_pool_limits_desc_t
+    ur_usm_pool_handle_t *ppPool ///< [out] pointer to USM memory pool
 ) {
     auto pfnPoolCreate = context.urDdiTable.USM.pfnPoolCreate;
 
@@ -1142,19 +1325,20 @@ urUSMPoolCreate(
     }
 
     ur_usm_pool_create_params_t params = {&hContext, &pPoolDesc, &ppPool};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_POOL_CREATE, "urUSMPoolCreate", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_POOL_CREATE,
+                                             "urUSMPoolCreate", &params);
 
     ur_result_t result = pfnPoolCreate(hContext, pPoolDesc, ppPool);
 
-    context.notify_end(UR_FUNCTION_USM_POOL_CREATE, "urUSMPoolCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_POOL_CREATE, "urUSMPoolCreate", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolDestroy
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolDestroy(
+__urdlllocal ur_result_t UR_APICALL urUSMPoolDestroy(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_handle_t pPool    ///< [in] pointer to USM memory pool
 ) {
@@ -1165,24 +1349,27 @@ urUSMPoolDestroy(
     }
 
     ur_usm_pool_destroy_params_t params = {&hContext, &pPool};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_POOL_DESTROY, "urUSMPoolDestroy", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_POOL_DESTROY,
+                                             "urUSMPoolDestroy", &params);
 
     ur_result_t result = pfnPoolDestroy(hContext, pPool);
 
-    context.notify_end(UR_FUNCTION_USM_POOL_DESTROY, "urUSMPoolDestroy", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_USM_POOL_DESTROY, "urUSMPoolDestroy",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithIL(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    const void *pIL,                            ///< [in] pointer to IL binary.
-    size_t length,                              ///< [in] length of `pIL` in bytes.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const void *pIL,              ///< [in] pointer to IL binary.
+    size_t length,                ///< [in] length of `pIL` in bytes.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreateWithIL = context.urDdiTable.Program.pfnCreateWithIL;
 
@@ -1190,26 +1377,32 @@ urProgramCreateWithIL(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_create_with_il_params_t params = {&hContext, &pIL, &length, &pProperties, &phProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_IL, "urProgramCreateWithIL", &params);
+    ur_program_create_with_il_params_t params = {&hContext, &pIL, &length,
+                                                 &pProperties, &phProgram};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_IL,
+                                             "urProgramCreateWithIL", &params);
 
-    ur_result_t result = pfnCreateWithIL(hContext, pIL, length, pProperties, phProgram);
+    ur_result_t result =
+        pfnCreateWithIL(hContext, pIL, length, pProperties, phProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_IL, "urProgramCreateWithIL", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_IL,
+                       "urProgramCreateWithIL", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithBinary(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
-    size_t size,                                ///< [in] size in bytes.
-    const uint8_t *pBinary,                     ///< [in] pointer to binary.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_device_handle_t
+        hDevice,            ///< [in] handle to device associated with binary.
+    size_t size,            ///< [in] size in bytes.
+    const uint8_t *pBinary, ///< [in] pointer to binary.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     auto pfnCreateWithBinary = context.urDdiTable.Program.pfnCreateWithBinary;
 
@@ -1217,23 +1410,28 @@ urProgramCreateWithBinary(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_create_with_binary_params_t params = {&hContext, &hDevice, &size, &pBinary, &pProperties, &phProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY, "urProgramCreateWithBinary", &params);
+    ur_program_create_with_binary_params_t params = {
+        &hContext, &hDevice, &size, &pBinary, &pProperties, &phProgram};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY,
+                             "urProgramCreateWithBinary", &params);
 
-    ur_result_t result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
+    ur_result_t result = pfnCreateWithBinary(hContext, hDevice, size, pBinary,
+                                             pProperties, phProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY, "urProgramCreateWithBinary", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY,
+                       "urProgramCreateWithBinary", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL
-urProgramBuild(
+__urdlllocal ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     auto pfnBuild = context.urDdiTable.Program.pfnBuild;
 
@@ -1242,22 +1440,25 @@ urProgramBuild(
     }
 
     ur_program_build_params_t params = {&hContext, &hProgram, &pOptions};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_BUILD, "urProgramBuild", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_BUILD,
+                                             "urProgramBuild", &params);
 
     ur_result_t result = pfnBuild(hContext, hProgram, pOptions);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_BUILD, "urProgramBuild", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_BUILD, "urProgramBuild", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL
-urProgramCompile(
+__urdlllocal ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    ur_program_handle_t hProgram, ///< [in][out] handle of the program to compile.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    ur_program_handle_t
+        hProgram, ///< [in][out] handle of the program to compile.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     auto pfnCompile = context.urDdiTable.Program.pfnCompile;
 
@@ -1266,24 +1467,28 @@ urProgramCompile(
     }
 
     ur_program_compile_params_t params = {&hContext, &hProgram, &pOptions};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_COMPILE, "urProgramCompile", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_COMPILE,
+                                             "urProgramCompile", &params);
 
     ur_result_t result = pfnCompile(hContext, hProgram, pOptions);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_COMPILE, "urProgramCompile", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_COMPILE, "urProgramCompile", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL
-urProgramLink(
-    ur_context_handle_t hContext,          ///< [in] handle of the context instance.
-    uint32_t count,                        ///< [in] number of program handles in `phPrograms`.
-    const ur_program_handle_t *phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
-    const char *pOptions,                  ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram         ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramLink(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance.
+    uint32_t count, ///< [in] number of program handles in `phPrograms`.
+    const ur_program_handle_t *
+        phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     auto pfnLink = context.urDdiTable.Program.pfnLink;
 
@@ -1291,20 +1496,23 @@ urProgramLink(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_link_params_t params = {&hContext, &count, &phPrograms, &pOptions, &phProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_LINK, "urProgramLink", &params);
+    ur_program_link_params_t params = {&hContext, &count, &phPrograms,
+                                       &pOptions, &phProgram};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_LINK,
+                                             "urProgramLink", &params);
 
-    ur_result_t result = pfnLink(hContext, count, phPrograms, pOptions, phProgram);
+    ur_result_t result =
+        pfnLink(hContext, count, phPrograms, pOptions, phProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_LINK, "urProgramLink", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_LINK, "urProgramLink", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL
-urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     auto pfnRetain = context.urDdiTable.Program.pfnRetain;
@@ -1314,19 +1522,20 @@ urProgramRetain(
     }
 
     ur_program_retain_params_t params = {&hProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_RETAIN, "urProgramRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_RETAIN,
+                                             "urProgramRetain", &params);
 
     ur_result_t result = pfnRetain(hProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_RETAIN, "urProgramRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_RETAIN, "urProgramRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL
-urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     auto pfnRelease = context.urDdiTable.Program.pfnRelease;
@@ -1336,55 +1545,68 @@ urProgramRelease(
     }
 
     ur_program_release_params_t params = {&hProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_RELEASE, "urProgramRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_RELEASE,
+                                             "urProgramRelease", &params);
 
     ur_result_t result = pfnRelease(hProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_RELEASE, "urProgramRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_RELEASE, "urProgramRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
-                                  ///< The program must already be built to the specified device, or
-                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
-    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program to search for function in.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
-    auto pfnGetFunctionPointer = context.urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer =
+        context.urDdiTable.Program.pfnGetFunctionPointer;
 
     if (nullptr == pfnGetFunctionPointer) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_get_function_pointer_params_t params = {&hDevice, &hProgram, &pFunctionName, &ppFunctionPointer};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER, "urProgramGetFunctionPointer", &params);
+    ur_program_get_function_pointer_params_t params = {
+        &hDevice, &hProgram, &pFunctionName, &ppFunctionPointer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER,
+                             "urProgramGetFunctionPointer", &params);
 
-    ur_result_t result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
+    ur_result_t result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
+                                               ppFunctionPointer);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER, "urProgramGetFunctionPointer", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER,
+                       "urProgramGetFunctionPointer", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName,   ///< [in] name of the Program property to query
-    size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
-                                  ///< If propSize is not equal to or greater than the real number of bytes
-                                  ///< needed to return
-                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+    ur_program_info_t propName, ///< [in] name of the Program property to query
+    size_t propSize,            ///< [in] the size of the Program property.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
 
@@ -1392,30 +1614,36 @@ urProgramGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_get_info_params_t params = {&hProgram, &propName, &propSize, &pProgramInfo, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_INFO, "urProgramGetInfo", &params);
+    ur_program_get_info_params_t params = {&hProgram, &propName, &propSize,
+                                           &pProgramInfo, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_INFO,
+                                             "urProgramGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_GET_INFO, "urProgramGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_GET_INFO, "urProgramGetInfo",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
-    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
-    size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
-                                      ///< If propSize is not equal to or greater than the real number of bytes
-                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
-    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
-                                      ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
+    ur_program_build_info_t
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = context.urDdiTable.Program.pfnGetBuildInfo;
 
@@ -1423,47 +1651,58 @@ urProgramGetBuildInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_get_build_info_params_t params = {&hProgram, &hDevice, &propName, &propSize, &pPropValue, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_BUILD_INFO, "urProgramGetBuildInfo", &params);
+    ur_program_get_build_info_params_t params = {
+        &hProgram, &hDevice, &propName, &propSize, &pPropValue, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_BUILD_INFO,
+                                             "urProgramGetBuildInfo", &params);
 
-    ur_result_t result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    ur_result_t result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize,
+                                         pPropValue, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_GET_BUILD_INFO, "urProgramGetBuildInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_GET_BUILD_INFO,
+                       "urProgramGetBuildInfo", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in][range(0, count)] array of specialization constant value
-                                                            ///< descriptions
+__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in][range(0, count)] array of specialization constant value
+                       ///< descriptions
 ) {
-    auto pfnSetSpecializationConstants = context.urDdiTable.Program.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        context.urDdiTable.Program.pfnSetSpecializationConstants;
 
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_set_specialization_constants_params_t params = {&hProgram, &count, &pSpecConstants};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS, "urProgramSetSpecializationConstants", &params);
+    ur_program_set_specialization_constants_params_t params = {
+        &hProgram, &count, &pSpecConstants};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS,
+                             "urProgramSetSpecializationConstants", &params);
 
-    ur_result_t result = pfnSetSpecializationConstants(hProgram, count, pSpecConstants);
+    ur_result_t result =
+        pfnSetSpecializationConstants(hProgram, count, pSpecConstants);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS, "urProgramSetSpecializationConstants", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS,
+                       "urProgramSetSpecializationConstants", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Program.pfnGetNativeHandle;
 
@@ -1471,47 +1710,59 @@ urProgramGetNativeHandle(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_get_native_handle_params_t params = {&hProgram, &phNativeProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE, "urProgramGetNativeHandle", &params);
+    ur_program_get_native_handle_params_t params = {&hProgram,
+                                                    &phNativeProgram};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE,
+                             "urProgramGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hProgram, phNativeProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE, "urProgramGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE,
+                       "urProgramGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Program.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_program_create_with_native_handle_params_t params = {&hNativeProgram, &hContext, &phProgram};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE, "urProgramCreateWithNativeHandle", &params);
+    ur_program_create_with_native_handle_params_t params = {
+        &hNativeProgram, &hContext, &phProgram};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE,
+                             "urProgramCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
 
-    context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE, "urProgramCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE,
+                       "urProgramCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to handle of kernel object created.
 ) {
     auto pfnCreate = context.urDdiTable.Kernel.pfnCreate;
 
@@ -1520,23 +1771,25 @@ urKernelCreate(
     }
 
     ur_kernel_create_params_t params = {&hProgram, &pKernelName, &phKernel};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_CREATE, "urKernelCreate", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_CREATE,
+                                             "urKernelCreate", &params);
 
     ur_result_t result = pfnCreate(hProgram, pKernelName, phKernel);
 
-    context.notify_end(UR_FUNCTION_KERNEL_CREATE, "urKernelCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_CREATE, "urKernelCreate", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,             ///< [in] size of argument type
-    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void
+        *pArgValue ///< [in] argument value represented as matching arg type.
 ) {
     auto pfnSetArgValue = context.urDdiTable.Kernel.pfnSetArgValue;
 
@@ -1544,23 +1797,26 @@ urKernelSetArgValue(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_set_arg_value_params_t params = {&hKernel, &argIndex, &argSize, &pArgValue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_VALUE, "urKernelSetArgValue", &params);
+    ur_kernel_set_arg_value_params_t params = {&hKernel, &argIndex, &argSize,
+                                               &pArgValue};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_VALUE,
+                                             "urKernelSetArgValue", &params);
 
     ur_result_t result = pfnSetArgValue(hKernel, argIndex, argSize, pArgValue);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_VALUE, "urKernelSetArgValue", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_VALUE, "urKernelSetArgValue",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = context.urDdiTable.Kernel.pfnSetArgLocal;
 
@@ -1569,29 +1825,32 @@ urKernelSetArgLocal(
     }
 
     ur_kernel_set_arg_local_params_t params = {&hKernel, &argIndex, &argSize};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_LOCAL, "urKernelSetArgLocal", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
+                                             "urKernelSetArgLocal", &params);
 
     ur_result_t result = pfnSetArgLocal(hKernel, argIndex, argSize);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_LOCAL, "urKernelSetArgLocal", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_LOCAL, "urKernelSetArgLocal",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return
-                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
-                                ///< queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Kernel.pfnGetInfo;
 
@@ -1599,28 +1858,34 @@ urKernelGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_get_info_params_t params = {&hKernel, &propName, &propSize, &pKernelInfo, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_INFO, "urKernelGetInfo", &params);
+    ur_kernel_get_info_params_t params = {&hKernel, &propName, &propSize,
+                                          &pKernelInfo, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_INFO,
+                                             "urKernelGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_KERNEL_GET_INFO, "urKernelGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_GET_INFO, "urKernelGetInfo", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
-    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                     ///< property.
-    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
-                                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_group_info_t
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = context.urDdiTable.Kernel.pfnGetGroupInfo;
 
@@ -1628,28 +1893,34 @@ urKernelGetGroupInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_get_group_info_params_t params = {&hKernel, &hDevice, &propName, &propSize, &pPropValue, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_GROUP_INFO, "urKernelGetGroupInfo", &params);
+    ur_kernel_get_group_info_params_t params = {
+        &hKernel, &hDevice, &propName, &propSize, &pPropValue, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_GROUP_INFO,
+                                             "urKernelGetGroupInfo", &params);
 
-    ur_result_t result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    ur_result_t result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize,
+                                         pPropValue, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_KERNEL_GET_GROUP_INFO, "urKernelGetGroupInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_GET_GROUP_INFO,
+                       "urKernelGetGroupInfo", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
-    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                         ///< property.
-    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
-                                         ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetSubGroupInfo = context.urDdiTable.Kernel.pfnGetSubGroupInfo;
 
@@ -1657,20 +1928,24 @@ urKernelGetSubGroupInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_get_sub_group_info_params_t params = {&hKernel, &hDevice, &propName, &propSize, &pPropValue, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO, "urKernelGetSubGroupInfo", &params);
+    ur_kernel_get_sub_group_info_params_t params = {
+        &hKernel, &hDevice, &propName, &propSize, &pPropValue, &pPropSizeRet};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO,
+                             "urKernelGetSubGroupInfo", &params);
 
-    ur_result_t result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    ur_result_t result = pfnGetSubGroupInfo(hKernel, hDevice, propName,
+                                            propSize, pPropValue, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO, "urKernelGetSubGroupInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO,
+                       "urKernelGetSubGroupInfo", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL
-urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     auto pfnRetain = context.urDdiTable.Kernel.pfnRetain;
@@ -1680,19 +1955,20 @@ urKernelRetain(
     }
 
     ur_kernel_retain_params_t params = {&hKernel};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_RETAIN, "urKernelRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_RETAIN,
+                                             "urKernelRetain", &params);
 
     ur_result_t result = pfnRetain(hKernel);
 
-    context.notify_end(UR_FUNCTION_KERNEL_RETAIN, "urKernelRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_RETAIN, "urKernelRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL
-urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     auto pfnRelease = context.urDdiTable.Kernel.pfnRelease;
@@ -1702,23 +1978,25 @@ urKernelRelease(
     }
 
     ur_kernel_release_params_t params = {&hKernel};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_RELEASE, "urKernelRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_RELEASE,
+                                             "urKernelRelease", &params);
 
     ur_result_t result = pfnRelease(hKernel);
 
-    context.notify_end(UR_FUNCTION_KERNEL_RELEASE, "urKernelRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_RELEASE, "urKernelRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
-                                ///< value. If null then argument value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = context.urDdiTable.Kernel.pfnSetArgPointer;
 
@@ -1726,25 +2004,28 @@ urKernelSetArgPointer(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_set_arg_pointer_params_t params = {&hKernel, &argIndex, &pArgValue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_POINTER, "urKernelSetArgPointer", &params);
+    ur_kernel_set_arg_pointer_params_t params = {&hKernel, &argIndex,
+                                                 &pArgValue};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_POINTER,
+                                             "urKernelSetArgPointer", &params);
 
     ur_result_t result = pfnSetArgPointer(hKernel, argIndex, pArgValue);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_POINTER, "urKernelSetArgPointer", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_POINTER,
+                       "urKernelSetArgPointer", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                    ///< property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
 
@@ -1752,22 +2033,25 @@ urKernelSetExecInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_set_exec_info_params_t params = {&hKernel, &propName, &propSize, &pPropValue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_EXEC_INFO, "urKernelSetExecInfo", &params);
+    ur_kernel_set_exec_info_params_t params = {&hKernel, &propName, &propSize,
+                                               &pPropValue};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_EXEC_INFO,
+                                             "urKernelSetExecInfo", &params);
 
-    ur_result_t result = pfnSetExecInfo(hKernel, propName, propSize, pPropValue);
+    ur_result_t result =
+        pfnSetExecInfo(hKernel, propName, propSize, pPropValue);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_EXEC_INFO, "urKernelSetExecInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_EXEC_INFO, "urKernelSetExecInfo",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
-    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     auto pfnSetArgSampler = context.urDdiTable.Kernel.pfnSetArgSampler;
@@ -1776,23 +2060,25 @@ urKernelSetArgSampler(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_set_arg_sampler_params_t params = {&hKernel, &argIndex, &hArgValue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, "urKernelSetArgSampler", &params);
+    ur_kernel_set_arg_sampler_params_t params = {&hKernel, &argIndex,
+                                                 &hArgValue};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_SAMPLER,
+                                             "urKernelSetArgSampler", &params);
 
     ur_result_t result = pfnSetArgSampler(hKernel, argIndex, hArgValue);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, "urKernelSetArgSampler", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_SAMPLER,
+                       "urKernelSetArgSampler", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = context.urDdiTable.Kernel.pfnSetArgMemObj;
 
@@ -1800,46 +2086,56 @@ urKernelSetArgMemObj(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_set_arg_mem_obj_params_t params = {&hKernel, &argIndex, &hArgValue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, "urKernelSetArgMemObj", &params);
+    ur_kernel_set_arg_mem_obj_params_t params = {&hKernel, &argIndex,
+                                                 &hArgValue};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ,
+                                             "urKernelSetArgMemObj", &params);
 
     ur_result_t result = pfnSetArgMemObj(hKernel, argIndex, hArgValue);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, "urKernelSetArgMemObj", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ,
+                       "urKernelSetArgMemObj", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in] array of specialization constant value descriptions
+__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in] array of specialization constant value descriptions
 ) {
-    auto pfnSetSpecializationConstants = context.urDdiTable.Kernel.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        context.urDdiTable.Kernel.pfnSetSpecializationConstants;
 
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_set_specialization_constants_params_t params = {&hKernel, &count, &pSpecConstants};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS, "urKernelSetSpecializationConstants", &params);
+    ur_kernel_set_specialization_constants_params_t params = {&hKernel, &count,
+                                                              &pSpecConstants};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS,
+                             "urKernelSetSpecializationConstants", &params);
 
-    ur_result_t result = pfnSetSpecializationConstants(hKernel, count, pSpecConstants);
+    ur_result_t result =
+        pfnSetSpecializationConstants(hKernel, count, pSpecConstants);
 
-    context.notify_end(UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS, "urKernelSetSpecializationConstants", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS,
+                       "urKernelSetSpecializationConstants", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
-    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_native_handle_t
+        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Kernel.pfnGetNativeHandle;
 
@@ -1848,48 +2144,59 @@ urKernelGetNativeHandle(
     }
 
     ur_kernel_get_native_handle_params_t params = {&hKernel, &phNativeKernel};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, "urKernelGetNativeHandle", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE,
+                             "urKernelGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hKernel, phNativeKernel);
 
-    context.notify_end(UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, "urKernelGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE,
+                       "urKernelGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to the handle of the kernel object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_kernel_create_with_native_handle_params_t params = {&hNativeKernel, &hContext, &phKernel};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE, "urKernelCreateWithNativeHandle", &params);
+    ur_kernel_create_with_native_handle_params_t params = {
+        &hNativeKernel, &hContext, &phKernel};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE,
+                             "urKernelCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativeKernel, hContext, phKernel);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativeKernel, hContext, phKernel);
 
-    context.notify_end(UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE, "urKernelCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE,
+                       "urKernelCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
-    size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out][optional] value of the queue property
+    size_t *
+        pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
     auto pfnGetInfo = context.urDdiTable.Queue.pfnGetInfo;
 
@@ -1897,29 +2204,34 @@ urQueueGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_queue_get_info_params_t params = {&hQueue, &propName, &propValueSize, &pPropValue, &pPropSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_GET_INFO, "urQueueGetInfo", &params);
+    ur_queue_get_info_params_t params = {&hQueue, &propName, &propValueSize,
+                                         &pPropValue, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_GET_INFO,
+                                             "urQueueGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
 
-    context.notify_end(UR_FUNCTION_QUEUE_GET_INFO, "urQueueGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_GET_INFO, "urQueueGetInfo", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_queue_property_t *
+        pProps, ///< [in][optional] specifies a list of queue properties and their
+                ///< corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to handle of queue object created
 ) {
     auto pfnCreate = context.urDdiTable.Queue.pfnCreate;
 
@@ -1928,19 +2240,20 @@ urQueueCreate(
     }
 
     ur_queue_create_params_t params = {&hContext, &hDevice, &pProps, &phQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_CREATE, "urQueueCreate", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_CREATE,
+                                             "urQueueCreate", &params);
 
     ur_result_t result = pfnCreate(hContext, hDevice, pProps, phQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_CREATE, "urQueueCreate", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_CREATE, "urQueueCreate", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL
-urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Queue.pfnRetain;
@@ -1950,19 +2263,20 @@ urQueueRetain(
     }
 
     ur_queue_retain_params_t params = {&hQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_RETAIN, "urQueueRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_RETAIN,
+                                             "urQueueRetain", &params);
 
     ur_result_t result = pfnRetain(hQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_RETAIN, "urQueueRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_RETAIN, "urQueueRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL
-urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     auto pfnRelease = context.urDdiTable.Queue.pfnRelease;
@@ -1972,21 +2286,23 @@ urQueueRelease(
     }
 
     ur_queue_release_params_t params = {&hQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_RELEASE, "urQueueRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_RELEASE,
+                                             "urQueueRelease", &params);
 
     ur_result_t result = pfnRelease(hQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_RELEASE, "urQueueRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_RELEASE, "urQueueRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
-    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_native_handle_t
+        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Queue.pfnGetNativeHandle;
 
@@ -1995,43 +2311,51 @@ urQueueGetNativeHandle(
     }
 
     ur_queue_get_native_handle_params_t params = {&hQueue, &phNativeQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, "urQueueGetNativeHandle", &params);
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, "urQueueGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hQueue, phNativeQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, "urQueueGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE,
+                       "urQueueGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to the handle of the queue object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Queue.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_queue_create_with_native_handle_params_t params = {&hNativeQueue, &hContext, &phQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE, "urQueueCreateWithNativeHandle", &params);
+    ur_queue_create_with_native_handle_params_t params = {&hNativeQueue,
+                                                          &hContext, &phQueue};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE,
+                             "urQueueCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativeQueue, hContext, phQueue);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativeQueue, hContext, phQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE, "urQueueCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE,
+                       "urQueueCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL
-urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = context.urDdiTable.Queue.pfnFinish;
@@ -2041,19 +2365,20 @@ urQueueFinish(
     }
 
     ur_queue_finish_params_t params = {&hQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_FINISH, "urQueueFinish", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_FINISH,
+                                             "urQueueFinish", &params);
 
     ur_result_t result = pfnFinish(hQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_FINISH, "urQueueFinish", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_FINISH, "urQueueFinish", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL
-urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = context.urDdiTable.Queue.pfnFlush;
@@ -2063,24 +2388,26 @@ urQueueFlush(
     }
 
     ur_queue_flush_params_t params = {&hQueue};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_FLUSH, "urQueueFlush", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_QUEUE_FLUSH, "urQueueFlush", &params);
 
     ur_result_t result = pfnFlush(hQueue);
 
-    context.notify_end(UR_FUNCTION_QUEUE_FLUSH, "urQueueFlush", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_QUEUE_FLUSH, "urQueueFlush", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize, ///< [in] size in bytes of the event property value
+    void *pPropValue,     ///< [out][optional] value of the event property
+    size_t
+        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
 
@@ -2088,26 +2415,32 @@ urEventGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_event_get_info_params_t params = {&hEvent, &propName, &propValueSize, &pPropValue, &pPropValueSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_GET_INFO, "urEventGetInfo", &params);
+    ur_event_get_info_params_t params = {&hEvent, &propName, &propValueSize,
+                                         &pPropValue, &pPropValueSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_GET_INFO,
+                                             "urEventGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
+                                    pPropValueSizeRet);
 
-    context.notify_end(UR_FUNCTION_EVENT_GET_INFO, "urEventGetInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_GET_INFO, "urEventGetInfo", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,     ///< [in] handle of the event object
-    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
-                                  ///< propValue
+__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_profiling_info_t
+        propName, ///< [in] the name of the profiling property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the profiling property value
+    void *pPropValue,  ///< [out][optional] value of the profiling property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
 
@@ -2115,23 +2448,28 @@ urEventGetProfilingInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_event_get_profiling_info_params_t params = {&hEvent, &propName, &propValueSize, &pPropValue, &pPropValueSizeRet};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_GET_PROFILING_INFO, "urEventGetProfilingInfo", &params);
+    ur_event_get_profiling_info_params_t params = {
+        &hEvent, &propName, &propValueSize, &pPropValue, &pPropValueSizeRet};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_EVENT_GET_PROFILING_INFO,
+                             "urEventGetProfilingInfo", &params);
 
-    ur_result_t result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
+                                             pPropValue, pPropValueSizeRet);
 
-    context.notify_end(UR_FUNCTION_EVENT_GET_PROFILING_INFO, "urEventGetProfilingInfo", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_GET_PROFILING_INFO,
+                       "urEventGetProfilingInfo", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL
-urEventWait(
-    uint32_t numEvents,                      ///< [in] number of events in the event list
-    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                             ///< completion
+__urdlllocal ur_result_t UR_APICALL urEventWait(
+    uint32_t numEvents, ///< [in] number of events in the event list
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     auto pfnWait = context.urDdiTable.Event.pfnWait;
 
@@ -2140,19 +2478,20 @@ urEventWait(
     }
 
     ur_event_wait_params_t params = {&numEvents, &phEventWaitList};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_WAIT, "urEventWait", &params);
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_EVENT_WAIT, "urEventWait", &params);
 
     ur_result_t result = pfnWait(numEvents, phEventWaitList);
 
-    context.notify_end(UR_FUNCTION_EVENT_WAIT, "urEventWait", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_WAIT, "urEventWait", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL
-urEventRetain(
+__urdlllocal ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRetain = context.urDdiTable.Event.pfnRetain;
@@ -2162,19 +2501,20 @@ urEventRetain(
     }
 
     ur_event_retain_params_t params = {&hEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_RETAIN, "urEventRetain", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_RETAIN,
+                                             "urEventRetain", &params);
 
     ur_result_t result = pfnRetain(hEvent);
 
-    context.notify_end(UR_FUNCTION_EVENT_RETAIN, "urEventRetain", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_RETAIN, "urEventRetain", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL
-urEventRelease(
+__urdlllocal ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRelease = context.urDdiTable.Event.pfnRelease;
@@ -2184,21 +2524,23 @@ urEventRelease(
     }
 
     ur_event_release_params_t params = {&hEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_RELEASE, "urEventRelease", &params);
+    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_RELEASE,
+                                             "urEventRelease", &params);
 
     ur_result_t result = pfnRelease(hEvent);
 
-    context.notify_end(UR_FUNCTION_EVENT_RELEASE, "urEventRelease", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_RELEASE, "urEventRelease", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventGetNativeHandle(
-    ur_event_handle_t hEvent,         ///< [in] handle of the event.
-    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ///< [in] handle of the event.
+    ur_native_handle_t
+        *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Event.pfnGetNativeHandle;
 
@@ -2207,47 +2549,56 @@ urEventGetNativeHandle(
     }
 
     ur_event_get_native_handle_params_t params = {&hEvent, &phNativeEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, "urEventGetNativeHandle", &params);
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, "urEventGetNativeHandle", &params);
 
     ur_result_t result = pfnGetNativeHandle(hEvent, phNativeEvent);
 
-    context.notify_end(UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, "urEventGetNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_GET_NATIVE_HANDLE,
+                       "urEventGetNativeHandle", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t
+        *phEvent ///< [out] pointer to the handle of the event object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Event.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_event_create_with_native_handle_params_t params = {&hNativeEvent, &hContext, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE, "urEventCreateWithNativeHandle", &params);
+    ur_event_create_with_native_handle_params_t params = {&hNativeEvent,
+                                                          &hContext, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE,
+                             "urEventCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativeEvent, hContext, phEvent);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativeEvent, hContext, phEvent);
 
-    context.notify_end(UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE, "urEventCreateWithNativeHandle", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE,
+                       "urEventCreateWithNativeHandle", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL
-urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = context.urDdiTable.Event.pfnSetCallback;
 
@@ -2255,41 +2606,50 @@ urEventSetCallback(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_event_set_callback_params_t params = {&hEvent, &execStatus, &pfnNotify, &pUserData};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback", &params);
+    ur_event_set_callback_params_t params = {&hEvent, &execStatus, &pfnNotify,
+                                             &pUserData};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_SET_CALLBACK,
+                                             "urEventSetCallback", &params);
 
-    ur_result_t result = pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
+    ur_result_t result =
+        pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
 
-    context.notify_end(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
-    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                              ///< work-group work-items
-    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< offset used to calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< number of global work-items in workDim that will execute the kernel
-                                              ///< function
-    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
-                                              ///< specify the number of local work-items forming a work-group that will
-                                              ///< execute the kernel function.
-                                              ///< If nullptr, the runtime implementation will choose the work-group
-                                              ///< size.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -2297,29 +2657,42 @@ urEnqueueKernelLaunch(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_kernel_launch_params_t params = {&hQueue, &hKernel, &workDim, &pGlobalWorkOffset, &pGlobalWorkSize, &pLocalWorkSize, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH, "urEnqueueKernelLaunch", &params);
+    ur_enqueue_kernel_launch_params_t params = {&hQueue,
+                                                &hKernel,
+                                                &workDim,
+                                                &pGlobalWorkOffset,
+                                                &pGlobalWorkSize,
+                                                &pLocalWorkSize,
+                                                &numEventsInWaitList,
+                                                &phEventWaitList,
+                                                &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
+                                             "urEnqueueKernelLaunch", &params);
 
-    ur_result_t result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnKernelLaunch(
+        hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH, "urEnqueueKernelLaunch", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
+                       "urEnqueueKernelLaunch", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
 
@@ -2327,63 +2700,76 @@ urEnqueueEventsWait(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_events_wait_params_t params = {&hQueue, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_EVENTS_WAIT, "urEnqueueEventsWait", &params);
+    ur_enqueue_events_wait_params_t params = {&hQueue, &numEventsInWaitList,
+                                              &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
+                                             "urEnqueueEventsWait", &params);
 
-    ur_result_t result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_EVENTS_WAIT, "urEnqueueEventsWait", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_EVENTS_WAIT, "urEnqueueEventsWait",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnEventsWaitWithBarrier = context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier =
+        context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
 
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_events_wait_with_barrier_params_t params = {&hQueue, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER, "urEnqueueEventsWaitWithBarrier", &params);
+    ur_enqueue_events_wait_with_barrier_params_t params = {
+        &hQueue, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER,
+                             "urEnqueueEventsWaitWithBarrier", &params);
 
-    ur_result_t result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
+                                                  phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER, "urEnqueueEventsWaitWithBarrier", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER,
+                       "urEnqueueEventsWaitWithBarrier", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being read
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being read
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -2391,33 +2777,43 @@ urEnqueueMemBufferRead(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_read_params_t params = {&hQueue, &hBuffer, &blockingRead, &offset, &size, &pDst, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, "urEnqueueMemBufferRead", &params);
+    ur_enqueue_mem_buffer_read_params_t params = {
+        &hQueue, &hBuffer, &blockingRead,        &offset,
+        &size,   &pDst,    &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, "urEnqueueMemBufferRead", &params);
 
-    ur_result_t result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
+                         numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, "urEnqueueMemBufferRead", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ,
+                       "urEnqueueMemBufferRead", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being written
-    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being written
+    const void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -2425,40 +2821,54 @@ urEnqueueMemBufferWrite(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_write_params_t params = {&hQueue, &hBuffer, &blockingWrite, &offset, &size, &pSrc, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, "urEnqueueMemBufferWrite", &params);
+    ur_enqueue_mem_buffer_write_params_t params = {
+        &hQueue, &hBuffer, &blockingWrite,       &offset,
+        &size,   &pSrc,    &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE,
+                             "urEnqueueMemBufferWrite", &params);
 
-    ur_result_t result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
+                          numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, "urEnqueueMemBufferWrite", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE,
+                       "urEnqueueMemBufferWrite", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< dst
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by dst
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
 
@@ -2466,75 +2876,125 @@ urEnqueueMemBufferReadRect(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_read_rect_params_t params = {&hQueue, &hBuffer, &blockingRead, &bufferOrigin, &hostOrigin, &region, &bufferRowPitch, &bufferSlicePitch, &hostRowPitch, &hostSlicePitch, &pDst, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, "urEnqueueMemBufferReadRect", &params);
+    ur_enqueue_mem_buffer_read_rect_params_t params = {&hQueue,
+                                                       &hBuffer,
+                                                       &blockingRead,
+                                                       &bufferOrigin,
+                                                       &hostOrigin,
+                                                       &region,
+                                                       &bufferRowPitch,
+                                                       &bufferSlicePitch,
+                                                       &hostRowPitch,
+                                                       &hostSlicePitch,
+                                                       &pDst,
+                                                       &numEventsInWaitList,
+                                                       &phEventWaitList,
+                                                       &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT,
+                             "urEnqueueMemBufferReadRect", &params);
 
-    ur_result_t result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemBufferReadRect(
+        hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
+        numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, "urEnqueueMemBufferReadRect", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT,
+                       "urEnqueueMemBufferReadRect", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
-                                              ///< written
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< src
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by src
-    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
+    void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferWriteRect = context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect =
+        context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
 
     if (nullptr == pfnMemBufferWriteRect) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_write_rect_params_t params = {&hQueue, &hBuffer, &blockingWrite, &bufferOrigin, &hostOrigin, &region, &bufferRowPitch, &bufferSlicePitch, &hostRowPitch, &hostSlicePitch, &pSrc, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, "urEnqueueMemBufferWriteRect", &params);
+    ur_enqueue_mem_buffer_write_rect_params_t params = {&hQueue,
+                                                        &hBuffer,
+                                                        &blockingWrite,
+                                                        &bufferOrigin,
+                                                        &hostOrigin,
+                                                        &region,
+                                                        &bufferRowPitch,
+                                                        &bufferSlicePitch,
+                                                        &hostRowPitch,
+                                                        &hostSlicePitch,
+                                                        &pSrc,
+                                                        &numEventsInWaitList,
+                                                        &phEventWaitList,
+                                                        &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT,
+                             "urEnqueueMemBufferWriteRect", &params);
 
-    ur_result_t result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemBufferWriteRect(
+        hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, "urEnqueueMemBufferWriteRect", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT,
+                       "urEnqueueMemBufferWriteRect", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                              ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
+    size_t size,      ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -2542,37 +3002,49 @@ urEnqueueMemBufferCopy(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_copy_params_t params = {&hQueue, &hBufferSrc, &hBufferDst, &srcOffset, &dstOffset, &size, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, "urEnqueueMemBufferCopy", &params);
+    ur_enqueue_mem_buffer_copy_params_t params = {
+        &hQueue, &hBufferSrc,          &hBufferDst,      &srcOffset, &dstOffset,
+        &size,   &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, "urEnqueueMemBufferCopy", &params);
 
-    ur_result_t result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset,
+                         size, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, "urEnqueueMemBufferCopy", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY,
+                       "urEnqueueMemBufferCopy", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t
+        region, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
@@ -2580,33 +3052,45 @@ urEnqueueMemBufferCopyRect(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_copy_rect_params_t params = {&hQueue, &hBufferSrc, &hBufferDst, &srcOrigin, &dstOrigin, &region, &srcRowPitch, &srcSlicePitch, &dstRowPitch, &dstSlicePitch, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, "urEnqueueMemBufferCopyRect", &params);
+    ur_enqueue_mem_buffer_copy_rect_params_t params = {
+        &hQueue,      &hBufferSrc,    &hBufferDst,          &srcOrigin,
+        &dstOrigin,   &region,        &srcRowPitch,         &srcSlicePitch,
+        &dstRowPitch, &dstSlicePitch, &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT,
+                             "urEnqueueMemBufferCopyRect", &params);
 
-    ur_result_t result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemBufferCopyRect(
+        hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region,
+        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, "urEnqueueMemBufferCopyRect", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT,
+                       "urEnqueueMemBufferCopyRect", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    const void *pPattern,                     ///< [in] pointer to the fill pattern
-    size_t patternSize,                       ///< [in] size in bytes of the pattern
-    size_t offset,                            ///< [in] offset into the buffer
-    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    const void *pPattern,     ///< [in] pointer to the fill pattern
+    size_t patternSize,       ///< [in] size in bytes of the pattern
+    size_t offset,            ///< [in] offset into the buffer
+    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -2614,36 +3098,51 @@ urEnqueueMemBufferFill(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_fill_params_t params = {&hQueue, &hBuffer, &pPattern, &patternSize, &offset, &size, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, "urEnqueueMemBufferFill", &params);
+    ur_enqueue_mem_buffer_fill_params_t params = {&hQueue,
+                                                  &hBuffer,
+                                                  &pPattern,
+                                                  &patternSize,
+                                                  &offset,
+                                                  &size,
+                                                  &numEventsInWaitList,
+                                                  &phEventWaitList,
+                                                  &phEvent};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, "urEnqueueMemBufferFill", &params);
 
-    ur_result_t result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size,
+                         numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, "urEnqueueMemBufferFill", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL,
+                       "urEnqueueMemBufferFill", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pDst, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -2651,36 +3150,48 @@ urEnqueueMemImageRead(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_image_read_params_t params = {&hQueue, &hImage, &blockingRead, &origin, &region, &rowPitch, &slicePitch, &pDst, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, "urEnqueueMemImageRead", &params);
+    ur_enqueue_mem_image_read_params_t params = {
+        &hQueue,          &hImage, &blockingRead,
+        &origin,          &region, &rowPitch,
+        &slicePitch,      &pDst,   &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ,
+                                             "urEnqueueMemImageRead", &params);
 
-    ur_result_t result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemImageRead(
+        hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch,
+        pDst, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, "urEnqueueMemImageRead", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ,
+                       "urEnqueueMemImageRead", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pSrc, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -2688,36 +3199,48 @@ urEnqueueMemImageWrite(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_image_write_params_t params = {&hQueue, &hImage, &blockingWrite, &origin, &region, &rowPitch, &slicePitch, &pSrc, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, "urEnqueueMemImageWrite", &params);
+    ur_enqueue_mem_image_write_params_t params = {
+        &hQueue,          &hImage, &blockingWrite,
+        &origin,          &region, &rowPitch,
+        &slicePitch,      &pSrc,   &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, "urEnqueueMemImageWrite", &params);
 
-    ur_result_t result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemImageWrite(
+        hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch,
+        pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, "urEnqueueMemImageWrite", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE,
+                       "urEnqueueMemImageWrite", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                              ///< image
-    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                              ///< or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -2725,35 +3248,42 @@ urEnqueueMemImageCopy(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_image_copy_params_t params = {&hQueue, &hImageSrc, &hImageDst, &srcOrigin, &dstOrigin, &region, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, "urEnqueueMemImageCopy", &params);
+    ur_enqueue_mem_image_copy_params_t params = {
+        &hQueue, &hImageSrc,           &hImageDst,       &srcOrigin, &dstOrigin,
+        &region, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY,
+                                             "urEnqueueMemImageCopy", &params);
 
-    ur_result_t result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
+                        region, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, "urEnqueueMemImageCopy", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY,
+                       "urEnqueueMemImageCopy", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
-    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
-                                              ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
+    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,   ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [out][optional] return an event object that identifies this particular
+                 ///< command instance.
+    void **ppRetMap ///< [out] return mapped pointer.  TODO: move it before
+                    ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = context.urDdiTable.Enqueue.pfnMemBufferMap;
 
@@ -2761,30 +3291,39 @@ urEnqueueMemBufferMap(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_map_params_t params = {&hQueue, &hBuffer, &blockingMap, &mapFlags, &offset, &size, &numEventsInWaitList, &phEventWaitList, &phEvent, &ppRetMap};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, "urEnqueueMemBufferMap", &params);
+    ur_enqueue_mem_buffer_map_params_t params = {
+        &hQueue,  &hBuffer, &blockingMap,         &mapFlags,
+        &offset,  &size,    &numEventsInWaitList, &phEventWaitList,
+        &phEvent, &ppRetMap};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP,
+                                             "urEnqueueMemBufferMap", &params);
 
-    ur_result_t result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
+    ur_result_t result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags,
+                                         offset, size, numEventsInWaitList,
+                                         phEventWaitList, phEvent, ppRetMap);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, "urEnqueueMemBufferMap", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP,
+                       "urEnqueueMemBufferMap", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr,                         ///< [in] mapped host address
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t
+        hMem,         ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr, ///< [in] mapped host address
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -2792,33 +3331,43 @@ urEnqueueMemUnmap(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_unmap_params_t params = {&hQueue, &hMem, &pMappedPtr, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_UNMAP, "urEnqueueMemUnmap", &params);
+    ur_enqueue_mem_unmap_params_t params = {
+        &hQueue,          &hMem,   &pMappedPtr, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_UNMAP,
+                                             "urEnqueueMemUnmap", &params);
 
-    ur_result_t result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
+                    phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_UNMAP, "urEnqueueMemUnmap", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_MEM_UNMAP, "urEnqueueMemUnmap",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    void *ptr,                                ///< [in] pointer to USM memory object
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t size,                              ///< [in] size in bytes to be set. Must be a multiple of patternSize.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    void *ptr,                ///< [in] pointer to USM memory object
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        size, ///< [in] size in bytes to be set. Must be a multiple of patternSize.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMFill = context.urDdiTable.Enqueue.pfnUSMFill;
 
@@ -2826,32 +3375,40 @@ urEnqueueUSMFill(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_fill_params_t params = {&hQueue, &ptr, &patternSize, &pPattern, &size, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_FILL, "urEnqueueUSMFill", &params);
+    ur_enqueue_usm_fill_params_t params = {
+        &hQueue,          &ptr,    &patternSize,
+        &pPattern,        &size,   &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_FILL,
+                                             "urEnqueueUSMFill", &params);
 
-    ur_result_t result = pfnUSMFill(hQueue, ptr, patternSize, pPattern, size, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnUSMFill(hQueue, ptr, patternSize, pPattern, size,
+                   numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_USM_FILL, "urEnqueueUSMFill", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_USM_FILL, "urEnqueueUSMFill",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking copy
-    void *pDst,                               ///< [in] pointer to the destination USM memory object
-    const void *pSrc,                         ///< [in] pointer to the source USM memory object
-    size_t size,                              ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool blocking,            ///< [in] blocking or non-blocking copy
+    void *pDst,       ///< [in] pointer to the destination USM memory object
+    const void *pSrc, ///< [in] pointer to the source USM memory object
+    size_t size,      ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -2859,31 +3416,38 @@ urEnqueueUSMMemcpy(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_memcpy_params_t params = {&hQueue, &blocking, &pDst, &pSrc, &size, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_MEMCPY, "urEnqueueUSMMemcpy", &params);
+    ur_enqueue_usm_memcpy_params_t params = {
+        &hQueue,          &blocking, &pDst, &pSrc, &size, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_MEMCPY,
+                                             "urEnqueueUSMMemcpy", &params);
 
-    ur_result_t result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
+                     phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY, "urEnqueueUSMMemcpy", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY, "urEnqueueUSMMemcpy",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    const void *pMem,                         ///< [in] pointer to the USM memory object
-    size_t size,                              ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
+    const void *pMem,               ///< [in] pointer to the USM memory object
+    size_t size,                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -2891,26 +3455,32 @@ urEnqueueUSMPrefetch(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_prefetch_params_t params = {&hQueue, &pMem, &size, &flags, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_PREFETCH, "urEnqueueUSMPrefetch", &params);
+    ur_enqueue_usm_prefetch_params_t params = {
+        &hQueue,          &pMem,   &size, &flags, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_PREFETCH,
+                                             "urEnqueueUSMPrefetch", &params);
 
-    ur_result_t result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
+                       phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_USM_PREFETCH, "urEnqueueUSMPrefetch", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_USM_PREFETCH, "urEnqueueUSMPrefetch",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    const void *pMem,          ///< [in] pointer to the USM memory object
-    size_t size,               ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
-                               ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    const void *pMem,         ///< [in] pointer to the USM memory object
+    size_t size,              ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,   ///< [in] USM memory advice
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMMemAdvise = context.urDdiTable.Enqueue.pfnUSMMemAdvise;
 
@@ -2918,36 +3488,44 @@ urEnqueueUSMMemAdvise(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_mem_advise_params_t params = {&hQueue, &pMem, &size, &advice, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_MEM_ADVISE, "urEnqueueUSMMemAdvise", &params);
+    ur_enqueue_usm_mem_advise_params_t params = {&hQueue, &pMem, &size, &advice,
+                                                 &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_MEM_ADVISE,
+                                             "urEnqueueUSMMemAdvise", &params);
 
     ur_result_t result = pfnUSMMemAdvise(hQueue, pMem, size, advice, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_USM_MEM_ADVISE, "urEnqueueUSMMemAdvise", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_USM_MEM_ADVISE,
+                       "urEnqueueUSMMemAdvise", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    void *pMem,                               ///< [in] pointer to memory to be filled.
-    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                             ///< [in] the width in bytes of each row to fill. Must be a multiple of
-                                              ///< patternSize.
-    size_t height,                            ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    void *pMem,               ///< [in] pointer to memory to be filled.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        width, ///< [in] the width in bytes of each row to fill. Must be a multiple of
+               ///< patternSize.
+    size_t height,                ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -2955,35 +3533,45 @@ urEnqueueUSMFill2D(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_fill2_d_params_t params = {&hQueue, &pMem, &pitch, &patternSize, &pPattern, &width, &height, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_FILL2_D, "urEnqueueUSMFill2D", &params);
+    ur_enqueue_usm_fill2_d_params_t params = {
+        &hQueue,          &pMem,   &pitch,  &patternSize,
+        &pPattern,        &width,  &height, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_FILL2_D,
+                                             "urEnqueueUSMFill2D", &params);
 
-    ur_result_t result = pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height,
+                     numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_USM_FILL2_D, "urEnqueueUSMFill2D", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_USM_FILL2_D, "urEnqueueUSMFill2D",
+                       &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    bool blocking,                            ///< [in] indicates if this operation should block the host.
-    void *pDst,                               ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
-    const void *pSrc,                         ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
-    size_t width,                             ///< [in] the width in bytes of each row to be copied.
-    size_t height,                            ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    bool blocking, ///< [in] indicates if this operation should block the host.
+    void *pDst,    ///< [in] pointer to memory where data will be copied.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
+    const void *pSrc, ///< [in] pointer to memory to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -2991,82 +3579,118 @@ urEnqueueUSMMemcpy2D(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_memcpy2_d_params_t params = {&hQueue, &blocking, &pDst, &dstPitch, &pSrc, &srcPitch, &width, &height, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D, "urEnqueueUSMMemcpy2D", &params);
+    ur_enqueue_usm_memcpy2_d_params_t params = {
+        &hQueue,          &blocking, &pDst,
+        &dstPitch,        &pSrc,     &srcPitch,
+        &width,           &height,   &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D,
+                                             "urEnqueueUSMMemcpy2D", &params);
 
-    ur_result_t result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result =
+        pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width,
+                       height, numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D, "urEnqueueUSMMemcpy2D", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D,
+                       "urEnqueueUSMMemcpy2D", &params, &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                       ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite, ///< [in] indicates if this operation should block.
+    size_t count,       ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc, ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableWrite = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite =
+        context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
 
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_device_global_variable_write_params_t params = {&hQueue, &hProgram, &name, &blockingWrite, &count, &offset, &pSrc, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE, "urEnqueueDeviceGlobalVariableWrite", &params);
+    ur_enqueue_device_global_variable_write_params_t params = {
+        &hQueue,          &hProgram, &name, &blockingWrite,
+        &count,           &offset,   &pSrc, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE,
+                             "urEnqueueDeviceGlobalVariableWrite", &params);
 
-    ur_result_t result = pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnDeviceGlobalVariableWrite(
+        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE, "urEnqueueDeviceGlobalVariableWrite", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE,
+                       "urEnqueueDeviceGlobalVariableWrite", &params, &result,
+                       instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                        ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst,                               ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingRead, ///< [in] indicates if this operation should block.
+    size_t count,      ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableRead = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead =
+        context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
 
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_device_global_variable_read_params_t params = {&hQueue, &hProgram, &name, &blockingRead, &count, &offset, &pDst, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ, "urEnqueueDeviceGlobalVariableRead", &params);
+    ur_enqueue_device_global_variable_read_params_t params = {
+        &hQueue,          &hProgram, &name, &blockingRead,
+        &count,           &offset,   &pDst, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ,
+                             "urEnqueueDeviceGlobalVariableRead", &params);
 
-    ur_result_t result = pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnDeviceGlobalVariableRead(
+        hQueue, hProgram, name, blockingRead, count, offset, pDst,
+        numEventsInWaitList, phEventWaitList, phEvent);
 
-    context.notify_end(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ, "urEnqueueDeviceGlobalVariableRead", &params, &result, instance);
+    context.notify_end(UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ,
+                       "urEnqueueDeviceGlobalVariableRead", &params, &result,
+                       instance);
 
     return result;
 }
@@ -3079,10 +3703,10 @@ urEnqueueDeviceGlobalVariableRead(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetGlobalProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_global_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Global;
 
@@ -3090,8 +3714,10 @@ urGetGlobalProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3116,10 +3742,10 @@ urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetContextProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetContextProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_context_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Context;
 
@@ -3127,8 +3753,10 @@ urGetContextProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3150,10 +3778,12 @@ urGetContextProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urContextGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urContextCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urContextCreateWithNativeHandle;
 
     dditable.pfnSetExtendedDeleter = pDdiTable->pfnSetExtendedDeleter;
-    pDdiTable->pfnSetExtendedDeleter = tracing_layer::urContextSetExtendedDeleter;
+    pDdiTable->pfnSetExtendedDeleter =
+        tracing_layer::urContextSetExtendedDeleter;
 
     return result;
 }
@@ -3165,10 +3795,10 @@ urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetEnqueueProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_enqueue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Enqueue;
 
@@ -3176,8 +3806,10 @@ urGetEnqueueProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3190,7 +3822,8 @@ urGetEnqueueProcAddrTable(
     pDdiTable->pfnEventsWait = tracing_layer::urEnqueueEventsWait;
 
     dditable.pfnEventsWaitWithBarrier = pDdiTable->pfnEventsWaitWithBarrier;
-    pDdiTable->pfnEventsWaitWithBarrier = tracing_layer::urEnqueueEventsWaitWithBarrier;
+    pDdiTable->pfnEventsWaitWithBarrier =
+        tracing_layer::urEnqueueEventsWaitWithBarrier;
 
     dditable.pfnMemBufferRead = pDdiTable->pfnMemBufferRead;
     pDdiTable->pfnMemBufferRead = tracing_layer::urEnqueueMemBufferRead;
@@ -3202,7 +3835,8 @@ urGetEnqueueProcAddrTable(
     pDdiTable->pfnMemBufferReadRect = tracing_layer::urEnqueueMemBufferReadRect;
 
     dditable.pfnMemBufferWriteRect = pDdiTable->pfnMemBufferWriteRect;
-    pDdiTable->pfnMemBufferWriteRect = tracing_layer::urEnqueueMemBufferWriteRect;
+    pDdiTable->pfnMemBufferWriteRect =
+        tracing_layer::urEnqueueMemBufferWriteRect;
 
     dditable.pfnMemBufferCopy = pDdiTable->pfnMemBufferCopy;
     pDdiTable->pfnMemBufferCopy = tracing_layer::urEnqueueMemBufferCopy;
@@ -3246,11 +3880,15 @@ urGetEnqueueProcAddrTable(
     dditable.pfnUSMMemcpy2D = pDdiTable->pfnUSMMemcpy2D;
     pDdiTable->pfnUSMMemcpy2D = tracing_layer::urEnqueueUSMMemcpy2D;
 
-    dditable.pfnDeviceGlobalVariableWrite = pDdiTable->pfnDeviceGlobalVariableWrite;
-    pDdiTable->pfnDeviceGlobalVariableWrite = tracing_layer::urEnqueueDeviceGlobalVariableWrite;
+    dditable.pfnDeviceGlobalVariableWrite =
+        pDdiTable->pfnDeviceGlobalVariableWrite;
+    pDdiTable->pfnDeviceGlobalVariableWrite =
+        tracing_layer::urEnqueueDeviceGlobalVariableWrite;
 
-    dditable.pfnDeviceGlobalVariableRead = pDdiTable->pfnDeviceGlobalVariableRead;
-    pDdiTable->pfnDeviceGlobalVariableRead = tracing_layer::urEnqueueDeviceGlobalVariableRead;
+    dditable.pfnDeviceGlobalVariableRead =
+        pDdiTable->pfnDeviceGlobalVariableRead;
+    pDdiTable->pfnDeviceGlobalVariableRead =
+        tracing_layer::urEnqueueDeviceGlobalVariableRead;
 
     return result;
 }
@@ -3262,10 +3900,10 @@ urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetEventProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetEventProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_event_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Event;
 
@@ -3273,8 +3911,10 @@ urGetEventProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3299,7 +3939,8 @@ urGetEventProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urEventGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urEventCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urEventCreateWithNativeHandle;
 
     dditable.pfnSetCallback = pDdiTable->pfnSetCallback;
     pDdiTable->pfnSetCallback = tracing_layer::urEventSetCallback;
@@ -3314,10 +3955,10 @@ urGetEventProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetKernelProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetKernelProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_kernel_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Kernel;
 
@@ -3325,8 +3966,10 @@ urGetKernelProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3354,7 +3997,8 @@ urGetKernelProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urKernelGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urKernelCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urKernelCreateWithNativeHandle;
 
     dditable.pfnSetArgValue = pDdiTable->pfnSetArgValue;
     pDdiTable->pfnSetArgValue = tracing_layer::urKernelSetArgValue;
@@ -3374,8 +4018,10 @@ urGetKernelProcAddrTable(
     dditable.pfnSetArgMemObj = pDdiTable->pfnSetArgMemObj;
     pDdiTable->pfnSetArgMemObj = tracing_layer::urKernelSetArgMemObj;
 
-    dditable.pfnSetSpecializationConstants = pDdiTable->pfnSetSpecializationConstants;
-    pDdiTable->pfnSetSpecializationConstants = tracing_layer::urKernelSetSpecializationConstants;
+    dditable.pfnSetSpecializationConstants =
+        pDdiTable->pfnSetSpecializationConstants;
+    pDdiTable->pfnSetSpecializationConstants =
+        tracing_layer::urKernelSetSpecializationConstants;
 
     return result;
 }
@@ -3387,10 +4033,10 @@ urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetMemProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetMemProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_mem_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Mem;
 
@@ -3398,8 +4044,10 @@ urGetMemProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3424,7 +4072,8 @@ urGetMemProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urMemGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urMemCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urMemCreateWithNativeHandle;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = tracing_layer::urMemGetInfo;
@@ -3442,10 +4091,10 @@ urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetPlatformProcAddrTable(
-    ur_api_version_t version,         ///< [in] API version requested
-    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetPlatformProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_platform_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Platform;
 
@@ -3453,8 +4102,10 @@ urGetPlatformProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3470,7 +4121,8 @@ urGetPlatformProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urPlatformGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urPlatformCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urPlatformCreateWithNativeHandle;
 
     dditable.pfnGetApiVersion = pDdiTable->pfnGetApiVersion;
     pDdiTable->pfnGetApiVersion = tracing_layer::urPlatformGetApiVersion;
@@ -3485,10 +4137,10 @@ urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetProgramProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetProgramProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_program_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Program;
 
@@ -3496,8 +4148,10 @@ urGetProgramProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3525,7 +4179,8 @@ urGetProgramProcAddrTable(
     pDdiTable->pfnRelease = tracing_layer::urProgramRelease;
 
     dditable.pfnGetFunctionPointer = pDdiTable->pfnGetFunctionPointer;
-    pDdiTable->pfnGetFunctionPointer = tracing_layer::urProgramGetFunctionPointer;
+    pDdiTable->pfnGetFunctionPointer =
+        tracing_layer::urProgramGetFunctionPointer;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = tracing_layer::urProgramGetInfo;
@@ -3533,14 +4188,17 @@ urGetProgramProcAddrTable(
     dditable.pfnGetBuildInfo = pDdiTable->pfnGetBuildInfo;
     pDdiTable->pfnGetBuildInfo = tracing_layer::urProgramGetBuildInfo;
 
-    dditable.pfnSetSpecializationConstants = pDdiTable->pfnSetSpecializationConstants;
-    pDdiTable->pfnSetSpecializationConstants = tracing_layer::urProgramSetSpecializationConstants;
+    dditable.pfnSetSpecializationConstants =
+        pDdiTable->pfnSetSpecializationConstants;
+    pDdiTable->pfnSetSpecializationConstants =
+        tracing_layer::urProgramSetSpecializationConstants;
 
     dditable.pfnGetNativeHandle = pDdiTable->pfnGetNativeHandle;
     pDdiTable->pfnGetNativeHandle = tracing_layer::urProgramGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urProgramCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urProgramCreateWithNativeHandle;
 
     return result;
 }
@@ -3552,10 +4210,10 @@ urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetQueueProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetQueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_queue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Queue;
 
@@ -3563,8 +4221,10 @@ urGetQueueProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3586,7 +4246,8 @@ urGetQueueProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urQueueGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urQueueCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urQueueCreateWithNativeHandle;
 
     dditable.pfnFinish = pDdiTable->pfnFinish;
     pDdiTable->pfnFinish = tracing_layer::urQueueFinish;
@@ -3604,10 +4265,10 @@ urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetSamplerProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetSamplerProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_sampler_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Sampler;
 
@@ -3615,8 +4276,10 @@ urGetSamplerProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3638,7 +4301,8 @@ urGetSamplerProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urSamplerGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urSamplerCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urSamplerCreateWithNativeHandle;
 
     return result;
 }
@@ -3650,10 +4314,10 @@ urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetUSMProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetUSMProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.USM;
 
@@ -3661,8 +4325,10 @@ urGetUSMProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3699,10 +4365,10 @@ urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL
-urGetDeviceProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+__urdlllocal ur_result_t UR_APICALL urGetDeviceProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_device_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = tracing_layer::context.urDdiTable.Device;
 
@@ -3710,8 +4376,10 @@ urGetDeviceProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(tracing_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(tracing_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3739,10 +4407,12 @@ urGetDeviceProcAddrTable(
     pDdiTable->pfnGetNativeHandle = tracing_layer::urDeviceGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = tracing_layer::urDeviceCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        tracing_layer::urDeviceCreateWithNativeHandle;
 
     dditable.pfnGetGlobalTimestamps = pDdiTable->pfnGetGlobalTimestamps;
-    pDdiTable->pfnGetGlobalTimestamps = tracing_layer::urDeviceGetGlobalTimestamps;
+    pDdiTable->pfnGetGlobalTimestamps =
+        tracing_layer::urDeviceGetGlobalTimestamps;
 
     return result;
 }
@@ -3751,51 +4421,63 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &dditable->Global);
+        result = tracing_layer::urGetGlobalProcAddrTable(UR_API_VERSION_0_9,
+                                                         &dditable->Global);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetContextProcAddrTable(UR_API_VERSION_0_9, &dditable->Context);
+        result = tracing_layer::urGetContextProcAddrTable(UR_API_VERSION_0_9,
+                                                          &dditable->Context);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &dditable->Enqueue);
+        result = tracing_layer::urGetEnqueueProcAddrTable(UR_API_VERSION_0_9,
+                                                          &dditable->Enqueue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetEventProcAddrTable(UR_API_VERSION_0_9, &dditable->Event);
+        result = tracing_layer::urGetEventProcAddrTable(UR_API_VERSION_0_9,
+                                                        &dditable->Event);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetKernelProcAddrTable(UR_API_VERSION_0_9, &dditable->Kernel);
+        result = tracing_layer::urGetKernelProcAddrTable(UR_API_VERSION_0_9,
+                                                         &dditable->Kernel);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetMemProcAddrTable(UR_API_VERSION_0_9, &dditable->Mem);
+        result = tracing_layer::urGetMemProcAddrTable(UR_API_VERSION_0_9,
+                                                      &dditable->Mem);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetPlatformProcAddrTable(UR_API_VERSION_0_9, &dditable->Platform);
+        result = tracing_layer::urGetPlatformProcAddrTable(UR_API_VERSION_0_9,
+                                                           &dditable->Platform);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetProgramProcAddrTable(UR_API_VERSION_0_9, &dditable->Program);
+        result = tracing_layer::urGetProgramProcAddrTable(UR_API_VERSION_0_9,
+                                                          &dditable->Program);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetQueueProcAddrTable(UR_API_VERSION_0_9, &dditable->Queue);
+        result = tracing_layer::urGetQueueProcAddrTable(UR_API_VERSION_0_9,
+                                                        &dditable->Queue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &dditable->Sampler);
+        result = tracing_layer::urGetSamplerProcAddrTable(UR_API_VERSION_0_9,
+                                                          &dditable->Sampler);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetUSMProcAddrTable(UR_API_VERSION_0_9, &dditable->USM);
+        result = tracing_layer::urGetUSMProcAddrTable(UR_API_VERSION_0_9,
+                                                      &dditable->USM);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = tracing_layer::urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &dditable->Device);
+        result = tracing_layer::urGetDeviceProcAddrTable(UR_API_VERSION_0_9,
+                                                         &dditable->Device);
     }
 
     return result;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -12,10 +12,9 @@
 namespace validation_layer {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL
-urInit(
+__urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     auto pfnInit = context.urDdiTable.Global.pfnInit;
 
@@ -34,8 +33,7 @@ urInit(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL
-urTearDown(
+__urdlllocal ur_result_t UR_APICALL urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     auto pfnTearDown = context.urDdiTable.Global.pfnTearDown;
@@ -55,16 +53,18 @@ urTearDown(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGet(
-    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
-                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                       ///< will be returned.
-    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                       ///< If NumEntries is less than the number of platforms available, then
-                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = context.urDdiTable.Platform.pfnGet;
 
@@ -80,16 +80,16 @@ urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Platform.pfnGetInfo;
 
@@ -107,13 +107,13 @@ urPlatformGetInfo(
         }
     }
 
-    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
+                      pSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -138,10 +138,10 @@ urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Platform.pfnGetNativeHandle;
 
@@ -164,12 +164,14 @@ urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Platform.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -190,11 +192,11 @@ urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL
-urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     auto pfnGetLastResult = context.urDdiTable.Global.pfnGetLastResult;
 
@@ -217,19 +219,20 @@ urGetLastResult(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
-                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                    ///< will be returned.
-    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                    ///< If NumEntries is less than the number of devices available, then
-                                    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
-                                    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = context.urDdiTable.Device.pfnGet;
 
@@ -252,17 +255,17 @@ urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return the info
-                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
 
@@ -285,9 +288,9 @@ urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRetain(
-    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+    ur_device_handle_t
+        hDevice ///< [in] handle of the device to get a reference of.
 ) {
     auto pfnRetain = context.urDdiTable.Device.pfnRetain;
 
@@ -306,8 +309,7 @@ urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     auto pfnRelease = context.urDdiTable.Device.pfnRelease;
@@ -327,16 +329,18 @@ urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL
-urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices, ///< [in] the number of sub-devices.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = context.urDdiTable.Device.pfnPartition;
 
@@ -354,20 +358,22 @@ urDevicePartition(
         }
     }
 
-    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
+    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
+                        pNumDevicesRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL
-urDeviceSelectBinary(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
-                                ///< Must greater than or equal to zero otherwise
-                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
-                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
+                          ///< Must greater than or equal to zero otherwise
+                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = context.urDdiTable.Device.pfnSelectBinary;
 
@@ -394,10 +400,10 @@ urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,        ///< [in] handle of the device.
-    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ///< [in] handle of the device.
+    ur_native_handle_t
+        *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Device.pfnGetNativeHandle;
 
@@ -420,13 +426,14 @@ urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t
+        *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Device.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -451,15 +458,17 @@ urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                                ///< correlates with the Host's global timestamp value
-    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
-                                ///< correlates with the Device's global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
-    auto pfnGetGlobalTimestamps = context.urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps =
+        context.urDdiTable.Device.pfnGetGlobalTimestamps;
 
     if (nullptr == pfnGetGlobalTimestamps) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -476,12 +485,14 @@ urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL
-urContextCreate(
-    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
-    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
-    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL urContextCreate(
+    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t
+        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *
+        pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t
+        *phContext ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = context.urDdiTable.Context.pfnCreate;
 
@@ -504,9 +515,9 @@ urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL
-urContextRetain(
-    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urContextRetain(
+    ur_context_handle_t
+        hContext ///< [in] handle of the context to get a reference of.
 ) {
     auto pfnRetain = context.urDdiTable.Context.pfnRetain;
 
@@ -525,8 +536,7 @@ urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL
-urContextRelease(
+__urdlllocal ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     auto pfnRelease = context.urDdiTable.Context.pfnRelease;
@@ -546,17 +556,18 @@ urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
 
@@ -574,15 +585,16 @@ urContextGetInfo(
         }
     }
 
-    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
+    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
+                      pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Context.pfnGetNativeHandle;
 
@@ -605,12 +617,14 @@ urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Context.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -631,13 +645,15 @@ urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL
-urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,             ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_context_extended_deleter_t
+        pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
-    auto pfnSetExtendedDeleter = context.urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter =
+        context.urDdiTable.Context.pfnSetExtendedDeleter;
 
     if (nullptr == pfnSetExtendedDeleter) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -658,14 +674,14 @@ urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemImageCreate(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    void *pHost,                           ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    void *pHost,           ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
 ) {
     auto pfnImageCreate = context.urDdiTable.Mem.pfnImageCreate;
 
@@ -698,27 +714,32 @@ urMemImageCreate(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {
+        if (pHost == NULL &&
+            (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
+                      UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {
             return UR_RESULT_ERROR_INVALID_HOST_PTR;
         }
 
-        if (pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0) {
+        if (pHost != NULL &&
+            (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
+                      UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0) {
             return UR_RESULT_ERROR_INVALID_HOST_PTR;
         }
     }
 
-    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
+    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost,
+                          phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
-    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
-    void *pHost,                  ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    size_t size, ///< [in] size in bytes of the memory object to be allocated
+    void *pHost, ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t
+        *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
     auto pfnBufferCreate = context.urDdiTable.Mem.pfnBufferCreate;
 
@@ -739,11 +760,15 @@ urMemBufferCreate(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {
+        if (pHost == NULL &&
+            (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
+                      UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {
             return UR_RESULT_ERROR_INVALID_HOST_PTR;
         }
 
-        if (pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0) {
+        if (pHost != NULL &&
+            (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
+                      UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0) {
             return UR_RESULT_ERROR_INVALID_HOST_PTR;
         }
     }
@@ -753,8 +778,7 @@ urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL
-urMemRetain(
+__urdlllocal ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Mem.pfnRetain;
@@ -774,8 +798,7 @@ urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL
-urMemRelease(
+__urdlllocal ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     auto pfnRelease = context.urDdiTable.Mem.pfnRelease;
@@ -795,13 +818,15 @@ urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t
+        hBuffer,          ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
-    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *
+        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
     auto pfnBufferPartition = context.urDdiTable.Mem.pfnBufferPartition;
 
@@ -831,15 +856,16 @@ urMemBufferPartition(
         }
     }
 
-    return pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
+    return pfnBufferPartition(hBuffer, flags, bufferCreateType,
+                              pBufferCreateInfo, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemGetNativeHandle(
-    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
-    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Mem.pfnGetNativeHandle;
 
@@ -862,13 +888,14 @@ urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of the mem object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Mem.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -893,16 +920,18 @@ urMemCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+    ur_mem_handle_t
+        hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
 
@@ -925,16 +954,17 @@ urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
 
@@ -952,17 +982,19 @@ urMemImageGetInfo(
         }
     }
 
-    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
+                           pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_property_t
+        *pProps, ///< [in] specifies a list of sampler property names and their
+                 ///< corresponding values.
+    ur_sampler_handle_t
+        *phSampler ///< [out] pointer to handle of sampler object created
 ) {
     auto pfnCreate = context.urDdiTable.Sampler.pfnCreate;
 
@@ -989,9 +1021,9 @@ urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRetain(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Sampler.pfnRetain;
 
@@ -1010,9 +1042,9 @@ urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRelease(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to release
 ) {
     auto pfnRelease = context.urDdiTable.Sampler.pfnRelease;
 
@@ -1031,13 +1063,14 @@ urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
-    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
+    size_t *
+        pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     auto pfnGetInfo = context.urDdiTable.Sampler.pfnGetInfo;
 
@@ -1063,15 +1096,16 @@ urSamplerGetInfo(
         }
     }
 
-    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
+                      pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Sampler.pfnGetNativeHandle;
 
@@ -1094,13 +1128,15 @@ urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1125,17 +1161,19 @@ urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM host memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = context.urDdiTable.USM.pfnHostAlloc;
 
@@ -1166,18 +1204,20 @@ urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM device memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = context.urDdiTable.USM.pfnDeviceAlloc;
 
@@ -1207,23 +1247,26 @@ urUSMDeviceAlloc(
         }
     }
 
-    return pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    return pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align,
+                          ppMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object.
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM shared memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object.
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = context.urDdiTable.USM.pfnSharedAlloc;
 
@@ -1253,13 +1296,13 @@ urUSMSharedAlloc(
         }
     }
 
-    return pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    return pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align,
+                          ppMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL
-urUSMFree(
+__urdlllocal ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1284,14 +1327,16 @@ urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL
-urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t
+        propName, ///< [in] the name of the USM allocation property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue, ///< [out][optional] value of the USM allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo = context.urDdiTable.USM.pfnGetMemAllocInfo;
 
@@ -1313,17 +1358,18 @@ urUSMGetMemAllocInfo(
         }
     }
 
-    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
+                              pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolCreate(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_usm_pool_desc_t *pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
-                                   ///< ::ur_usm_pool_limits_desc_t
-    ur_usm_pool_handle_t *ppPool   ///< [out] pointer to USM memory pool
+__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_pool_desc_t *
+        pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
+                   ///< ::ur_usm_pool_limits_desc_t
+    ur_usm_pool_handle_t *ppPool ///< [out] pointer to USM memory pool
 ) {
     auto pfnPoolCreate = context.urDdiTable.USM.pfnPoolCreate;
 
@@ -1354,8 +1400,7 @@ urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolDestroy
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolDestroy(
+__urdlllocal ur_result_t UR_APICALL urUSMPoolDestroy(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_handle_t pPool    ///< [in] pointer to USM memory pool
 ) {
@@ -1380,13 +1425,14 @@ urUSMPoolDestroy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithIL(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    const void *pIL,                            ///< [in] pointer to IL binary.
-    size_t length,                              ///< [in] length of `pIL` in bytes.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const void *pIL,              ///< [in] pointer to IL binary.
+    size_t length,                ///< [in] length of `pIL` in bytes.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreateWithIL = context.urDdiTable.Program.pfnCreateWithIL;
 
@@ -1407,11 +1453,13 @@ urProgramCreateWithIL(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas) {
+        if (NULL != pProperties && pProperties->count > 0 &&
+            NULL == pProperties->pMetadatas) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0) {
+        if (NULL != pProperties && NULL != pProperties->pMetadatas &&
+            pProperties->count == 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
     }
@@ -1421,14 +1469,16 @@ urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithBinary(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
-    size_t size,                                ///< [in] size in bytes.
-    const uint8_t *pBinary,                     ///< [in] pointer to binary.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_device_handle_t
+        hDevice,            ///< [in] handle to device associated with binary.
+    size_t size,            ///< [in] size in bytes.
+    const uint8_t *pBinary, ///< [in] pointer to binary.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     auto pfnCreateWithBinary = context.urDdiTable.Program.pfnCreateWithBinary;
 
@@ -1453,25 +1503,28 @@ urProgramCreateWithBinary(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas) {
+        if (NULL != pProperties && pProperties->count > 0 &&
+            NULL == pProperties->pMetadatas) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0) {
+        if (NULL != pProperties && NULL != pProperties->pMetadatas &&
+            pProperties->count == 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
     }
 
-    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
+    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties,
+                               phProgram);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL
-urProgramBuild(
+__urdlllocal ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     auto pfnBuild = context.urDdiTable.Program.pfnBuild;
 
@@ -1494,11 +1547,12 @@ urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL
-urProgramCompile(
+__urdlllocal ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    ur_program_handle_t hProgram, ///< [in][out] handle of the program to compile.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    ur_program_handle_t
+        hProgram, ///< [in][out] handle of the program to compile.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     auto pfnCompile = context.urDdiTable.Program.pfnCompile;
 
@@ -1521,13 +1575,15 @@ urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL
-urProgramLink(
-    ur_context_handle_t hContext,          ///< [in] handle of the context instance.
-    uint32_t count,                        ///< [in] number of program handles in `phPrograms`.
-    const ur_program_handle_t *phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
-    const char *pOptions,                  ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram         ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramLink(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance.
+    uint32_t count, ///< [in] number of program handles in `phPrograms`.
+    const ur_program_handle_t *
+        phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     auto pfnLink = context.urDdiTable.Program.pfnLink;
 
@@ -1554,8 +1610,7 @@ urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL
-urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     auto pfnRetain = context.urDdiTable.Program.pfnRetain;
@@ -1575,8 +1630,7 @@ urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL
-urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     auto pfnRelease = context.urDdiTable.Program.pfnRelease;
@@ -1596,16 +1650,20 @@ urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
-                                  ///< The program must already be built to the specified device, or
-                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
-    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program to search for function in.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
-    auto pfnGetFunctionPointer = context.urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer =
+        context.urDdiTable.Program.pfnGetFunctionPointer;
 
     if (nullptr == pfnGetFunctionPointer) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1629,22 +1687,24 @@ urProgramGetFunctionPointer(
         }
     }
 
-    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
+    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
+                                 ppFunctionPointer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName,   ///< [in] name of the Program property to query
-    size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
-                                  ///< If propSize is not equal to or greater than the real number of bytes
-                                  ///< needed to return
-                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+    ur_program_info_t propName, ///< [in] name of the Program property to query
+    size_t propSize,            ///< [in] the size of the Program property.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
 ) {
     auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
 
@@ -1667,18 +1727,20 @@ urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
-    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
-    size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
-                                      ///< If propSize is not equal to or greater than the real number of bytes
-                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
-    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
-                                      ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
+    ur_program_build_info_t
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = context.urDdiTable.Program.pfnGetBuildInfo;
 
@@ -1700,19 +1762,21 @@ urProgramGetBuildInfo(
         }
     }
 
-    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
+                           pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in][range(0, count)] array of specialization constant value
-                                                            ///< descriptions
+__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in][range(0, count)] array of specialization constant value
+                       ///< descriptions
 ) {
-    auto pfnSetSpecializationConstants = context.urDdiTable.Program.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        context.urDdiTable.Program.pfnSetSpecializationConstants;
 
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1737,10 +1801,10 @@ urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Program.pfnGetNativeHandle;
 
@@ -1763,13 +1827,15 @@ urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Program.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1794,11 +1860,11 @@ urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to handle of kernel object created.
 ) {
     auto pfnCreate = context.urDdiTable.Kernel.pfnCreate;
 
@@ -1825,12 +1891,12 @@ urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,             ///< [in] size of argument type
-    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void
+        *pArgValue ///< [in] argument value represented as matching arg type.
 ) {
     auto pfnSetArgValue = context.urDdiTable.Kernel.pfnSetArgValue;
 
@@ -1853,11 +1919,11 @@ urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = context.urDdiTable.Kernel.pfnSetArgLocal;
 
@@ -1876,18 +1942,19 @@ urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return
-                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
-                                ///< queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Kernel.pfnGetInfo;
 
@@ -1910,16 +1977,18 @@ urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
-    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                     ///< property.
-    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
-                                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_group_info_t
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = context.urDdiTable.Kernel.pfnGetGroupInfo;
 
@@ -1941,21 +2010,24 @@ urKernelGetGroupInfo(
         }
     }
 
-    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
+                           pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
-    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                         ///< property.
-    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
-                                         ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetSubGroupInfo = context.urDdiTable.Kernel.pfnGetSubGroupInfo;
 
@@ -1977,13 +2049,13 @@ urKernelGetSubGroupInfo(
         }
     }
 
-    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
+                              pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL
-urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     auto pfnRetain = context.urDdiTable.Kernel.pfnRetain;
@@ -2003,8 +2075,7 @@ urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL
-urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     auto pfnRelease = context.urDdiTable.Kernel.pfnRelease;
@@ -2024,12 +2095,12 @@ urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
-                                ///< value. If null then argument value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = context.urDdiTable.Kernel.pfnSetArgPointer;
 
@@ -2048,13 +2119,13 @@ urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                    ///< property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
 
@@ -2081,10 +2152,9 @@ urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
-    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     auto pfnSetArgSampler = context.urDdiTable.Kernel.pfnSetArgSampler;
@@ -2108,11 +2178,10 @@ urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = context.urDdiTable.Kernel.pfnSetArgMemObj;
 
@@ -2131,13 +2200,14 @@ urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in] array of specialization constant value descriptions
+__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in] array of specialization constant value descriptions
 ) {
-    auto pfnSetSpecializationConstants = context.urDdiTable.Kernel.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        context.urDdiTable.Kernel.pfnSetSpecializationConstants;
 
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2162,10 +2232,10 @@ urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
-    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_native_handle_t
+        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Kernel.pfnGetNativeHandle;
 
@@ -2188,13 +2258,14 @@ urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to the handle of the kernel object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Kernel.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2219,13 +2290,14 @@ urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
-    size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out][optional] value of the queue property
+    size_t *
+        pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
     auto pfnGetInfo = context.urDdiTable.Queue.pfnGetInfo;
 
@@ -2243,22 +2315,24 @@ urQueueGetInfo(
         }
     }
 
-    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
+                      pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_queue_property_t *
+        pProps, ///< [in][optional] specifies a list of queue properties and their
+                ///< corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to handle of queue object created
 ) {
     auto pfnCreate = context.urDdiTable.Queue.pfnCreate;
 
@@ -2285,8 +2359,7 @@ urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL
-urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     auto pfnRetain = context.urDdiTable.Queue.pfnRetain;
@@ -2306,8 +2379,7 @@ urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL
-urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     auto pfnRelease = context.urDdiTable.Queue.pfnRelease;
@@ -2327,10 +2399,10 @@ urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
-    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_native_handle_t
+        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Queue.pfnGetNativeHandle;
 
@@ -2353,13 +2425,14 @@ urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to the handle of the queue object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Queue.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2384,8 +2457,7 @@ urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL
-urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = context.urDdiTable.Queue.pfnFinish;
@@ -2405,8 +2477,7 @@ urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL
-urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = context.urDdiTable.Queue.pfnFlush;
@@ -2426,13 +2497,13 @@ urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize, ///< [in] size in bytes of the event property value
+    void *pPropValue,     ///< [out][optional] value of the event property
+    size_t
+        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
 
@@ -2450,19 +2521,22 @@ urEventGetInfo(
         }
     }
 
-    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
+                      pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,     ///< [in] handle of the event object
-    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
-                                  ///< propValue
+__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_profiling_info_t
+        propName, ///< [in] the name of the profiling property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the profiling property value
+    void *pPropValue,  ///< [out][optional] value of the profiling property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
 
@@ -2480,16 +2554,17 @@ urEventGetProfilingInfo(
         }
     }
 
-    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
+                               pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL
-urEventWait(
-    uint32_t numEvents,                      ///< [in] number of events in the event list
-    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                             ///< completion
+__urdlllocal ur_result_t UR_APICALL urEventWait(
+    uint32_t numEvents, ///< [in] number of events in the event list
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     auto pfnWait = context.urDdiTable.Event.pfnWait;
 
@@ -2508,8 +2583,7 @@ urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL
-urEventRetain(
+__urdlllocal ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRetain = context.urDdiTable.Event.pfnRetain;
@@ -2529,8 +2603,7 @@ urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL
-urEventRelease(
+__urdlllocal ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRelease = context.urDdiTable.Event.pfnRelease;
@@ -2550,10 +2623,10 @@ urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventGetNativeHandle(
-    ur_event_handle_t hEvent,         ///< [in] handle of the event.
-    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ///< [in] handle of the event.
+    ur_native_handle_t
+        *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     auto pfnGetNativeHandle = context.urDdiTable.Event.pfnGetNativeHandle;
 
@@ -2576,13 +2649,14 @@ urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t
+        *phEvent ///< [out] pointer to the handle of the event object created.
 ) {
-    auto pfnCreateWithNativeHandle = context.urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        context.urDdiTable.Event.pfnCreateWithNativeHandle;
 
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2607,12 +2681,12 @@ urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL
-urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = context.urDdiTable.Event.pfnSetCallback;
 
@@ -2639,29 +2713,34 @@ urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
-    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                              ///< work-group work-items
-    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< offset used to calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< number of global work-items in workDim that will execute the kernel
-                                              ///< function
-    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
-                                              ///< specify the number of local work-items forming a work-group that will
-                                              ///< execute the kernel function.
-                                              ///< If nullptr, the runtime implementation will choose the work-group
-                                              ///< size.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -2695,22 +2774,25 @@ urEnqueueKernelLaunch(
         }
     }
 
-    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
+                           pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList,
+                           phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
 
@@ -2737,19 +2819,21 @@ urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnEventsWaitWithBarrier = context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier =
+        context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
 
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -2769,26 +2853,28 @@ urEnqueueEventsWaitWithBarrier(
         }
     }
 
-    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
+                                    phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being read
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being read
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -2818,26 +2904,30 @@ urEnqueueMemBufferRead(
         }
     }
 
-    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
+                            numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being written
-    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being written
+    const void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -2867,33 +2957,40 @@ urEnqueueMemBufferWrite(
         }
     }
 
-    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
+                             numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< dst
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by dst
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
 
@@ -2934,7 +3031,8 @@ urEnqueueMemBufferReadRect(
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
-        if (bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch) {
+        if (bufferSlicePitch != 0 &&
+            bufferSlicePitch < region.height * bufferRowPitch) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
@@ -2942,7 +3040,8 @@ urEnqueueMemBufferReadRect(
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
-        if (hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch) {
+        if (hostSlicePitch != 0 &&
+            hostSlicePitch < region.height * hostRowPitch) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
@@ -2951,36 +3050,48 @@ urEnqueueMemBufferReadRect(
         }
     }
 
-    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferReadRect(
+        hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
+        numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
-                                              ///< written
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< src
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by src
-    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
+    void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferWriteRect = context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect =
+        context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
 
     if (nullptr == pfnMemBufferWriteRect) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3019,7 +3130,8 @@ urEnqueueMemBufferWriteRect(
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
-        if (bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch) {
+        if (bufferSlicePitch != 0 &&
+            bufferSlicePitch < region.height * bufferRowPitch) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
@@ -3027,7 +3139,8 @@ urEnqueueMemBufferWriteRect(
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
-        if (hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch) {
+        if (hostSlicePitch != 0 &&
+            hostSlicePitch < region.height * hostRowPitch) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
@@ -3036,26 +3149,30 @@ urEnqueueMemBufferWriteRect(
         }
     }
 
-    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWriteRect(
+        hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                              ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
+    size_t size,      ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -3085,30 +3202,38 @@ urEnqueueMemBufferCopy(
         }
     }
 
-    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
+                            dstOffset, size, numEventsInWaitList,
+                            phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t
+        region, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
@@ -3166,26 +3291,30 @@ urEnqueueMemBufferCopyRect(
         }
     }
 
-    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin,
+                                dstOrigin, region, srcRowPitch, srcSlicePitch,
+                                dstRowPitch, dstSlicePitch, numEventsInWaitList,
+                                phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    const void *pPattern,                     ///< [in] pointer to the fill pattern
-    size_t patternSize,                       ///< [in] size in bytes of the pattern
-    size_t offset,                            ///< [in] offset into the buffer
-    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    const void *pPattern,     ///< [in] pointer to the fill pattern
+    size_t patternSize,       ///< [in] size in bytes of the pattern
+    size_t offset,            ///< [in] offset into the buffer
+    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -3215,29 +3344,34 @@ urEnqueueMemBufferFill(
         }
     }
 
-    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset,
+                            size, numEventsInWaitList, phEventWaitList,
+                            phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pDst, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -3267,29 +3401,35 @@ urEnqueueMemImageRead(
         }
     }
 
-    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
+                           rowPitch, slicePitch, pDst, numEventsInWaitList,
+                           phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pSrc, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -3319,29 +3459,35 @@ urEnqueueMemImageWrite(
         }
     }
 
-    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
+                            rowPitch, slicePitch, pSrc, numEventsInWaitList,
+                            phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                              ///< image
-    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                              ///< or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -3371,28 +3517,31 @@ urEnqueueMemImageCopy(
         }
     }
 
-    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
+                           region, numEventsInWaitList, phEventWaitList,
+                           phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
-    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
-                                              ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
+    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,   ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [out][optional] return an event object that identifies this particular
+                 ///< command instance.
+    void **ppRetMap ///< [out] return mapped pointer.  TODO: move it before
+                    ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = context.urDdiTable.Enqueue.pfnMemBufferMap;
 
@@ -3426,23 +3575,27 @@ urEnqueueMemBufferMap(
         }
     }
 
-    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
+    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size,
+                           numEventsInWaitList, phEventWaitList, phEvent,
+                           ppRetMap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr,                         ///< [in] mapped host address
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t
+        hMem,         ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr, ///< [in] mapped host address
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -3472,26 +3625,31 @@ urEnqueueMemUnmap(
         }
     }
 
-    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
+                       phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    void *ptr,                                ///< [in] pointer to USM memory object
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t size,                              ///< [in] size in bytes to be set. Must be a multiple of patternSize.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    void *ptr,                ///< [in] pointer to USM memory object
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        size, ///< [in] size in bytes to be set. Must be a multiple of patternSize.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMFill = context.urDdiTable.Enqueue.pfnUSMFill;
 
@@ -3541,25 +3699,27 @@ urEnqueueUSMFill(
         }
     }
 
-    return pfnUSMFill(hQueue, ptr, patternSize, pPattern, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMFill(hQueue, ptr, patternSize, pPattern, size,
+                      numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking copy
-    void *pDst,                               ///< [in] pointer to the destination USM memory object
-    const void *pSrc,                         ///< [in] pointer to the source USM memory object
-    size_t size,                              ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool blocking,            ///< [in] blocking or non-blocking copy
+    void *pDst,       ///< [in] pointer to the destination USM memory object
+    const void *pSrc, ///< [in] pointer to the source USM memory object
+    size_t size,      ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -3593,24 +3753,26 @@ urEnqueueUSMMemcpy(
         }
     }
 
-    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
+                        phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    const void *pMem,                         ///< [in] pointer to the USM memory object
-    size_t size,                              ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
+    const void *pMem,               ///< [in] pointer to the USM memory object
+    size_t size,                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -3644,19 +3806,20 @@ urEnqueueUSMPrefetch(
         }
     }
 
-    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
+                          phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    const void *pMem,          ///< [in] pointer to the USM memory object
-    size_t size,               ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
-                               ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    const void *pMem,         ///< [in] pointer to the USM memory object
+    size_t size,              ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,   ///< [in] USM memory advice
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMMemAdvise = context.urDdiTable.Enqueue.pfnUSMMemAdvise;
 
@@ -3687,24 +3850,29 @@ urEnqueueUSMMemAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    void *pMem,                               ///< [in] pointer to memory to be filled.
-    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                             ///< [in] the width in bytes of each row to fill. Must be a multiple of
-                                              ///< patternSize.
-    size_t height,                            ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    void *pMem,               ///< [in] pointer to memory to be filled.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        width, ///< [in] the width in bytes of each row to fill. Must be a multiple of
+               ///< patternSize.
+    size_t height,                ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -3766,28 +3934,32 @@ urEnqueueUSMFill2D(
         }
     }
 
-    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
+                        height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    bool blocking,                            ///< [in] indicates if this operation should block the host.
-    void *pDst,                               ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
-    const void *pSrc,                         ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
-    size_t width,                             ///< [in] the width in bytes of each row to be copied.
-    size_t height,                            ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    bool blocking, ///< [in] indicates if this operation should block the host.
+    void *pDst,    ///< [in] pointer to memory where data will be copied.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
+    const void *pSrc, ///< [in] pointer to memory to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -3837,29 +4009,36 @@ urEnqueueUSMMemcpy2D(
         }
     }
 
-    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch,
+                          width, height, numEventsInWaitList, phEventWaitList,
+                          phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                       ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite, ///< [in] indicates if this operation should block.
+    size_t count,       ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc, ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableWrite = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite =
+        context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
 
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3891,29 +4070,36 @@ urEnqueueDeviceGlobalVariableWrite(
         }
     }
 
-    return pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableWrite(
+        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                        ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst,                               ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingRead, ///< [in] indicates if this operation should block.
+    size_t count,      ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableRead = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead =
+        context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
 
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -3945,7 +4131,9 @@ urEnqueueDeviceGlobalVariableRead(
         }
     }
 
-    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead,
+                                       count, offset, pDst, numEventsInWaitList,
+                                       phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3956,10 +4144,10 @@ urEnqueueDeviceGlobalVariableRead(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetGlobalProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_global_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Global;
 
@@ -3967,8 +4155,10 @@ urGetGlobalProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -3994,10 +4184,10 @@ urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetContextProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_context_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Context;
 
@@ -4005,8 +4195,10 @@ urGetContextProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4028,10 +4220,12 @@ urGetContextProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urContextGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urContextCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urContextCreateWithNativeHandle;
 
     dditable.pfnSetExtendedDeleter = pDdiTable->pfnSetExtendedDeleter;
-    pDdiTable->pfnSetExtendedDeleter = validation_layer::urContextSetExtendedDeleter;
+    pDdiTable->pfnSetExtendedDeleter =
+        validation_layer::urContextSetExtendedDeleter;
 
     return result;
 }
@@ -4044,10 +4238,10 @@ urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetEnqueueProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_enqueue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Enqueue;
 
@@ -4055,8 +4249,10 @@ urGetEnqueueProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4069,7 +4265,8 @@ urGetEnqueueProcAddrTable(
     pDdiTable->pfnEventsWait = validation_layer::urEnqueueEventsWait;
 
     dditable.pfnEventsWaitWithBarrier = pDdiTable->pfnEventsWaitWithBarrier;
-    pDdiTable->pfnEventsWaitWithBarrier = validation_layer::urEnqueueEventsWaitWithBarrier;
+    pDdiTable->pfnEventsWaitWithBarrier =
+        validation_layer::urEnqueueEventsWaitWithBarrier;
 
     dditable.pfnMemBufferRead = pDdiTable->pfnMemBufferRead;
     pDdiTable->pfnMemBufferRead = validation_layer::urEnqueueMemBufferRead;
@@ -4078,16 +4275,19 @@ urGetEnqueueProcAddrTable(
     pDdiTable->pfnMemBufferWrite = validation_layer::urEnqueueMemBufferWrite;
 
     dditable.pfnMemBufferReadRect = pDdiTable->pfnMemBufferReadRect;
-    pDdiTable->pfnMemBufferReadRect = validation_layer::urEnqueueMemBufferReadRect;
+    pDdiTable->pfnMemBufferReadRect =
+        validation_layer::urEnqueueMemBufferReadRect;
 
     dditable.pfnMemBufferWriteRect = pDdiTable->pfnMemBufferWriteRect;
-    pDdiTable->pfnMemBufferWriteRect = validation_layer::urEnqueueMemBufferWriteRect;
+    pDdiTable->pfnMemBufferWriteRect =
+        validation_layer::urEnqueueMemBufferWriteRect;
 
     dditable.pfnMemBufferCopy = pDdiTable->pfnMemBufferCopy;
     pDdiTable->pfnMemBufferCopy = validation_layer::urEnqueueMemBufferCopy;
 
     dditable.pfnMemBufferCopyRect = pDdiTable->pfnMemBufferCopyRect;
-    pDdiTable->pfnMemBufferCopyRect = validation_layer::urEnqueueMemBufferCopyRect;
+    pDdiTable->pfnMemBufferCopyRect =
+        validation_layer::urEnqueueMemBufferCopyRect;
 
     dditable.pfnMemBufferFill = pDdiTable->pfnMemBufferFill;
     pDdiTable->pfnMemBufferFill = validation_layer::urEnqueueMemBufferFill;
@@ -4125,11 +4325,15 @@ urGetEnqueueProcAddrTable(
     dditable.pfnUSMMemcpy2D = pDdiTable->pfnUSMMemcpy2D;
     pDdiTable->pfnUSMMemcpy2D = validation_layer::urEnqueueUSMMemcpy2D;
 
-    dditable.pfnDeviceGlobalVariableWrite = pDdiTable->pfnDeviceGlobalVariableWrite;
-    pDdiTable->pfnDeviceGlobalVariableWrite = validation_layer::urEnqueueDeviceGlobalVariableWrite;
+    dditable.pfnDeviceGlobalVariableWrite =
+        pDdiTable->pfnDeviceGlobalVariableWrite;
+    pDdiTable->pfnDeviceGlobalVariableWrite =
+        validation_layer::urEnqueueDeviceGlobalVariableWrite;
 
-    dditable.pfnDeviceGlobalVariableRead = pDdiTable->pfnDeviceGlobalVariableRead;
-    pDdiTable->pfnDeviceGlobalVariableRead = validation_layer::urEnqueueDeviceGlobalVariableRead;
+    dditable.pfnDeviceGlobalVariableRead =
+        pDdiTable->pfnDeviceGlobalVariableRead;
+    pDdiTable->pfnDeviceGlobalVariableRead =
+        validation_layer::urEnqueueDeviceGlobalVariableRead;
 
     return result;
 }
@@ -4142,10 +4346,10 @@ urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetEventProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_event_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Event;
 
@@ -4153,8 +4357,10 @@ urGetEventProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4179,7 +4385,8 @@ urGetEventProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urEventGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urEventCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urEventCreateWithNativeHandle;
 
     dditable.pfnSetCallback = pDdiTable->pfnSetCallback;
     pDdiTable->pfnSetCallback = validation_layer::urEventSetCallback;
@@ -4195,10 +4402,10 @@ urGetEventProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetKernelProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_kernel_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Kernel;
 
@@ -4206,8 +4413,10 @@ urGetKernelProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4235,7 +4444,8 @@ urGetKernelProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urKernelGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urKernelCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urKernelCreateWithNativeHandle;
 
     dditable.pfnSetArgValue = pDdiTable->pfnSetArgValue;
     pDdiTable->pfnSetArgValue = validation_layer::urKernelSetArgValue;
@@ -4255,8 +4465,10 @@ urGetKernelProcAddrTable(
     dditable.pfnSetArgMemObj = pDdiTable->pfnSetArgMemObj;
     pDdiTable->pfnSetArgMemObj = validation_layer::urKernelSetArgMemObj;
 
-    dditable.pfnSetSpecializationConstants = pDdiTable->pfnSetSpecializationConstants;
-    pDdiTable->pfnSetSpecializationConstants = validation_layer::urKernelSetSpecializationConstants;
+    dditable.pfnSetSpecializationConstants =
+        pDdiTable->pfnSetSpecializationConstants;
+    pDdiTable->pfnSetSpecializationConstants =
+        validation_layer::urKernelSetSpecializationConstants;
 
     return result;
 }
@@ -4269,10 +4481,10 @@ urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetMemProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_mem_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Mem;
 
@@ -4280,8 +4492,10 @@ urGetMemProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4306,7 +4520,8 @@ urGetMemProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urMemGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urMemCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urMemCreateWithNativeHandle;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = validation_layer::urMemGetInfo;
@@ -4325,10 +4540,10 @@ urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetPlatformProcAddrTable(
-    ur_api_version_t version,         ///< [in] API version requested
-    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_platform_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Platform;
 
@@ -4336,8 +4551,10 @@ urGetPlatformProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4353,7 +4570,8 @@ urGetPlatformProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urPlatformGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urPlatformCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urPlatformCreateWithNativeHandle;
 
     dditable.pfnGetApiVersion = pDdiTable->pfnGetApiVersion;
     pDdiTable->pfnGetApiVersion = validation_layer::urPlatformGetApiVersion;
@@ -4369,10 +4587,10 @@ urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetProgramProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_program_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Program;
 
@@ -4380,8 +4598,10 @@ urGetProgramProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4391,7 +4611,8 @@ urGetProgramProcAddrTable(
     pDdiTable->pfnCreateWithIL = validation_layer::urProgramCreateWithIL;
 
     dditable.pfnCreateWithBinary = pDdiTable->pfnCreateWithBinary;
-    pDdiTable->pfnCreateWithBinary = validation_layer::urProgramCreateWithBinary;
+    pDdiTable->pfnCreateWithBinary =
+        validation_layer::urProgramCreateWithBinary;
 
     dditable.pfnBuild = pDdiTable->pfnBuild;
     pDdiTable->pfnBuild = validation_layer::urProgramBuild;
@@ -4409,7 +4630,8 @@ urGetProgramProcAddrTable(
     pDdiTable->pfnRelease = validation_layer::urProgramRelease;
 
     dditable.pfnGetFunctionPointer = pDdiTable->pfnGetFunctionPointer;
-    pDdiTable->pfnGetFunctionPointer = validation_layer::urProgramGetFunctionPointer;
+    pDdiTable->pfnGetFunctionPointer =
+        validation_layer::urProgramGetFunctionPointer;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = validation_layer::urProgramGetInfo;
@@ -4417,14 +4639,17 @@ urGetProgramProcAddrTable(
     dditable.pfnGetBuildInfo = pDdiTable->pfnGetBuildInfo;
     pDdiTable->pfnGetBuildInfo = validation_layer::urProgramGetBuildInfo;
 
-    dditable.pfnSetSpecializationConstants = pDdiTable->pfnSetSpecializationConstants;
-    pDdiTable->pfnSetSpecializationConstants = validation_layer::urProgramSetSpecializationConstants;
+    dditable.pfnSetSpecializationConstants =
+        pDdiTable->pfnSetSpecializationConstants;
+    pDdiTable->pfnSetSpecializationConstants =
+        validation_layer::urProgramSetSpecializationConstants;
 
     dditable.pfnGetNativeHandle = pDdiTable->pfnGetNativeHandle;
     pDdiTable->pfnGetNativeHandle = validation_layer::urProgramGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urProgramCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urProgramCreateWithNativeHandle;
 
     return result;
 }
@@ -4437,10 +4662,10 @@ urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetQueueProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_queue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Queue;
 
@@ -4448,8 +4673,10 @@ urGetQueueProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4471,7 +4698,8 @@ urGetQueueProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urQueueGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urQueueCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urQueueCreateWithNativeHandle;
 
     dditable.pfnFinish = pDdiTable->pfnFinish;
     pDdiTable->pfnFinish = validation_layer::urQueueFinish;
@@ -4490,10 +4718,10 @@ urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetSamplerProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_sampler_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Sampler;
 
@@ -4501,8 +4729,10 @@ urGetSamplerProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4524,7 +4754,8 @@ urGetSamplerProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urSamplerGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urSamplerCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urSamplerCreateWithNativeHandle;
 
     return result;
 }
@@ -4537,10 +4768,10 @@ urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetUSMProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.USM;
 
@@ -4548,8 +4779,10 @@ urGetUSMProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4587,10 +4820,10 @@ urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetDeviceProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_device_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     auto &dditable = validation_layer::context.urDdiTable.Device;
 
@@ -4598,8 +4831,10 @@ urGetDeviceProcAddrTable(
         return UR_RESULT_ERROR_INVALID_NULL_POINTER;
     }
 
-    if (UR_MAJOR_VERSION(validation_layer::context.version) != UR_MAJOR_VERSION(version) ||
-        UR_MINOR_VERSION(validation_layer::context.version) > UR_MINOR_VERSION(version)) {
+    if (UR_MAJOR_VERSION(validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
         return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
     }
 
@@ -4627,64 +4862,77 @@ urGetDeviceProcAddrTable(
     pDdiTable->pfnGetNativeHandle = validation_layer::urDeviceGetNativeHandle;
 
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
-    pDdiTable->pfnCreateWithNativeHandle = validation_layer::urDeviceCreateWithNativeHandle;
+    pDdiTable->pfnCreateWithNativeHandle =
+        validation_layer::urDeviceCreateWithNativeHandle;
 
     dditable.pfnGetGlobalTimestamps = pDdiTable->pfnGetGlobalTimestamps;
-    pDdiTable->pfnGetGlobalTimestamps = validation_layer::urDeviceGetGlobalTimestamps;
+    pDdiTable->pfnGetGlobalTimestamps =
+        validation_layer::urDeviceGetGlobalTimestamps;
 
     return result;
 }
 
-ur_result_t context_t::init(
-    ur_dditable_t *dditable) {
+ur_result_t context_t::init(ur_dditable_t *dditable) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &dditable->Global);
+        result = validation_layer::urGetGlobalProcAddrTable(UR_API_VERSION_0_9,
+                                                            &dditable->Global);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetContextProcAddrTable(UR_API_VERSION_0_9, &dditable->Context);
+        result = validation_layer::urGetContextProcAddrTable(
+            UR_API_VERSION_0_9, &dditable->Context);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &dditable->Enqueue);
+        result = validation_layer::urGetEnqueueProcAddrTable(
+            UR_API_VERSION_0_9, &dditable->Enqueue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetEventProcAddrTable(UR_API_VERSION_0_9, &dditable->Event);
+        result = validation_layer::urGetEventProcAddrTable(UR_API_VERSION_0_9,
+                                                           &dditable->Event);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetKernelProcAddrTable(UR_API_VERSION_0_9, &dditable->Kernel);
+        result = validation_layer::urGetKernelProcAddrTable(UR_API_VERSION_0_9,
+                                                            &dditable->Kernel);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetMemProcAddrTable(UR_API_VERSION_0_9, &dditable->Mem);
+        result = validation_layer::urGetMemProcAddrTable(UR_API_VERSION_0_9,
+                                                         &dditable->Mem);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetPlatformProcAddrTable(UR_API_VERSION_0_9, &dditable->Platform);
+        result = validation_layer::urGetPlatformProcAddrTable(
+            UR_API_VERSION_0_9, &dditable->Platform);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetProgramProcAddrTable(UR_API_VERSION_0_9, &dditable->Program);
+        result = validation_layer::urGetProgramProcAddrTable(
+            UR_API_VERSION_0_9, &dditable->Program);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetQueueProcAddrTable(UR_API_VERSION_0_9, &dditable->Queue);
+        result = validation_layer::urGetQueueProcAddrTable(UR_API_VERSION_0_9,
+                                                           &dditable->Queue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &dditable->Sampler);
+        result = validation_layer::urGetSamplerProcAddrTable(
+            UR_API_VERSION_0_9, &dditable->Sampler);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetUSMProcAddrTable(UR_API_VERSION_0_9, &dditable->USM);
+        result = validation_layer::urGetUSMProcAddrTable(UR_API_VERSION_0_9,
+                                                         &dditable->USM);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = validation_layer::urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &dditable->Device);
+        result = validation_layer::urGetDeviceProcAddrTable(UR_API_VERSION_0_9,
+                                                            &dditable->Device);
     }
 
     return result;

--- a/source/loader/linux/lib_init.cpp
+++ b/source/loader/linux/lib_init.cpp
@@ -10,7 +10,9 @@
 
 namespace ur_lib {
 
-void __attribute__((constructor)) createLibContext() { context = new context_t; }
+void __attribute__((constructor)) createLibContext() {
+    context = new context_t;
+}
 
 void __attribute__((destructor)) deleteLibContext() { delete context; }
 

--- a/source/loader/linux/loader_init.cpp
+++ b/source/loader/linux/loader_init.cpp
@@ -10,7 +10,9 @@
 
 namespace loader {
 
-void __attribute__((constructor)) createLoaderContext() { context = new context_t; }
+void __attribute__((constructor)) createLoaderContext() {
+    context = new context_t;
+}
 
 void __attribute__((destructor)) deleteLoaderContext() { delete context; }
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -25,10 +25,9 @@ ur_usm_pool_factory_t ur_usm_pool_factory;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
-__urdlllocal ur_result_t UR_APICALL
-urInit(
+__urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -52,8 +51,7 @@ urInit(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urTearDown
-__urdlllocal ur_result_t UR_APICALL
-urTearDown(
+__urdlllocal ur_result_t UR_APICALL urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -67,16 +65,18 @@ urTearDown(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGet(
-    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
-                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                       ///< will be returned.
-    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                       ///< If NumEntries is less than the number of platforms available, then
-                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -93,16 +93,21 @@ urPlatformGet(
 
         uint32_t library_platform_handle_count = 0;
 
-        result = platform.dditable.ur.Platform.pfnGet(0, nullptr, &library_platform_handle_count);
+        result = platform.dditable.ur.Platform.pfnGet(
+            0, nullptr, &library_platform_handle_count);
         if (UR_RESULT_SUCCESS != result) {
             break;
         }
 
         if (nullptr != phPlatforms && NumEntries != 0) {
-            if (total_platform_handle_count + library_platform_handle_count > NumEntries) {
-                library_platform_handle_count = NumEntries - total_platform_handle_count;
+            if (total_platform_handle_count + library_platform_handle_count >
+                NumEntries) {
+                library_platform_handle_count =
+                    NumEntries - total_platform_handle_count;
             }
-            result = platform.dditable.ur.Platform.pfnGet(library_platform_handle_count, &phPlatforms[total_platform_handle_count], nullptr);
+            result = platform.dditable.ur.Platform.pfnGet(
+                library_platform_handle_count,
+                &phPlatforms[total_platform_handle_count], nullptr);
             if (UR_RESULT_SUCCESS != result) {
                 break;
             }
@@ -110,8 +115,11 @@ urPlatformGet(
             try {
                 for (uint32_t i = 0; i < library_platform_handle_count; ++i) {
                     uint32_t platform_index = total_platform_handle_count + i;
-                    phPlatforms[platform_index] = reinterpret_cast<ur_platform_handle_t>(
-                        ur_platform_factory.getInstance(phPlatforms[platform_index], &platform.dditable));
+                    phPlatforms[platform_index] =
+                        reinterpret_cast<ur_platform_handle_t>(
+                            ur_platform_factory.getInstance(
+                                phPlatforms[platform_index],
+                                &platform.dditable));
                 }
             } catch (std::bad_alloc &) {
                 result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
@@ -130,21 +138,22 @@ urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetInfo(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetInfo = dditable->ur.Platform.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -154,15 +163,15 @@ urPlatformGetInfo(
     hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+    result =
+        pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetApiVersion(
+__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -186,15 +195,16 @@ urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetNativeHandle = dditable->ur.Platform.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -223,22 +233,26 @@ urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativePlatform)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Platform.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativePlatform)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Platform.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativePlatform = reinterpret_cast<ur_native_object_t *>(hNativePlatform)->handle;
+    hNativePlatform =
+        reinterpret_cast<ur_native_object_t *>(hNativePlatform)->handle;
 
     // forward to device-platform
     result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
@@ -260,16 +274,17 @@ urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urGetLastResult
-__urdlllocal ur_result_t UR_APICALL
-urGetLastResult(
+__urdlllocal ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetLastResult = dditable->ur.Global.pfnGetLastResult;
     if (nullptr == pfnGetLastResult) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -286,24 +301,26 @@ urGetLastResult(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGet(
+__urdlllocal ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
-                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                    ///< will be returned.
-    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                    ///< If NumEntries is less than the number of devices available, then
-                                    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
-                                    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGet = dditable->ur.Device.pfnGet;
     if (nullptr == pfnGet) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -334,17 +351,17 @@ urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetInfo(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return the info
-                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -366,9 +383,9 @@ urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRetain(
-    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+    ur_device_handle_t
+        hDevice ///< [in] handle of the device to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -390,8 +407,7 @@ urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL
-urDeviceRelease(
+__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -414,16 +430,18 @@ urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL
-urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices, ///< [in] the number of sub-devices.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -438,7 +456,8 @@ urDevicePartition(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
+    result = pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
+                          pNumDevicesRet);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -459,15 +478,16 @@ urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL
-urDeviceSelectBinary(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
-                                ///< Must greater than or equal to zero otherwise
-                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
-                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
+                          ///< Must greater than or equal to zero otherwise
+                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -489,10 +509,10 @@ urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,        ///< [in] handle of the device.
-    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ///< [in] handle of the device.
+    ur_native_handle_t
+        *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -526,23 +546,26 @@ urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urDeviceCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t
+        *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeDevice)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Device.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeDevice)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Device.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeDevice = reinterpret_cast<ur_native_object_t *>(hNativeDevice)->handle;
+    hNativeDevice =
+        reinterpret_cast<ur_native_object_t *>(hNativeDevice)->handle;
 
     // convert loader handle to platform handle
     hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
@@ -567,13 +590,14 @@ urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL
-urDeviceGetGlobalTimestamps(
+__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                                ///< correlates with the Host's global timestamp value
-    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
-                                ///< correlates with the Device's global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -595,17 +619,20 @@ urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL
-urContextCreate(
-    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
-    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
-    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
+__urdlllocal ur_result_t UR_APICALL urContextCreate(
+    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t
+        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *
+        pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t
+        *phContext ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_device_object_t *>(*phDevices)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_device_object_t *>(*phDevices)->dditable;
     auto pfnCreate = dditable->ur.Context.pfnCreate;
     if (nullptr == pfnCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -614,7 +641,8 @@ urContextCreate(
     // convert loader handles to platform handles
     auto phDevicesLocal = new ur_device_handle_t[DeviceCount];
     for (size_t i = 0; (nullptr != phDevices) && (i < DeviceCount); ++i) {
-        phDevicesLocal[i] = reinterpret_cast<ur_device_object_t *>(phDevices[i])->handle;
+        phDevicesLocal[i] =
+            reinterpret_cast<ur_device_object_t *>(phDevices[i])->handle;
     }
 
     // forward to device-platform
@@ -638,9 +666,9 @@ urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL
-urContextRetain(
-    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+__urdlllocal ur_result_t UR_APICALL urContextRetain(
+    ur_context_handle_t
+        hContext ///< [in] handle of the context to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -662,8 +690,7 @@ urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL
-urContextRelease(
+__urdlllocal ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -686,17 +713,18 @@ urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urContextGetInfo(
+__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -711,17 +739,18 @@ urContextGetInfo(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
+    result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
+                        pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -755,22 +784,26 @@ urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeContext)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Context.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeContext)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Context.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeContext = reinterpret_cast<ur_native_object_t *>(hNativeContext)->handle;
+    hNativeContext =
+        reinterpret_cast<ur_native_object_t *>(hNativeContext)->handle;
 
     // forward to device-platform
     result = pfnCreateWithNativeHandle(hNativeContext, phContext);
@@ -792,11 +825,12 @@ urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL
-urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,             ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_context_extended_deleter_t
+        pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -818,14 +852,14 @@ urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemImageCreate(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    void *pHost,                           ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    void *pHost,           ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -840,7 +874,8 @@ urMemImageCreate(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
+    result =
+        pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -859,13 +894,13 @@ urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferCreate(
+__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
-    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
-    void *pHost,                  ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    size_t size, ///< [in] size in bytes of the memory object to be allocated
+    void *pHost, ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t
+        *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -899,8 +934,7 @@ urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL
-urMemRetain(
+__urdlllocal ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -923,8 +957,7 @@ urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL
-urMemRelease(
+__urdlllocal ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -947,13 +980,15 @@ urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL
-urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t
+        hBuffer,          ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
-    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *
+        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -968,7 +1003,8 @@ urMemBufferPartition(
     hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
 
     // forward to device-platform
-    result = pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
+    result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
+                                pBufferCreateInfo, phMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -987,10 +1023,10 @@ urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemGetNativeHandle(
-    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
-    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1024,16 +1060,17 @@ urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urMemCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of the mem object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeMem)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeMem)->dditable;
     auto pfnCreateWithNativeHandle = dditable->ur.Mem.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -1065,16 +1102,18 @@ urMemCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+    ur_mem_handle_t
+        hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1096,16 +1135,17 @@ urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1120,19 +1160,21 @@ urMemImageGetInfo(
     hMemory = reinterpret_cast<ur_mem_object_t *>(hMemory)->handle;
 
     // forward to device-platform
-    result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+    result =
+        pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_property_t
+        *pProps, ///< [in] specifies a list of sampler property names and their
+                 ///< corresponding values.
+    ur_sampler_handle_t
+        *phSampler ///< [out] pointer to handle of sampler object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1166,9 +1208,9 @@ urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRetain(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1190,9 +1232,9 @@ urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL
-urSamplerRelease(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1214,13 +1256,14 @@ urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetInfo(
+__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
-    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
+    size_t *
+        pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1235,17 +1278,18 @@ urSamplerGetInfo(
     hSampler = reinterpret_cast<ur_sampler_object_t *>(hSampler)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+    result =
+        pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1279,23 +1323,27 @@ urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeSampler)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Sampler.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeSampler)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Sampler.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeSampler = reinterpret_cast<ur_native_object_t *>(hNativeSampler)->handle;
+    hNativeSampler =
+        reinterpret_cast<ur_native_object_t *>(hNativeSampler)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -1320,17 +1368,19 @@ urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMHostAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM host memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1345,7 +1395,8 @@ urUSMHostAlloc(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // convert loader handle to platform handle
-    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle : nullptr;
+    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle
+                  : nullptr;
 
     // forward to device-platform
     result = pfnHostAlloc(hContext, pUSMDesc, pool, size, align, ppMem);
@@ -1355,18 +1406,20 @@ urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMDeviceAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM device memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1384,28 +1437,32 @@ urUSMDeviceAlloc(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // convert loader handle to platform handle
-    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle : nullptr;
+    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle
+                  : nullptr;
 
     // forward to device-platform
-    result = pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    result =
+        pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL
-urUSMSharedAlloc(
+__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object.
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM shared memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object.
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1423,18 +1480,19 @@ urUSMSharedAlloc(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // convert loader handle to platform handle
-    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle : nullptr;
+    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle
+                  : nullptr;
 
     // forward to device-platform
-    result = pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    result =
+        pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL
-urUSMFree(
+__urdlllocal ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1458,14 +1516,16 @@ urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL
-urUSMGetMemAllocInfo(
+__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t
+        propName, ///< [in] the name of the USM allocation property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue, ///< [out][optional] value of the USM allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1480,19 +1540,20 @@ urUSMGetMemAllocInfo(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
+                                pPropValue, pPropValueSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolCreate(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_usm_pool_desc_t *pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
-                                   ///< ::ur_usm_pool_limits_desc_t
-    ur_usm_pool_handle_t *ppPool   ///< [out] pointer to USM memory pool
+__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_pool_desc_t *
+        pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
+                   ///< ::ur_usm_pool_limits_desc_t
+    ur_usm_pool_handle_t *ppPool ///< [out] pointer to USM memory pool
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1526,8 +1587,7 @@ urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolDestroy
-__urdlllocal ur_result_t UR_APICALL
-urUSMPoolDestroy(
+__urdlllocal ur_result_t UR_APICALL urUSMPoolDestroy(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_handle_t pPool    ///< [in] pointer to USM memory pool
 ) {
@@ -1554,13 +1614,14 @@ urUSMPoolDestroy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithIL(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    const void *pIL,                            ///< [in] pointer to IL binary.
-    size_t length,                              ///< [in] length of `pIL` in bytes.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const void *pIL,              ///< [in] pointer to IL binary.
+    size_t length,                ///< [in] length of `pIL` in bytes.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1594,14 +1655,16 @@ urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithBinary(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
-    size_t size,                                ///< [in] size in bytes.
-    const uint8_t *pBinary,                     ///< [in] pointer to binary.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_device_handle_t
+        hDevice,            ///< [in] handle to device associated with binary.
+    size_t size,            ///< [in] size in bytes.
+    const uint8_t *pBinary, ///< [in] pointer to binary.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1619,7 +1682,8 @@ urProgramCreateWithBinary(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
+    result = pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties,
+                                 phProgram);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -1638,11 +1702,11 @@ urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL
-urProgramBuild(
+__urdlllocal ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1667,11 +1731,12 @@ urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL
-urProgramCompile(
+__urdlllocal ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    ur_program_handle_t hProgram, ///< [in][out] handle of the program to compile.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    ur_program_handle_t
+        hProgram, ///< [in][out] handle of the program to compile.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1696,13 +1761,15 @@ urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL
-urProgramLink(
-    ur_context_handle_t hContext,          ///< [in] handle of the context instance.
-    uint32_t count,                        ///< [in] number of program handles in `phPrograms`.
-    const ur_program_handle_t *phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
-    const char *pOptions,                  ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram         ///< [out] pointer to handle of program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramLink(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance.
+    uint32_t count, ///< [in] number of program handles in `phPrograms`.
+    const ur_program_handle_t *
+        phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1719,7 +1786,8 @@ urProgramLink(
     // convert loader handles to platform handles
     auto phProgramsLocal = new ur_program_handle_t[count];
     for (size_t i = 0; (nullptr != phPrograms) && (i < count); ++i) {
-        phProgramsLocal[i] = reinterpret_cast<ur_program_object_t *>(phPrograms[i])->handle;
+        phProgramsLocal[i] =
+            reinterpret_cast<ur_program_object_t *>(phPrograms[i])->handle;
     }
 
     // forward to device-platform
@@ -1743,8 +1811,7 @@ urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL
-urProgramRetain(
+__urdlllocal ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1767,8 +1834,7 @@ urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL
-urProgramRelease(
+__urdlllocal ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1791,14 +1857,17 @@ urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
-                                  ///< The program must already be built to the specified device, or
-                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
-    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program to search for function in.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1816,24 +1885,26 @@ urProgramGetFunctionPointer(
     hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
 
     // forward to device-platform
-    result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
+    result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
+                                   ppFunctionPointer);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetInfo(
+__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName,   ///< [in] name of the Program property to query
-    size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
-                                  ///< If propSize is not equal to or greater than the real number of bytes
-                                  ///< needed to return
-                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+    ur_program_info_t propName, ///< [in] name of the Program property to query
+    size_t propSize,            ///< [in] the size of the Program property.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1848,25 +1919,28 @@ urProgramGetInfo(
     hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+    result =
+        pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
-    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
-    size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
-                                      ///< If propSize is not equal to or greater than the real number of bytes
-                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
-    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
-                                      ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
+    ur_program_build_info_t
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1884,25 +1958,27 @@ urProgramGetBuildInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
+                             pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in][range(0, count)] array of specialization constant value
-                                                            ///< descriptions
+__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in][range(0, count)] array of specialization constant value
+                       ///< descriptions
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_program_object_t *>(hProgram)->dditable;
-    auto pfnSetSpecializationConstants = dditable->ur.Program.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        dditable->ur.Program.pfnSetSpecializationConstants;
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1918,10 +1994,10 @@ urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1955,23 +2031,27 @@ urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeProgram)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Program.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeProgram)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Program.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeProgram = reinterpret_cast<ur_native_object_t *>(hNativeProgram)->handle;
+    hNativeProgram =
+        reinterpret_cast<ur_native_object_t *>(hNativeProgram)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -1996,11 +2076,11 @@ urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreate(
+__urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to handle of kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2034,12 +2114,12 @@ urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgValue(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,             ///< [in] size of argument type
-    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void
+        *pArgValue ///< [in] argument value represented as matching arg type.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2061,11 +2141,11 @@ urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgLocal(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2087,18 +2167,19 @@ urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return
-                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
-                                ///< queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2120,16 +2201,18 @@ urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
-    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                     ///< property.
-    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
-                                     ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_group_info_t
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2147,23 +2230,26 @@ urKernelGetGroupInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
+                             pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
-    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                         ///< property.
-    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
-                                         ///< queried by propName.
+__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2181,15 +2267,15 @@ urKernelGetSubGroupInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
+                                pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL
-urKernelRetain(
+__urdlllocal ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2212,8 +2298,7 @@ urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL
-urKernelRelease(
+__urdlllocal ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2236,12 +2321,12 @@ urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgPointer(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
-                                ///< value. If null then argument value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2263,13 +2348,13 @@ urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetExecInfo(
+__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                    ///< property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2291,10 +2376,9 @@ urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
-    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2320,11 +2404,10 @@ urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetArgMemObj(
+__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2339,7 +2422,9 @@ urKernelSetArgMemObj(
     hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
 
     // convert loader handle to platform handle
-    hArgValue = (hArgValue) ? reinterpret_cast<ur_mem_object_t *>(hArgValue)->handle : nullptr;
+    hArgValue = (hArgValue)
+                    ? reinterpret_cast<ur_mem_object_t *>(hArgValue)->handle
+                    : nullptr;
 
     // forward to device-platform
     result = pfnSetArgMemObj(hKernel, argIndex, hArgValue);
@@ -2349,17 +2434,18 @@ urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL
-urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in] array of specialization constant value descriptions
+__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in] array of specialization constant value descriptions
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_kernel_object_t *>(hKernel)->dditable;
-    auto pfnSetSpecializationConstants = dditable->ur.Kernel.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        dditable->ur.Kernel.pfnSetSpecializationConstants;
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2375,10 +2461,10 @@ urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
-    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_native_handle_t
+        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2412,23 +2498,26 @@ urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urKernelCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to the handle of the kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeKernel)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Kernel.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeKernel)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Kernel.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hNativeKernel = reinterpret_cast<ur_native_object_t *>(hNativeKernel)->handle;
+    hNativeKernel =
+        reinterpret_cast<ur_native_object_t *>(hNativeKernel)->handle;
 
     // convert loader handle to platform handle
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
@@ -2453,13 +2542,14 @@ urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetInfo(
+__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
-    size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out][optional] value of the queue property
+    size_t *
+        pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2474,24 +2564,26 @@ urQueueGetInfo(
     hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+    result =
+        pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_queue_property_t *
+        pProps, ///< [in][optional] specifies a list of queue properties and their
+                ///< corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2528,8 +2620,7 @@ urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL
-urQueueRetain(
+__urdlllocal ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2552,8 +2643,7 @@ urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL
-urQueueRelease(
+__urdlllocal ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2576,10 +2666,10 @@ urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
-    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_native_handle_t
+        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2613,17 +2703,19 @@ urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urQueueCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to the handle of the queue object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeQueue)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Queue.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeQueue)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Queue.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2654,8 +2746,7 @@ urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL
-urQueueFinish(
+__urdlllocal ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2678,8 +2769,7 @@ urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL
-urQueueFlush(
+__urdlllocal ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2702,13 +2792,13 @@ urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetInfo(
+__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize, ///< [in] size in bytes of the event property value
+    void *pPropValue,     ///< [out][optional] value of the event property
+    size_t
+        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2723,21 +2813,24 @@ urEventGetInfo(
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
+                        pPropValueSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL
-urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,     ///< [in] handle of the event object
-    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
-                                  ///< propValue
+__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_profiling_info_t
+        propName, ///< [in] the name of the profiling property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the profiling property value
+    void *pPropValue,  ///< [out][optional] value of the profiling property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2752,23 +2845,25 @@ urEventGetProfilingInfo(
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;
 
     // forward to device-platform
-    result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
+                                 pPropValueSizeRet);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL
-urEventWait(
-    uint32_t numEvents,                      ///< [in] number of events in the event list
-    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                             ///< completion
+__urdlllocal ur_result_t UR_APICALL urEventWait(
+    uint32_t numEvents, ///< [in] number of events in the event list
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_event_object_t *>(*phEventWaitList)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_event_object_t *>(*phEventWaitList)->dditable;
     auto pfnWait = dditable->ur.Event.pfnWait;
     if (nullptr == pfnWait) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -2777,7 +2872,8 @@ urEventWait(
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEvents];
     for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEvents); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
@@ -2789,8 +2885,7 @@ urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL
-urEventRetain(
+__urdlllocal ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2813,8 +2908,7 @@ urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL
-urEventRelease(
+__urdlllocal ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2837,10 +2931,10 @@ urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventGetNativeHandle(
-    ur_event_handle_t hEvent,         ///< [in] handle of the event.
-    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ///< [in] handle of the event.
+    ur_native_handle_t
+        *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2874,17 +2968,19 @@ urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL
-urEventCreateWithNativeHandle(
+__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t
+        *phEvent ///< [out] pointer to the handle of the event object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_native_object_t *>(hNativeEvent)->dditable;
-    auto pfnCreateWithNativeHandle = dditable->ur.Event.pfnCreateWithNativeHandle;
+    auto dditable =
+        reinterpret_cast<ur_native_object_t *>(hNativeEvent)->dditable;
+    auto pfnCreateWithNativeHandle =
+        dditable->ur.Event.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2915,12 +3011,12 @@ urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL
-urEventSetCallback(
+__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2942,29 +3038,34 @@ urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
-    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                              ///< work-group work-items
-    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< offset used to calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< number of global work-items in workDim that will execute the kernel
-                                              ///< function
-    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
-                                              ///< specify the number of local work-items forming a work-group that will
-                                              ///< execute the kernel function.
-                                              ///< If nullptr, the runtime implementation will choose the work-group
-                                              ///< size.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2983,12 +3084,16 @@ urEnqueueKernelLaunch(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
+                             pGlobalWorkSize, pLocalWorkSize,
+                             numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3010,17 +3115,18 @@ urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3036,12 +3142,15 @@ urEnqueueEventsWait(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3063,23 +3172,25 @@ urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnEventsWaitWithBarrier = dditable->ur.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier =
+        dditable->ur.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3089,12 +3200,15 @@ urEnqueueEventsWaitWithBarrier(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
+                                      phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3116,21 +3230,22 @@ urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being read
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being read
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3149,12 +3264,15 @@ urEnqueueMemBufferRead(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
+                              numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3176,21 +3294,24 @@ urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being written
-    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being written
+    const void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3209,12 +3330,16 @@ urEnqueueMemBufferWrite(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
+                          numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3236,28 +3361,34 @@ urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< dst
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by dst
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3276,12 +3407,17 @@ urEnqueueMemBufferReadRect(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferReadRect(
+        hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
+        numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3303,29 +3439,37 @@ urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
-                                              ///< written
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< src
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by src
-    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
+    void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3344,12 +3488,17 @@ urEnqueueMemBufferWriteRect(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferWriteRect(
+        hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3371,21 +3520,22 @@ urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                              ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
+    size_t size,      ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3407,12 +3557,16 @@ urEnqueueMemBufferCopy(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset,
+                         size, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3434,25 +3588,31 @@ urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t
+        region, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3474,12 +3634,17 @@ urEnqueueMemBufferCopyRect(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferCopyRect(
+        hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region,
+        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3501,21 +3666,22 @@ urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    const void *pPattern,                     ///< [in] pointer to the fill pattern
-    size_t patternSize,                       ///< [in] size in bytes of the pattern
-    size_t offset,                            ///< [in] offset into the buffer
-    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    const void *pPattern,     ///< [in] pointer to the fill pattern
+    size_t patternSize,       ///< [in] size in bytes of the pattern
+    size_t offset,            ///< [in] offset into the buffer
+    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3534,12 +3700,16 @@ urEnqueueMemBufferFill(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size,
+                         numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3561,24 +3731,27 @@ urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pDst, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3597,12 +3770,16 @@ urEnqueueMemImageRead(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
+                             rowPitch, slicePitch, pDst, numEventsInWaitList,
+                             phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3624,24 +3801,28 @@ urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pSrc, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3660,12 +3841,16 @@ urEnqueueMemImageWrite(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
+                              rowPitch, slicePitch, pSrc, numEventsInWaitList,
+                              phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3687,24 +3872,28 @@ urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                              ///< image
-    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                              ///< or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3726,12 +3915,16 @@ urEnqueueMemImageCopy(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
+                        region, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3753,23 +3946,24 @@ urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
-    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
-                                              ///< numEventsInWaitList?
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
+    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,   ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [out][optional] return an event object that identifies this particular
+                 ///< command instance.
+    void **ppRetMap ///< [out] return mapped pointer.  TODO: move it before
+                    ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3788,12 +3982,16 @@ urEnqueueMemBufferMap(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
+    result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset,
+                             size, numEventsInWaitList, phEventWaitList,
+                             phEvent, ppRetMap);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3815,18 +4013,20 @@ urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr,                         ///< [in] mapped host address
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t
+        hMem,         ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr, ///< [in] mapped host address
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3845,12 +4045,15 @@ urEnqueueMemUnmap(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
+                         phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3872,21 +4075,25 @@ urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    void *ptr,                                ///< [in] pointer to USM memory object
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t size,                              ///< [in] size in bytes to be set. Must be a multiple of patternSize.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    void *ptr,                ///< [in] pointer to USM memory object
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        size, ///< [in] size in bytes to be set. Must be a multiple of patternSize.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3902,12 +4109,15 @@ urEnqueueUSMFill(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMFill(hQueue, ptr, patternSize, pPattern, size, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMFill(hQueue, ptr, patternSize, pPattern, size,
+                        numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3929,20 +4139,21 @@ urEnqueueUSMFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking copy
-    void *pDst,                               ///< [in] pointer to the destination USM memory object
-    const void *pSrc,                         ///< [in] pointer to the source USM memory object
-    size_t size,                              ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool blocking,            ///< [in] blocking or non-blocking copy
+    void *pDst,       ///< [in] pointer to the destination USM memory object
+    const void *pSrc, ///< [in] pointer to the source USM memory object
+    size_t size,      ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3958,12 +4169,15 @@ urEnqueueUSMMemcpy(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size,
+                          numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3985,19 +4199,20 @@ urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    const void *pMem,                         ///< [in] pointer to the USM memory object
-    size_t size,                              ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
+    const void *pMem,               ///< [in] pointer to the USM memory object
+    size_t size,                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4013,12 +4228,15 @@ urEnqueueUSMPrefetch(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
+                            phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -4040,14 +4258,14 @@ urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemAdvise
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    const void *pMem,          ///< [in] pointer to the USM memory object
-    size_t size,               ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
-                               ///< command instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    const void *pMem,         ///< [in] pointer to the USM memory object
+    size_t size,              ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,   ///< [in] USM memory advice
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4083,24 +4301,29 @@ urEnqueueUSMMemAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    void *pMem,                               ///< [in] pointer to memory to be filled.
-    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                             ///< [in] the width in bytes of each row to fill. Must be a multiple of
-                                              ///< patternSize.
-    size_t height,                            ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    void *pMem,               ///< [in] pointer to memory to be filled.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        width, ///< [in] the width in bytes of each row to fill. Must be a multiple of
+               ///< patternSize.
+    size_t height,                ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4116,12 +4339,16 @@ urEnqueueUSMFill2D(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height,
+                     numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -4143,23 +4370,26 @@ urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    bool blocking,                            ///< [in] indicates if this operation should block the host.
-    void *pDst,                               ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
-    const void *pSrc,                         ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
-    size_t width,                             ///< [in] the width in bytes of each row to be copied.
-    size_t height,                            ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    bool blocking, ///< [in] indicates if this operation should block the host.
+    void *pDst,    ///< [in] pointer to memory where data will be copied.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
+    const void *pSrc, ///< [in] pointer to memory to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4175,12 +4405,16 @@ urEnqueueUSMMemcpy2D(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    result =
+        pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width,
+                       height, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -4202,28 +4436,33 @@ urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                       ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite, ///< [in] indicates if this operation should block.
+    size_t count,       ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc, ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnDeviceGlobalVariableWrite = dditable->ur.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite =
+        dditable->ur.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4236,12 +4475,16 @@ urEnqueueDeviceGlobalVariableWrite(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnDeviceGlobalVariableWrite(
+        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -4263,28 +4506,33 @@ urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                        ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst,                               ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingRead, ///< [in] indicates if this operation should block.
+    size_t count,      ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnDeviceGlobalVariableRead = dditable->ur.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead =
+        dditable->ur.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -4297,12 +4545,16 @@ urEnqueueDeviceGlobalVariableRead(
 
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0; (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] = reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
     // forward to device-platform
-    result = pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnDeviceGlobalVariableRead(
+        hQueue, hProgram, name, blockingRead, count, offset, pDst,
+        numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -4337,10 +4589,10 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetGlobalProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_global_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4382,7 +4634,8 @@ urGetGlobalProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnInit = loader::urInit;
             pDdiTable->pfnGetLastResult = loader::urGetLastResult;
@@ -4405,10 +4658,10 @@ urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetContextProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_context_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_context_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4450,15 +4703,18 @@ urGetContextProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urContextCreate;
             pDdiTable->pfnRetain = loader::urContextRetain;
             pDdiTable->pfnRelease = loader::urContextRelease;
             pDdiTable->pfnGetInfo = loader::urContextGetInfo;
             pDdiTable->pfnGetNativeHandle = loader::urContextGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urContextCreateWithNativeHandle;
-            pDdiTable->pfnSetExtendedDeleter = loader::urContextSetExtendedDeleter;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urContextCreateWithNativeHandle;
+            pDdiTable->pfnSetExtendedDeleter =
+                loader::urContextSetExtendedDeleter;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Context;
@@ -4477,10 +4733,10 @@ urGetContextProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetEnqueueProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_enqueue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_enqueue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4522,17 +4778,22 @@ urGetEnqueueProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnKernelLaunch = loader::urEnqueueKernelLaunch;
             pDdiTable->pfnEventsWait = loader::urEnqueueEventsWait;
-            pDdiTable->pfnEventsWaitWithBarrier = loader::urEnqueueEventsWaitWithBarrier;
+            pDdiTable->pfnEventsWaitWithBarrier =
+                loader::urEnqueueEventsWaitWithBarrier;
             pDdiTable->pfnMemBufferRead = loader::urEnqueueMemBufferRead;
             pDdiTable->pfnMemBufferWrite = loader::urEnqueueMemBufferWrite;
-            pDdiTable->pfnMemBufferReadRect = loader::urEnqueueMemBufferReadRect;
-            pDdiTable->pfnMemBufferWriteRect = loader::urEnqueueMemBufferWriteRect;
+            pDdiTable->pfnMemBufferReadRect =
+                loader::urEnqueueMemBufferReadRect;
+            pDdiTable->pfnMemBufferWriteRect =
+                loader::urEnqueueMemBufferWriteRect;
             pDdiTable->pfnMemBufferCopy = loader::urEnqueueMemBufferCopy;
-            pDdiTable->pfnMemBufferCopyRect = loader::urEnqueueMemBufferCopyRect;
+            pDdiTable->pfnMemBufferCopyRect =
+                loader::urEnqueueMemBufferCopyRect;
             pDdiTable->pfnMemBufferFill = loader::urEnqueueMemBufferFill;
             pDdiTable->pfnMemImageRead = loader::urEnqueueMemImageRead;
             pDdiTable->pfnMemImageWrite = loader::urEnqueueMemImageWrite;
@@ -4545,8 +4806,10 @@ urGetEnqueueProcAddrTable(
             pDdiTable->pfnUSMMemAdvise = loader::urEnqueueUSMMemAdvise;
             pDdiTable->pfnUSMFill2D = loader::urEnqueueUSMFill2D;
             pDdiTable->pfnUSMMemcpy2D = loader::urEnqueueUSMMemcpy2D;
-            pDdiTable->pfnDeviceGlobalVariableWrite = loader::urEnqueueDeviceGlobalVariableWrite;
-            pDdiTable->pfnDeviceGlobalVariableRead = loader::urEnqueueDeviceGlobalVariableRead;
+            pDdiTable->pfnDeviceGlobalVariableWrite =
+                loader::urEnqueueDeviceGlobalVariableWrite;
+            pDdiTable->pfnDeviceGlobalVariableRead =
+                loader::urEnqueueDeviceGlobalVariableRead;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Enqueue;
@@ -4565,10 +4828,10 @@ urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetEventProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_event_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_event_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4610,7 +4873,8 @@ urGetEventProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetInfo = loader::urEventGetInfo;
             pDdiTable->pfnGetProfilingInfo = loader::urEventGetProfilingInfo;
@@ -4618,7 +4882,8 @@ urGetEventProcAddrTable(
             pDdiTable->pfnRetain = loader::urEventRetain;
             pDdiTable->pfnRelease = loader::urEventRelease;
             pDdiTable->pfnGetNativeHandle = loader::urEventGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urEventCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urEventCreateWithNativeHandle;
             pDdiTable->pfnSetCallback = loader::urEventSetCallback;
         } else {
             // return pointers directly to platform's DDIs
@@ -4638,10 +4903,10 @@ urGetEventProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetKernelProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_kernel_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_kernel_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4683,7 +4948,8 @@ urGetKernelProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urKernelCreate;
             pDdiTable->pfnGetInfo = loader::urKernelGetInfo;
@@ -4692,14 +4958,16 @@ urGetKernelProcAddrTable(
             pDdiTable->pfnRetain = loader::urKernelRetain;
             pDdiTable->pfnRelease = loader::urKernelRelease;
             pDdiTable->pfnGetNativeHandle = loader::urKernelGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urKernelCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urKernelCreateWithNativeHandle;
             pDdiTable->pfnSetArgValue = loader::urKernelSetArgValue;
             pDdiTable->pfnSetArgLocal = loader::urKernelSetArgLocal;
             pDdiTable->pfnSetArgPointer = loader::urKernelSetArgPointer;
             pDdiTable->pfnSetExecInfo = loader::urKernelSetExecInfo;
             pDdiTable->pfnSetArgSampler = loader::urKernelSetArgSampler;
             pDdiTable->pfnSetArgMemObj = loader::urKernelSetArgMemObj;
-            pDdiTable->pfnSetSpecializationConstants = loader::urKernelSetSpecializationConstants;
+            pDdiTable->pfnSetSpecializationConstants =
+                loader::urKernelSetSpecializationConstants;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Kernel;
@@ -4718,10 +4986,10 @@ urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetMemProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_mem_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_mem_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4763,7 +5031,8 @@ urGetMemProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnImageCreate = loader::urMemImageCreate;
             pDdiTable->pfnBufferCreate = loader::urMemBufferCreate;
@@ -4771,7 +5040,8 @@ urGetMemProcAddrTable(
             pDdiTable->pfnRelease = loader::urMemRelease;
             pDdiTable->pfnBufferPartition = loader::urMemBufferPartition;
             pDdiTable->pfnGetNativeHandle = loader::urMemGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urMemCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urMemCreateWithNativeHandle;
             pDdiTable->pfnGetInfo = loader::urMemGetInfo;
             pDdiTable->pfnImageGetInfo = loader::urMemImageGetInfo;
         } else {
@@ -4792,10 +5062,10 @@ urGetMemProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetPlatformProcAddrTable(
-    ur_api_version_t version,         ///< [in] API version requested
-    ur_platform_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_platform_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4837,16 +5107,19 @@ urGetPlatformProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet = loader::urPlatformGet;
             pDdiTable->pfnGetInfo = loader::urPlatformGetInfo;
             pDdiTable->pfnGetNativeHandle = loader::urPlatformGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urPlatformCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urPlatformCreateWithNativeHandle;
             pDdiTable->pfnGetApiVersion = loader::urPlatformGetApiVersion;
         } else {
             // return pointers directly to platform's DDIs
-            *pDdiTable = loader::context->platforms.front().dditable.ur.Platform;
+            *pDdiTable =
+                loader::context->platforms.front().dditable.ur.Platform;
         }
     }
 
@@ -4862,10 +5135,10 @@ urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetProgramProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_program_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_program_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4907,7 +5180,8 @@ urGetProgramProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreateWithIL = loader::urProgramCreateWithIL;
             pDdiTable->pfnCreateWithBinary = loader::urProgramCreateWithBinary;
@@ -4916,12 +5190,15 @@ urGetProgramProcAddrTable(
             pDdiTable->pfnLink = loader::urProgramLink;
             pDdiTable->pfnRetain = loader::urProgramRetain;
             pDdiTable->pfnRelease = loader::urProgramRelease;
-            pDdiTable->pfnGetFunctionPointer = loader::urProgramGetFunctionPointer;
+            pDdiTable->pfnGetFunctionPointer =
+                loader::urProgramGetFunctionPointer;
             pDdiTable->pfnGetInfo = loader::urProgramGetInfo;
             pDdiTable->pfnGetBuildInfo = loader::urProgramGetBuildInfo;
-            pDdiTable->pfnSetSpecializationConstants = loader::urProgramSetSpecializationConstants;
+            pDdiTable->pfnSetSpecializationConstants =
+                loader::urProgramSetSpecializationConstants;
             pDdiTable->pfnGetNativeHandle = loader::urProgramGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urProgramCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urProgramCreateWithNativeHandle;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Program;
@@ -4940,10 +5217,10 @@ urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetQueueProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_queue_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -4985,14 +5262,16 @@ urGetQueueProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGetInfo = loader::urQueueGetInfo;
             pDdiTable->pfnCreate = loader::urQueueCreate;
             pDdiTable->pfnRetain = loader::urQueueRetain;
             pDdiTable->pfnRelease = loader::urQueueRelease;
             pDdiTable->pfnGetNativeHandle = loader::urQueueGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urQueueCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urQueueCreateWithNativeHandle;
             pDdiTable->pfnFinish = loader::urQueueFinish;
             pDdiTable->pfnFlush = loader::urQueueFlush;
         } else {
@@ -5013,10 +5292,10 @@ urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetSamplerProcAddrTable(
-    ur_api_version_t version,        ///< [in] API version requested
-    ur_sampler_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_sampler_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5058,14 +5337,16 @@ urGetSamplerProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnCreate = loader::urSamplerCreate;
             pDdiTable->pfnRetain = loader::urSamplerRetain;
             pDdiTable->pfnRelease = loader::urSamplerRelease;
             pDdiTable->pfnGetInfo = loader::urSamplerGetInfo;
             pDdiTable->pfnGetNativeHandle = loader::urSamplerGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urSamplerCreateWithNativeHandle;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urSamplerCreateWithNativeHandle;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Sampler;
@@ -5084,10 +5365,10 @@ urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetUSMProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5129,7 +5410,8 @@ urGetUSMProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnHostAlloc = loader::urUSMHostAlloc;
             pDdiTable->pfnDeviceAlloc = loader::urUSMDeviceAlloc;
@@ -5156,10 +5438,10 @@ urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetDeviceProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_device_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_device_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
 ) {
     if (loader::context->platforms.size() < 1) {
         return UR_RESULT_ERROR_UNINITIALIZED;
@@ -5201,7 +5483,8 @@ urGetDeviceProcAddrTable(
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        if ((loader::context->platforms.size() > 1) || loader::context->forceIntercept) {
+        if ((loader::context->platforms.size() > 1) ||
+            loader::context->forceIntercept) {
             // return pointers to loader's DDIs
             pDdiTable->pfnGet = loader::urDeviceGet;
             pDdiTable->pfnGetInfo = loader::urDeviceGetInfo;
@@ -5210,8 +5493,10 @@ urGetDeviceProcAddrTable(
             pDdiTable->pfnPartition = loader::urDevicePartition;
             pDdiTable->pfnSelectBinary = loader::urDeviceSelectBinary;
             pDdiTable->pfnGetNativeHandle = loader::urDeviceGetNativeHandle;
-            pDdiTable->pfnCreateWithNativeHandle = loader::urDeviceCreateWithNativeHandle;
-            pDdiTable->pfnGetGlobalTimestamps = loader::urDeviceGetGlobalTimestamps;
+            pDdiTable->pfnCreateWithNativeHandle =
+                loader::urDeviceCreateWithNativeHandle;
+            pDdiTable->pfnGetGlobalTimestamps =
+                loader::urDeviceGetGlobalTimestamps;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = loader::context->platforms.front().dditable.ur.Device;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -13,37 +13,47 @@
 namespace loader {
 ///////////////////////////////////////////////////////////////////////////////
 using ur_platform_object_t = object_t<ur_platform_handle_t>;
-using ur_platform_factory_t = singleton_factory_t<ur_platform_object_t, ur_platform_handle_t>;
+using ur_platform_factory_t =
+    singleton_factory_t<ur_platform_object_t, ur_platform_handle_t>;
 
 using ur_device_object_t = object_t<ur_device_handle_t>;
-using ur_device_factory_t = singleton_factory_t<ur_device_object_t, ur_device_handle_t>;
+using ur_device_factory_t =
+    singleton_factory_t<ur_device_object_t, ur_device_handle_t>;
 
 using ur_context_object_t = object_t<ur_context_handle_t>;
-using ur_context_factory_t = singleton_factory_t<ur_context_object_t, ur_context_handle_t>;
+using ur_context_factory_t =
+    singleton_factory_t<ur_context_object_t, ur_context_handle_t>;
 
 using ur_event_object_t = object_t<ur_event_handle_t>;
-using ur_event_factory_t = singleton_factory_t<ur_event_object_t, ur_event_handle_t>;
+using ur_event_factory_t =
+    singleton_factory_t<ur_event_object_t, ur_event_handle_t>;
 
 using ur_program_object_t = object_t<ur_program_handle_t>;
-using ur_program_factory_t = singleton_factory_t<ur_program_object_t, ur_program_handle_t>;
+using ur_program_factory_t =
+    singleton_factory_t<ur_program_object_t, ur_program_handle_t>;
 
 using ur_kernel_object_t = object_t<ur_kernel_handle_t>;
-using ur_kernel_factory_t = singleton_factory_t<ur_kernel_object_t, ur_kernel_handle_t>;
+using ur_kernel_factory_t =
+    singleton_factory_t<ur_kernel_object_t, ur_kernel_handle_t>;
 
 using ur_queue_object_t = object_t<ur_queue_handle_t>;
-using ur_queue_factory_t = singleton_factory_t<ur_queue_object_t, ur_queue_handle_t>;
+using ur_queue_factory_t =
+    singleton_factory_t<ur_queue_object_t, ur_queue_handle_t>;
 
 using ur_native_object_t = object_t<ur_native_handle_t>;
-using ur_native_factory_t = singleton_factory_t<ur_native_object_t, ur_native_handle_t>;
+using ur_native_factory_t =
+    singleton_factory_t<ur_native_object_t, ur_native_handle_t>;
 
 using ur_sampler_object_t = object_t<ur_sampler_handle_t>;
-using ur_sampler_factory_t = singleton_factory_t<ur_sampler_object_t, ur_sampler_handle_t>;
+using ur_sampler_factory_t =
+    singleton_factory_t<ur_sampler_object_t, ur_sampler_handle_t>;
 
 using ur_mem_object_t = object_t<ur_mem_handle_t>;
 using ur_mem_factory_t = singleton_factory_t<ur_mem_object_t, ur_mem_handle_t>;
 
 using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
-using ur_usm_pool_factory_t = singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
+using ur_usm_pool_factory_t =
+    singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
 
 } // namespace loader
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -37,10 +37,9 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urInit(
+ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     static ur_result_t result = UR_RESULT_SUCCESS;
     std::call_once(ur_lib::context->initOnce, [device_flags]() {
@@ -69,8 +68,7 @@ urInit(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pParams`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urTearDown(
+ur_result_t UR_APICALL urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     auto pfnTearDown = ur_lib::context->urDdiTable.Global.pfnTearDown;
@@ -99,16 +97,18 @@ urTearDown(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL
-urPlatformGet(
-    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
-                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                       ///< will be returned.
-    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                       ///< If NumEntries is less than the number of platforms available, then
-                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+ur_result_t UR_APICALL urPlatformGet(
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     auto pfnGet = ur_lib::context->urDdiTable.Platform.pfnGet;
     if (nullptr == pfnGet) {
@@ -137,23 +137,24 @@ urPlatformGet(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
-ur_result_t UR_APICALL
-urPlatformGetInfo(
+ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Platform.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
+                      pSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -171,12 +172,12 @@ urPlatformGetInfo(
 ///         + `NULL == hDriver`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
-ur_result_t UR_APICALL
-urPlatformGetApiVersion(
+ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
-    auto pfnGetApiVersion = ur_lib::context->urDdiTable.Platform.pfnGetApiVersion;
+    auto pfnGetApiVersion =
+        ur_lib::context->urDdiTable.Platform.pfnGetApiVersion;
     if (nullptr == pfnGetApiVersion) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -204,12 +205,13 @@ urPlatformGetApiVersion(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativePlatform`
-ur_result_t UR_APICALL
-urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Platform.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Platform.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -234,12 +236,14 @@ urPlatformGetNativeHandle(
 ///         + `NULL == hNativePlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
-ur_result_t UR_APICALL
-urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Platform.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -273,11 +277,11 @@ urPlatformCreateWithNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
-ur_result_t UR_APICALL
-urGetLastResult(
+ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     auto pfnGetLastResult = ur_lib::context->urDdiTable.Global.pfnGetLastResult;
     if (nullptr == pfnGetLastResult) {
@@ -314,19 +318,20 @@ urGetLastResult(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urDeviceGet(
+ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
-                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                    ///< will be returned.
-    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                    ///< If NumEntries is less than the number of devices available, then
-                                    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
-                                    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     auto pfnGet = ur_lib::context->urDdiTable.Device.pfnGet;
     if (nullptr == pfnGet) {
@@ -356,17 +361,17 @@ urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < infoType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urDeviceGetInfo(
+ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return the info
-                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Device.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -397,9 +402,9 @@ urDeviceGetInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL
-urDeviceRetain(
-    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+ur_result_t UR_APICALL urDeviceRetain(
+    ur_device_handle_t
+        hDevice ///< [in] handle of the device to get a reference of.
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Device.pfnRetain;
     if (nullptr == pfnRetain) {
@@ -427,8 +432,7 @@ urDeviceRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL
-urDeviceRelease(
+ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Device.pfnRelease;
@@ -465,23 +469,26 @@ urDeviceRelease(
 ///         + `NULL == pProperties`
 ///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
-ur_result_t UR_APICALL
-urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices, ///< [in] the number of sub-devices.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     auto pfnPartition = ur_lib::context->urDdiTable.Device.pfnPartition;
     if (nullptr == pfnPartition) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices, pNumDevicesRet);
+    return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
+                        pNumDevicesRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -508,15 +515,16 @@ urDevicePartition(
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urDeviceSelectBinary(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
-                                ///< Must greater than or equal to zero otherwise
-                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
-                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
+                          ///< Must greater than or equal to zero otherwise
+                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     auto pfnSelectBinary = ur_lib::context->urDdiTable.Device.pfnSelectBinary;
     if (nullptr == pfnSelectBinary) {
@@ -546,12 +554,13 @@ urDeviceSelectBinary(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeDevice`
-ur_result_t UR_APICALL
-urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,        ///< [in] handle of the device.
-    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ///< [in] handle of the device.
+    ur_native_handle_t
+        *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Device.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Device.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -577,13 +586,14 @@ urDeviceGetNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phDevice`
-ur_result_t UR_APICALL
-urDeviceCreateWithNativeHandle(
+ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t
+        *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Device.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Device.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -609,15 +619,17 @@ urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL
-urDeviceGetGlobalTimestamps(
+ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                                ///< correlates with the Host's global timestamp value
-    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
-                                ///< correlates with the Device's global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
-    auto pfnGetGlobalTimestamps = ur_lib::context->urDdiTable.Device.pfnGetGlobalTimestamps;
+    auto pfnGetGlobalTimestamps =
+        ur_lib::context->urDdiTable.Device.pfnGetGlobalTimestamps;
     if (nullptr == pfnGetGlobalTimestamps) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -652,12 +664,14 @@ urDeviceGetGlobalTimestamps(
 ///         + `NULL == phContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
-ur_result_t UR_APICALL
-urContextCreate(
-    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
-    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
-    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
+ur_result_t UR_APICALL urContextCreate(
+    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t
+        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *
+        pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t
+        *phContext ///< [out] pointer to handle of context object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Context.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -688,9 +702,9 @@ urContextCreate(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL
-urContextRetain(
-    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+ur_result_t UR_APICALL urContextRetain(
+    ur_context_handle_t
+        hContext ///< [in] handle of the context to get a reference of.
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Context.pfnRetain;
     if (nullptr == pfnRetain) {
@@ -718,8 +732,7 @@ urContextRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL
-urContextRelease(
+ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Context.pfnRelease;
@@ -749,24 +762,26 @@ urContextRelease(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < ContextInfoType`
-ur_result_t UR_APICALL
-urContextGetInfo(
+ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Context.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo, pPropSizeRet);
+    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
+                      pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -789,12 +804,13 @@ urContextGetInfo(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeContext`
-ur_result_t UR_APICALL
-urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Context.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Context.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -819,12 +835,14 @@ urContextGetNativeHandle(
 ///         + `NULL == hNativeContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phContext`
-ur_result_t UR_APICALL
-urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Context.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Context.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -853,13 +871,15 @@ urContextCreateWithNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
-ur_result_t UR_APICALL
-urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,             ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_context_extended_deleter_t
+        pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
-    auto pfnSetExtendedDeleter = ur_lib::context->urDdiTable.Context.pfnSetExtendedDeleter;
+    auto pfnSetExtendedDeleter =
+        ur_lib::context->urDdiTable.Context.pfnSetExtendedDeleter;
     if (nullptr == pfnSetExtendedDeleter) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -897,21 +917,22 @@ urContextSetExtendedDeleter(
 ///         + `pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemImageCreate(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    void *pHost,                           ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    void *pHost,           ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
 ) {
     auto pfnImageCreate = ur_lib::context->urDdiTable.Mem.pfnImageCreate;
     if (nullptr == pfnImageCreate) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
+    return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost,
+                          phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -939,13 +960,13 @@ urMemImageCreate(
 ///         + `pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemBufferCreate(
+ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
-    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
-    void *pHost,                  ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    size_t size, ///< [in] size in bytes of the memory object to be allocated
+    void *pHost, ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t
+        *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
     auto pfnBufferCreate = ur_lib::context->urDdiTable.Mem.pfnBufferCreate;
     if (nullptr == pfnBufferCreate) {
@@ -976,8 +997,7 @@ urMemBufferCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemRetain(
+ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Mem.pfnRetain;
@@ -1004,8 +1024,7 @@ urMemRetain(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urMemRelease(
+ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Mem.pfnRelease;
@@ -1042,20 +1061,24 @@ urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t
+        hBuffer,          ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
-    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *
+        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
-    auto pfnBufferPartition = ur_lib::context->urDdiTable.Mem.pfnBufferPartition;
+    auto pfnBufferPartition =
+        ur_lib::context->urDdiTable.Mem.pfnBufferPartition;
     if (nullptr == pfnBufferPartition) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnBufferPartition(hBuffer, flags, bufferCreateType, pBufferCreateInfo, phMem);
+    return pfnBufferPartition(hBuffer, flags, bufferCreateType,
+                              pBufferCreateInfo, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1078,12 +1101,13 @@ urMemBufferPartition(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeMem`
-ur_result_t UR_APICALL
-urMemGetNativeHandle(
-    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
-    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+ur_result_t UR_APICALL urMemGetNativeHandle(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Mem.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Mem.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1109,13 +1133,14 @@ urMemGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phMem`
-ur_result_t UR_APICALL
-urMemCreateWithNativeHandle(
+ur_result_t UR_APICALL urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of the mem object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Mem.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Mem.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1141,16 +1166,18 @@ urMemCreateWithNativeHandle(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
-ur_result_t UR_APICALL
-urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+ur_result_t UR_APICALL urMemGetInfo(
+    ur_mem_handle_t
+        hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Mem.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -1178,23 +1205,25 @@ urMemGetInfo(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
-ur_result_t UR_APICALL
-urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     auto pfnImageGetInfo = ur_lib::context->urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr == pfnImageGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
+                           pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1224,12 +1253,13 @@ urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_property_t
+        *pProps, ///< [in] specifies a list of sampler property names and their
+                 ///< corresponding values.
+    ur_sampler_handle_t
+        *phSampler ///< [out] pointer to handle of sampler object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Sampler.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -1256,9 +1286,9 @@ urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerRetain(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+ur_result_t UR_APICALL urSamplerRetain(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to get access
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Sampler.pfnRetain;
     if (nullptr == pfnRetain) {
@@ -1285,9 +1315,9 @@ urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerRelease(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+ur_result_t UR_APICALL urSamplerRelease(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Sampler.pfnRelease;
     if (nullptr == pfnRelease) {
@@ -1319,20 +1349,22 @@ urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerGetInfo(
+ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
-    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
+    size_t *
+        pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Sampler.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
+                      pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1355,12 +1387,13 @@ urSamplerGetInfo(
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeSampler`
-ur_result_t UR_APICALL
-urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Sampler.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Sampler.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1386,13 +1419,15 @@ urSamplerGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phSampler`
-ur_result_t UR_APICALL
-urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Sampler.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Sampler.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -1432,17 +1467,19 @@ urSamplerCreateWithNativeHandle(
 ///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urUSMHostAlloc(
+ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM host memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = ur_lib::context->urDdiTable.USM.pfnHostAlloc;
     if (nullptr == pfnHostAlloc) {
@@ -1485,25 +1522,28 @@ urUSMHostAlloc(
 ///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urUSMDeviceAlloc(
+ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM device memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = ur_lib::context->urDdiTable.USM.pfnDeviceAlloc;
     if (nullptr == pfnDeviceAlloc) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    return pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, align,
+                          ppMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1539,25 +1579,28 @@ urUSMDeviceAlloc(
 ///         + If `UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT` and `UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT` are both false.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urUSMSharedAlloc(
+ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object.
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM shared memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object.
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = ur_lib::context->urDdiTable.USM.pfnSharedAlloc;
     if (nullptr == pfnSharedAlloc) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align, ppMem);
+    return pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, align,
+                          ppMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1573,8 +1616,7 @@ urUSMSharedAlloc(
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urUSMFree(
+ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1603,21 +1645,25 @@ urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urUSMGetMemAllocInfo(
+ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t
+        propName, ///< [in] the name of the USM allocation property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue, ///< [out][optional] value of the USM allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
-    auto pfnGetMemAllocInfo = ur_lib::context->urDdiTable.USM.pfnGetMemAllocInfo;
+    auto pfnGetMemAllocInfo =
+        ur_lib::context->urDdiTable.USM.pfnGetMemAllocInfo;
     if (nullptr == pfnGetMemAllocInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
+                              pPropValue, pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1640,12 +1686,12 @@ urUSMGetMemAllocInfo(
 ///         + `0x1 < pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urUSMPoolCreate(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_usm_pool_desc_t *pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
-                                   ///< ::ur_usm_pool_limits_desc_t
-    ur_usm_pool_handle_t *ppPool   ///< [out] pointer to USM memory pool
+ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_pool_desc_t *
+        pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
+                   ///< ::ur_usm_pool_limits_desc_t
+    ur_usm_pool_handle_t *ppPool ///< [out] pointer to USM memory pool
 ) {
     auto pfnPoolCreate = ur_lib::context->urDdiTable.USM.pfnPoolCreate;
     if (nullptr == pfnPoolCreate) {
@@ -1671,8 +1717,7 @@ urUSMPoolCreate(
 ///         + `NULL == hContext`
 ///         + `NULL == pPool`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urUSMPoolDestroy(
+ur_result_t UR_APICALL urUSMPoolDestroy(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_handle_t pPool    ///< [in] pointer to USM memory pool
 ) {
@@ -1710,13 +1755,14 @@ urUSMPoolDestroy(
 ///         + If `pIL` is not a valid IL binary for devices in `hContext`.
 ///     - ::UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE
 ///         + If devices in `hContext` don't have the capability to compile an IL binary at runtime.
-ur_result_t UR_APICALL
-urProgramCreateWithIL(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    const void *pIL,                            ///< [in] pointer to IL binary.
-    size_t length,                              ///< [in] length of `pIL` in bytes.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
+ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const void *pIL,              ///< [in] pointer to IL binary.
+    size_t length,                ///< [in] length of `pIL` in bytes.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     auto pfnCreateWithIL = ur_lib::context->urDdiTable.Program.pfnCreateWithIL;
     if (nullptr == pfnCreateWithIL) {
@@ -1751,21 +1797,25 @@ urProgramCreateWithIL(
 ///         + `NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_NATIVE_BINARY
 ///         + If `pBinary` isn't a valid binary for `hDevice.`
-ur_result_t UR_APICALL
-urProgramCreateWithBinary(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
-    size_t size,                                ///< [in] size in bytes.
-    const uint8_t *pBinary,                     ///< [in] pointer to binary.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
+ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_device_handle_t
+        hDevice,            ///< [in] handle to device associated with binary.
+    size_t size,            ///< [in] size in bytes.
+    const uint8_t *pBinary, ///< [in] pointer to binary.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of Program object created.
 ) {
-    auto pfnCreateWithBinary = ur_lib::context->urDdiTable.Program.pfnCreateWithBinary;
+    auto pfnCreateWithBinary =
+        ur_lib::context->urDdiTable.Program.pfnCreateWithBinary;
     if (nullptr == pfnCreateWithBinary) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties, phProgram);
+    return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties,
+                               phProgram);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1793,11 +1843,11 @@ urProgramCreateWithBinary(
 ///         + If `hProgram` isn't a valid program object.
 ///     - ::UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE
 ///         + If an error occurred when building `hProgram`.
-ur_result_t UR_APICALL
-urProgramBuild(
+ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     auto pfnBuild = ur_lib::context->urDdiTable.Program.pfnBuild;
     if (nullptr == pfnBuild) {
@@ -1831,11 +1881,12 @@ urProgramBuild(
 ///         + If `hProgram` isn't a valid program object.
 ///     - ::UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE
 ///         + If an error occurred while compiling `hProgram`.
-ur_result_t UR_APICALL
-urProgramCompile(
+ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    ur_program_handle_t hProgram, ///< [in][out] handle of the program to compile.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    ur_program_handle_t
+        hProgram, ///< [in][out] handle of the program to compile.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     auto pfnCompile = ur_lib::context->urDdiTable.Program.pfnCompile;
     if (nullptr == pfnCompile) {
@@ -1872,13 +1923,15 @@ urProgramCompile(
 ///         + If one of the programs in `phPrograms` isn't a valid program object.
 ///     - ::UR_RESULT_ERROR_PROGRAM_LINK_FAILURE
 ///         + If an error occurred while linking `phPrograms`.
-ur_result_t UR_APICALL
-urProgramLink(
-    ur_context_handle_t hContext,          ///< [in] handle of the context instance.
-    uint32_t count,                        ///< [in] number of program handles in `phPrograms`.
-    const ur_program_handle_t *phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
-    const char *pOptions,                  ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram         ///< [out] pointer to handle of program object created.
+ur_result_t UR_APICALL urProgramLink(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance.
+    uint32_t count, ///< [in] number of program handles in `phPrograms`.
+    const ur_program_handle_t *
+        phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     auto pfnLink = ur_lib::context->urDdiTable.Program.pfnLink;
     if (nullptr == pfnLink) {
@@ -1907,8 +1960,7 @@ urProgramLink(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL
-urProgramRetain(
+ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Program.pfnRetain;
@@ -1938,8 +1990,7 @@ urProgramRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL
-urProgramRelease(
+ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Program.pfnRelease;
@@ -1976,21 +2027,26 @@ urProgramRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pFunctionName`
 ///         + `NULL == ppFunctionPointer`
-ur_result_t UR_APICALL
-urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
-                                  ///< The program must already be built to the specified device, or
-                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
-    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program to search for function in.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
-    auto pfnGetFunctionPointer = ur_lib::context->urDdiTable.Program.pfnGetFunctionPointer;
+    auto pfnGetFunctionPointer =
+        ur_lib::context->urDdiTable.Program.pfnGetFunctionPointer;
     if (nullptr == pfnGetFunctionPointer) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName, ppFunctionPointer);
+    return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
+                                 ppFunctionPointer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2008,17 +2064,18 @@ urProgramGetFunctionPointer(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
-ur_result_t UR_APICALL
-urProgramGetInfo(
+ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName,   ///< [in] name of the Program property to query
-    size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
-                                  ///< If propSize is not equal to or greater than the real number of bytes
-                                  ///< needed to return
-                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+    ur_program_info_t propName, ///< [in] name of the Program property to query
+    size_t propSize,            ///< [in] the size of the Program property.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Program.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -2044,25 +2101,28 @@ urProgramGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
-ur_result_t UR_APICALL
-urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
-    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
-    size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
-                                      ///< If propSize is not equal to or greater than the real number of bytes
-                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
-    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
-                                      ///< queried by propName.
+ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
+    ur_program_build_info_t
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetBuildInfo = ur_lib::context->urDdiTable.Program.pfnGetBuildInfo;
     if (nullptr == pfnGetBuildInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
+                           pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2087,14 +2147,15 @@ urProgramGetBuildInfo(
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + `count == 0`
-ur_result_t UR_APICALL
-urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in][range(0, count)] array of specialization constant value
-                                                            ///< descriptions
+ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in][range(0, count)] array of specialization constant value
+                       ///< descriptions
 ) {
-    auto pfnSetSpecializationConstants = ur_lib::context->urDdiTable.Program.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        ur_lib::context->urDdiTable.Program.pfnSetSpecializationConstants;
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2122,12 +2183,13 @@ urProgramSetSpecializationConstants(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeProgram`
-ur_result_t UR_APICALL
-urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Program.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Program.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2153,13 +2215,15 @@ urProgramGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL
-urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Program.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Program.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2185,11 +2249,11 @@ urProgramCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pKernelName`
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL
-urKernelCreate(
+ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to handle of kernel object created.
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Kernel.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -2217,12 +2281,12 @@ urKernelCreate(
 ///         + `NULL == pArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL
-urKernelSetArgValue(
+ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,             ///< [in] size of argument type
-    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void
+        *pArgValue ///< [in] argument value represented as matching arg type.
 ) {
     auto pfnSetArgValue = ur_lib::context->urDdiTable.Kernel.pfnSetArgValue;
     if (nullptr == pfnSetArgValue) {
@@ -2248,11 +2312,11 @@ urKernelSetArgValue(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL
-urKernelSetArgLocal(
+ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     auto pfnSetArgLocal = ur_lib::context->urDdiTable.Kernel.pfnSetArgLocal;
     if (nullptr == pfnSetArgLocal) {
@@ -2277,18 +2341,19 @@ urKernelSetArgLocal(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
-ur_result_t UR_APICALL
-urKernelGetInfo(
+ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return
-                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
-                                ///< queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Kernel.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
@@ -2314,23 +2379,26 @@ urKernelGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
-ur_result_t UR_APICALL
-urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
-    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                     ///< property.
-    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
-                                     ///< queried by propName.
+ur_result_t UR_APICALL urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_group_info_t
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     auto pfnGetGroupInfo = ur_lib::context->urDdiTable.Kernel.pfnGetGroupInfo;
     if (nullptr == pfnGetGroupInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
+                           pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2345,23 +2413,27 @@ urKernelGetGroupInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
-ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
-    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                         ///< property.
-    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
-                                         ///< queried by propName.
+ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
-    auto pfnGetSubGroupInfo = ur_lib::context->urDdiTable.Kernel.pfnGetSubGroupInfo;
+    auto pfnGetSubGroupInfo =
+        ur_lib::context->urDdiTable.Kernel.pfnGetSubGroupInfo;
     if (nullptr == pfnGetSubGroupInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue, pPropSizeRet);
+    return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
+                              pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2383,8 +2455,7 @@ urKernelGetSubGroupInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL
-urKernelRetain(
+ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Kernel.pfnRetain;
@@ -2414,8 +2485,7 @@ urKernelRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL
-urKernelRelease(
+ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Kernel.pfnRelease;
@@ -2446,12 +2516,12 @@ urKernelRelease(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL
-urKernelSetArgPointer(
+ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
-                                ///< value. If null then argument value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     auto pfnSetArgPointer = ur_lib::context->urDdiTable.Kernel.pfnSetArgPointer;
     if (nullptr == pfnSetArgPointer) {
@@ -2483,13 +2553,13 @@ urKernelSetArgPointer(
 ///         + `::UR_KERNEL_EXEC_INFO_USM_PTRS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-ur_result_t UR_APICALL
-urKernelSetExecInfo(
+ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                    ///< property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     auto pfnSetExecInfo = ur_lib::context->urDdiTable.Kernel.pfnSetExecInfo;
     if (nullptr == pfnSetExecInfo) {
@@ -2515,10 +2585,9 @@ urKernelSetExecInfo(
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL
-urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
-    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     auto pfnSetArgSampler = ur_lib::context->urDdiTable.Kernel.pfnSetArgSampler;
@@ -2544,11 +2613,10 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL
-urKernelSetArgMemObj(
+ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = ur_lib::context->urDdiTable.Kernel.pfnSetArgMemObj;
     if (nullptr == pfnSetArgMemObj) {
@@ -2587,13 +2655,14 @@ urKernelSetArgMemObj(
 ///         + `count == 0`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 ///         + If ::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS query is false
-ur_result_t UR_APICALL
-urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in] array of specialization constant value descriptions
+ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in] array of specialization constant value descriptions
 ) {
-    auto pfnSetSpecializationConstants = ur_lib::context->urDdiTable.Kernel.pfnSetSpecializationConstants;
+    auto pfnSetSpecializationConstants =
+        ur_lib::context->urDdiTable.Kernel.pfnSetSpecializationConstants;
     if (nullptr == pfnSetSpecializationConstants) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2621,12 +2690,13 @@ urKernelSetSpecializationConstants(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
-ur_result_t UR_APICALL
-urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
-    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_native_handle_t
+        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Kernel.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Kernel.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2652,13 +2722,14 @@ urKernelGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL
-urKernelCreateWithNativeHandle(
+ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to the handle of the kernel object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Kernel.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Kernel.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2685,20 +2756,22 @@ urKernelCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueGetInfo(
+ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
-    size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out][optional] value of the queue property
+    size_t *
+        pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Queue.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
+                      pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2723,17 +2796,18 @@ urQueueGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_queue_property_t *
+        pProps, ///< [in][optional] specifies a list of queue properties and their
+                ///< corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to handle of queue object created
 ) {
     auto pfnCreate = ur_lib::context->urDdiTable.Queue.pfnCreate;
     if (nullptr == pfnCreate) {
@@ -2764,8 +2838,7 @@ urQueueCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueRetain(
+ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Queue.pfnRetain;
@@ -2799,8 +2872,7 @@ urQueueRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueRelease(
+ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Queue.pfnRelease;
@@ -2831,12 +2903,13 @@ urQueueRelease(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeQueue`
-ur_result_t UR_APICALL
-urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
-    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_native_handle_t
+        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Queue.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Queue.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2862,13 +2935,14 @@ urQueueGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phQueue`
-ur_result_t UR_APICALL
-urQueueCreateWithNativeHandle(
+ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to the handle of the queue object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Queue.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Queue.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -2899,8 +2973,7 @@ urQueueCreateWithNativeHandle(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urQueueFinish(
+ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = ur_lib::context->urDdiTable.Queue.pfnFinish;
@@ -2933,8 +3006,7 @@ urQueueFinish(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urQueueFlush(
+ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = ur_lib::context->urDdiTable.Queue.pfnFlush;
@@ -2964,20 +3036,21 @@ urQueueFlush(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventGetInfo(
+ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize, ///< [in] size in bytes of the event property value
+    void *pPropValue,     ///< [out][optional] value of the event property
+    size_t
+        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Event.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
+                      pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3000,21 +3073,25 @@ urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,     ///< [in] handle of the event object
-    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
-                                  ///< propValue
+ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_profiling_info_t
+        propName, ///< [in] the name of the profiling property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the profiling property value
+    void *pPropValue,  ///< [out][optional] value of the profiling property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
-    auto pfnGetProfilingInfo = ur_lib::context->urDdiTable.Event.pfnGetProfilingInfo;
+    auto pfnGetProfilingInfo =
+        ur_lib::context->urDdiTable.Event.pfnGetProfilingInfo;
     if (nullptr == pfnGetProfilingInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
+                               pPropValueSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3035,11 +3112,11 @@ urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEventWait(
-    uint32_t numEvents,                      ///< [in] number of events in the event list
-    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                             ///< completion
+ur_result_t UR_APICALL urEventWait(
+    uint32_t numEvents, ///< [in] number of events in the event list
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     auto pfnWait = ur_lib::context->urDdiTable.Event.pfnWait;
     if (nullptr == pfnWait) {
@@ -3066,8 +3143,7 @@ urEventWait(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventRetain(
+ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRetain = ur_lib::context->urDdiTable.Event.pfnRetain;
@@ -3095,8 +3171,7 @@ urEventRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventRelease(
+ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     auto pfnRelease = ur_lib::context->urDdiTable.Event.pfnRelease;
@@ -3127,12 +3202,13 @@ urEventRelease(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeEvent`
-ur_result_t UR_APICALL
-urEventGetNativeHandle(
-    ur_event_handle_t hEvent,         ///< [in] handle of the event.
-    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ///< [in] handle of the event.
+    ur_native_handle_t
+        *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
-    auto pfnGetNativeHandle = ur_lib::context->urDdiTable.Event.pfnGetNativeHandle;
+    auto pfnGetNativeHandle =
+        ur_lib::context->urDdiTable.Event.pfnGetNativeHandle;
     if (nullptr == pfnGetNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3158,13 +3234,14 @@ urEventGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
-ur_result_t UR_APICALL
-urEventCreateWithNativeHandle(
+ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t
+        *phEvent ///< [out] pointer to the handle of the event object created.
 ) {
-    auto pfnCreateWithNativeHandle = ur_lib::context->urDdiTable.Event.pfnCreateWithNativeHandle;
+    auto pfnCreateWithNativeHandle =
+        ur_lib::context->urDdiTable.Event.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
@@ -3194,12 +3271,12 @@ urEventCreateWithNativeHandle(
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnNotify`
-ur_result_t UR_APICALL
-urEventSetCallback(
+ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     auto pfnSetCallback = ur_lib::context->urDdiTable.Event.pfnSetCallback;
     if (nullptr == pfnSetCallback) {
@@ -3238,36 +3315,43 @@ urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
-    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                              ///< work-group work-items
-    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< offset used to calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< number of global work-items in workDim that will execute the kernel
-                                              ///< function
-    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
-                                              ///< specify the number of local work-items forming a work-group that will
-                                              ///< execute the kernel function.
-                                              ///< If nullptr, the runtime implementation will choose the work-group
-                                              ///< size.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnKernelLaunch = ur_lib::context->urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr == pfnKernelLaunch) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
+                           pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList,
+                           phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3298,17 +3382,18 @@ urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnEventsWait = ur_lib::context->urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr == pfnEventsWait) {
@@ -3348,24 +3433,27 @@ urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnEventsWaitWithBarrier = ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
+    auto pfnEventsWaitWithBarrier =
+        ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr == pfnEventsWaitWithBarrier) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
+                                    phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3399,28 +3487,31 @@ urEnqueueEventsWaitWithBarrier(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being read
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being read
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferRead = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
+    auto pfnMemBufferRead =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
     if (nullptr == pfnMemBufferRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
+                            numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3454,28 +3545,33 @@ urEnqueueMemBufferRead(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being written
-    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being written
+    const void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
+    auto pfnMemBufferWrite =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
     if (nullptr == pfnMemBufferWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
+                             numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3519,35 +3615,45 @@ urEnqueueMemBufferWrite(
 ///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< dst
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by dst
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferReadRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
+    auto pfnMemBufferReadRect =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr == pfnMemBufferReadRect) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferReadRect(
+        hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
+        numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3591,36 +3697,48 @@ urEnqueueMemBufferReadRect(
 ///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
-                                              ///< written
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< src
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by src
-    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
+    void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferWriteRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
+    auto pfnMemBufferWriteRect =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr == pfnMemBufferWriteRect) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWriteRect(
+        hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3650,28 +3768,32 @@ urEnqueueMemBufferWriteRect(
 ///         + If `dstOffset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                              ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
+    size_t size,      ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
+    auto pfnMemBufferCopy =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
     if (nullptr == pfnMemBufferCopy) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset,
+                            dstOffset, size, numEventsInWaitList,
+                            phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3709,32 +3831,42 @@ urEnqueueMemBufferCopy(
 ///         + If the combination of `dstOrigin`, `region`, `dstRowPitch`, and `dstSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t
+        region, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferCopyRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
+    auto pfnMemBufferCopyRect =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr == pfnMemBufferCopyRect) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin,
+                                dstOrigin, region, srcRowPitch, srcSlicePitch,
+                                dstRowPitch, dstSlicePitch, numEventsInWaitList,
+                                phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3765,28 +3897,32 @@ urEnqueueMemBufferCopyRect(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    const void *pPattern,                     ///< [in] pointer to the fill pattern
-    size_t patternSize,                       ///< [in] size in bytes of the pattern
-    size_t offset,                            ///< [in] offset into the buffer
-    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    const void *pPattern,     ///< [in] pointer to the fill pattern
+    size_t patternSize,       ///< [in] size in bytes of the pattern
+    size_t offset,            ///< [in] offset into the buffer
+    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemBufferFill = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
+    auto pfnMemBufferFill =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
     if (nullptr == pfnMemBufferFill) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset,
+                            size, numEventsInWaitList, phEventWaitList,
+                            phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3819,31 +3955,36 @@ urEnqueueMemBufferFill(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pDst, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageRead = ur_lib::context->urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr == pfnMemImageRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageRead(hQueue, hImage, blockingRead, origin, region,
+                           rowPitch, slicePitch, pDst, numEventsInWaitList,
+                           phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3876,31 +4017,38 @@ urEnqueueMemImageRead(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pSrc, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
-    auto pfnMemImageWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
+    auto pfnMemImageWrite =
+        ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr == pfnMemImageWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageWrite(hQueue, hImage, blockingWrite, origin, region,
+                            rowPitch, slicePitch, pSrc, numEventsInWaitList,
+                            phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3927,31 +4075,37 @@ urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                              ///< image
-    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                              ///< or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemImageCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr == pfnMemImageCopy) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin, region, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
+                           region, numEventsInWaitList, phEventWaitList,
+                           phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3991,30 +4145,33 @@ urEnqueueMemImageCopy(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
-    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
-                                              ///< numEventsInWaitList?
+ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
+    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,   ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [out][optional] return an event object that identifies this particular
+                 ///< command instance.
+    void **ppRetMap ///< [out] return mapped pointer.  TODO: move it before
+                    ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferMap;
     if (nullptr == pfnMemBufferMap) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size, numEventsInWaitList, phEventWaitList, phEvent, ppRetMap);
+    return pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size,
+                           numEventsInWaitList, phEventWaitList, phEvent,
+                           ppRetMap);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4043,25 +4200,28 @@ urEnqueueMemBufferMap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr,                         ///< [in] mapped host address
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t
+        hMem,         ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr, ///< [in] mapped host address
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnMemUnmap = ur_lib::context->urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr == pfnMemUnmap) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
+                       phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4092,28 +4252,33 @@ urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    void *ptr,                                ///< [in] pointer to USM memory object
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t size,                              ///< [in] size in bytes to be set. Must be a multiple of patternSize.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    void *ptr,                ///< [in] pointer to USM memory object
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        size, ///< [in] size in bytes to be set. Must be a multiple of patternSize.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMFill = ur_lib::context->urDdiTable.Enqueue.pfnUSMFill;
     if (nullptr == pfnUSMFill) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMFill(hQueue, ptr, patternSize, pPattern, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMFill(hQueue, ptr, patternSize, pPattern, size,
+                      numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4140,27 +4305,29 @@ urEnqueueUSMFill(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking copy
-    void *pDst,                               ///< [in] pointer to the destination USM memory object
-    const void *pSrc,                         ///< [in] pointer to the source USM memory object
-    size_t size,                              ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool blocking,            ///< [in] blocking or non-blocking copy
+    void *pDst,       ///< [in] pointer to the destination USM memory object
+    const void *pSrc, ///< [in] pointer to the source USM memory object
+    size_t size,      ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMMemcpy = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr == pfnUSMMemcpy) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
+                        phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4188,26 +4355,28 @@ urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    const void *pMem,                         ///< [in] pointer to the USM memory object
-    size_t size,                              ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
+    const void *pMem,               ///< [in] pointer to the USM memory object
+    size_t size,                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMPrefetch = ur_lib::context->urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr == pfnUSMPrefetch) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
+                          phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4231,14 +4400,14 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    const void *pMem,          ///< [in] pointer to the USM memory object
-    size_t size,               ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
-                               ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    const void *pMem,         ///< [in] pointer to the USM memory object
+    size_t size,              ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,   ///< [in] USM memory advice
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     auto pfnUSMMemAdvise = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvise;
     if (nullptr == pfnUSMMemAdvise) {
@@ -4278,31 +4447,37 @@ urEnqueueUSMMemAdvise(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL
-urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    void *pMem,                               ///< [in] pointer to memory to be filled.
-    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                             ///< [in] the width in bytes of each row to fill. Must be a multiple of
-                                              ///< patternSize.
-    size_t height,                            ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    void *pMem,               ///< [in] pointer to memory to be filled.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        width, ///< [in] the width in bytes of each row to fill. Must be a multiple of
+               ///< patternSize.
+    size_t height,                ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnUSMFill2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr == pfnUSMFill2D) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
+                        height, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4333,30 +4508,35 @@ urEnqueueUSMFill2D(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL
-urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    bool blocking,                            ///< [in] indicates if this operation should block the host.
-    void *pDst,                               ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
-    const void *pSrc,                         ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
-    size_t width,                             ///< [in] the width in bytes of each row to be copied.
-    size_t height,                            ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    bool blocking, ///< [in] indicates if this operation should block the host.
+    void *pDst,    ///< [in] pointer to memory where data will be copied.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
+    const void *pSrc, ///< [in] pointer to memory to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr == pfnUSMMemcpy2D) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width, height, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch,
+                          width, height, numEventsInWaitList, phEventWaitList,
+                          phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4377,29 +4557,36 @@ urEnqueueUSMMemcpy2D(
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
-ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                       ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite, ///< [in] indicates if this operation should block.
+    size_t count,       ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc, ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableWrite = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
+    auto pfnDeviceGlobalVariableWrite =
+        ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr == pfnDeviceGlobalVariableWrite) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnDeviceGlobalVariableWrite(hQueue, hProgram, name, blockingWrite, count, offset, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableWrite(
+        hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
+        numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4420,29 +4607,36 @@ urEnqueueDeviceGlobalVariableWrite(
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
-ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                        ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst,                               ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingRead, ///< [in] indicates if this operation should block.
+    size_t count,      ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
-    auto pfnDeviceGlobalVariableRead = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
+    auto pfnDeviceGlobalVariableRead =
+        ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr == pfnDeviceGlobalVariableRead) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead, count, offset, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnDeviceGlobalVariableRead(hQueue, hProgram, name, blockingRead,
+                                       count, offset, pDst, numEventsInWaitList,
+                                       phEventWaitList, phEvent);
 }
 
 } // extern "C"

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -19,15 +19,18 @@ __urdlllocal ur_result_t context_t::urInit() {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Global);
+        result =
+            urGetGlobalProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Global);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetContextProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Context);
+        result =
+            urGetContextProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Context);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Enqueue);
+        result =
+            urGetEnqueueProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Enqueue);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -35,7 +38,8 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetKernelProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Kernel);
+        result =
+            urGetKernelProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Kernel);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -43,11 +47,13 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetPlatformProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Platform);
+        result = urGetPlatformProcAddrTable(UR_API_VERSION_0_9,
+                                            &urDdiTable.Platform);
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetProgramProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Program);
+        result =
+            urGetProgramProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Program);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -55,7 +61,8 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Sampler);
+        result =
+            urGetSamplerProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Sampler);
     }
 
     if (UR_RESULT_SUCCESS == result) {
@@ -63,7 +70,8 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
-        result = urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Device);
+        result =
+            urGetDeviceProcAddrTable(UR_API_VERSION_0_9, &urDdiTable.Device);
     }
 
     return result;

--- a/source/loader/ur_object.hpp
+++ b/source/loader/ur_object.hpp
@@ -22,8 +22,7 @@ struct dditable_t {
 };
 
 //////////////////////////////////////////////////////////////////////////
-template <typename _handle_t>
-class __urdlllocal object_t {
+template <typename _handle_t> class __urdlllocal object_t {
   public:
     using handle_t = _handle_t;
 
@@ -32,7 +31,8 @@ class __urdlllocal object_t {
 
     object_t() = delete;
 
-    object_t(handle_t _handle, dditable_t *_dditable) : handle(_handle), dditable(_dditable) {}
+    object_t(handle_t _handle, dditable_t *_dditable)
+        : handle(_handle), dditable(_dditable) {}
 
     ~object_t() = default;
 };

--- a/source/loader/windows/lib_init.cpp
+++ b/source/loader/windows/lib_init.cpp
@@ -11,7 +11,8 @@
 
 namespace ur_lib {
 
-extern "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+extern "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason,
+                                 LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_DETACH) {
         delete context;
         delete loader::context;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -34,10 +34,9 @@
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `0x1 < device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urInit(
+ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
-                                        ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
+    ///< must be 0 (default) or a combination of ::ur_device_init_flag_t.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -53,8 +52,7 @@ urInit(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pParams`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urTearDown(
+ur_result_t UR_APICALL urTearDown(
     void *pParams ///< [in] pointer to tear down parameters
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -79,16 +77,18 @@ urTearDown(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL
-urPlatformGet(
-    uint32_t NumEntries,               ///< [in] the number of platforms to be added to phPlatforms.
-                                       ///< If phPlatforms is not NULL, then NumEntries should be greater than
-                                       ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
-                                       ///< will be returned.
-    ur_platform_handle_t *phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
-                                       ///< If NumEntries is less than the number of platforms available, then
-                                       ///< ::urPlatformGet shall only retrieve that number of platforms.
-    uint32_t *pNumPlatforms            ///< [out][optional] returns the total number of platforms available.
+ur_result_t UR_APICALL urPlatformGet(
+    uint32_t
+        NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
+    ///< If phPlatforms is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_platform_handle_t *
+        phPlatforms, ///< [out][optional][range(0, NumEntries)] array of handle of platforms.
+    ///< If NumEntries is less than the number of platforms available, then
+    ///< ::urPlatformGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumPlatforms ///< [out][optional] returns the total number of platforms available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -113,16 +113,16 @@ urPlatformGet(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PLATFORM_INFO_PROFILE < PlatformInfoType`
-ur_result_t UR_APICALL
-urPlatformGetInfo(
+ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
     ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPlatformInfo is not used.
+    size_t *
+        pSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -143,8 +143,7 @@ urPlatformGetInfo(
 ///         + `NULL == hDriver`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
-ur_result_t UR_APICALL
-urPlatformGetApiVersion(
+ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hDriver, ///< [in] handle of the platform
     ur_api_version_t *pVersion    ///< [out] api version
 ) {
@@ -172,10 +171,10 @@ urPlatformGetApiVersion(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativePlatform`
-ur_result_t UR_APICALL
-urPlatformGetNativeHandle(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform.
-    ur_native_handle_t *phNativePlatform ///< [out] a pointer to the native handle of the platform.
+ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
+    ur_native_handle_t *
+        phNativePlatform ///< [out] a pointer to the native handle of the platform.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -198,10 +197,11 @@ urPlatformGetNativeHandle(
 ///         + `NULL == hNativePlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
-ur_result_t UR_APICALL
-urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativePlatform, ///< [in] the native handle of the platform.
+    ur_platform_handle_t *
+        phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -233,11 +233,11 @@ urPlatformCreateWithNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
-ur_result_t UR_APICALL
-urGetLastResult(
+ur_result_t UR_APICALL urGetLastResult(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **
+        ppMessage ///< [out] pointer to a string containing adapter specific result in string
+                  ///< representation.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -270,19 +270,20 @@ urGetLastResult(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urDeviceGet(
+ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
-    uint32_t NumEntries,            ///< [in] the number of devices to be added to phDevices.
-                                    ///< If phDevices in not NULL then NumEntries should be greater than zero,
-                                    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
-                                    ///< will be returned.
-    ur_device_handle_t *phDevices,  ///< [out][optional][range(0, NumEntries)] array of handle of devices.
-                                    ///< If NumEntries is less than the number of devices available, then
-                                    ///< platform shall only retrieve that number of devices.
-    uint32_t *pNumDevices           ///< [out][optional] pointer to the number of devices.
-                                    ///< pNumDevices will be updated with the total number of devices available.
+    uint32_t
+        NumEntries, ///< [in] the number of devices to be added to phDevices.
+    ///< If phDevices in not NULL then NumEntries should be greater than zero,
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_VALUE,
+    ///< will be returned.
+    ur_device_handle_t *
+        phDevices, ///< [out][optional][range(0, NumEntries)] array of handle of devices.
+    ///< If NumEntries is less than the number of devices available, then
+    ///< platform shall only retrieve that number of devices.
+    uint32_t *pNumDevices ///< [out][optional] pointer to the number of devices.
+    ///< pNumDevices will be updated with the total number of devices available.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -308,17 +309,17 @@ urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < infoType`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urDeviceGetInfo(
+ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return the info
-                                ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
+    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info
+    ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
+    ///< pDeviceInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -345,9 +346,9 @@ urDeviceGetInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL
-urDeviceRetain(
-    ur_device_handle_t hDevice ///< [in] handle of the device to get a reference of.
+ur_result_t UR_APICALL urDeviceRetain(
+    ur_device_handle_t
+        hDevice ///< [in] handle of the device to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -371,8 +372,7 @@ urDeviceRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL
-urDeviceRelease(
+ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t hDevice ///< [in] handle of the device to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -405,16 +405,18 @@ urDeviceRelease(
 ///         + `NULL == pProperties`
 ///     - ::UR_RESULT_ERROR_DEVICE_PARTITION_FAILED
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
-ur_result_t UR_APICALL
-urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
+    const ur_device_partition_property_t *
+        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    uint32_t NumDevices, ///< [in] the number of sub-devices.
+    ur_device_handle_t *
+        phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+    ///< If NumDevices is less than the number of sub-devices available, then
+    ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *
+        pNumDevicesRet ///< [out][optional] pointer to the number of sub-devices the device can be
+    ///< partitioned into according to the partitioning property.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -444,15 +446,16 @@ urDevicePartition(
 ///         + `NULL == ppBinaries`
 ///         + `NULL == pSelectedBinary`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urDeviceSelectBinary(
-    ur_device_handle_t hDevice, ///< [in] handle of the device to select binary for.
+ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to select binary for.
     const uint8_t **ppBinaries, ///< [in] the array of binaries to select from.
-    uint32_t NumBinaries,       ///< [in] the number of binaries passed in ppBinaries.
-                                ///< Must greater than or equal to zero otherwise
-                                ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
-    uint32_t *pSelectedBinary   ///< [out] the index of the selected binary in the input array of binaries.
-                                ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
+    uint32_t NumBinaries, ///< [in] the number of binaries passed in ppBinaries.
+                          ///< Must greater than or equal to zero otherwise
+                          ///< ::UR_RESULT_ERROR_INVALID_VALUE is returned.
+    uint32_t *
+        pSelectedBinary ///< [out] the index of the selected binary in the input array of binaries.
+    ///< If a suitable binary was not found the function returns ${X}_INVALID_BINARY.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -478,10 +481,10 @@ urDeviceSelectBinary(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeDevice`
-ur_result_t UR_APICALL
-urDeviceGetNativeHandle(
-    ur_device_handle_t hDevice,        ///< [in] handle of the device.
-    ur_native_handle_t *phNativeDevice ///< [out] a pointer to the native handle of the device.
+ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ///< [in] handle of the device.
+    ur_native_handle_t
+        *phNativeDevice ///< [out] a pointer to the native handle of the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -505,11 +508,11 @@ urDeviceGetNativeHandle(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phDevice`
-ur_result_t UR_APICALL
-urDeviceCreateWithNativeHandle(
+ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_device_handle_t
+        *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -533,13 +536,14 @@ urDeviceCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
-ur_result_t UR_APICALL
-urDeviceGetGlobalTimestamps(
+ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    uint64_t *pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
-                                ///< correlates with the Host's global timestamp value
-    uint64_t *pHostTimestamp    ///< [out][optional] pointer to the Host's global timestamp that
-                                ///< correlates with the Device's global timestamp value
+    uint64_t *
+        pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
+                          ///< correlates with the Host's global timestamp value
+    uint64_t *
+        pHostTimestamp ///< [out][optional] pointer to the Host's global timestamp that
+                       ///< correlates with the Device's global timestamp value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -572,12 +576,14 @@ urDeviceGetGlobalTimestamps(
 ///         + `NULL == phContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
-ur_result_t UR_APICALL
-urContextCreate(
-    uint32_t DeviceCount,                       ///< [in] the number of devices given in phDevices
-    const ur_device_handle_t *phDevices,        ///< [in][range(0, DeviceCount)] array of handle of devices.
-    const ur_context_properties_t *pProperties, ///< [in][optional] pointer to context creation properties.
-    ur_context_handle_t *phContext              ///< [out] pointer to handle of context object created
+ur_result_t UR_APICALL urContextCreate(
+    uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
+    const ur_device_handle_t
+        *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
+    const ur_context_properties_t *
+        pProperties, ///< [in][optional] pointer to context creation properties.
+    ur_context_handle_t
+        *phContext ///< [out] pointer to handle of context object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -604,9 +610,9 @@ urContextCreate(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL
-urContextRetain(
-    ur_context_handle_t hContext ///< [in] handle of the context to get a reference of.
+ur_result_t UR_APICALL urContextRetain(
+    ur_context_handle_t
+        hContext ///< [in] handle of the context to get a reference of.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -630,8 +636,7 @@ urContextRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
-ur_result_t UR_APICALL
-urContextRelease(
+ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -657,17 +662,18 @@ urContextRelease(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < ContextInfoType`
-ur_result_t UR_APICALL
-urContextGetInfo(
+ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext,      ///< [in] handle of the context
     ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
+    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+    ///< if propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pContextInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -693,10 +699,10 @@ urContextGetInfo(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeContext`
-ur_result_t UR_APICALL
-urContextGetNativeHandle(
-    ur_context_handle_t hContext,       ///< [in] handle of the context.
-    ur_native_handle_t *phNativeContext ///< [out] a pointer to the native handle of the context.
+ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_native_handle_t *
+        phNativeContext ///< [out] a pointer to the native handle of the context.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -719,10 +725,11 @@ urContextGetNativeHandle(
 ///         + `NULL == hNativeContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phContext`
-ur_result_t UR_APICALL
-urContextCreateWithNativeHandle(
-    ur_native_handle_t hNativeContext, ///< [in] the native handle of the context.
-    ur_context_handle_t *phContext     ///< [out] pointer to the handle of the context object created.
+ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeContext, ///< [in] the native handle of the context.
+    ur_context_handle_t *
+        phContext ///< [out] pointer to the handle of the context object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -749,11 +756,12 @@ urContextCreateWithNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnDeleter`
-ur_result_t UR_APICALL
-urContextSetExtendedDeleter(
-    ur_context_handle_t hContext,             ///< [in] handle of the context.
-    ur_context_extended_deleter_t pfnDeleter, ///< [in] Function pointer to extended deleter.
-    void *pUserData                           ///< [in][out][optional] pointer to data to be passed to callback.
+ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ///< [in] handle of the context.
+    ur_context_extended_deleter_t
+        pfnDeleter, ///< [in] Function pointer to extended deleter.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -789,14 +797,14 @@ urContextSetExtendedDeleter(
 ///         + `pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemImageCreate(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_mem_flags_t flags,                  ///< [in] allocation and usage information flags
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    void *pHost,                           ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phMem                 ///< [out] pointer to handle of image object created
+ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    void *pHost,           ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t *phMem ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -827,13 +835,13 @@ urMemImageCreate(
 ///         + `pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemBufferCreate(
+ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_mem_flags_t flags,         ///< [in] allocation and usage information flags
-    size_t size,                  ///< [in] size in bytes of the memory object to be allocated
-    void *pHost,                  ///< [in][optional] pointer to the buffer data
-    ur_mem_handle_t *phBuffer     ///< [out] pointer to handle of the memory buffer created
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
+    size_t size, ///< [in] size in bytes of the memory object to be allocated
+    void *pHost, ///< [in][optional] pointer to the buffer data
+    ur_mem_handle_t
+        *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -860,8 +868,7 @@ urMemBufferCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemRetain(
+ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -884,8 +891,7 @@ urMemRetain(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urMemRelease(
+ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -918,13 +924,15 @@ urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urMemBufferPartition(
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object to allocate from
-    ur_mem_flags_t flags,                     ///< [in] allocation and usage information flags
+ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t
+        hBuffer,          ///< [in] handle of the buffer object to allocate from
+    ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *pBufferCreateInfo,    ///< [in] pointer to buffer create region information
-    ur_mem_handle_t *phMem                    ///< [out] pointer to the handle of sub buffer created
+    ur_buffer_region_t *
+        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -950,10 +958,10 @@ urMemBufferPartition(
 ///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeMem`
-ur_result_t UR_APICALL
-urMemGetNativeHandle(
-    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
-    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+ur_result_t UR_APICALL urMemGetNativeHandle(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -977,11 +985,11 @@ urMemGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phMem`
-ur_result_t UR_APICALL
-urMemCreateWithNativeHandle(
+ur_result_t UR_APICALL urMemCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ///< [in] the native handle of the mem.
     ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_mem_handle_t *phMem         ///< [out] pointer to the handle of the mem object created.
+    ur_mem_handle_t
+        *phMem ///< [out] pointer to the handle of the mem object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1005,16 +1013,18 @@ urMemCreateWithNativeHandle(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
-ur_result_t UR_APICALL
-urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
+ur_result_t UR_APICALL urMemGetInfo(
+    ur_mem_handle_t
+        hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
+    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pMemInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1038,16 +1048,17 @@ urMemGetInfo(
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
-ur_result_t UR_APICALL
-urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
+ur_result_t UR_APICALL urMemImageGetInfo(
+    ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    size_t
+        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
+    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+    ///< If propSize is less than the real number of bytes needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pImgInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1080,12 +1091,13 @@ urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+ur_result_t UR_APICALL urSamplerCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_property_t
+        *pProps, ///< [in] specifies a list of sampler property names and their
+                 ///< corresponding values.
+    ur_sampler_handle_t
+        *phSampler ///< [out] pointer to handle of sampler object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1108,9 +1120,9 @@ urSamplerCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerRetain(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to get access
+ur_result_t UR_APICALL urSamplerRetain(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1133,9 +1145,9 @@ urSamplerRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerRelease(
-    ur_sampler_handle_t hSampler ///< [in] handle of the sampler object to release
+ur_result_t UR_APICALL urSamplerRelease(
+    ur_sampler_handle_t
+        hSampler ///< [in] handle of the sampler object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1163,13 +1175,14 @@ urSamplerRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urSamplerGetInfo(
+ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
-    ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
-    size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
+    ur_sampler_info_t propName, ///< [in] name of the sampler property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue, ///< [out] value of the sampler property
+    size_t *
+        pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1195,10 +1208,10 @@ urSamplerGetInfo(
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeSampler`
-ur_result_t UR_APICALL
-urSamplerGetNativeHandle(
-    ur_sampler_handle_t hSampler,       ///< [in] handle of the sampler.
-    ur_native_handle_t *phNativeSampler ///< [out] a pointer to the native handle of the sampler.
+ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
+    ur_native_handle_t *
+        phNativeSampler ///< [out] a pointer to the native handle of the sampler.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1222,11 +1235,12 @@ urSamplerGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phSampler`
-ur_result_t UR_APICALL
-urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeSampler,           ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_sampler_handle_t *
+        phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1264,17 +1278,19 @@ urSamplerCreateWithNativeHandle(
 ///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urUSMHostAlloc(
+ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM host memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1313,18 +1329,20 @@ urUSMHostAlloc(
 ///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urUSMDeviceAlloc(
+ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM device memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1363,18 +1381,20 @@ urUSMDeviceAlloc(
 ///         + If `UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT` and `UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT` are both false.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urUSMSharedAlloc(
+ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_usm_desc_t *pUSMDesc,      ///< [in][optional] USM memory allocation descriptor
-    ur_usm_pool_handle_t pool,    ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                  ///< [in] size in bytes of the USM memory object to be allocated
-    uint32_t align,               ///< [in] alignment of the USM memory object.
-                                  ///< Must be zero or a power of 2.
-                                  ///< Must be equal to or smaller than the size of the largest data type
-                                  ///< supported by `hDevice`.
-    void **ppMem                  ///< [out] pointer to USM shared memory object
+    ur_usm_desc_t
+        *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        size, ///< [in] size in bytes of the USM memory object to be allocated
+    uint32_t align, ///< [in] alignment of the USM memory object.
+                    ///< Must be zero or a power of 2.
+    ///< Must be equal to or smaller than the size of the largest data type
+    ///< supported by `hDevice`.
+    void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1393,8 +1413,7 @@ urUSMSharedAlloc(
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urUSMFree(
+ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1419,14 +1438,16 @@ urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urUSMGetMemAllocInfo(
+ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
-    ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    ur_usm_alloc_info_t
+        propName, ///< [in] the name of the USM allocation property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue, ///< [out][optional] value of the USM allocation property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1452,12 +1473,12 @@ urUSMGetMemAllocInfo(
 ///         + `0x1 < pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urUSMPoolCreate(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_usm_pool_desc_t *pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
-                                   ///< ::ur_usm_pool_limits_desc_t
-    ur_usm_pool_handle_t *ppPool   ///< [out] pointer to USM memory pool
+ur_result_t UR_APICALL urUSMPoolCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_usm_pool_desc_t *
+        pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
+                   ///< ::ur_usm_pool_limits_desc_t
+    ur_usm_pool_handle_t *ppPool ///< [out] pointer to USM memory pool
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1479,8 +1500,7 @@ urUSMPoolCreate(
 ///         + `NULL == hContext`
 ///         + `NULL == pPool`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL
-urUSMPoolDestroy(
+ur_result_t UR_APICALL urUSMPoolDestroy(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_handle_t pPool    ///< [in] pointer to USM memory pool
 ) {
@@ -1514,13 +1534,14 @@ urUSMPoolDestroy(
 ///         + If `pIL` is not a valid IL binary for devices in `hContext`.
 ///     - ::UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE
 ///         + If devices in `hContext` don't have the capability to compile an IL binary at runtime.
-ur_result_t UR_APICALL
-urProgramCreateWithIL(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    const void *pIL,                            ///< [in] pointer to IL binary.
-    size_t length,                              ///< [in] length of `pIL` in bytes.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of program object created.
+ur_result_t UR_APICALL urProgramCreateWithIL(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const void *pIL,              ///< [in] pointer to IL binary.
+    size_t length,                ///< [in] length of `pIL` in bytes.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1551,14 +1572,16 @@ urProgramCreateWithIL(
 ///         + `NULL != pProperties && NULL != pProperties->pMetadatas && pProperties->count == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_NATIVE_BINARY
 ///         + If `pBinary` isn't a valid binary for `hDevice.`
-ur_result_t UR_APICALL
-urProgramCreateWithBinary(
-    ur_context_handle_t hContext,               ///< [in] handle of the context instance
-    ur_device_handle_t hDevice,                 ///< [in] handle to device associated with binary.
-    size_t size,                                ///< [in] size in bytes.
-    const uint8_t *pBinary,                     ///< [in] pointer to binary.
-    const ur_program_properties_t *pProperties, ///< [in][optional] pointer to program creation properties.
-    ur_program_handle_t *phProgram              ///< [out] pointer to handle of Program object created.
+ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_device_handle_t
+        hDevice,            ///< [in] handle to device associated with binary.
+    size_t size,            ///< [in] size in bytes.
+    const uint8_t *pBinary, ///< [in] pointer to binary.
+    const ur_program_properties_t *
+        pProperties, ///< [in][optional] pointer to program creation properties.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of Program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1589,11 +1612,11 @@ urProgramCreateWithBinary(
 ///         + If `hProgram` isn't a valid program object.
 ///     - ::UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE
 ///         + If an error occurred when building `hProgram`.
-ur_result_t UR_APICALL
-urProgramBuild(
+ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1623,11 +1646,12 @@ urProgramBuild(
 ///         + If `hProgram` isn't a valid program object.
 ///     - ::UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE
 ///         + If an error occurred while compiling `hProgram`.
-ur_result_t UR_APICALL
-urProgramCompile(
+ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
-    ur_program_handle_t hProgram, ///< [in][out] handle of the program to compile.
-    const char *pOptions          ///< [in][optional] pointer to build options null-terminated string.
+    ur_program_handle_t
+        hProgram, ///< [in][out] handle of the program to compile.
+    const char *
+        pOptions ///< [in][optional] pointer to build options null-terminated string.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1660,13 +1684,15 @@ urProgramCompile(
 ///         + If one of the programs in `phPrograms` isn't a valid program object.
 ///     - ::UR_RESULT_ERROR_PROGRAM_LINK_FAILURE
 ///         + If an error occurred while linking `phPrograms`.
-ur_result_t UR_APICALL
-urProgramLink(
-    ur_context_handle_t hContext,          ///< [in] handle of the context instance.
-    uint32_t count,                        ///< [in] number of program handles in `phPrograms`.
-    const ur_program_handle_t *phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
-    const char *pOptions,                  ///< [in][optional] pointer to linker options null-terminated string.
-    ur_program_handle_t *phProgram         ///< [out] pointer to handle of program object created.
+ur_result_t UR_APICALL urProgramLink(
+    ur_context_handle_t hContext, ///< [in] handle of the context instance.
+    uint32_t count, ///< [in] number of program handles in `phPrograms`.
+    const ur_program_handle_t *
+        phPrograms, ///< [in][range(0, count)] pointer to array of program handles.
+    const char *
+        pOptions, ///< [in][optional] pointer to linker options null-terminated string.
+    ur_program_handle_t
+        *phProgram ///< [out] pointer to handle of program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1691,8 +1717,7 @@ urProgramLink(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL
-urProgramRetain(
+ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t hProgram ///< [in] handle for the Program to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1718,8 +1743,7 @@ urProgramRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hProgram`
-ur_result_t UR_APICALL
-urProgramRelease(
+ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t hProgram ///< [in] handle for the Program to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1752,14 +1776,17 @@ urProgramRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pFunctionName`
 ///         + `NULL == ppFunctionPointer`
-ur_result_t UR_APICALL
-urProgramGetFunctionPointer(
-    ur_device_handle_t hDevice,   ///< [in] handle of the device to retrieve pointer for.
-    ur_program_handle_t hProgram, ///< [in] handle of the program to search for function in.
-                                  ///< The program must already be built to the specified device, or
-                                  ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
-    const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
-    void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program to search for function in.
+    ///< The program must already be built to the specified device, or
+    ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+    const char *
+        pFunctionName, ///< [in] A null-terminates string denoting the mangled function name.
+    void **
+        ppFunctionPointer ///< [out] Returns the pointer to the function if it is found in the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1780,17 +1807,18 @@ urProgramGetFunctionPointer(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_INFO_KERNEL_NAMES < propName`
-ur_result_t UR_APICALL
-urProgramGetInfo(
+ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
-    ur_program_info_t propName,   ///< [in] name of the Program property to query
-    size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
-                                  ///< If propSize is not equal to or greater than the real number of bytes
-                                  ///< needed to return
-                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+    ur_program_info_t propName, ///< [in] name of the Program property to query
+    size_t propSize,            ///< [in] the size of the Program property.
+    void *
+        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pProgramInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1812,18 +1840,20 @@ urProgramGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROGRAM_BUILD_INFO_BINARY_TYPE < propName`
-ur_result_t UR_APICALL
-urProgramGetBuildInfo(
-    ur_program_handle_t hProgram,     ///< [in] handle of the Program object
-    ur_device_handle_t hDevice,       ///< [in] handle of the Device object
-    ur_program_build_info_t propName, ///< [in] name of the Program build info to query
-    size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
-                                      ///< If propSize is not equal to or greater than the real number of bytes
-                                      ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
-    size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
-                                      ///< queried by propName.
+ur_result_t UR_APICALL urProgramGetBuildInfo(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    ur_device_handle_t hDevice,   ///< [in] handle of the Device object
+    ur_program_build_info_t
+        propName,    ///< [in] name of the Program build info to query
+    size_t propSize, ///< [in] size of the Program build info property.
+    void *
+        pPropValue, ///< [in,out][optional] value of the Program build property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
+    ///< error is returned and pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1851,12 +1881,12 @@ urProgramGetBuildInfo(
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + `count == 0`
-ur_result_t UR_APICALL
-urProgramSetSpecializationConstants(
-    ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in][range(0, count)] array of specialization constant value
-                                                            ///< descriptions
+ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, ///< [in] handle of the Program object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in][range(0, count)] array of specialization constant value
+                       ///< descriptions
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1882,10 +1912,10 @@ urProgramSetSpecializationConstants(
 ///         + `NULL == hProgram`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeProgram`
-ur_result_t UR_APICALL
-urProgramGetNativeHandle(
-    ur_program_handle_t hProgram,       ///< [in] handle of the program.
-    ur_native_handle_t *phNativeProgram ///< [out] a pointer to the native handle of the program.
+ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ///< [in] handle of the program.
+    ur_native_handle_t *
+        phNativeProgram ///< [out] a pointer to the native handle of the program.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1909,11 +1939,12 @@ urProgramGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phProgram`
-ur_result_t UR_APICALL
-urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t
+        hNativeProgram,           ///< [in] the native handle of the program.
+    ur_context_handle_t hContext, ///< [in] handle of the context instance
+    ur_program_handle_t *
+        phProgram ///< [out] pointer to the handle of the program object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1937,11 +1968,11 @@ urProgramCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pKernelName`
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL
-urKernelCreate(
+ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
-    ur_kernel_handle_t *phKernel  ///< [out] pointer to handle of kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to handle of kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1965,12 +1996,12 @@ urKernelCreate(
 ///         + `NULL == pArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL
-urKernelSetArgValue(
+ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize,             ///< [in] size of argument type
-    const void *pArgValue       ///< [in] argument value represented as matching arg type.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t argSize,    ///< [in] size of argument type
+    const void
+        *pArgValue ///< [in] argument value represented as matching arg type.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1992,11 +2023,11 @@ urKernelSetArgValue(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL
-urKernelSetArgLocal(
+ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    size_t argSize              ///< [in] size of the local buffer to be allocated by the runtime
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    size_t
+        argSize ///< [in] size of the local buffer to be allocated by the runtime
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2017,18 +2048,19 @@ urKernelSetArgLocal(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_INFO_ATTRIBUTES < propName`
-ur_result_t UR_APICALL
-urKernelGetInfo(
+ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
-                                ///< If propSize is not equal to or greater than the real number of bytes
-                                ///< needed to return
-                                ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
-                                ///< queried by propName.
+    void *
+        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+    ///< If propSize is not equal to or greater than the real number of bytes
+    ///< needed to return
+    ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+    ///< pKernelInfo is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2050,16 +2082,18 @@ urKernelGetInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE < propName`
-ur_result_t UR_APICALL
-urKernelGetGroupInfo(
-    ur_kernel_handle_t hKernel,      ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,      ///< [in] handle of the Device object
-    ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
-    size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
-                                     ///< property.
-    size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
-                                     ///< queried by propName.
+ur_result_t UR_APICALL urKernelGetGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_group_info_t
+        propName,    ///< [in] name of the work Group property to query
+    size_t propSize, ///< [in] size of the Kernel Work Group property value
+    void *
+        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2077,16 +2111,18 @@ urKernelGetGroupInfo(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL < propName`
-ur_result_t UR_APICALL
-urKernelGetSubGroupInfo(
-    ur_kernel_handle_t hKernel,          ///< [in] handle of the Kernel object
-    ur_device_handle_t hDevice,          ///< [in] handle of the Device object
-    ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
-    size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
-                                         ///< property.
-    size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
-                                         ///< queried by propName.
+ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
+    ur_device_handle_t hDevice, ///< [in] handle of the Device object
+    ur_kernel_sub_group_info_t
+        propName,    ///< [in] name of the SubGroup property to query
+    size_t propSize, ///< [in] size of the Kernel SubGroup property value
+    void *
+        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+                    ///< property.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
+                     ///< queried by propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2111,8 +2147,7 @@ urKernelGetSubGroupInfo(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL
-urKernelRetain(
+ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2138,8 +2173,7 @@ urKernelRetain(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-ur_result_t UR_APICALL
-urKernelRelease(
+ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2166,12 +2200,12 @@ urKernelRelease(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE
-ur_result_t UR_APICALL
-urKernelSetArgPointer(
+ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    const void *pArgValue       ///< [in][optional] SVM pointer to memory location holding the argument
-                                ///< value. If null then argument value is considered null.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    const void *
+        pArgValue ///< [in][optional] SVM pointer to memory location holding the argument
+                  ///< value. If null then argument value is considered null.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2199,13 +2233,13 @@ urKernelSetArgPointer(
 ///         + `::UR_KERNEL_EXEC_INFO_USM_PTRS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pPropValue`
-ur_result_t UR_APICALL
-urKernelSetExecInfo(
+ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
-                                    ///< property value.
+    const void *
+        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+                   ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2227,10 +2261,9 @@ urKernelSetExecInfo(
 ///         + `NULL == hKernel`
 ///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL
-urKernelSetArgSampler(
-    ur_kernel_handle_t hKernel,   ///< [in] handle of the kernel object
-    uint32_t argIndex,            ///< [in] argument index in range [0, num args - 1]
+ur_result_t UR_APICALL urKernelSetArgSampler(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     ur_sampler_handle_t hArgValue ///< [in] handle of Sampler object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2252,11 +2285,10 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
-ur_result_t UR_APICALL
-urKernelSetArgMemObj(
+ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
-    uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
+    uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2291,11 +2323,11 @@ urKernelSetArgMemObj(
 ///         + `count == 0`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 ///         + If ::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS query is false
-ur_result_t UR_APICALL
-urKernelSetSpecializationConstants(
-    ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object
-    uint32_t count,                                         ///< [in] the number of elements in the pSpecConstants array
-    const ur_specialization_constant_info_t *pSpecConstants ///< [in] array of specialization constant value descriptions
+ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t count, ///< [in] the number of elements in the pSpecConstants array
+    const ur_specialization_constant_info_t *
+        pSpecConstants ///< [in] array of specialization constant value descriptions
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2321,10 +2353,10 @@ urKernelSetSpecializationConstants(
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
-ur_result_t UR_APICALL
-urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
-    ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
+ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_native_handle_t
+        *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2348,11 +2380,11 @@ urKernelGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
-ur_result_t UR_APICALL
-urKernelCreateWithNativeHandle(
+ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel, ///< [in] the native handle of the kernel.
     ur_context_handle_t hContext,     ///< [in] handle of the context object
-    ur_kernel_handle_t *phKernel      ///< [out] pointer to the handle of the kernel object created.
+    ur_kernel_handle_t
+        *phKernel ///< [out] pointer to the handle of the kernel object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2377,13 +2409,14 @@ urKernelCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueGetInfo(
+ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
-    size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
+    size_t
+        propValueSize, ///< [in] size in bytes of the queue property value provided
+    void *pPropValue, ///< [out][optional] value of the queue property
+    size_t *
+        pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2411,17 +2444,18 @@ urQueueGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_queue_property_t *
+        pProps, ///< [in][optional] specifies a list of queue properties and their
+                ///< corresponding values.
+    ///< Each property name is immediately followed by the corresponding
+    ///< desired value.
+    ///< The list is terminated with a 0.
+    ///< If a property value is not specified, then its default value will be used.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to handle of queue object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2448,8 +2482,7 @@ urQueueCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueRetain(
+ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to get access
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2479,8 +2512,7 @@ urQueueRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urQueueRelease(
+ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t hQueue ///< [in] handle of the queue object to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2507,10 +2539,10 @@ urQueueRelease(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeQueue`
-ur_result_t UR_APICALL
-urQueueGetNativeHandle(
-    ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
-    ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
+ur_result_t UR_APICALL urQueueGetNativeHandle(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_native_handle_t
+        *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2534,11 +2566,11 @@ urQueueGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phQueue`
-ur_result_t UR_APICALL
-urQueueCreateWithNativeHandle(
+ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t hNativeQueue, ///< [in] the native handle of the queue.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_queue_handle_t *phQueue       ///< [out] pointer to the handle of the queue object created.
+    ur_queue_handle_t
+        *phQueue ///< [out] pointer to the handle of the queue object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2567,8 +2599,7 @@ urQueueCreateWithNativeHandle(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urQueueFinish(
+ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2597,8 +2628,7 @@ urQueueFinish(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urQueueFlush(
+ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2624,13 +2654,13 @@ urQueueFlush(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventGetInfo(
+ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propValueSize, ///< [in] size in bytes of the event property value
+    void *pPropValue,     ///< [out][optional] value of the event property
+    size_t
+        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2656,14 +2686,16 @@ urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventGetProfilingInfo(
-    ur_event_handle_t hEvent,     ///< [in] handle of the event object
-    ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
-                                  ///< propValue
+ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ///< [in] handle of the event object
+    ur_profiling_info_t
+        propName, ///< [in] the name of the profiling property to query
+    size_t
+        propValueSize, ///< [in] size in bytes of the profiling property value
+    void *pPropValue,  ///< [out][optional] value of the profiling property
+    size_t *
+        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                          ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2687,11 +2719,11 @@ urEventGetProfilingInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEventWait(
-    uint32_t numEvents,                      ///< [in] number of events in the event list
-    const ur_event_handle_t *phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
-                                             ///< completion
+ur_result_t UR_APICALL urEventWait(
+    uint32_t numEvents, ///< [in] number of events in the event list
+    const ur_event_handle_t *
+        phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
+                        ///< completion
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2714,8 +2746,7 @@ urEventWait(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventRetain(
+ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2739,8 +2770,7 @@ urEventRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL
-urEventRelease(
+ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2767,10 +2797,10 @@ urEventRelease(
 ///         + `NULL == hEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeEvent`
-ur_result_t UR_APICALL
-urEventGetNativeHandle(
-    ur_event_handle_t hEvent,         ///< [in] handle of the event.
-    ur_native_handle_t *phNativeEvent ///< [out] a pointer to the native handle of the event.
+ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ///< [in] handle of the event.
+    ur_native_handle_t
+        *phNativeEvent ///< [out] a pointer to the native handle of the event.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2794,11 +2824,11 @@ urEventGetNativeHandle(
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
-ur_result_t UR_APICALL
-urEventCreateWithNativeHandle(
+ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent, ///< [in] the native handle of the event.
     ur_context_handle_t hContext,    ///< [in] handle of the context object
-    ur_event_handle_t *phEvent       ///< [out] pointer to the handle of the event object created.
+    ur_event_handle_t
+        *phEvent ///< [out] pointer to the handle of the event object created.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2826,12 +2856,12 @@ urEventCreateWithNativeHandle(
 ///         + `::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED < execStatus`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pfnNotify`
-ur_result_t UR_APICALL
-urEventSetCallback(
+ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
-    void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2866,29 +2896,34 @@ urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueKernelLaunch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_kernel_handle_t hKernel,               ///< [in] handle of the kernel object
-    uint32_t workDim,                         ///< [in] number of dimensions, from 1 to 3, to specify the global and
-                                              ///< work-group work-items
-    const size_t *pGlobalWorkOffset,          ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< offset used to calculate the global ID of a work-item
-    const size_t *pGlobalWorkSize,            ///< [in] pointer to an array of workDim unsigned values that specify the
-                                              ///< number of global work-items in workDim that will execute the kernel
-                                              ///< function
-    const size_t *pLocalWorkSize,             ///< [in][optional] pointer to an array of workDim unsigned values that
-                                              ///< specify the number of local work-items forming a work-group that will
-                                              ///< execute the kernel function.
-                                              ///< If nullptr, the runtime implementation will choose the work-group
-                                              ///< size.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
+    uint32_t
+        workDim, ///< [in] number of dimensions, from 1 to 3, to specify the global and
+                 ///< work-group work-items
+    const size_t *
+        pGlobalWorkOffset, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< offset used to calculate the global ID of a work-item
+    const size_t *
+        pGlobalWorkSize, ///< [in] pointer to an array of workDim unsigned values that specify the
+    ///< number of global work-items in workDim that will execute the kernel
+    ///< function
+    const size_t *
+        pLocalWorkSize, ///< [in][optional] pointer to an array of workDim unsigned values that
+    ///< specify the number of local work-items forming a work-group that will
+    ///< execute the kernel function.
+    ///< If nullptr, the runtime implementation will choose the work-group
+    ///< size.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2922,17 +2957,18 @@ urEnqueueKernelLaunch(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueEventsWait(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2968,17 +3004,18 @@ urEnqueueEventsWait(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                              ///< previously enqueued commands
-                                              ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3015,21 +3052,22 @@ urEnqueueEventsWaitWithBarrier(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being read
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being read
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3066,21 +3104,24 @@ urEnqueueMemBufferRead(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    size_t offset,                            ///< [in] offset in bytes in the buffer object
-    size_t size,                              ///< [in] size in bytes of data being written
-    const void *pSrc,                         ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    size_t offset,     ///< [in] offset in bytes in the buffer object
+    size_t size,       ///< [in] size in bytes of data being written
+    const void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3127,28 +3168,34 @@ urEnqueueMemBufferWrite(
 ///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferReadRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< dst
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by dst
-    void *pDst,                               ///< [in] pointer to host memory where data is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< dst
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by dst
+    void *pDst, ///< [in] pointer to host memory where data is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3195,29 +3242,37 @@ urEnqueueMemBufferReadRect(
 ///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferWriteRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
-    ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
-    size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
-    size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
-                                              ///< written
-    size_t hostRowPitch,                      ///< [in] length of each row in bytes in the host memory region pointed by
-                                              ///< src
-    size_t hostSlicePitch,                    ///< [in] length of each 2D slice in bytes in the host memory region
-                                              ///< pointed by src
-    void *pSrc,                               ///< [in] pointer to host memory where data is to be written from
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t bufferOrigin, ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,   ///< [in] 3D offset in the host region
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed by
+                      ///< src
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed by src
+    void
+        *pSrc, ///< [in] pointer to host memory where data is to be written from
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] points to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3250,21 +3305,22 @@ urEnqueueMemBufferWriteRect(
 ///         + If `dstOffset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the src buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    size_t srcOffset,                         ///< [in] offset into hBufferSrc to begin copying from
-    size_t dstOffset,                         ///< [in] offset info hBufferDst to begin copying into
-    size_t size,                              ///< [in] size in bytes of data being copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the src buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    size_t srcOffset, ///< [in] offset into hBufferSrc to begin copying from
+    size_t dstOffset, ///< [in] offset info hBufferDst to begin copying into
+    size_t size,      ///< [in] size in bytes of data being copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3305,25 +3361,31 @@ urEnqueueMemBufferCopy(
 ///         + If the combination of `dstOrigin`, `region`, `dstRowPitch`, and `dstSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferCopyRect(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBufferSrc,               ///< [in] handle of the source buffer object
-    ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
-    ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
-    ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
-    size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
-    size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
-    size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
-    size_t dstSlicePitch,                     ///< [in] length of each 2D slice in bytes in the destination buffer object
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
+    ur_mem_handle_t hBufferSrc, ///< [in] handle of the source buffer object
+    ur_mem_handle_t hBufferDst, ///< [in] handle of the dest buffer object
+    ur_rect_offset_t srcOrigin, ///< [in] 3D offset in the source buffer
+    ur_rect_offset_t dstOrigin, ///< [in] 3D offset in the destination buffer
+    ur_rect_region_t
+        region, ///< [in] source 3D rectangular region descriptor: width, height, depth
+    size_t
+        srcRowPitch, ///< [in] length of each row in bytes in the source buffer object
+    size_t
+        srcSlicePitch, ///< [in] length of each 2D slice in bytes in the source buffer object
+    size_t
+        dstRowPitch, ///< [in] length of each row in bytes in the destination buffer object
+    size_t
+        dstSlicePitch, ///< [in] length of each 2D slice in bytes in the destination buffer object
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3357,21 +3419,22 @@ urEnqueueMemBufferCopyRect(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    const void *pPattern,                     ///< [in] pointer to the fill pattern
-    size_t patternSize,                       ///< [in] size in bytes of the pattern
-    size_t offset,                            ///< [in] offset into the buffer
-    size_t size,                              ///< [in] fill size in bytes, must be a multiple of patternSize
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    const void *pPattern,     ///< [in] pointer to the fill pattern
+    size_t patternSize,       ///< [in] size in bytes of the pattern
+    size_t offset,            ///< [in] offset into the buffer
+    size_t size, ///< [in] fill size in bytes, must be a multiple of patternSize
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3407,24 +3470,27 @@ urEnqueueMemBufferFill(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemImageRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pDst,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool blockingRead, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pDst, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3460,24 +3526,28 @@ urEnqueueMemImageRead(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemImageWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImage,                   ///< [in] handle of the image object
-    bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t origin,                  ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    size_t rowPitch,                          ///< [in] length of each row in bytes
-    size_t slicePitch,                        ///< [in] length of each 2D slice of the 3D image
-    void *pSrc,                               ///< [in] pointer to host memory where image is to be read into
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hImage,   ///< [in] handle of the image object
+    bool
+        blockingWrite, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_rect_offset_t
+        origin, ///< [in] defines the (x,y,z) offset in pixels in the 1D, 2D, or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    size_t rowPitch,   ///< [in] length of each row in bytes
+    size_t slicePitch, ///< [in] length of each 2D slice of the 3D image
+    void *pSrc, ///< [in] pointer to host memory where image is to be read into
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3507,24 +3577,28 @@ urEnqueueMemImageWrite(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemImageCopy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hImageSrc,                ///< [in] handle of the src image object
-    ur_mem_handle_t hImageDst,                ///< [in] handle of the dest image object
-    ur_rect_offset_t srcOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
-                                              ///< image
-    ur_rect_offset_t dstOrigin,               ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
-                                              ///< or 3D image
-    ur_rect_region_t region,                  ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                                              ///< image
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
+    ur_mem_handle_t hImageSrc, ///< [in] handle of the src image object
+    ur_mem_handle_t hImageDst, ///< [in] handle of the dest image object
+    ur_rect_offset_t
+        srcOrigin, ///< [in] defines the (x,y,z) offset in pixels in the source 1D, 2D, or 3D
+                   ///< image
+    ur_rect_offset_t
+        dstOrigin, ///< [in] defines the (x,y,z) offset in pixels in the destination 1D, 2D,
+                   ///< or 3D image
+    ur_rect_region_t
+        region, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
+                ///< image
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3567,23 +3641,24 @@ urEnqueueMemImageCopy(
 ///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemBufferMap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
-    bool blockingMap,                         ///< [in] indicates blocking (true), non-blocking (false)
-    ur_map_flags_t mapFlags,                  ///< [in] flags for read, write, readwrite mapping
-    size_t offset,                            ///< [in] offset in bytes of the buffer region being mapped
-    size_t size,                              ///< [in] size in bytes of the buffer region being mapped
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
-    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
-                                              ///< numEventsInWaitList?
+ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t hBuffer,  ///< [in] handle of the buffer object
+    bool blockingMap, ///< [in] indicates blocking (true), non-blocking (false)
+    ur_map_flags_t mapFlags, ///< [in] flags for read, write, readwrite mapping
+    size_t offset, ///< [in] offset in bytes of the buffer region being mapped
+    size_t size,   ///< [in] size in bytes of the buffer region being mapped
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent, ///< [out][optional] return an event object that identifies this particular
+                 ///< command instance.
+    void **ppRetMap ///< [out] return mapped pointer.  TODO: move it before
+                    ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3615,18 +3690,20 @@ urEnqueueMemBufferMap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueMemUnmap(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    ur_mem_handle_t hMem,                     ///< [in] handle of the memory (buffer or image) object
-    void *pMappedPtr,                         ///< [in] mapped host address
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_mem_handle_t
+        hMem,         ///< [in] handle of the memory (buffer or image) object
+    void *pMappedPtr, ///< [in] mapped host address
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3660,21 +3737,25 @@ urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMFill(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    void *ptr,                                ///< [in] pointer to USM memory object
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t size,                              ///< [in] size in bytes to be set. Must be a multiple of patternSize.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    void *ptr,                ///< [in] pointer to USM memory object
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        size, ///< [in] size in bytes to be set. Must be a multiple of patternSize.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3704,20 +3785,21 @@ urEnqueueUSMFill(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMMemcpy(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking copy
-    void *pDst,                               ///< [in] pointer to the destination USM memory object
-    const void *pSrc,                         ///< [in] pointer to the source USM memory object
-    size_t size,                              ///< [in] size in bytes to be copied
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool blocking,            ///< [in] blocking or non-blocking copy
+    void *pDst,       ///< [in] pointer to the destination USM memory object
+    const void *pSrc, ///< [in] pointer to the source USM memory object
+    size_t size,      ///< [in] size in bytes to be copied
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3748,19 +3830,20 @@ urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMPrefetch(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    const void *pMem,                         ///< [in] pointer to the USM memory object
-    size_t size,                              ///< [in] size in bytes to be fetched
-    ur_usm_migration_flags_t flags,           ///< [in] USM prefetch flags
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before this command can be executed.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
-                                              ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue,       ///< [in] handle of the queue object
+    const void *pMem,               ///< [in] pointer to the USM memory object
+    size_t size,                    ///< [in] size in bytes to be fetched
+    ur_usm_migration_flags_t flags, ///< [in] USM prefetch flags
+    uint32_t numEventsInWaitList,   ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3787,14 +3870,14 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL
-urEnqueueUSMMemAdvise(
-    ur_queue_handle_t hQueue,  ///< [in] handle of the queue object
-    const void *pMem,          ///< [in] pointer to the USM memory object
-    size_t size,               ///< [in] size in bytes to be advised
-    ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
-                               ///< command instance.
+ur_result_t UR_APICALL urEnqueueUSMMemAdvise(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    const void *pMem,         ///< [in] pointer to the USM memory object
+    size_t size,              ///< [in] size in bytes to be advised
+    ur_mem_advice_t advice,   ///< [in] USM memory advice
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3830,24 +3913,29 @@ urEnqueueUSMMemAdvise(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL
-urEnqueueUSMFill2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    void *pMem,                               ///< [in] pointer to memory to be filled.
-    size_t pitch,                             ///< [in] the total width of the destination memory including padding.
-    size_t patternSize,                       ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
-                                              ///< than or equal to width.
-    const void *pPattern,                     ///< [in] pointer with the bytes of the pattern to set.
-    size_t width,                             ///< [in] the width in bytes of each row to fill. Must be a multiple of
-                                              ///< patternSize.
-    size_t height,                            ///< [in] the height of the columns to fill.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    void *pMem,               ///< [in] pointer to memory to be filled.
+    size_t
+        pitch, ///< [in] the total width of the destination memory including padding.
+    size_t
+        patternSize, ///< [in] the size in bytes of the pattern. Must be a power of 2 and less
+                     ///< than or equal to width.
+    const void
+        *pPattern, ///< [in] pointer with the bytes of the pattern to set.
+    size_t
+        width, ///< [in] the width in bytes of each row to fill. Must be a multiple of
+               ///< patternSize.
+    size_t height,                ///< [in] the height of the columns to fill.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3881,23 +3969,26 @@ urEnqueueUSMFill2D(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-ur_result_t UR_APICALL
-urEnqueueUSMMemcpy2D(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    bool blocking,                            ///< [in] indicates if this operation should block the host.
-    void *pDst,                               ///< [in] pointer to memory where data will be copied.
-    size_t dstPitch,                          ///< [in] the total width of the source memory including padding.
-    const void *pSrc,                         ///< [in] pointer to memory to be copied.
-    size_t srcPitch,                          ///< [in] the total width of the source memory including padding.
-    size_t width,                             ///< [in] the width in bytes of each row to be copied.
-    size_t height,                            ///< [in] the height of columns to be copied.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    bool blocking, ///< [in] indicates if this operation should block the host.
+    void *pDst,    ///< [in] pointer to memory where data will be copied.
+    size_t
+        dstPitch, ///< [in] the total width of the source memory including padding.
+    const void *pSrc, ///< [in] pointer to memory to be copied.
+    size_t
+        srcPitch, ///< [in] the total width of the source memory including padding.
+    size_t width,  ///< [in] the width in bytes of each row to be copied.
+    size_t height, ///< [in] the height of columns to be copied.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3921,22 +4012,26 @@ urEnqueueUSMMemcpy2D(
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
-ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingWrite,                       ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    const void *pSrc,                         ///< [in] pointer to where the data must be copied from.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingWrite, ///< [in] indicates if this operation should block.
+    size_t count,       ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    const void *pSrc, ///< [in] pointer to where the data must be copied from.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3960,22 +4055,26 @@ urEnqueueDeviceGlobalVariableWrite(
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
-ur_result_t UR_APICALL
-urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue to submit to.
-    ur_program_handle_t hProgram,             ///< [in] handle of the program containing the device global variable.
-    const char *name,                         ///< [in] the unique identifier for the device global variable.
-    bool blockingRead,                        ///< [in] indicates if this operation should block.
-    size_t count,                             ///< [in] the number of bytes to copy.
-    size_t offset,                            ///< [in] the byte offset into the device global variable to start copying.
-    void *pDst,                               ///< [in] pointer to where the data must be copied to.
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list.
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                              ///< events that must be complete before the kernel execution.
-                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-                                              ///< event.
-    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
-                                              ///< kernel execution instance.
+ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program containing the device global variable.
+    const char
+        *name, ///< [in] the unique identifier for the device global variable.
+    bool blockingRead, ///< [in] indicates if this operation should block.
+    size_t count,      ///< [in] the number of bytes to copy.
+    size_t
+        offset, ///< [in] the byte offset into the device global variable to start copying.
+    void *pDst, ///< [in] pointer to where the data must be copied to.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list.
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -22,7 +22,8 @@ TEST_P(urContextGetInfoTestWithInfoParam, Success) {
     ASSERT_SUCCESS(urContextGetInfo(context, info, 0, nullptr, &info_size));
     ASSERT_NE(info_size, 0);
     std::vector<uint8_t> info_data(info_size);
-    ASSERT_SUCCESS(urContextGetInfo(context, info, info_size, info_data.data(), nullptr));
+    ASSERT_SUCCESS(
+        urContextGetInfo(context, info, info_size, info_data.data(), nullptr));
 }
 
 using urContextGetInfoTest = uur::urContextTest;

--- a/test/conformance/context/urContextSetExtendedDeleter.cpp
+++ b/test/conformance/context/urContextSetExtendedDeleter.cpp
@@ -13,7 +13,9 @@ TEST_P(urContextSetExtendedDeleterTest, Success) {
     ASSERT_NE(context, nullptr);
 
     bool called = false;
-    ur_context_extended_deleter_t deleter = [](void *userdata) { *static_cast<bool *>(userdata) = true; };
+    ur_context_extended_deleter_t deleter = [](void *userdata) {
+        *static_cast<bool *>(userdata) = true;
+    };
 
     ASSERT_SUCCESS(urContextSetExtendedDeleter(context, deleter, &called));
     ASSERT_SUCCESS(urContextRelease(context));

--- a/test/conformance/device/urDeviceGet.cpp
+++ b/test/conformance/device/urDeviceGet.cpp
@@ -7,10 +7,12 @@ using urDeviceGetTest = uur::urPlatformTest;
 
 TEST_F(urDeviceGetTest, Success) {
     uint32_t count = 0;
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_SUCCESS(
+        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
     ASSERT_NE(count, 0);
     std::vector<ur_device_handle_t> devices(count);
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, devices.data(), nullptr));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count,
+                               devices.data(), nullptr));
     for (auto device : devices) {
         ASSERT_NE(nullptr, device);
     }
@@ -18,12 +20,14 @@ TEST_F(urDeviceGetTest, Success) {
 
 TEST_F(urDeviceGetTest, SuccessSubsetOfDevices) {
     uint32_t count;
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_SUCCESS(
+        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
     if (count < 2) {
         GTEST_SKIP();
     }
     std::vector<ur_device_handle_t> devices(count - 1);
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count - 1, devices.data(), nullptr));
+    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count - 1,
+                               devices.data(), nullptr));
     for (auto device : devices) {
         ASSERT_NE(nullptr, device);
     }
@@ -31,17 +35,22 @@ TEST_F(urDeviceGetTest, SuccessSubsetOfDevices) {
 
 TEST_F(urDeviceGetTest, InvalidNullHandlePlatform) {
     uint32_t count;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceGet(nullptr, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urDeviceGet(nullptr, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
 }
 
 TEST_F(urDeviceGetTest, InvalidEnumerationDevicesType) {
     uint32_t count;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urDeviceGet(platform, UR_DEVICE_TYPE_FORCE_UINT32, 0, nullptr, &count));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_ENUMERATION,
+        urDeviceGet(platform, UR_DEVICE_TYPE_FORCE_UINT32, 0, nullptr, &count));
 }
 
 TEST_F(urDeviceGetTest, InvalidValueNumEntries) {
     uint32_t count = 0;
-    ASSERT_SUCCESS(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_SUCCESS(
+        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
     ASSERT_NE(count, 0);
     std::vector<ur_device_handle_t> devices(count);
     ASSERT_EQ_RESULT(

--- a/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
+++ b/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
@@ -56,7 +56,8 @@ TEST_F(urDeviceGetGlobalTimestampTest, SuccessSynchronizedTime) {
     for (auto device : devices) {
         // get the timer resolution of the device
         size_t deviceTimerResolutionNanoSecs = 0;
-        ASSERT_SUCCESS(uur::GetDeviceProfilingTimerResolution(device, deviceTimerResolutionNanoSecs));
+        ASSERT_SUCCESS(uur::GetDeviceProfilingTimerResolution(
+            device, deviceTimerResolutionNanoSecs));
         size_t delayAmountNanoSecs =
             delayTimerMultiplier * deviceTimerResolutionNanoSecs;
 

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -3,117 +3,121 @@
 
 #include <uur/fixtures.h>
 
-struct urDeviceGetInfoTest : uur::urAllDevicesTest, ::testing::WithParamInterface<ur_device_info_t> {
+struct urDeviceGetInfoTest : uur::urAllDevicesTest,
+                             ::testing::WithParamInterface<ur_device_info_t> {
 
-    void SetUp() override { UUR_RETURN_ON_FATAL_FAILURE(uur::urAllDevicesTest::SetUp()); }
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(uur::urAllDevicesTest::SetUp());
+    }
 };
 
-INSTANTIATE_TEST_SUITE_P(, urDeviceGetInfoTest,
-                         ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(
+    , urDeviceGetInfoTest,
+    ::testing::Values(
 
-                             UR_DEVICE_INFO_TYPE,
-                             UR_DEVICE_INFO_VENDOR_ID,                              //
-                             UR_DEVICE_INFO_DEVICE_ID,                              //
-                             UR_DEVICE_INFO_MAX_COMPUTE_UNITS,                      //
-                             UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,               //
-                             UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,                    //
-                             UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,                    //
-                             UR_DEVICE_INFO_SINGLE_FP_CONFIG,                       //
-                             UR_DEVICE_INFO_HALF_FP_CONFIG,                         //
-                             UR_DEVICE_INFO_DOUBLE_FP_CONFIG,                       //
-                             UR_DEVICE_INFO_QUEUE_PROPERTIES,                       //
-                             UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR,            //
-                             UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT,           //
-                             UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG,            //
-                             UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT,           //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR,               //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT,              //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT,                //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG,               //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT,              //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE,             //
-                             UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF,               //
-                             UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY,                    //
-                             UR_DEVICE_INFO_MEMORY_CLOCK_RATE,                      //
-                             UR_DEVICE_INFO_ADDRESS_BITS,                           //
-                             UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,                     //
-                             UR_DEVICE_INFO_IMAGE_SUPPORTED,                        //
-                             UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS,                    //
-                             UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS,                   //
-                             UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS,              //
-                             UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH,                      //
-                             UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT,                     //
-                             UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH,                      //
-                             UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT,                     //
-                             UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH,                      //
-                             UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE,                  //
-                             UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE,                   //
-                             UR_DEVICE_INFO_MAX_SAMPLERS,                           //
-                             UR_DEVICE_INFO_MAX_PARAMETER_SIZE,                     //
-                             UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN,                    //
-                             UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE,                  //
-                             UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE,              //
-                             UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE,                  //
-                             UR_DEVICE_INFO_GLOBAL_MEM_SIZE,                        //
-                             UR_DEVICE_INFO_GLOBAL_MEM_FREE,                        //
-                             UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE,               //
-                             UR_DEVICE_INFO_MAX_CONSTANT_ARGS,                      //
-                             UR_DEVICE_INFO_LOCAL_MEM_TYPE,                         //
-                             UR_DEVICE_INFO_LOCAL_MEM_SIZE,                         //
-                             UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT,               //
-                             UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,                    //
-                             UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION,             //
-                             UR_DEVICE_INFO_ENDIAN_LITTLE,                          //
-                             UR_DEVICE_INFO_AVAILABLE,                              //
-                             UR_DEVICE_INFO_COMPILER_AVAILABLE,                     //
-                             UR_DEVICE_INFO_LINKER_AVAILABLE,                       //
-                             UR_DEVICE_INFO_EXECUTION_CAPABILITIES,                 //
-                             UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,             //
-                             UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES,               //
-                             UR_DEVICE_INFO_BUILT_IN_KERNELS,                       //
-                             UR_DEVICE_INFO_PLATFORM,                               //
-                             UR_DEVICE_INFO_REFERENCE_COUNT,                        //
-                             UR_DEVICE_INFO_IL_VERSION,                             //
-                             UR_DEVICE_INFO_NAME,                                   //
-                             UR_DEVICE_INFO_VENDOR,                                 //
-                             UR_DEVICE_INFO_DRIVER_VERSION,                         //
-                             UR_DEVICE_INFO_PROFILE,                                //
-                             UR_DEVICE_INFO_VERSION,                                //
-                             UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION,                //
-                             UR_DEVICE_INFO_EXTENSIONS,                             //
-                             UR_DEVICE_INFO_PRINTF_BUFFER_SIZE,                     //
-                             UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC,            //
-                             UR_DEVICE_INFO_PARENT_DEVICE,                          //
-                             UR_DEVICE_INFO_PARTITION_PROPERTIES,                   //
-                             UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES,              //
-                             UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,              //
-                             UR_DEVICE_INFO_PARTITION_TYPE,                         //
-                             UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS,                     //
-                             UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, //
-                             UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL,                  //
-                             UR_DEVICE_INFO_USM_HOST_SUPPORT,                       //
-                             UR_DEVICE_INFO_USM_DEVICE_SUPPORT,                     //
-                             UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,              //
-                             UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,               //
-                             UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,              //
-                             UR_DEVICE_INFO_UUID,                                   //
-                             UR_DEVICE_INFO_PCI_ADDRESS,                            //
-                             UR_DEVICE_INFO_GPU_EU_COUNT,                           //
-                             UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,                      //
-                             UR_DEVICE_INFO_GPU_EU_SLICES,                          //
-                             UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,                //
-                             UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,                   //
-                             UR_DEVICE_INFO_IMAGE_SRGB,                             //
-                             UR_DEVICE_INFO_ATOMIC_64,                              //
-                             UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,       //
-                             UR_DEVICE_INFO_BFLOAT16,                               //
-                             UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES               //
-                             ),
-                         [](const ::testing::TestParamInfo<ur_device_info_t> &info) {
-                             std::stringstream ss;
-                             ss << info.param;
-                             return ss.str();
-                         });
+        UR_DEVICE_INFO_TYPE,
+        UR_DEVICE_INFO_VENDOR_ID,                              //
+        UR_DEVICE_INFO_DEVICE_ID,                              //
+        UR_DEVICE_INFO_MAX_COMPUTE_UNITS,                      //
+        UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,               //
+        UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,                    //
+        UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,                    //
+        UR_DEVICE_INFO_SINGLE_FP_CONFIG,                       //
+        UR_DEVICE_INFO_HALF_FP_CONFIG,                         //
+        UR_DEVICE_INFO_DOUBLE_FP_CONFIG,                       //
+        UR_DEVICE_INFO_QUEUE_PROPERTIES,                       //
+        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR,            //
+        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT,           //
+        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG,            //
+        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT,           //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR,               //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT,              //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT,                //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG,               //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT,              //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE,             //
+        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF,               //
+        UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY,                    //
+        UR_DEVICE_INFO_MEMORY_CLOCK_RATE,                      //
+        UR_DEVICE_INFO_ADDRESS_BITS,                           //
+        UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,                     //
+        UR_DEVICE_INFO_IMAGE_SUPPORTED,                        //
+        UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS,                    //
+        UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS,                   //
+        UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS,              //
+        UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH,                      //
+        UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT,                     //
+        UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH,                      //
+        UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT,                     //
+        UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH,                      //
+        UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE,                  //
+        UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE,                   //
+        UR_DEVICE_INFO_MAX_SAMPLERS,                           //
+        UR_DEVICE_INFO_MAX_PARAMETER_SIZE,                     //
+        UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN,                    //
+        UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE,                  //
+        UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE,              //
+        UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE,                  //
+        UR_DEVICE_INFO_GLOBAL_MEM_SIZE,                        //
+        UR_DEVICE_INFO_GLOBAL_MEM_FREE,                        //
+        UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE,               //
+        UR_DEVICE_INFO_MAX_CONSTANT_ARGS,                      //
+        UR_DEVICE_INFO_LOCAL_MEM_TYPE,                         //
+        UR_DEVICE_INFO_LOCAL_MEM_SIZE,                         //
+        UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT,               //
+        UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,                    //
+        UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION,             //
+        UR_DEVICE_INFO_ENDIAN_LITTLE,                          //
+        UR_DEVICE_INFO_AVAILABLE,                              //
+        UR_DEVICE_INFO_COMPILER_AVAILABLE,                     //
+        UR_DEVICE_INFO_LINKER_AVAILABLE,                       //
+        UR_DEVICE_INFO_EXECUTION_CAPABILITIES,                 //
+        UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,             //
+        UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES,               //
+        UR_DEVICE_INFO_BUILT_IN_KERNELS,                       //
+        UR_DEVICE_INFO_PLATFORM,                               //
+        UR_DEVICE_INFO_REFERENCE_COUNT,                        //
+        UR_DEVICE_INFO_IL_VERSION,                             //
+        UR_DEVICE_INFO_NAME,                                   //
+        UR_DEVICE_INFO_VENDOR,                                 //
+        UR_DEVICE_INFO_DRIVER_VERSION,                         //
+        UR_DEVICE_INFO_PROFILE,                                //
+        UR_DEVICE_INFO_VERSION,                                //
+        UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION,                //
+        UR_DEVICE_INFO_EXTENSIONS,                             //
+        UR_DEVICE_INFO_PRINTF_BUFFER_SIZE,                     //
+        UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC,            //
+        UR_DEVICE_INFO_PARENT_DEVICE,                          //
+        UR_DEVICE_INFO_PARTITION_PROPERTIES,                   //
+        UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES,              //
+        UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,              //
+        UR_DEVICE_INFO_PARTITION_TYPE,                         //
+        UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS,                     //
+        UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, //
+        UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL,                  //
+        UR_DEVICE_INFO_USM_HOST_SUPPORT,                       //
+        UR_DEVICE_INFO_USM_DEVICE_SUPPORT,                     //
+        UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,              //
+        UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,               //
+        UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,              //
+        UR_DEVICE_INFO_UUID,                                   //
+        UR_DEVICE_INFO_PCI_ADDRESS,                            //
+        UR_DEVICE_INFO_GPU_EU_COUNT,                           //
+        UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,                      //
+        UR_DEVICE_INFO_GPU_EU_SLICES,                          //
+        UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,                //
+        UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,                   //
+        UR_DEVICE_INFO_IMAGE_SRGB,                             //
+        UR_DEVICE_INFO_ATOMIC_64,                              //
+        UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,       //
+        UR_DEVICE_INFO_BFLOAT16,                               //
+        UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES               //
+        ),
+    [](const ::testing::TestParamInfo<ur_device_info_t> &info) {
+        std::stringstream ss;
+        ss << info.param;
+        return ss.str();
+    });
 
 TEST_P(urDeviceGetInfoTest, Success) {
     ur_device_info_t info_type = GetParam();
@@ -122,7 +126,8 @@ TEST_P(urDeviceGetInfoTest, Success) {
         ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, 0, nullptr, &size));
         ASSERT_NE(size, 0);
         void *info_data = alloca(size);
-        ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, size, info_data, nullptr));
+        ASSERT_SUCCESS(
+            urDeviceGetInfo(device, info_type, size, info_data, nullptr));
         ASSERT_NE(info_data, nullptr);
     }
 }

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -14,7 +14,8 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
 
 TEST_F(urDeviceGetNativeHandleTest, InvalidNullHandleDevice) {
     ur_native_handle_t native_handle = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urDeviceGetNativeHandle(nullptr, &native_handle));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urDeviceGetNativeHandle(nullptr, &native_handle));
 }
 
 TEST_F(urDeviceGetNativeHandleTest, InvalidNullPointerNativeDevice) {

--- a/test/conformance/device/urDevicePartition.cpp
+++ b/test/conformance/device/urDevicePartition.cpp
@@ -4,7 +4,8 @@
 
 using urDevicePartitionTest = uur::urAllDevicesTest;
 
-void getNumberComputeUnits(ur_device_handle_t device, uint32_t &n_compute_units) {
+void getNumberComputeUnits(ur_device_handle_t device,
+                           uint32_t &n_compute_units) {
     ASSERT_SUCCESS(uur::GetDeviceMaxComputeUnits(device, n_compute_units));
     ASSERT_NE(n_compute_units, 0);
 }
@@ -12,7 +13,8 @@ void getNumberComputeUnits(ur_device_handle_t device, uint32_t &n_compute_units)
 TEST_F(urDevicePartitionTest, PartitionEquallySuccess) {
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_EQUALLY)) {
+        if (!uur::hasDevicePartitionSupport(device,
+                                            UR_DEVICE_PARTITION_EQUALLY)) {
             GTEST_SKIP();
         }
 
@@ -20,15 +22,19 @@ TEST_F(urDevicePartitionTest, PartitionEquallySuccess) {
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_compute_units));
 
         for (uint32_t i = 1; i < n_compute_units; ++i) {
-            ur_device_partition_property_t properties[] = {UR_DEVICE_PARTITION_EQUALLY, i, 0};
+            ur_device_partition_property_t properties[] = {
+                UR_DEVICE_PARTITION_EQUALLY, i, 0};
 
             // Get the number of devices that will be created
             uint32_t n_devices;
-            ASSERT_SUCCESS(urDevicePartition(device, properties, 0, nullptr, &n_devices));
+            ASSERT_SUCCESS(
+                urDevicePartition(device, properties, 0, nullptr, &n_devices));
             ASSERT_NE(n_devices, 0);
 
             std::vector<ur_device_handle_t> sub_devices(n_devices);
-            ASSERT_SUCCESS(urDevicePartition(device, properties, static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
+            ASSERT_SUCCESS(urDevicePartition(
+                device, properties, static_cast<uint32_t>(sub_devices.size()),
+                sub_devices.data(), nullptr));
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
                 ASSERT_SUCCESS(urDeviceRelease(sub_device));
@@ -41,21 +47,21 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
 
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_BY_COUNTS)) {
+        if (!uur::hasDevicePartitionSupport(device,
+                                            UR_DEVICE_PARTITION_BY_COUNTS)) {
             GTEST_SKIP();
         }
 
         uint32_t n_cu_in_device = 0;
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_cu_in_device));
 
-        std::vector<ur_device_partition_property_t> properties = {UR_DEVICE_PARTITION_BY_COUNTS};
+        std::vector<ur_device_partition_property_t> properties = {
+            UR_DEVICE_PARTITION_BY_COUNTS};
 
-        enum class Combination { ONE,
-                                 HALF,
-                                 ALL_MINUS_ONE,
-                                 ALL };
+        enum class Combination { ONE, HALF, ALL_MINUS_ONE, ALL };
 
-        std::vector<Combination> combinations{Combination::ONE, Combination::ALL};
+        std::vector<Combination> combinations{Combination::ONE,
+                                              Combination::ALL};
 
         if (n_cu_in_device >= 2) {
             combinations.push_back(Combination::HALF);
@@ -72,7 +78,8 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
             }
             case Combination::HALF: {
                 n_cu_across_sub_devices = (n_cu_in_device / 2) * 2;
-                properties.insert(properties.end(), {n_cu_in_device / 2, n_cu_in_device / 2, 0});
+                properties.insert(properties.end(),
+                                  {n_cu_in_device / 2, n_cu_in_device / 2, 0});
                 break;
             }
             case Combination::ALL_MINUS_ONE: {
@@ -89,18 +96,22 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
 
             // Get the number of devices that will be created
             uint32_t n_devices;
-            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0, nullptr, &n_devices));
+            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0,
+                                             nullptr, &n_devices));
             ASSERT_EQ(n_devices, properties.size() - 2);
 
             std::vector<ur_device_handle_t> sub_devices(n_devices);
             ASSERT_SUCCESS(
-                urDevicePartition(device, properties.data(), static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
+                urDevicePartition(device, properties.data(),
+                                  static_cast<uint32_t>(sub_devices.size()),
+                                  sub_devices.data(), nullptr));
 
             uint32_t sum = 0;
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
                 uint32_t n_cu_in_sub_device;
-                ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(sub_device, n_cu_in_sub_device));
+                ASSERT_NO_FATAL_FAILURE(
+                    getNumberComputeUnits(sub_device, n_cu_in_sub_device));
                 sum += n_cu_in_sub_device;
                 ASSERT_SUCCESS(urDeviceRelease(sub_device));
             }
@@ -113,34 +124,41 @@ TEST_F(urDevicePartitionTest, PartitionByAffinityDomain) {
 
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN)) {
+        if (!uur::hasDevicePartitionSupport(
+                device, UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN)) {
             GTEST_SKIP();
         }
 
         uint32_t n_compute_units = 0;
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_compute_units));
 
-        std::vector<ur_device_affinity_domain_flag_t> testFlags = {UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
-                                                                   UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE};
+        std::vector<ur_device_affinity_domain_flag_t> testFlags = {
+            UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
+            UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE};
 
         for (auto flag : testFlags) {
 
-            std::vector<ur_device_partition_property_t> properties = {UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, flag, 0};
+            std::vector<ur_device_partition_property_t> properties = {
+                UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, flag, 0};
 
             // Get the number of devices that will be created
             uint32_t n_devices;
-            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0, nullptr, &n_devices));
+            ASSERT_SUCCESS(urDevicePartition(device, properties.data(), 0,
+                                             nullptr, &n_devices));
             ASSERT_NE(n_devices, 0);
 
             std::vector<ur_device_handle_t> sub_devices(n_devices);
             ASSERT_SUCCESS(
-                urDevicePartition(device, properties.data(), static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
+                urDevicePartition(device, properties.data(),
+                                  static_cast<uint32_t>(sub_devices.size()),
+                                  sub_devices.data(), nullptr));
 
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
 
                 ur_device_affinity_domain_flag_t type;
-                urDeviceGetInfo(sub_device, UR_DEVICE_INFO_PARTITION_TYPE, sizeof(type), &type, nullptr);
+                urDeviceGetInfo(sub_device, UR_DEVICE_INFO_PARTITION_TYPE,
+                                sizeof(type), &type, nullptr);
 
                 /* UR only supports splitting with the NUMA flag. So even if the
                  * NEXT_PARTITIONABLE flag is used, the result should always be
@@ -173,7 +191,8 @@ TEST_F(urDevicePartitionTest, InvalidNullPointerProperties) {
 TEST_F(urDevicePartitionTest, SuccessSubSet) {
     for (auto device : devices) {
 
-        if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_EQUALLY)) {
+        if (!uur::hasDevicePartitionSupport(device,
+                                            UR_DEVICE_PARTITION_EQUALLY)) {
             GTEST_SKIP();
         }
 
@@ -181,17 +200,21 @@ TEST_F(urDevicePartitionTest, SuccessSubSet) {
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_compute_units));
 
         // partition for 1 compute unit per sub-device
-        ur_device_partition_property_t properties[] = {UR_DEVICE_PARTITION_EQUALLY, 1, 0};
+        ur_device_partition_property_t properties[] = {
+            UR_DEVICE_PARTITION_EQUALLY, 1, 0};
 
         // Get the number of devices that will be created
         uint32_t n_devices;
-        ASSERT_SUCCESS(urDevicePartition(device, properties, 0, nullptr, &n_devices));
+        ASSERT_SUCCESS(
+            urDevicePartition(device, properties, 0, nullptr, &n_devices));
         ASSERT_NE(n_devices, 0);
 
         // We can request only a subset of these devices from [0, n_devices]
         for (size_t subset = 0; subset <= n_devices; ++subset) {
             std::vector<ur_device_handle_t> sub_devices(subset);
-            ASSERT_SUCCESS(urDevicePartition(device, properties, static_cast<uint32_t>(sub_devices.size()), sub_devices.data(), nullptr));
+            ASSERT_SUCCESS(urDevicePartition(
+                device, properties, static_cast<uint32_t>(sub_devices.size()),
+                sub_devices.data(), nullptr));
             for (auto sub_device : sub_devices) {
                 ASSERT_NE(sub_device, nullptr);
                 ASSERT_SUCCESS(urDeviceRelease(sub_device));

--- a/test/conformance/enqueue/helpers.h
+++ b/test/conformance/enqueue/helpers.h
@@ -23,7 +23,8 @@ struct test_parameters_t {
 };
 
 template <typename T>
-inline std::string printRectTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
+inline std::string
+printRectTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
     // ParamType will be std::tuple<ur_device_handle_t, test_parameters_t>
     const auto device_handle = std::get<0>(info.param);
     const auto platform_device_name = GetPlatformAndDeviceName(device_handle);
@@ -33,13 +34,17 @@ inline std::string printRectTestString(const testing::TestParamInfo<typename T::
 
 // Performs host side equivalent of urEnqueueMemBufferReadRect,
 // urEnqueueMemBufferWriteRect and urEnqueueMemBufferCopyRect.
-inline void copyRect(std::vector<uint8_t> src, ur_rect_offset_t src_offset, ur_rect_offset_t dst_offset, ur_rect_region_t region,
-                     size_t src_row_pitch, size_t src_slice_pitch, size_t dst_row_pitch, size_t dst_slice_pitch,
+inline void copyRect(std::vector<uint8_t> src, ur_rect_offset_t src_offset,
+                     ur_rect_offset_t dst_offset, ur_rect_region_t region,
+                     size_t src_row_pitch, size_t src_slice_pitch,
+                     size_t dst_row_pitch, size_t dst_slice_pitch,
                      std::vector<uint8_t> &dst) {
-    const auto src_linear_offset = src_offset.x + src_offset.y * src_row_pitch + src_offset.z * src_slice_pitch;
+    const auto src_linear_offset = src_offset.x + src_offset.y * src_row_pitch +
+                                   src_offset.z * src_slice_pitch;
     const auto src_start = src.data() + src_linear_offset;
 
-    const auto dst_linear_offset = dst_offset.x + dst_offset.y * dst_row_pitch + dst_offset.z * dst_slice_pitch;
+    const auto dst_linear_offset = dst_offset.x + dst_offset.y * dst_row_pitch +
+                                   dst_offset.z * dst_slice_pitch;
     const auto dst_start = dst.data() + dst_linear_offset;
 
     for (unsigned k = 0; k < region.depth; ++k) {
@@ -60,12 +65,16 @@ struct TestParameters2D {
 };
 
 template <typename T>
-inline std::string print2DTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
+inline std::string
+print2DTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
     const auto device_handle = std::get<0>(info.param);
-    const auto platform_device_name = uur::GetPlatformAndDeviceName(device_handle);
+    const auto platform_device_name =
+        uur::GetPlatformAndDeviceName(device_handle);
     std::stringstream test_name;
-    test_name << platform_device_name << "__pitch__" << std::get<1>(info.param).pitch << "__width__" << std::get<1>(info.param).width
-              << "__height__" << std::get<1>(info.param).height;
+    test_name << platform_device_name << "__pitch__"
+              << std::get<1>(info.param).pitch << "__width__"
+              << std::get<1>(info.param).width << "__height__"
+              << std::get<1>(info.param).height;
     return test_name.str();
 }
 

--- a/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -5,10 +5,14 @@
 struct urEnqueueEventsWaitTest : uur::urMultiQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                         nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0,
+                                               size, input.data(), 0, nullptr,
+                                               nullptr));
     }
 
     void TearDown() override {
@@ -33,22 +37,27 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitTest);
 TEST_P(urEnqueueEventsWaitTest, Success) {
     ur_event_handle_t event1 = nullptr;
     ur_event_handle_t waitEvent = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event1));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, &event1));
     ASSERT_SUCCESS(urEnqueueEventsWait(queue2, 1, &event1, &waitEvent));
     ASSERT_SUCCESS(urQueueFlush(queue1));
     ASSERT_SUCCESS(urQueueFlush(queue2));
     ASSERT_SUCCESS(urEventWait(1, &waitEvent));
 
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     ASSERT_EQ(input, output);
 
     ur_event_handle_t event2 = nullptr;
     input.assign(count, 420);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size, input.data(), 0, nullptr, &event2));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size,
+                                           input.data(), 0, nullptr, &event2));
     ASSERT_SUCCESS(urEventWait(1, &event2));
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     ASSERT_EQ(input, output);
     EXPECT_SUCCESS(urEventRelease(event1));
     EXPECT_SUCCESS(urEventRelease(waitEvent));

--- a/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -5,10 +5,14 @@
 struct urEnqueueEventsWaitWithBarrierTest : uur::urMultiQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urMultiQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                         nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue1, src_buffer, true, 0,
+                                               size, input.data(), 0, nullptr,
+                                               nullptr));
     }
 
     void TearDown() override {
@@ -33,27 +37,34 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitWithBarrierTest);
 TEST_P(urEnqueueEventsWaitWithBarrierTest, Success) {
     ur_event_handle_t event1 = nullptr;
     ur_event_handle_t waitEvent = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event1));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue2, 1, &event1, &waitEvent));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue1, src_buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, &event1));
+    EXPECT_SUCCESS(
+        urEnqueueEventsWaitWithBarrier(queue2, 1, &event1, &waitEvent));
     EXPECT_SUCCESS(urQueueFlush(queue2));
     EXPECT_SUCCESS(urQueueFlush(queue1));
     EXPECT_SUCCESS(urEventWait(1, &waitEvent));
 
     std::vector<uint32_t> output(count, 1);
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue1, dst_buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     EXPECT_EQ(input, output);
     EXPECT_SUCCESS(urEventRelease(waitEvent));
     EXPECT_SUCCESS(urEventRelease(event1));
 
     ur_event_handle_t event2 = nullptr;
     input.assign(count, 420);
-    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
-    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event2));
-    EXPECT_SUCCESS(urEnqueueEventsWaitWithBarrier(queue1, 1, &event2, &waitEvent));
+    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue2, src_buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queue2, src_buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, &event2));
+    EXPECT_SUCCESS(
+        urEnqueueEventsWaitWithBarrier(queue1, 1, &event2, &waitEvent));
     EXPECT_SUCCESS(urQueueFlush(queue2));
     EXPECT_SUCCESS(urQueueFlush(queue1));
     EXPECT_SUCCESS(urEventWait(1, &waitEvent));
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue2, dst_buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     EXPECT_SUCCESS(urEventRelease(waitEvent));
     EXPECT_SUCCESS(urEventRelease(event2));
     EXPECT_EQ(input, output);

--- a/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -6,10 +6,14 @@
 struct urEnqueueMemBufferCopyTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                         nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size,
+                                               input.data(), 0, nullptr,
+                                               nullptr));
     }
 
     void TearDown() override {
@@ -31,25 +35,30 @@ struct urEnqueueMemBufferCopyTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferCopyTest);
 
 TEST_P(urEnqueueMemBufferCopyTest, Success) {
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     ASSERT_EQ(input, output);
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullHandleQueue) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopy(nullptr, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(nullptr, src_buffer, dst_buffer, 0,
+                                            0, size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullHandleBufferSrc) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopy(queue, nullptr, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(queue, nullptr, dst_buffer, 0, 0,
+                                            size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullHandleBufferDst) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopy(queue, src_buffer, nullptr, 0, 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(queue, src_buffer, nullptr, 0, 0,
+                                            size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidNullPtrEventWaitList) {
@@ -67,24 +76,29 @@ TEST_P(urEnqueueMemBufferCopyTest, InvalidNullPtrEventWaitList) {
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidSize) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer,
-                                            1, 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 1, 0,
+                                            size, 0, nullptr, nullptr));
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer,
-                                            0, 1, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 1,
+                                            size, 0, nullptr, nullptr));
 }
 
-using urEnqueueMemBufferCopyMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferCopyMultiDeviceTest =
+    uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
     // First queue does a fill.
     const uint32_t input = 42;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input, sizeof(input), 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input,
+                                          sizeof(input), 0, size, 0, nullptr,
+                                          nullptr));
 
     // Then a copy.
     ur_mem_handle_t dst_buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
-    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queues[0], buffer, dst_buffer, 0, 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                     nullptr, &dst_buffer));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopy(queues[0], buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, nullptr));
 
     // Wait for the queue to finish executing.
     EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
@@ -95,9 +109,13 @@ TEST_F(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
+                                              output.data(), 0, nullptr,
+                                              nullptr));
         for (unsigned j = 0; j < count; ++j) {
-            EXPECT_EQ(input, output[j]) << "Result on queue " << i << " did not match at index " << j << "!";
+            EXPECT_EQ(input, output[j])
+                << "Result on queue " << i << " did not match at index " << j
+                << "!";
         }
     }
 

--- a/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -7,56 +7,71 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
     std::vector<uur::test_parameters_t> parameterizations;
 
 // Choose parameters so that we get good coverage and catch some edge cases.
-#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin, dst_origin, region, src_row_pitch, src_slice_pitch, \
-                         dst_row_pitch, dst_slice_pitch)                                                                         \
-    uur::test_parameters_t name{#name, src_buffer_size, dst_buffer_size, src_origin, dst_origin,                                 \
-                                region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch};                         \
-    parameterizations.push_back(name);                                                                                           \
+#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin,   \
+                         dst_origin, region, src_row_pitch, src_slice_pitch,   \
+                         dst_row_pitch, dst_slice_pitch)                       \
+    uur::test_parameters_t name{                                               \
+        #name,         src_buffer_size, dst_buffer_size, src_origin,           \
+        dst_origin,    region,          src_row_pitch,   src_slice_pitch,      \
+        dst_row_pitch, dst_slice_pitch};                                       \
+    parameterizations.push_back(name);                                         \
     (void)0
     // Tests that a 16x16x1 region can be read from a 16x16x1 device buffer at
     // offset {0,0,0} to a 16x16x1 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(copy_whole_buffer_2D, 256, 256, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
+    PARAMETERIZATION(copy_whole_buffer_2D, 256, 256,
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
                      (ur_rect_region_t{16, 16, 1}), 16, 256, 16, 256);
     // Tests that a 2x2x1 region can be read from a 4x4x1 device buffer at
     // offset {2,2,0} to a 8x4x1 host buffer at offset {4,2,0}.
-    PARAMETERIZATION(copy_non_zero_offsets_2D, 16, 32, (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
+    PARAMETERIZATION(copy_non_zero_offsets_2D, 16, 32,
+                     (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
                      (ur_rect_region_t{2, 2, 1}), 4, 16, 8, 32);
     // Tests that a 4x4x1 region can be read from a 4x4x16 device buffer at
     // offset {0,0,0} to a 8x4x16 host buffer at offset {4,0,0}.
-    PARAMETERIZATION(copy_different_buffer_sizes_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
+    PARAMETERIZATION(copy_different_buffer_sizes_2D, 256, 512,
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
                      (ur_rect_region_t{4, 4, 1}), 4, 16, 8, 32);
     // Tests that a 1x256x1 region can be read from a 1x256x1 device buffer at
     // offset {0,0,0} to a 2x256x1 host buffer at offset {1,0,0}.
-    PARAMETERIZATION(copy_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}), 1,
-                     256, 2, 512);
+    PARAMETERIZATION(copy_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}),
+                     1, 256, 2, 512);
     // Tests that a 256x1x1 region can be read from a 256x1x1 device buffer at
     // offset {0,0,0} to a 256x2x1 host buffer at offset {0,1,0}.
-    PARAMETERIZATION(copy_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}), 256,
-                     256, 256, 512);
+    PARAMETERIZATION(copy_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}),
+                     256, 256, 256, 512);
     // Tests that a 8x8x8 region can be read from a 8x8x8 device buffer at
     // offset {0,0,0} to a 8x8x8 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(copy_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}), 8, 64, 8,
-                     64);
+    PARAMETERIZATION(copy_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}),
+                     8, 64, 8, 64);
     // Tests that a 4x3x2 region can be read from a 8x8x8 device buffer at
     // offset {1,2,3} to a 8x8x8 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(copy_3d_with_offsets, 512, 512, (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 3, 2}),
-                     8, 64, 8, 64);
+    PARAMETERIZATION(copy_3d_with_offsets, 512, 512,
+                     (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}),
+                     (ur_rect_region_t{4, 3, 2}), 8, 64, 8, 64);
     // Tests that a 4x16x2 region can be read from a 8x32x1 device buffer at
     // offset {1,2,0} to a 8x32x4 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(copy_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}), 8, 256,
-                     8, 256);
+    PARAMETERIZATION(copy_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}),
+                     (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}),
+                     8, 256, 8, 256);
     // Tests that a 1x4x1 region can be read from a 8x16x4 device buffer at
     // offset {7,3,3} to a 2x8x1 host buffer at offset {1,3,0}.
-    PARAMETERIZATION(copy_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}), (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}), 8, 128, 2,
-                     16);
+    PARAMETERIZATION(copy_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}),
+                     (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}),
+                     8, 128, 2, 16);
 #undef PARAMETERIZATION
     return parameterizations;
 }
 
-struct urEnqueueMemBufferCopyRectTestWithParam : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+struct urEnqueueMemBufferCopyRectTestWithParam
+    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_TEST_SUITE_P(urEnqueueMemBufferCopyRectTestWithParam, testing::ValuesIn(generateParameterizations()),
-                 uur::printRectTestString<urEnqueueMemBufferCopyRectTestWithParam>);
+UUR_TEST_SUITE_P(
+    urEnqueueMemBufferCopyRectTestWithParam,
+    testing::ValuesIn(generateParameterizations()),
+    uur::printRectTestString<urEnqueueMemBufferCopyRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
     // Unpack the parameters.
@@ -72,35 +87,45 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
 
     // Create two buffers to copy between.
     ur_mem_handle_t src_buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, src_buffer_size, nullptr, &src_buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     src_buffer_size, nullptr, &src_buffer));
 
     // Fill src buffer with sequentially increasing values.
     std::vector<uint8_t> input(src_buffer_size, 0x0);
     std::iota(std::begin(input), std::end(input), 0x0);
     EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer,
-                                           /* is_blocking */ true, 0, src_buffer_size, input.data(), 0, nullptr, nullptr));
+                                           /* is_blocking */ true, 0,
+                                           src_buffer_size, input.data(), 0,
+                                           nullptr, nullptr));
 
     ur_mem_handle_t dst_buffer = nullptr;
-    EXPECT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, dst_buffer_size, nullptr, &dst_buffer));
+    EXPECT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     dst_buffer_size, nullptr, &dst_buffer));
 
     // Zero destination buffer to begin with since the write may not cover the
     // whole buffer.
     const uint8_t zero = 0x0;
-    EXPECT_SUCCESS(urEnqueueMemBufferFill(queue, dst_buffer, &zero, sizeof(zero), 0, dst_buffer_size, 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferFill(queue, dst_buffer, &zero,
+                                          sizeof(zero), 0, dst_buffer_size, 0,
+                                          nullptr, nullptr));
 
     // Enqueue the rectangular copy between the buffers.
-    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer, src_buffer_origin, dst_buffer_origin, region,
-                                              src_buffer_row_pitch, src_buffer_slice_pitch, dst_buffer_row_pitch, dst_buffer_slice_pitch, 0,
-                                              nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(
+        queue, src_buffer, dst_buffer, src_buffer_origin, dst_buffer_origin,
+        region, src_buffer_row_pitch, src_buffer_slice_pitch,
+        dst_buffer_row_pitch, dst_buffer_slice_pitch, 0, nullptr, nullptr));
 
     std::vector<uint8_t> output(dst_buffer_size, 0x0);
     EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer,
-                                          /* is_blocking */ true, 0, dst_buffer_size, output.data(), 0, nullptr, nullptr));
+                                          /* is_blocking */ true, 0,
+                                          dst_buffer_size, output.data(), 0,
+                                          nullptr, nullptr));
 
     // Do host side equivalent.
     std::vector<uint8_t> expected(dst_buffer_size, 0x0);
-    uur::copyRect(input, src_buffer_origin, dst_buffer_origin, region, src_buffer_row_pitch, src_buffer_slice_pitch, dst_buffer_row_pitch,
-                  dst_buffer_slice_pitch, expected);
+    uur::copyRect(input, src_buffer_origin, dst_buffer_origin, region,
+                  src_buffer_row_pitch, src_buffer_slice_pitch,
+                  dst_buffer_row_pitch, dst_buffer_slice_pitch, expected);
 
     // Verify the results.
     EXPECT_EQ(expected, output);
@@ -113,10 +138,14 @@ TEST_P(urEnqueueMemBufferCopyRectTestWithParam, Success) {
 struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                         nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, true, 0, size,
+                                               input.data(), 0, nullptr,
+                                               nullptr));
     }
 
     void TearDown() override {
@@ -142,8 +171,10 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleQueue) {
     ur_rect_offset_t src_origin{0, 0, 0};
     ur_rect_offset_t dst_origin{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopyRect(nullptr, src_buffer, dst_buffer, src_origin, dst_origin, src_region, size, size, size, size,
-                                                0, nullptr, nullptr));
+                     urEnqueueMemBufferCopyRect(nullptr, src_buffer, dst_buffer,
+                                                src_origin, dst_origin,
+                                                src_region, size, size, size,
+                                                size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferSrc) {
@@ -151,8 +182,10 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferSrc) {
     ur_rect_offset_t src_origin{0, 0, 0};
     ur_rect_offset_t dst_origin{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopyRect(queue, nullptr, dst_buffer, src_origin, dst_origin, src_region, size, size, size, size, 0,
-                                                nullptr, nullptr));
+                     urEnqueueMemBufferCopyRect(queue, nullptr, dst_buffer,
+                                                src_origin, dst_origin,
+                                                src_region, size, size, size,
+                                                size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferDst) {
@@ -160,8 +193,10 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleBufferDst) {
     ur_rect_offset_t src_origin{0, 0, 0};
     ur_rect_offset_t dst_origin{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferCopyRect(queue, src_buffer, nullptr, src_origin, dst_origin, src_region, size, size, size, size, 0,
-                                                nullptr, nullptr));
+                     urEnqueueMemBufferCopyRect(queue, src_buffer, nullptr,
+                                                src_origin, dst_origin,
+                                                src_region, size, size, size,
+                                                size, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
@@ -184,19 +219,24 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
-using urEnqueueMemBufferCopyRectMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferCopyRectMultiDeviceTest =
+    uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
     // First queue does a fill.
     const uint32_t input = 42;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input, sizeof(input), 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input,
+                                          sizeof(input), 0, size, 0, nullptr,
+                                          nullptr));
 
     // Then a rectangular copy treating both buffers as 1024x1x1 1D buffers with
     // zero offsets.
     ur_mem_handle_t dst_buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
-    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(queues[0], buffer, dst_buffer, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size, size, size, size, 0,
-                                              nullptr, nullptr));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                     nullptr, &dst_buffer));
+    EXPECT_SUCCESS(urEnqueueMemBufferCopyRect(
+        queues[0], buffer, dst_buffer, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size,
+        size, size, size, 0, nullptr, nullptr));
 
     // Wait for the queue to finish executing.
     EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
@@ -207,9 +247,13 @@ TEST_F(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, true, 0, size,
+                                              output.data(), 0, nullptr,
+                                              nullptr));
         for (unsigned j = 0; j < count; ++j) {
-            EXPECT_EQ(input, output[j]) << "Result on queue " << i << " did not match at index " << j << "!";
+            EXPECT_EQ(input, output[j])
+                << "Result on queue " << i << " did not match at index " << j
+                << "!";
         }
     }
 

--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -7,9 +7,12 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferFillTest);
 
 TEST_P(urEnqueueMemBufferFillTest, Success) {
     const uint32_t pattern = 0xdeadbeef;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern, sizeof(pattern), 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern,
+                                          sizeof(pattern), 0, size, 0, nullptr,
+                                          nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     for (unsigned i = 0; i < count; ++i) {
         ASSERT_EQ(output[i], pattern) << "Result mismatch at index: " << i;
     }
@@ -17,13 +20,17 @@ TEST_P(urEnqueueMemBufferFillTest, Success) {
 
 TEST_P(urEnqueueMemBufferFillTest, SuccessPartialFill) {
     const std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
     const uint32_t pattern = 0xdeadbeef;
     const size_t partial_fill_size = size / 2;
     const size_t fill_count = count / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern, sizeof(pattern), 0, partial_fill_size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern,
+                                          sizeof(pattern), 0, partial_fill_size,
+                                          0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     for (size_t i = 0; i < count - fill_count; ++i) {
         ASSERT_EQ(output[i], pattern) << "Result mismatch at index: " << i;
     }
@@ -35,13 +42,17 @@ TEST_P(urEnqueueMemBufferFillTest, SuccessPartialFill) {
 
 TEST_P(urEnqueueMemBufferFillTest, SuccessOffset) {
     const std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
     const uint32_t pattern = 0xdeadbeef;
     const size_t offset_size = size / 2;
     const size_t offset_count = count / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern, sizeof(pattern), offset_size, offset_size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &pattern,
+                                          sizeof(pattern), offset_size,
+                                          offset_size, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     for (size_t i = 0; i < offset_count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
     }
@@ -54,18 +65,24 @@ TEST_P(urEnqueueMemBufferFillTest, SuccessOffset) {
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullHandleQueue) {
     const uint32_t pattern = 0xdeadbeef;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferFill(nullptr, buffer, &pattern, sizeof(pattern), 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferFill(nullptr, buffer, &pattern,
+                                            sizeof(pattern), 0, size, 0,
+                                            nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullHandleBuffer) {
     const uint32_t pattern = 0xdeadbeef;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferFill(queue, nullptr, &pattern, sizeof(pattern), 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferFill(queue, nullptr, &pattern,
+                                            sizeof(pattern), 0, size, 0,
+                                            nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullHandlePointerPattern) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferFill(queue, buffer, nullptr, sizeof(uint32_t), 0, size, 0, nullptr, nullptr));
+                     urEnqueueMemBufferFill(queue, buffer, nullptr,
+                                            sizeof(uint32_t), 0, size, 0,
+                                            nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferFillTest, InvalidNullPtrEventWaitList) {
@@ -92,12 +109,15 @@ TEST_P(urEnqueueMemBufferFillTest, InvalidSize) {
                                             nullptr, nullptr));
 }
 
-using urEnqueueMemBufferFillMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferFillMultiDeviceTest =
+    uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
     // First queue does a fill.
     const uint32_t input = 42;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input, sizeof(input), 0, size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queues[0], buffer, &input,
+                                          sizeof(input), 0, size, 0, nullptr,
+                                          nullptr));
 
     // Wait for the queue to finish executing.
     EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
@@ -108,9 +128,12 @@ TEST_F(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(
+            queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
         for (unsigned j = 0; j < count; ++j) {
-            ASSERT_EQ(input, output[j]) << "Result on queue " << i << " did not match at index " << j << "!";
+            ASSERT_EQ(input, output[j])
+                << "Result on queue " << i << " did not match at index " << j
+                << "!";
         }
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -7,10 +7,13 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferMapTest);
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessRead) {
     const std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     uint32_t *map = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ, 0, size, 0, nullptr, nullptr, (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ,
+                                         0, size, 0, nullptr, nullptr,
+                                         (void **)&map));
     for (unsigned i = 0; i < count; ++i) {
         ASSERT_EQ(map[i], 42) << "Result mismatch at index: " << i;
     }
@@ -18,16 +21,20 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessRead) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessWrite) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     uint32_t *map = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, 0, size, 0, nullptr, nullptr, (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
+                                         0, size, 0, nullptr, nullptr,
+                                         (void **)&map));
     for (unsigned i = 0; i < count; ++i) {
         map[i] = 42;
     }
     ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     for (unsigned i = 0; i < count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
     }
@@ -35,12 +42,14 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessWrite) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessOffset) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     uint32_t *map = nullptr;
     const size_t offset_size = size / 2;
-    ASSERT_SUCCESS(
-        urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, offset_size, size - offset_size, 0, nullptr, nullptr, (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
+                                         offset_size, size - offset_size, 0,
+                                         nullptr, nullptr, (void **)&map));
 
     const size_t offset_count = count / 2;
     for (size_t i = 0; i < offset_count; ++i) {
@@ -49,7 +58,8 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessOffset) {
 
     ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
 
     for (size_t i = 0; i < offset_count; ++i) {
         ASSERT_EQ(output[i], 0) << "Result mismatch at index: " << i;
@@ -61,10 +71,13 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessOffset) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessPartialMap) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
     uint32_t *map = nullptr;
     const size_t map_size = size / 2;
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, 0, map_size, 0, nullptr, nullptr, (void **)&map));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
+                                         0, map_size, 0, nullptr, nullptr,
+                                         (void **)&map));
 
     const size_t offset_count = count / 2;
     for (unsigned i = 0; i < offset_count; ++i) {
@@ -73,7 +86,8 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessPartialMap) {
 
     ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
 
     for (size_t i = 0; i < offset_count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
@@ -85,7 +99,8 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessPartialMap) {
 
 TEST_P(urEnqueueMemBufferMapTest, SuccessMultiMaps) {
     const std::vector<uint32_t> input(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     // Create two maps with non-overlapping ranges and write separate values
     // into each of them to check we can maintain multiple maps on the same
@@ -96,19 +111,25 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessMultiMaps) {
     const auto map_offset = size / 2;
     const auto map_count = count / 2;
 
-    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, 0, map_size, 0, nullptr, nullptr, (void **)&map_a));
-    ASSERT_SUCCESS(
-        urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE, map_offset, map_size, 0, nullptr, nullptr, (void **)&map_b));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
+                                         0, map_size, 0, nullptr, nullptr,
+                                         (void **)&map_a));
+    ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_WRITE,
+                                         map_offset, map_size, 0, nullptr,
+                                         nullptr, (void **)&map_b));
     for (size_t i = 0; i < map_count; ++i) {
         map_a[i] = 42;
     }
     for (size_t i = map_count; i < count; ++i) {
         map_a[i] = 24;
     }
-    ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map_a, 0, nullptr, nullptr));
-    ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map_b, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(
+        urEnqueueMemUnmap(queue, buffer, map_a, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(
+        urEnqueueMemUnmap(queue, buffer, map_b, 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 1);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     for (size_t i = 0; i < map_count; ++i) {
         ASSERT_EQ(output[i], 42) << "Result mismatch at index: " << i;
     }
@@ -119,25 +140,36 @@ TEST_P(urEnqueueMemBufferMapTest, SuccessMultiMaps) {
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullHandleQueue) {
     uint32_t *map = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemBufferMap(nullptr, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                                                                0, size, 0, nullptr, nullptr, (void **)&map));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEnqueueMemBufferMap(nullptr, buffer, true,
+                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                           0, size, 0, nullptr, nullptr,
+                                           (void **)&map));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullHandleBuffer) {
     uint32_t *map = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemBufferMap(queue, nullptr, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                                                                0, size, 0, nullptr, nullptr, (void **)&map));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEnqueueMemBufferMap(queue, nullptr, true,
+                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                           0, size, 0, nullptr, nullptr,
+                                           (void **)&map));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidEnumerationMapFlags) {
     uint32_t *map = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_FORCE_UINT32, 0, size, 0, nullptr, nullptr, (void **)&map));
+                     urEnqueueMemBufferMap(queue, buffer, true,
+                                           UR_MAP_FLAG_FORCE_UINT32, 0, size, 0,
+                                           nullptr, nullptr, (void **)&map));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullPointerRetMap) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
-                                                                                 0, size, 0, nullptr, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urEnqueueMemBufferMap(queue, buffer, true,
+                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                           0, size, 0, nullptr, nullptr,
+                                           nullptr));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidNullPtrEventWaitList) {
@@ -164,12 +196,14 @@ TEST_P(urEnqueueMemBufferMapTest, InvalidSize) {
                                            nullptr, nullptr, &map));
 }
 
-using urEnqueueMemBufferMapMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferMapMultiDeviceTest =
+    uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferMapMultiDeviceTest, WriteMapDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     // Then the remaining queues map the buffer into some host memory. Since the
     // queues target different devices this checks that any devices memory has
@@ -177,10 +211,15 @@ TEST_F(urEnqueueMemBufferMapMultiDeviceTest, WriteMapDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         uint32_t *map = nullptr;
-        ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ, 0, size, 0, nullptr, nullptr, (void **)&map));
+        ASSERT_SUCCESS(urEnqueueMemBufferMap(queue, buffer, true,
+                                             UR_MAP_FLAG_READ, 0, size, 0,
+                                             nullptr, nullptr, (void **)&map));
         for (unsigned j = 0; j < count; ++j) {
-            ASSERT_EQ(input[j], map[j]) << "Result on queue " << i << " at index " << j << " did not match!";
+            ASSERT_EQ(input[j], map[j])
+                << "Result on queue " << i << " at index " << j
+                << " did not match!";
         }
-        ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
+        ASSERT_SUCCESS(
+            urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -7,25 +7,31 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferReadTest);
 
 TEST_P(urEnqueueMemBufferReadTest, Success) {
     std::vector<uint32_t> output(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullHandleQueue) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferRead(nullptr, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+                     urEnqueueMemBufferRead(nullptr, buffer, true, 0, size,
+                                            output.data(), 0, nullptr,
+                                            nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullHandleBuffer) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferRead(queue, nullptr, true, 0, size, output.data(), 0, nullptr, nullptr));
+                     urEnqueueMemBufferRead(queue, nullptr, true, 0, size,
+                                            output.data(), 0, nullptr,
+                                            nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullPointerDst) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferRead(queue, buffer, true, 0, size, nullptr, 0, nullptr, nullptr));
+                     urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                            nullptr, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidNullPtrEventWaitList) {
@@ -47,15 +53,18 @@ TEST_P(urEnqueueMemBufferReadTest, InvalidSize) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urEnqueueMemBufferRead(queue, buffer, true, 1, size,
-                                            output.data(), 0, nullptr, nullptr));
+                                            output.data(), 0, nullptr,
+                                            nullptr));
 }
 
-using urEnqueueMemBufferReadMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferReadMultiDeviceTest =
+    uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     // Then the remaining queues do blocking reads from the buffer. Since the
     // queues target different devices this checks that any devices memory has
@@ -63,7 +72,9 @@ TEST_F(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
-        ASSERT_EQ(input, output) << "Result on queue " << i << " did not match!";
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(
+            queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        ASSERT_EQ(input, output)
+            << "Result on queue " << i << " did not match!";
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -8,56 +8,71 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
     std::vector<uur::test_parameters_t> parameterizations;
 
 // Choose parameters so that we get good coverage and catch some edge cases.
-#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin, dst_origin, region, src_row_pitch, src_slice_pitch, \
-                         dst_row_pitch, dst_slice_pitch)                                                                         \
-    uur::test_parameters_t name{#name, src_buffer_size, dst_buffer_size, src_origin, dst_origin,                                 \
-                                region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch};                         \
-    parameterizations.push_back(name);                                                                                           \
+#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin,   \
+                         dst_origin, region, src_row_pitch, src_slice_pitch,   \
+                         dst_row_pitch, dst_slice_pitch)                       \
+    uur::test_parameters_t name{                                               \
+        #name,         src_buffer_size, dst_buffer_size, src_origin,           \
+        dst_origin,    region,          src_row_pitch,   src_slice_pitch,      \
+        dst_row_pitch, dst_slice_pitch};                                       \
+    parameterizations.push_back(name);                                         \
     (void)0
     // Tests that a 16x16x1 region can be read from a 16x16x1 device buffer at
     // offset {0,0,0} to a 16x16x1 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_whole_buffer_2D, 256, 256, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
+    PARAMETERIZATION(write_whole_buffer_2D, 256, 256,
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
                      (ur_rect_region_t{16, 16, 1}), 16, 256, 16, 256);
     // Tests that a 2x2x1 region can be read from a 4x4x1 device buffer at
     // offset {2,2,0} to a 8x4x1 host buffer at offset {4,2,0}.
-    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32, (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
+    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32,
+                     (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
                      (ur_rect_region_t{2, 2, 1}), 4, 16, 8, 32);
     // Tests that a 4x4x1 region can be read from a 4x4x16 device buffer at
     // offset {0,0,0} to a 8x4x16 host buffer at offset {4,0,0}.
-    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
+    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512,
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
                      (ur_rect_region_t{4, 4, 1}), 4, 16, 8, 32);
     // Tests that a 1x256x1 region can be read from a 1x256x1 device buffer at
     // offset {0,0,0} to a 2x256x1 host buffer at offset {1,0,0}.
-    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}), 1,
-                     256, 2, 512);
+    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}),
+                     1, 256, 2, 512);
     // Tests that a 256x1x1 region can be read from a 256x1x1 device buffer at
     // offset {0,0,0} to a 256x2x1 host buffer at offset {0,1,0}.
-    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}), 256,
-                     256, 256, 512);
+    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}),
+                     256, 256, 256, 512);
     // Tests that a 8x8x8 region can be read from a 8x8x8 device buffer at
     // offset {0,0,0} to a 8x8x8 host buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}), 8, 64, 8,
-                     64);
+    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}),
+                     8, 64, 8, 64);
     // Tests that a 4x3x2 region can be read from a 8x8x8 device buffer at
     // offset {1,2,3} to a 8x8x8 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_3d_with_offsets, 512, 512, (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 3, 2}),
-                     8, 64, 8, 64);
+    PARAMETERIZATION(write_3d_with_offsets, 512, 512,
+                     (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}),
+                     (ur_rect_region_t{4, 3, 2}), 8, 64, 8, 64);
     // Tests that a 4x16x2 region can be read from a 8x32x1 device buffer at
     // offset {1,2,0} to a 8x32x4 host buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}), 8, 256,
-                     8, 256);
+    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}),
+                     (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}),
+                     8, 256, 8, 256);
     // Tests that a 1x4x1 region can be read from a 8x16x4 device buffer at
     // offset {7,3,3} to a 2x8x1 host buffer at offset {1,3,0}.
-    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}), (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}), 8, 128, 2,
-                     16);
+    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}),
+                     (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}),
+                     8, 128, 2, 16);
 #undef PARAMETERIZATION
     return parameterizations;
 }
 
-struct urEnqueueMemBufferReadRectTestWithParam : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+struct urEnqueueMemBufferReadRectTestWithParam
+    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_TEST_SUITE_P(urEnqueueMemBufferReadRectTestWithParam, testing::ValuesIn(generateParameterizations()),
-                 uur::printRectTestString<urEnqueueMemBufferReadRectTestWithParam>);
+UUR_TEST_SUITE_P(
+    urEnqueueMemBufferReadRectTestWithParam,
+    testing::ValuesIn(generateParameterizations()),
+    uur::printRectTestString<urEnqueueMemBufferReadRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
     // Unpack the parameters.
@@ -73,20 +88,26 @@ TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
 
     // Create a buffer we will read from.
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     buffer_size, nullptr, &buffer));
     // The input will just be sequentially increasing values.
     std::vector<uint8_t> input(buffer_size, 0x0);
     std::iota(std::begin(input), std::end(input), 0x0);
-    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* isBlocking */ true, 0, input.size(), input.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* isBlocking */ true,
+                                           0, input.size(), input.data(), 0,
+                                           nullptr, nullptr));
 
     // Enqueue the rectangular read.
     std::vector<uint8_t> output(host_size, 0x0);
-    EXPECT_SUCCESS(urEnqueueMemBufferReadRect(queue, buffer, /* isBlocking */ true, buffer_offset, host_offset, region, buffer_row_pitch,
-                                              buffer_slice_pitch, host_row_pitch, host_slice_pitch, output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferReadRect(
+        queue, buffer, /* isBlocking */ true, buffer_offset, host_offset,
+        region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
+        host_slice_pitch, output.data(), 0, nullptr, nullptr));
 
     // Do host side equivalent.
     std::vector<uint8_t> expected(host_size, 0x0);
-    uur::copyRect(input, buffer_offset, host_offset, region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch, host_slice_pitch,
+    uur::copyRect(input, buffer_offset, host_offset, region, buffer_row_pitch,
+                  buffer_slice_pitch, host_row_pitch, host_slice_pitch,
                   expected);
 
     // Verify the results.
@@ -103,9 +124,11 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleQueue) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferReadRect(nullptr, buffer, true, buffer_offset, host_offset, region, size, size, size, size,
-                                                dst.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEnqueueMemBufferReadRect(nullptr, buffer, true, buffer_offset,
+                                   host_offset, region, size, size, size, size,
+                                   dst.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleBuffer) {
@@ -113,9 +136,11 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleBuffer) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferReadRect(queue, nullptr, true, buffer_offset, host_offset, region, size, size, size, size,
-                                                dst.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEnqueueMemBufferReadRect(queue, nullptr, true, buffer_offset,
+                                   host_offset, region, size, size, size, size,
+                                   dst.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPointerDst) {
@@ -124,8 +149,10 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPointerDst) {
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferReadRect(queue, buffer, true, buffer_offset, host_offset, region, size, size, size, size, nullptr, 0,
-                                                nullptr, nullptr));
+                     urEnqueueMemBufferReadRect(queue, buffer, true,
+                                                buffer_offset, host_offset,
+                                                region, size, size, size, size,
+                                                nullptr, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
@@ -149,15 +176,18 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
-using urEnqueueMemBufferReadRectMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
+using urEnqueueMemBufferReadRectMultiDeviceTest =
+    uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest, WriteReadDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     // Then a rectangular write the buffer as 1024x1x1 1D.
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWriteRect(queues[0], buffer, true, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size, size, size, size,
-                                               input.data(), 0, nullptr, nullptr));
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWriteRect(
+        queues[0], buffer, true, {0, 0, 0}, {0, 0, 0}, {size, 1, 1}, size, size,
+        size, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queues[0], buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 
     // Then the remaining queues do blocking reads from the buffer. Since the
     // queues target different devices this checks that any devices memory has
@@ -165,7 +195,9 @@ TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest, WriteReadDifferentQueues) {
     for (unsigned i = 1; i < queues.size(); ++i) {
         const auto queue = queues[i];
         std::vector<uint32_t> output(count, 0);
-        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
-        ASSERT_EQ(input, output) << "Result on queue " << i << " did not match!";
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(
+            queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+        ASSERT_EQ(input, output)
+            << "Result on queue " << i << " did not match!";
     }
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -7,14 +7,17 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferWriteTest);
 
 TEST_P(urEnqueueMemBufferWriteTest, Success) {
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, SuccessWriteRead) {
     std::vector<uint32_t> input(count, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                           input.data(), 0, nullptr, nullptr));
     std::vector<uint32_t> output(count, 0);
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size, output.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                          output.data(), 0, nullptr, nullptr));
     for (size_t index = 0; index < count; index++) {
         ASSERT_EQ(input[index], output[index]);
     }
@@ -23,19 +26,24 @@ TEST_P(urEnqueueMemBufferWriteTest, SuccessWriteRead) {
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullHandleQueue) {
     std::vector<uint32_t> input(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferWrite(nullptr, buffer, true, 0, size, input.data(), 0, nullptr, nullptr));
+                     urEnqueueMemBufferWrite(nullptr, buffer, true, 0, size,
+                                             input.data(), 0, nullptr,
+                                             nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullHandleBuffer) {
     std::vector<uint32_t> input(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferWrite(queue, nullptr, true, 0, size, input.data(), 0, nullptr, nullptr));
+                     urEnqueueMemBufferWrite(queue, nullptr, true, 0, size,
+                                             input.data(), 0, nullptr,
+                                             nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullPointerSrc) {
     std::vector<uint32_t> input(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferWrite(queue, buffer, true, 0, size, nullptr, 0, nullptr, nullptr));
+                     urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                             nullptr, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidNullPtrEventWaitList) {
@@ -57,5 +65,6 @@ TEST_P(urEnqueueMemBufferWriteTest, InvalidSize) {
     std::vector<uint32_t> output(count, 42);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urEnqueueMemBufferWrite(queue, buffer, true, 1, size,
-                                             output.data(), 0, nullptr, nullptr));
+                                             output.data(), 0, nullptr,
+                                             nullptr));
 }

--- a/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -7,56 +7,71 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
     std::vector<uur::test_parameters_t> parameterizations;
 
 // Choose parameters so that we get good coverage and catch some edge cases.
-#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin, dst_origin, region, src_row_pitch, src_slice_pitch, \
-                         dst_row_pitch, dst_slice_pitch)                                                                         \
-    uur::test_parameters_t name{#name, src_buffer_size, dst_buffer_size, src_origin, dst_origin,                                 \
-                                region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch};                         \
-    parameterizations.push_back(name);                                                                                           \
+#define PARAMETERIZATION(name, src_buffer_size, dst_buffer_size, src_origin,   \
+                         dst_origin, region, src_row_pitch, src_slice_pitch,   \
+                         dst_row_pitch, dst_slice_pitch)                       \
+    uur::test_parameters_t name{                                               \
+        #name,         src_buffer_size, dst_buffer_size, src_origin,           \
+        dst_origin,    region,          src_row_pitch,   src_slice_pitch,      \
+        dst_row_pitch, dst_slice_pitch};                                       \
+    parameterizations.push_back(name);                                         \
     (void)0
     // Tests that a 16x16x1 region can be written from a 16x16x1 host buffer at
     // offset {0,0,0} to a 16x16x1 device buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_whole_buffer_2D, 256, 256, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
+    PARAMETERIZATION(write_whole_buffer_2D, 256, 256,
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}),
                      (ur_rect_region_t{16, 16, 1}), 16, 256, 16, 256);
     // Tests that a 2x2x1 region can be written from a 4x4x1 host buffer at
     // offset {2,2,0} to a 8x4x1 device buffer at offset {4,2,0}.
-    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32, (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
+    PARAMETERIZATION(write_non_zero_offsets_2D, 16, 32,
+                     (ur_rect_offset_t{2, 2, 0}), (ur_rect_offset_t{4, 2, 0}),
                      (ur_rect_region_t{2, 2, 1}), 4, 16, 8, 32);
     // Tests that a 4x4x1 region can be written from a 4x4x16 host buffer at
     // offset {0,0,0} to a 8x4x16 device buffer at offset {4,0,0}.
-    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
+    PARAMETERIZATION(write_different_buffer_sizes_2D, 256, 512,
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{4, 0, 0}),
                      (ur_rect_region_t{4, 4, 1}), 4, 16, 8, 32);
     // Tests that a 1x256x1 region can be written from a 1x256x1 host buffer at
     // offset {0,0,0} to a 2x256x1 device buffer at offset {1,0,0}.
-    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}), 1,
-                     256, 2, 512);
+    PARAMETERIZATION(write_column_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{1, 0, 0}), (ur_rect_region_t{1, 256, 1}),
+                     1, 256, 2, 512);
     // Tests that a 256x1x1 region can be written from a 256x1x1 host buffer at
     // offset {0,0,0} to a 256x2x1 device buffer at offset {0,1,0}.
-    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}), 256,
-                     256, 256, 512);
+    PARAMETERIZATION(write_row_2D, 256, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{0, 1, 0}), (ur_rect_region_t{256, 1, 1}),
+                     256, 256, 256, 512);
     // Tests that a 8x8x8 region can be written from a 8x8x8 host buffer at
     // offset {0,0,0} to a 8x8x8 device buffer at offset {0,0,0}.
-    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}), (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}), 8, 64, 8,
-                     64);
+    PARAMETERIZATION(write_3d, 512, 512, (ur_rect_offset_t{0, 0, 0}),
+                     (ur_rect_offset_t{0, 0, 0}), (ur_rect_region_t{8, 8, 8}),
+                     8, 64, 8, 64);
     // Tests that a 4x3x2 region can be written from a 8x8x8 host buffer at
     // offset {1,2,3} to a 8x8x8 device buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_3d_with_offsets, 512, 512, (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 3, 2}),
-                     8, 64, 8, 64);
+    PARAMETERIZATION(write_3d_with_offsets, 512, 512,
+                     (ur_rect_offset_t{1, 2, 3}), (ur_rect_offset_t{4, 1, 3}),
+                     (ur_rect_region_t{4, 3, 2}), 8, 64, 8, 64);
     // Tests that a 4x16x2 region can be written from a 8x32x1 host buffer at
     // offset {1,2,0} to a 8x32x4 device buffer at offset {4,1,3}.
-    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}), (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}), 8, 256,
-                     8, 256);
+    PARAMETERIZATION(write_2d_3d, 256, 1024, (ur_rect_offset_t{1, 2, 0}),
+                     (ur_rect_offset_t{4, 1, 3}), (ur_rect_region_t{4, 16, 1}),
+                     8, 256, 8, 256);
     // Tests that a 1x4x1 region can be written from a 8x16x4 host buffer at
     // offset {7,3,3} to a 2x8x1 device buffer at offset {1,3,0}.
-    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}), (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}), 8, 128, 2,
-                     16);
+    PARAMETERIZATION(write_3d_2d, 512, 16, (ur_rect_offset_t{7, 3, 3}),
+                     (ur_rect_offset_t{1, 3, 0}), (ur_rect_region_t{1, 4, 1}),
+                     8, 128, 2, 16);
 #undef PARAMETERIZATION
     return parameterizations;
 }
 
-struct urEnqueueMemBufferWriteRectTestWithParam : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
+struct urEnqueueMemBufferWriteRectTestWithParam
+    : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_TEST_SUITE_P(urEnqueueMemBufferWriteRectTestWithParam, testing::ValuesIn(generateParameterizations()),
-                 uur::printRectTestString<urEnqueueMemBufferWriteRectTestWithParam>);
+UUR_TEST_SUITE_P(
+    urEnqueueMemBufferWriteRectTestWithParam,
+    testing::ValuesIn(generateParameterizations()),
+    uur::printRectTestString<urEnqueueMemBufferWriteRectTestWithParam>);
 
 TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
     // Unpack the parameters.
@@ -72,26 +87,33 @@ TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
 
     // Create a buffer we will read from.
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     buffer_size, nullptr, &buffer));
 
     // Zero it to begin with since the write may not cover the whole buffer.
     const uint8_t zero = 0x0;
-    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &zero, sizeof(zero), 0, buffer_size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, buffer, &zero, sizeof(zero), 0,
+                                          buffer_size, 0, nullptr, nullptr));
 
     // Create a host buffer of sequentially increasing values.
     std::vector<uint8_t> input(host_size, 0x0);
     std::iota(std::begin(input), std::end(input), 0x0);
 
     // Enqueue the rectangular write from that host buffer.
-    EXPECT_SUCCESS(urEnqueueMemBufferWriteRect(queue, buffer, /* isBlocking */ true, buffer_origin, host_origin, region, buffer_row_pitch,
-                                               buffer_slice_pitch, host_row_pitch, host_slice_pitch, input.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferWriteRect(
+        queue, buffer, /* isBlocking */ true, buffer_origin, host_origin,
+        region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
+        host_slice_pitch, input.data(), 0, nullptr, nullptr));
 
     std::vector<uint8_t> output(buffer_size, 0x0);
-    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, /* is_blocking */ true, 0, buffer_size, output.data(), 0, nullptr, nullptr));
+    EXPECT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, /* is_blocking */ true,
+                                          0, buffer_size, output.data(), 0,
+                                          nullptr, nullptr));
 
     // Do host side equivalent.
     std::vector<uint8_t> expected(buffer_size, 0x0);
-    uur::copyRect(input, host_origin, buffer_origin, region, host_row_pitch, host_slice_pitch, buffer_row_pitch, buffer_slice_pitch,
+    uur::copyRect(input, host_origin, buffer_origin, region, host_row_pitch,
+                  host_slice_pitch, buffer_row_pitch, buffer_slice_pitch,
                   expected);
 
     // Verify the results.
@@ -109,9 +131,11 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleQueue) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferWriteRect(nullptr, buffer, true, buffer_offset, host_offset, region, size, size, size, size,
-                                                 src.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEnqueueMemBufferWriteRect(nullptr, buffer, true, buffer_offset,
+                                    host_offset, region, size, size, size, size,
+                                    src.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleBuffer) {
@@ -119,9 +143,11 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleBuffer) {
     ur_rect_region_t region{size, 1, 1};
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urEnqueueMemBufferWriteRect(queue, nullptr, true, buffer_offset, host_offset, region, size, size, size, size,
-                                                 src.data(), 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEnqueueMemBufferWriteRect(queue, nullptr, true, buffer_offset,
+                                    host_offset, region, size, size, size, size,
+                                    src.data(), 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPointerSrc) {
@@ -130,8 +156,10 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPointerSrc) {
     ur_rect_offset_t buffer_offset{0, 0, 0};
     ur_rect_offset_t host_offset{0, 0, 0};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urEnqueueMemBufferWriteRect(queue, buffer, true, buffer_offset, host_offset, region, size, size, size, size, nullptr,
-                                                 0, nullptr, nullptr));
+                     urEnqueueMemBufferWriteRect(queue, buffer, true,
+                                                 buffer_offset, host_offset,
+                                                 region, size, size, size, size,
+                                                 nullptr, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {

--- a/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -5,8 +5,9 @@
 struct urEnqueueMemUnmapTest : public uur::urMemBufferQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urMemBufferQueueTest::SetUp());
-        ASSERT_SUCCESS(
-            urEnqueueMemBufferMap(queue, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE, 0, size, 0, nullptr, nullptr, (void **)&map));
+        ASSERT_SUCCESS(urEnqueueMemBufferMap(
+            queue, buffer, true, UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE, 0, size,
+            0, nullptr, nullptr, (void **)&map));
     };
 
     void TearDown() override { uur::urMemBufferQueueTest::TearDown(); }
@@ -15,18 +16,26 @@ struct urEnqueueMemUnmapTest : public uur::urMemBufferQueueTest {
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemUnmapTest);
 
-TEST_P(urEnqueueMemUnmapTest, Success) { ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr)); }
+TEST_P(urEnqueueMemUnmapTest, Success) {
+    ASSERT_SUCCESS(urEnqueueMemUnmap(queue, buffer, map, 0, nullptr, nullptr));
+}
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullHandleQueue) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemUnmap(nullptr, buffer, map, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEnqueueMemUnmap(nullptr, buffer, map, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullHandleMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urEnqueueMemUnmap(queue, nullptr, map, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urEnqueueMemUnmap(queue, nullptr, map, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullPtrMap) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEnqueueMemUnmap(queue, buffer, nullptr, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urEnqueueMemUnmap(queue, buffer, nullptr, 0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueMemUnmapTest, InvalidNullPtrEventWaitList) {

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -10,14 +10,15 @@ struct testParametersFill {
 };
 
 template <typename T>
-inline std::string printFillTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
+inline std::string
+printFillTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
     const auto device_handle = std::get<0>(info.param);
-    const auto
-        platform_device_name = uur::GetPlatformAndDeviceName(device_handle);
+    const auto platform_device_name =
+        uur::GetPlatformAndDeviceName(device_handle);
     std::stringstream test_name;
     test_name << platform_device_name << "__size__"
-              << std::get<1>(info.param).size
-              << "__patternSize__" << std::get<1>(info.param).pattern_size;
+              << std::get<1>(info.param).size << "__patternSize__"
+              << std::get<1>(info.param).pattern_size;
     return test_name.str();
 }
 
@@ -64,9 +65,8 @@ struct urEnqueueUSMFillTestWithParam
     }
 
     void verifyData() {
-        ASSERT_SUCCESS(
-            urEnqueueUSMMemcpy(queue, true, host_mem.data(), ptr, size, 0,
-                               nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, true, host_mem.data(), ptr,
+                                          size, 0, nullptr, nullptr));
 
         size_t pattern_index = 0;
         for (size_t i = 0; i < size; ++i) {
@@ -97,23 +97,21 @@ static std::vector<testParametersFill> test_cases{
     {1024, 256},
 };
 
-UUR_TEST_SUITE_P(urEnqueueUSMFillTestWithParam,
-                 testing::ValuesIn(test_cases),
+UUR_TEST_SUITE_P(urEnqueueUSMFillTestWithParam, testing::ValuesIn(test_cases),
                  printFillTestString<urEnqueueUSMFillTestWithParam>);
 
 TEST_P(urEnqueueUSMFillTestWithParam, Success) {
 
     ur_event_handle_t event = nullptr;
 
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(), size, 0,
-                         nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
+                                    size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ur_event_status_t event_status;
-    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(event,
-                                                        UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
+    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
+        event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
     EXPECT_SUCCESS(urEventRelease(event));
 
@@ -151,77 +149,72 @@ struct urEnqueueUSMFillNegativeTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMFillNegativeTest);
 
 TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullQueueHandle) {
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(nullptr, ptr, pattern_size, pattern.data(), size, 0,
-                         nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(nullptr, ptr, pattern_size,
+                                      pattern.data(), size, 0, nullptr,
+                                      nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullPtr) {
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, pattern_size, pattern.data(), size, 0,
-                         nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
+                                      pattern.data(), size, 0, nullptr,
+                                      nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
 TEST_P(urEnqueueUSMFillNegativeTest, InvalidSize) {
 
     /* size is 0 */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, pattern_size, pattern.data(), 0, 0,
-                         nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
+                                      pattern.data(), 0, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* size is not a multiple of pattern_size */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, pattern_size, pattern.data(), 7, 0,
-                         nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
+                                      pattern.data(), 7, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFillNegativeTest, OutOfBounds) {
 
     size_t out_of_bounds = size + 1;
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, pattern_size, pattern.data(),
-                         out_of_bounds, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
+                                      pattern.data(), out_of_bounds, 0, nullptr,
+                                      nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFillNegativeTest, invalidPatternSize) {
 
     /* pattern_size is 0 */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, 0, pattern.data(),
-                         size, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, 0, pattern.data(), size,
+                                      0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* pattern_size is not a power of 2 */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, 3, pattern.data(),
-                         size, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, 3, pattern.data(), size,
+                                      0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* pattern_size is larger than size */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, 32, pattern.data(),
-                         size, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, 32, pattern.data(), size,
+                                      0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullPtrEventWaitList) {
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, pattern_size, pattern.data(),
-                         size, 1, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
+                                      pattern.data(), size, 1, nullptr,
+                                      nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
     ur_event_handle_t validEvent;
     ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill(queue, nullptr, pattern_size, pattern.data(),
-                         size, 0, &validEvent, nullptr),
-        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
+                                      pattern.data(), size, 0, &validEvent,
+                                      nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -12,16 +12,17 @@ struct testParametersFill2D {
 };
 
 template <typename T>
-inline std::string printFill2DTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
+inline std::string printFill2DTestString(
+    const testing::TestParamInfo<typename T::ParamType> &info) {
     const auto device_handle = std::get<0>(info.param);
-    const auto
-        platform_device_name = uur::GetPlatformAndDeviceName(device_handle);
+    const auto platform_device_name =
+        uur::GetPlatformAndDeviceName(device_handle);
     std::stringstream test_name;
     test_name << platform_device_name << "__pitch__"
-              << std::get<1>(info.param).pitch
-              << "__width__" << std::get<1>(info.param).width
-              << "__height__" << std::get<1>(info.param).height
-              << "__patternSize__" << std::get<1>(info.param).pattern_size;
+              << std::get<1>(info.param).pitch << "__width__"
+              << std::get<1>(info.param).width << "__height__"
+              << std::get<1>(info.param).height << "__patternSize__"
+              << std::get<1>(info.param).pattern_size;
     return test_name.str();
 }
 
@@ -45,9 +46,8 @@ struct urEnqueueUSMFill2DTestWithParam
             GTEST_SKIP() << "Device USM is not supported";
         }
 
-        ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, nullptr, allocation_size,
-                             0, &ptr));
+        ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                        allocation_size, 0, &ptr));
     }
 
     void TearDown() override {
@@ -72,9 +72,9 @@ struct urEnqueueUSMFill2DTestWithParam
     }
 
     void verifyData() {
-        ASSERT_SUCCESS(
-            urEnqueueUSMMemcpy2D(queue, true, host_mem.data(), pitch, ptr,
-                                 pitch, width, height, 0, nullptr, nullptr));
+        ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, true, host_mem.data(), pitch,
+                                            ptr, pitch, width, height, 0,
+                                            nullptr, nullptr));
 
         size_t pattern_index = 0;
         for (size_t w = 0; w < width; ++w) {
@@ -108,7 +108,8 @@ static std::vector<testParametersFill2D> test_cases{
     {1024, 256, 1, 256},
     /* Height == 1 && Pitch > width && pattern_size < width*/
     {1024, 256, 1, 4},
-    /* Height == 1 && Pitch > width && width != power_of_2 && pattern_size == 1*/
+    /* Height == 1 && Pitch > width && width != power_of_2 && pattern_size ==
+       1*/
     {1024, 57, 1, 1},
     /* Height == 1 && Pitch == width && pattern_size < width */
     {1024, 1024, 1, 256},
@@ -127,23 +128,22 @@ static std::vector<testParametersFill2D> test_cases{
     /* Height != power_of_2 && width == power_of_2 && pattern_size == 128 */
     {1024, 256, 35, 128}};
 
-UUR_TEST_SUITE_P(urEnqueueUSMFill2DTestWithParam,
-                 testing::ValuesIn(test_cases),
+UUR_TEST_SUITE_P(urEnqueueUSMFill2DTestWithParam, testing::ValuesIn(test_cases),
                  printFill2DTestString<urEnqueueUSMFill2DTestWithParam>);
 
 TEST_P(urEnqueueUSMFill2DTestWithParam, Success) {
 
     ur_event_handle_t event = nullptr;
 
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size, pattern.data(),
-                           width, height, 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                      pattern.data(), width, height, 0, nullptr,
+                                      &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ur_event_status_t event_status;
-    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(event,
-                                                        UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
+    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
+        event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
     EXPECT_SUCCESS(urEventRelease(event));
 
@@ -160,9 +160,8 @@ struct urEnqueueUSMFill2DNegativeTest : uur::urQueueTest {
             GTEST_SKIP() << "Device USM is not supported";
         }
 
-        ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, nullptr, allocation_size,
-                             0, &ptr));
+        ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                        allocation_size, 0, &ptr));
     }
 
     void TearDown() override {
@@ -185,58 +184,58 @@ struct urEnqueueUSMFill2DNegativeTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMFill2DNegativeTest);
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullQueueHandle) {
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(nullptr, ptr, pitch, pattern_size, pattern.data(),
-                           width, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(nullptr, ptr, pitch, pattern_size,
+                                        pattern.data(), width, height, 0,
+                                        nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtr) {
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, nullptr, pitch, pattern_size, pattern.data(),
-                           width, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, nullptr, pitch, pattern_size,
+                                        pattern.data(), width, height, 0,
+                                        nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size, nullptr,
-                           width, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        nullptr, width, height, 0, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidPitch) {
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, 0, pattern_size, pattern.data(),
-                           width, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, 0, pattern_size,
+                                        pattern.data(), width, height, 0,
+                                        nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, width - 1, pattern_size, pattern.data(),
-                           width, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, width - 1, pattern_size,
+                                        pattern.data(), width, height, 0,
+                                        nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidWidth) {
 
     /* width is 0 */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size, pattern.data(),
-                           0, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        pattern.data(), 0, height, 0, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* width is not a multiple of pattern_size */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size, pattern.data(),
-                           7, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        pattern.data(), 7, height, 0, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidHeight) {
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size, pattern.data(),
-                           width, 0, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        pattern.data(), width, 0, 0, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, OutOfBounds) {
@@ -244,58 +243,48 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, OutOfBounds) {
     size_t out_of_bounds = pitch * height + 1;
 
     /* Interpret memory as having just one row */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, out_of_bounds, pattern_size,
-                           pattern.data(),
-                           width, 1, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, out_of_bounds, pattern_size,
+                                        pattern.data(), width, 1, 0, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* Interpret memory as having just one column */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, out_of_bounds, pattern_size,
-                           pattern.data(),
-                           1, height, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, out_of_bounds, pattern_size,
+                                        pattern.data(), 1, height, 0, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, invalidPatternSize) {
 
     /* pattern size is 0 */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, 0,
-                           pattern.data(),
-                           width, 1, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, 0, pattern.data(),
+                                        width, 1, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* pattern_size is not a power of 2 */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, 3,
-                           pattern.data(),
-                           width, 1, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, 3, pattern.data(),
+                                        width, 1, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 
     /* pattern_size is larger than size */
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, 32,
-                           pattern.data(),
-                           width, 1, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_SIZE);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, 32, pattern.data(),
+                                        width, 1, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtrEventWaitList) {
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
-                           pattern.data(),
-                           width, 1, 1, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        pattern.data(), width, 1, 1, nullptr,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
     ur_event_handle_t validEvent;
     ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
-                           pattern.data(),
-                           width, 1, 0, &validEvent, nullptr),
-        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        pattern.data(), width, 1, 0,
+                                        &validEvent, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -21,10 +21,9 @@ struct urEnqueueUSMMemcpyTest : uur::urQueueTest {
             urUSMDeviceAlloc(context, device, nullptr, nullptr, allocation_size,
                              0, reinterpret_cast<void **>(&device_dst)));
 
-        ASSERT_SUCCESS(
-            urEnqueueUSMFill(queue, device_src, sizeof(memset_value),
-                             &memset_value, allocation_size, 0, nullptr,
-                             &memset_event));
+        ASSERT_SUCCESS(urEnqueueUSMFill(queue, device_src, sizeof(memset_value),
+                                        &memset_value, allocation_size, 0,
+                                        nullptr, &memset_event));
         ASSERT_SUCCESS(urQueueFlush(queue));
     }
 
@@ -44,19 +43,19 @@ struct urEnqueueUSMMemcpyTest : uur::urQueueTest {
 
     bool memsetHasFinished() {
         ur_event_status_t memset_event_status;
-        EXPECT_SUCCESS(urEventGetInfo(memset_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
-                                      sizeof(ur_event_status_t), &memset_event_status, nullptr));
+        EXPECT_SUCCESS(urEventGetInfo(
+            memset_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+            sizeof(ur_event_status_t), &memset_event_status, nullptr));
         return UR_EVENT_STATUS_COMPLETE == memset_event_status;
     }
 
     void verifyData() {
-        ASSERT_SUCCESS(
-            urEnqueueUSMMemcpy(queue, true, host_mem.data(), device_dst,
-                               allocation_size, 0, nullptr, nullptr));
-        bool good = std::all_of(host_mem.begin(), host_mem.end(),
-                                [this](uint8_t i) {
-                                    return i == memset_value;
-                                });
+        ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, true, host_mem.data(),
+                                          device_dst, allocation_size, 0,
+                                          nullptr, nullptr));
+        bool good =
+            std::all_of(host_mem.begin(), host_mem.end(),
+                        [this](uint8_t i) { return i == memset_value; });
         ASSERT_TRUE(good);
     }
 
@@ -71,29 +70,33 @@ struct urEnqueueUSMMemcpyTest : uur::urQueueTest {
 };
 
 /**
- * Test that urEnqueueUSMMemcpy blocks when the blocking parameter is set to true.
+ * Test that urEnqueueUSMMemcpy blocks when the blocking parameter is set to
+ * true.
  */
 TEST_P(urEnqueueUSMMemcpyTest, Blocking) {
     ASSERT_SUCCESS(urEventWait(1, &memset_event));
     ASSERT_TRUE(memsetHasFinished());
-    ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, true, device_dst, device_src, allocation_size, 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, true, device_dst, device_src,
+                                      allocation_size, 0, nullptr, nullptr));
     ASSERT_NO_FATAL_FAILURE(verifyData());
 }
 
 /**
- * Test that urEnqueueUSMMemcpy blocks and returns an event with UR_EVENT_STATUS_COMPLETE when the blocking
- * parameter is set to true.
+ * Test that urEnqueueUSMMemcpy blocks and returns an event with
+ * UR_EVENT_STATUS_COMPLETE when the blocking parameter is set to true.
  */
 TEST_P(urEnqueueUSMMemcpyTest, BlockingWithEvent) {
     ur_event_handle_t memcpy_event = nullptr;
     ASSERT_SUCCESS(urEventWait(1, &memset_event));
     ASSERT_TRUE(memsetHasFinished());
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemcpy(queue, true, device_dst, device_src, allocation_size, 0, nullptr, &memcpy_event));
+    ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, true, device_dst, device_src,
+                                      allocation_size, 0, nullptr,
+                                      &memcpy_event));
 
     ur_event_status_t event_status;
-    ASSERT_SUCCESS(urEventGetInfo(memcpy_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, sizeof(ur_event_status_t),
-                                  &event_status, nullptr));
+    ASSERT_SUCCESS(
+        urEventGetInfo(memcpy_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+                       sizeof(ur_event_status_t), &event_status, nullptr));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
     EXPECT_SUCCESS(urEventRelease(memcpy_event));
     ASSERT_NO_FATAL_FAILURE(verifyData());
@@ -107,46 +110,52 @@ TEST_P(urEnqueueUSMMemcpyTest, NonBlocking) {
     ASSERT_SUCCESS(urEventWait(1, &memset_event));
     ASSERT_TRUE(memsetHasFinished());
     ur_event_handle_t memcpy_event = nullptr;
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemcpy(queue, false, device_dst, device_src, allocation_size, 0, nullptr, &memcpy_event));
+    ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, false, device_dst, device_src,
+                                      allocation_size, 0, nullptr,
+                                      &memcpy_event));
     ASSERT_SUCCESS(urEventWait(1, &memcpy_event));
 
     ASSERT_NO_FATAL_FAILURE(verifyData());
 }
 
 /**
- * Test that urEnqueueUSMMemcpy waits for the events dependencies before copying the memory.
+ * Test that urEnqueueUSMMemcpy waits for the events dependencies before copying
+ * the memory.
  */
 TEST_P(urEnqueueUSMMemcpyTest, WaitForDependencies) {
-    ASSERT_SUCCESS(
-        urEnqueueUSMMemcpy(queue, true, device_dst, device_src, sizeof(int), 1, &memset_event, nullptr));
+    ASSERT_SUCCESS(urEnqueueUSMMemcpy(queue, true, device_dst, device_src,
+                                      sizeof(int), 1, &memset_event, nullptr));
     ASSERT_TRUE(memsetHasFinished());
     ASSERT_NO_FATAL_FAILURE(verifyData());
 }
 
 TEST_P(urEnqueueUSMMemcpyTest, InvalidNullQueueHandle) {
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMMemcpy(nullptr, true, device_dst, device_src, allocation_size, 0, nullptr, nullptr),
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(nullptr, true, device_dst, device_src,
+                                        allocation_size, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEnqueueUSMMemcpyTest, InvalidNullDst) {
-    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, nullptr, device_src, allocation_size, 0, nullptr, nullptr),
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, nullptr, device_src,
+                                        allocation_size, 0, nullptr, nullptr),
                      UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
 TEST_P(urEnqueueUSMMemcpyTest, InvalidNullSrc) {
-    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, device_dst, nullptr, allocation_size, 0, nullptr, nullptr),
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, device_dst, nullptr,
+                                        allocation_size, 0, nullptr, nullptr),
                      UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
 TEST_P(urEnqueueUSMMemcpyTest, InvalidNullPtrEventWaitList) {
-    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, device_dst, device_src, allocation_size, 1, nullptr, nullptr),
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, device_dst, device_src,
+                                        allocation_size, 1, nullptr, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
-    ASSERT_EQ_RESULT(
-        urEnqueueUSMMemcpy(queue, true, device_dst, device_src, allocation_size, 0, &memset_event, nullptr),
-        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, device_dst, device_src,
+                                        allocation_size, 0, &memset_event,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMMemcpyTest);

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -20,18 +20,15 @@ struct urEnqueueUSMMemcpy2DTestWithParam
             std::make_tuple(inPitch, inWidth, inHeight);
 
         const size_t num_elements = pitch * height;
-        ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, nullptr, num_elements, 0,
-                             &pSrc));
-        ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, nullptr, num_elements, 0,
-                             &pDst));
+        ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                        num_elements, 0, &pSrc));
+        ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                        num_elements, 0, &pDst));
         ur_event_handle_t memset_event = nullptr;
 
-        ASSERT_SUCCESS(
-            urEnqueueUSMFill2D(queue, pSrc, pitch, sizeof(memset_value),
-                               &memset_value, width, height, 0, nullptr,
-                               &memset_event));
+        ASSERT_SUCCESS(urEnqueueUSMFill2D(
+            queue, pSrc, pitch, sizeof(memset_value), &memset_value, width,
+            height, 0, nullptr, &memset_event));
 
         ASSERT_SUCCESS(urQueueFlush(queue));
         ASSERT_SUCCESS(urEventWait(1, &memset_event));
@@ -102,8 +99,8 @@ TEST_P(urEnqueueUSMMemcpy2DTestWithParam, SuccessNonBlocking) {
     ASSERT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &memcpy_event));
     ur_event_status_t event_status;
-    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(memcpy_event,
-                                                        UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
+    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
+        memcpy_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
 
     ASSERT_NO_FATAL_FAILURE(verifyMemcpySucceeded());

--- a/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -12,16 +12,15 @@ UUR_TEST_SUITE_P(urEnqueueUSMPrefetchWithParamTest,
 
 TEST_P(urEnqueueUSMPrefetchWithParamTest, Success) {
     ur_event_handle_t prefetch_event = nullptr;
-    ASSERT_SUCCESS(urEnqueueUSMPrefetch(queue, ptr, allocation_size,
-                                        getParam(), 0, nullptr,
-                                        &prefetch_event));
+    ASSERT_SUCCESS(urEnqueueUSMPrefetch(queue, ptr, allocation_size, getParam(),
+                                        0, nullptr, &prefetch_event));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &prefetch_event));
 
     ur_event_status_t event_status;
-    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(prefetch_event,
-                                                        UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
+    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
+        prefetch_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
     ASSERT_SUCCESS(urEventRelease(prefetch_event));
 }
@@ -38,32 +37,29 @@ TEST_P(urEnqueueUSMPrefetchWithParamTest, CheckWaitEvent) {
     size_t big_allocation = 65536;
     uint8_t fill_pattern = 0;
     void *fill_ptr = nullptr;
-    ASSERT_SUCCESS(
-        urUSMDeviceAlloc(context, device, nullptr, nullptr,
-                         big_allocation, 0, &fill_ptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                    big_allocation, 0, &fill_ptr));
 
     ur_event_handle_t fill_event;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(fill_queue, fill_ptr, 1, &fill_pattern, big_allocation,
-                         0, nullptr, &fill_event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(fill_queue, fill_ptr, 1, &fill_pattern,
+                                    big_allocation, 0, nullptr, &fill_event));
 
     ur_event_handle_t prefetch_event = nullptr;
-    ASSERT_SUCCESS(urEnqueueUSMPrefetch(queue, ptr, allocation_size,
-                                        getParam(), 1, &fill_event,
-                                        &prefetch_event));
+    ASSERT_SUCCESS(urEnqueueUSMPrefetch(queue, ptr, allocation_size, getParam(),
+                                        1, &fill_event, &prefetch_event));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urQueueFlush(fill_queue));
     ASSERT_SUCCESS(urEventWait(1, &prefetch_event));
 
     ur_event_status_t memset_status;
-    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(fill_event,
-                                                        UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, memset_status));
+    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
+        fill_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, memset_status));
     ASSERT_EQ(memset_status, UR_EVENT_STATUS_COMPLETE);
 
     ur_event_status_t event_status;
-    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(prefetch_event,
-                                                        UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
+    ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
+        prefetch_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
 
     ASSERT_SUCCESS(urEventRelease(prefetch_event));
@@ -80,48 +76,42 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidNullHandleQueue) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urEnqueueUSMPrefetch(nullptr, ptr, allocation_size,
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 0,
-                                          nullptr,
-                                          nullptr));
+                                          nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMPrefetchTest, InvalidNullPointerMem) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                      urEnqueueUSMPrefetch(queue, nullptr, allocation_size,
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 0,
-                                          nullptr,
-                                          nullptr));
+                                          nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMPrefetchTest, InvalidEnumeration) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urEnqueueUSMPrefetch(queue, ptr, allocation_size,
                                           UR_USM_MIGRATION_FLAG_FORCE_UINT32, 0,
-                                          nullptr,
-                                          nullptr));
+                                          nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMPrefetchTest, InvalidSizeZero) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_SIZE,
-        urEnqueueUSMPrefetch(queue, ptr, 0, UR_USM_MIGRATION_FLAG_DEFAULT, 0,
-                             nullptr,
-                             nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueUSMPrefetch(queue, ptr, 0,
+                                          UR_USM_MIGRATION_FLAG_DEFAULT, 0,
+                                          nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMPrefetchTest, InvalidSizeTooLarge) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urEnqueueUSMPrefetch(queue, ptr, allocation_size * 2,
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 0,
-                                          nullptr,
-                                          nullptr));
+                                          nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                      urEnqueueUSMPrefetch(queue, ptr, allocation_size,
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 1,
-                                          nullptr,
-                                          nullptr));
+                                          nullptr, nullptr));
 
     ur_event_handle_t validEvent;
     ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
@@ -129,6 +119,5 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                      urEnqueueUSMPrefetch(queue, ptr, allocation_size,
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 0,
-                                          &validEvent,
-                                          nullptr));
+                                          &validEvent, nullptr));
 }

--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -15,8 +15,7 @@ namespace event {
  * - Execution Status: UR_EVENT_STATUS_COMPLETE
  * - Reference Count: 1
  */
-template <class T>
-struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
+template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -8,7 +8,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
 
 TEST_P(urEventCreateWithNativeHandleTest, InvalidNullHandleNativeEvent) {
     ur_event_handle_t event = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEventCreateWithNativeHandle(nullptr, context, &event));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEventCreateWithNativeHandle(nullptr, context, &event));
 }

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -12,7 +12,8 @@ TEST_P(urEventGetInfoTest, Success) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, size, data.data(), nullptr));
+    ASSERT_SUCCESS(
+        urEventGetInfo(event, info_type, size, data.data(), nullptr));
 
     switch (info_type) {
     case UR_EVENT_INFO_COMMAND_QUEUE: {
@@ -21,7 +22,8 @@ TEST_P(urEventGetInfoTest, Success) {
         break;
     }
     case UR_EVENT_INFO_CONTEXT: {
-        auto returned_context = reinterpret_cast<ur_context_handle_t>(data.data());
+        auto returned_context =
+            reinterpret_cast<ur_context_handle_t>(data.data());
         ASSERT_EQ(context, returned_context);
         break;
     }
@@ -31,12 +33,14 @@ TEST_P(urEventGetInfoTest, Success) {
         break;
     }
     case UR_EVENT_INFO_COMMAND_EXECUTION_STATUS: {
-        auto returned_status = reinterpret_cast<ur_event_status_t *>(data.data());
+        auto returned_status =
+            reinterpret_cast<ur_event_status_t *>(data.data());
         ASSERT_EQ(UR_EVENT_STATUS_COMPLETE, *returned_status);
         break;
     }
     case UR_EVENT_INFO_REFERENCE_COUNT: {
-        auto returned_reference_count = reinterpret_cast<uint32_t *>(data.data());
+        auto returned_reference_count =
+            reinterpret_cast<uint32_t *>(data.data());
         ASSERT_EQ(1, *returned_reference_count);
         break;
     }
@@ -46,8 +50,11 @@ TEST_P(urEventGetInfoTest, Success) {
 }
 
 UUR_TEST_SUITE_P(urEventGetInfoTest,
-                 ::testing::Values(UR_EVENT_INFO_COMMAND_QUEUE, UR_EVENT_INFO_CONTEXT, UR_EVENT_INFO_COMMAND_TYPE,
-                                   UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, UR_EVENT_INFO_REFERENCE_COUNT),
+                 ::testing::Values(UR_EVENT_INFO_COMMAND_QUEUE,
+                                   UR_EVENT_INFO_CONTEXT,
+                                   UR_EVENT_INFO_COMMAND_TYPE,
+                                   UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+                                   UR_EVENT_INFO_REFERENCE_COUNT),
                  uur::deviceTestWithParamPrinter<ur_event_info_t>);
 
 using urEventGetInfoNegativeTest = uur::event::urEventTest;
@@ -60,14 +67,16 @@ TEST_P(urEventGetInfoNegativeTest, InvalidNullHandle) {
     std::vector<uint8_t> data(size);
 
     /* Invalid hEvent */
-    ASSERT_EQ_RESULT(urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0, nullptr, &size),
-                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(
+        urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0, nullptr, &size),
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventGetInfoNegativeTest, InvalidEnumeration) {
     size_t size;
-    ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0, nullptr, &size),
-                     UR_RESULT_ERROR_INVALID_ENUMERATION);
+    ASSERT_EQ_RESULT(
+        urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0, nullptr, &size),
+        UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urEventGetInfoNegativeTest, InvalidValue) {
@@ -78,7 +87,8 @@ TEST_P(urEventGetInfoNegativeTest, InvalidValue) {
     std::vector<uint8_t> data(size);
 
     /* Invalid propValueSize */
-    ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0, data.data(), nullptr),
+    ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0,
+                                    data.data(), nullptr),
                      UR_RESULT_ERROR_INVALID_VALUE);
 }
 

--- a/test/conformance/event/urEventGetNativeHandle.cpp
+++ b/test/conformance/event/urEventGetNativeHandle.cpp
@@ -14,13 +14,11 @@ TEST_P(urEventGetNativeHandleTest, Success) {
 
 TEST_P(urEventGetNativeHandleTest, InvalidNullHandleEvent) {
     ur_native_handle_t native_event = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEventGetNativeHandle(nullptr, &native_event));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urEventGetNativeHandle(nullptr, &native_event));
 }
 
 TEST_P(urEventGetNativeHandleTest, InvalidNullPointerNativeEvent) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urEventGetNativeHandle(event, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urEventGetNativeHandle(event, nullptr));
 }

--- a/test/conformance/event/urEventGetProfilingInfo.cpp
+++ b/test/conformance/event/urEventGetProfilingInfo.cpp
@@ -3,17 +3,20 @@
 
 #include "fixtures.h"
 
-using urEventGetProfilingInfoTest = uur::event::urEventTestWithParam<ur_profiling_info_t>;
+using urEventGetProfilingInfoTest =
+    uur::event::urEventTestWithParam<ur_profiling_info_t>;
 
 TEST_P(urEventGetProfilingInfoTest, Success) {
 
     ur_profiling_info_t info_type = getParam();
     size_t size;
-    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, 8);
 
     std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, size, data.data(), nullptr));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, info_type, size, data.data(), nullptr));
 
     if (sizeof(size_t) == size) {
         auto returned_value = reinterpret_cast<size_t *>(data.data());
@@ -22,8 +25,10 @@ TEST_P(urEventGetProfilingInfoTest, Success) {
 }
 
 UUR_TEST_SUITE_P(urEventGetProfilingInfoTest,
-                 ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED, UR_PROFILING_INFO_COMMAND_SUBMIT,
-                                   UR_PROFILING_INFO_COMMAND_START, UR_PROFILING_INFO_COMMAND_END),
+                 ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED,
+                                   UR_PROFILING_INFO_COMMAND_SUBMIT,
+                                   UR_PROFILING_INFO_COMMAND_START,
+                                   UR_PROFILING_INFO_COMMAND_END),
                  uur::deviceTestWithParamPrinter<ur_profiling_info_t>);
 
 using urEventGetProfilingInfoNegativeTest = uur::event::urEventTest;
@@ -31,31 +36,37 @@ using urEventGetProfilingInfoNegativeTest = uur::event::urEventTest;
 TEST_P(urEventGetProfilingInfoNegativeTest, InvalidNullHandle) {
     ur_profiling_info_t info_type = UR_PROFILING_INFO_COMMAND_QUEUED;
     size_t size;
-    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
 
     /* Invalid hEvent */
-    ASSERT_EQ_RESULT(urEventGetProfilingInfo(nullptr, info_type, 0, nullptr, &size),
-                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(
+        urEventGetProfilingInfo(nullptr, info_type, 0, nullptr, &size),
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventGetProfilingInfoNegativeTest, InvalidEnumeration) {
     size_t size;
-    ASSERT_EQ_RESULT(urEventGetProfilingInfo(event, UR_PROFILING_INFO_FORCE_UINT32, 0, nullptr, &size),
+    ASSERT_EQ_RESULT(urEventGetProfilingInfo(event,
+                                             UR_PROFILING_INFO_FORCE_UINT32, 0,
+                                             nullptr, &size),
                      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urEventGetProfilingInfoNegativeTest, InvalidValue) {
     ur_profiling_info_t info_type = UR_PROFILING_INFO_COMMAND_QUEUED;
     size_t size;
-    ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
 
     /* Invalid propValueSize */
-    ASSERT_EQ_RESULT(urEventGetProfilingInfo(event, info_type, 0, data.data(), nullptr),
-                     UR_RESULT_ERROR_INVALID_VALUE);
+    ASSERT_EQ_RESULT(
+        urEventGetProfilingInfo(event, info_type, 0, data.data(), nullptr),
+        UR_RESULT_ERROR_INVALID_VALUE);
 }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetProfilingInfoNegativeTest);

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -12,7 +12,8 @@ using urEventSetCallbackTest = uur::event::urEventReferenceTest;
 TEST_P(urEventSetCallbackTest, Success) {
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent,
+                             ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<bool *>(pUserData);
             *status = true;
@@ -20,8 +21,9 @@ TEST_P(urEventSetCallbackTest, Success) {
     };
 
     bool didRun = false;
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-                                      Callback::callback, &didRun));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
+        Callback::callback, &didRun));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ASSERT_SUCCESS(urEventRelease(event));
@@ -39,7 +41,8 @@ TEST_P(urEventSetCallbackTest, ValidateParameters) {
     };
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent,
+                             ur_execution_info_t execStatus, void *pUserData) {
 
             auto parameters = reinterpret_cast<CallbackParameters *>(pUserData);
             parameters->event = hEvent;
@@ -49,13 +52,15 @@ TEST_P(urEventSetCallbackTest, ValidateParameters) {
 
     CallbackParameters parameters{};
 
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-                                      Callback::callback, &parameters));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
+        Callback::callback, &parameters));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ASSERT_SUCCESS(urEventRelease(event));
     ASSERT_EQ(event, parameters.event);
-    ASSERT_EQ(ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE, parameters.execStatus);
+    ASSERT_EQ(ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
+              parameters.execStatus);
 }
 
 /**
@@ -71,7 +76,8 @@ TEST_P(urEventSetCallbackTest, AllStates) {
     };
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent,
+                             ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<CallbackStatus *>(pUserData);
             switch (execStatus) {
@@ -79,15 +85,18 @@ TEST_P(urEventSetCallbackTest, AllStates) {
                 status->queued = true;
                 break;
             }
-            case ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED: {
+            case ur_execution_info_t::
+                UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED: {
                 status->submitted = true;
                 break;
             }
-            case ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING: {
+            case ur_execution_info_t::
+                UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING: {
                 status->running = true;
                 break;
             }
-            case ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE: {
+            case ur_execution_info_t::
+                UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE: {
                 status->complete = true;
                 break;
             }
@@ -100,14 +109,18 @@ TEST_P(urEventSetCallbackTest, AllStates) {
 
     CallbackStatus status{};
 
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
-                                      Callback::callback, &status));
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED,
-                                      Callback::callback, &status));
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING,
-                                      Callback::callback, &status));
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-                                      Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
+        Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_SUBMITTED,
+        Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_RUNNING,
+        Callback::callback, &status));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
+        Callback::callback, &status));
 
     ASSERT_SUCCESS(urEventWait(1, &event));
     ASSERT_SUCCESS(urEventRelease(event));
@@ -127,7 +140,8 @@ TEST_P(urEventSetCallbackTest, EventAlreadyCompleted) {
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {
+        static void callback(ur_event_handle_t hEvent,
+                             ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<bool *>(pUserData);
             *status = true;
@@ -136,8 +150,9 @@ TEST_P(urEventSetCallbackTest, EventAlreadyCompleted) {
 
     bool didRun = false;
 
-    ASSERT_SUCCESS(urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
-                                      Callback::callback, &didRun));
+    ASSERT_SUCCESS(urEventSetCallback(
+        event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE,
+        Callback::callback, &didRun));
 
     ASSERT_SUCCESS(urEventRelease(event));
     ASSERT_TRUE(didRun);
@@ -148,22 +163,30 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventSetCallbackTest);
 /* Negative tests */
 using urEventSetCallbackNegativeTest = uur::event::urEventTest;
 
-void emptyCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus, void *pUserData) {}
+void emptyCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
+                   void *pUserData) {}
 
 TEST_P(urEventSetCallbackNegativeTest, InvalidNullHandle) {
 
-    ASSERT_EQ_RESULT(urEventSetCallback(nullptr, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
-                                        emptyCallback, nullptr),
-                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(
+        urEventSetCallback(
+            nullptr,
+            ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
+            emptyCallback, nullptr),
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
     ASSERT_EQ_RESULT(
-        urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED, nullptr, nullptr),
+        urEventSetCallback(
+            event, ur_execution_info_t::UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED,
+            nullptr, nullptr),
         UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventSetCallbackNegativeTest, InvalidEnumeration) {
     ASSERT_EQ_RESULT(
-        urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_FORCE_UINT32, emptyCallback, nullptr),
+        urEventSetCallback(event,
+                           ur_execution_info_t::UR_EXECUTION_INFO_FORCE_UINT32,
+                           emptyCallback, nullptr),
         UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 

--- a/test/conformance/event/urEventWait.cpp
+++ b/test/conformance/event/urEventWait.cpp
@@ -6,11 +6,14 @@
 struct urEventWaitTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size, nullptr, &src_buffer));
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size, nullptr, &dst_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
+                                         nullptr, &src_buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, size,
+                                         nullptr, &dst_buffer));
         input.assign(count, 42);
-        ASSERT_SUCCESS(
-            urEnqueueMemBufferWrite(queue, src_buffer, false, 0, size, input.data(), 0, nullptr, &event));
+        ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, src_buffer, false, 0,
+                                               size, input.data(), 0, nullptr,
+                                               &event));
         ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
@@ -38,13 +41,16 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitTest);
 
 TEST_P(urEventWaitTest, Success) {
     ur_event_handle_t event1 = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0, size, 0, nullptr, &event1));
+    ASSERT_SUCCESS(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
+                                          size, 0, nullptr, &event1));
     std::vector<uint32_t> output(count, 1);
     ur_event_handle_t event2 = nullptr;
-    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, false, 0, size, output.data(), 0, nullptr, &event2));
+    ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, dst_buffer, false, 0, size,
+                                          output.data(), 0, nullptr, &event2));
     std::vector<ur_event_handle_t> events{event1, event2};
     EXPECT_SUCCESS(urQueueFlush(queue));
-    ASSERT_SUCCESS(urEventWait(static_cast<uint32_t>(events.size()), events.data()));
+    ASSERT_SUCCESS(
+        urEventWait(static_cast<uint32_t>(events.size()), events.data()));
     ASSERT_EQ(input, output);
 
     EXPECT_SUCCESS(urEventRelease(event1));
@@ -60,5 +66,6 @@ TEST_P(urEventWaitNegativeTest, ZeroSize) {
 }
 
 TEST_P(urEventWaitNegativeTest, InvalidNullPointerEventList) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urEventWait(1, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urEventWait(1, nullptr));
 }

--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -7,40 +7,55 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateTest);
 
 TEST_P(urMemBufferCreateTest, Success) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096,
+                                     nullptr, &buffer));
     ASSERT_NE(nullptr, buffer);
     ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidNullHandleContext) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemBufferCreate(nullptr, UR_MEM_FLAG_READ_WRITE, 4096, nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urMemBufferCreate(nullptr, UR_MEM_FLAG_READ_WRITE, 4096,
+                                       nullptr, &buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidEnumerationFlags) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urMemBufferCreate(context, UR_MEM_FLAG_FORCE_UINT32, 4096, nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
+                     urMemBufferCreate(context, UR_MEM_FLAG_FORCE_UINT32, 4096,
+                                       nullptr, &buffer));
 }
 
-using urMemBufferCreateTestWithFlagsParam = uur::urContextTestWithParam<ur_mem_flag_t>;
+using urMemBufferCreateTestWithFlagsParam =
+    uur::urContextTestWithParam<ur_mem_flag_t>;
 
-using urMemBufferCreateWithHostPtrFlagsTest = urMemBufferCreateTestWithFlagsParam;
+using urMemBufferCreateWithHostPtrFlagsTest =
+    urMemBufferCreateTestWithFlagsParam;
 UUR_TEST_SUITE_P(urMemBufferCreateWithHostPtrFlagsTest,
-                 ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER, UR_MEM_FLAG_ALLOC_HOST_POINTER, UR_MEM_FLAG_USE_HOST_POINTER),
+                 ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
+                                   UR_MEM_FLAG_ALLOC_HOST_POINTER,
+                                   UR_MEM_FLAG_USE_HOST_POINTER),
                  uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferCreateWithHostPtrFlagsTest, InvalidHostPtr) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_HOST_PTR, urMemBufferCreate(context, getParam(), 4096, nullptr, &buffer));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_HOST_PTR,
+        urMemBufferCreate(context, getParam(), 4096, nullptr, &buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidNullPointerBuffer) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096,
+                                       nullptr, nullptr));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidBufferSizeZero) {
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE, urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 0, nullptr, &buffer));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
+                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 0,
+                                       nullptr, &buffer));
 }
 
 TEST_P(urMemBufferCreateTest, InvalidBufferSizeMax) {
@@ -49,5 +64,6 @@ TEST_P(urMemBufferCreateTest, InvalidBufferSizeMax) {
     ASSERT_SUCCESS(uur::GetDeviceMaxMemAllocSize(device, max_size));
     ASSERT_NE(max_size, 0);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
-                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, max_size + 1, nullptr, &buffer));
+                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                       max_size + 1, nullptr, &buffer));
 }

--- a/test/conformance/memory/urMemBufferPartition.cpp
+++ b/test/conformance/memory/urMemBufferPartition.cpp
@@ -9,7 +9,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferPartitionTest);
 TEST_P(urMemBufferPartitionTest, Success) {
     ur_buffer_region_t region{0, 1024};
     ur_mem_handle_t partition = nullptr;
-    ASSERT_SUCCESS(urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE, UR_BUFFER_CREATE_TYPE_REGION, &region, &partition));
+    ASSERT_SUCCESS(urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
+                                        UR_BUFFER_CREATE_TYPE_REGION, &region,
+                                        &partition));
     ASSERT_NE(partition, nullptr);
 }
 

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -4,7 +4,8 @@
 
 using urMemGetInfoTest = uur::urMemBufferTestWithParam<ur_mem_info_t>;
 
-UUR_TEST_SUITE_P(urMemGetInfoTest, ::testing::Values(UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT),
+UUR_TEST_SUITE_P(urMemGetInfoTest,
+                 ::testing::Values(UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT),
                  uur::deviceTestWithParamPrinter<ur_mem_info_t>);
 
 TEST_P(urMemGetInfoTest, Success) {

--- a/test/conformance/memory/urMemGetNativeHandle.cpp
+++ b/test/conformance/memory/urMemGetNativeHandle.cpp
@@ -13,9 +13,11 @@ TEST_P(urMemGetNativeHandleTest, Success) {
 
 TEST_P(urMemGetNativeHandleTest, InvalidNullHandleMem) {
     ur_native_handle_t phNativeMem;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemGetNativeHandle(nullptr, &phNativeMem));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urMemGetNativeHandle(nullptr, &phNativeMem));
 }
 
 TEST_P(urMemGetNativeHandleTest, InvalidNullPointerNativeMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urMemGetNativeHandle(buffer, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                     urMemGetNativeHandle(buffer, nullptr));
 }

--- a/test/conformance/memory/urMemImageCreate.cpp
+++ b/test/conformance/memory/urMemImageCreate.cpp
@@ -5,29 +5,28 @@
 using urMemImageCreateTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemImageCreateTest);
 
-static ur_image_format_t image_format{
-    UR_IMAGE_CHANNEL_ORDER_A,
-    UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32};
+static ur_image_format_t image_format{UR_IMAGE_CHANNEL_ORDER_A,
+                                      UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32};
 
 static ur_image_desc_t image_desc{
     UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
-    nullptr,                      ///< [in][optional] pointer to extension-specific structure
-    UR_MEM_TYPE_IMAGE3D,          ///< [in] memory object type
-    1,                            ///< [in] image width
-    1,                            ///< [in] image height
-    1,                            ///< [in] image depth
-    1,                            ///< [in] image array size
-    0,                            ///< [in] image row pitch
-    0,                            ///< [in] image slice pitch
-    0,                            ///< [in] number of MIP levels
-    0                             ///< [in] number of samples
+    nullptr, ///< [in][optional] pointer to extension-specific structure
+    UR_MEM_TYPE_IMAGE3D, ///< [in] memory object type
+    1,                   ///< [in] image width
+    1,                   ///< [in] image height
+    1,                   ///< [in] image depth
+    1,                   ///< [in] image array size
+    0,                   ///< [in] image row pitch
+    0,                   ///< [in] image slice pitch
+    0,                   ///< [in] number of MIP levels
+    0                    ///< [in] number of samples
 };
 
 TEST_P(urMemImageCreateTest, Success) {
     ur_mem_handle_t image_handle = nullptr;
-    ASSERT_SUCCESS(
-        urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE, &image_format,
-                         &image_desc, nullptr, &image_handle));
+    ASSERT_SUCCESS(urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                    &image_format, &image_desc, nullptr,
+                                    &image_handle));
     ASSERT_NE(nullptr, image_handle);
     ASSERT_SUCCESS(urMemRelease(image_handle));
 }
@@ -36,16 +35,16 @@ TEST_P(urMemImageCreateTest, InvalidNullHandleContext) {
     ur_mem_handle_t image_handle = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urMemImageCreate(nullptr, UR_MEM_FLAG_READ_WRITE,
-                                      &image_format,
-                                      &image_desc, nullptr, &image_handle));
+                                      &image_format, &image_desc, nullptr,
+                                      &image_handle));
 }
 
 TEST_P(urMemImageCreateTest, InvalidEnumerationFlags) {
     ur_mem_handle_t image_handle = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urMemImageCreate(context, UR_MEM_FLAG_FORCE_UINT32,
-                                      &image_format,
-                                      &image_desc, nullptr, &image_handle));
+                                      &image_format, &image_desc, nullptr,
+                                      &image_handle));
 }
 
 TEST_P(urMemImageCreateTest, InvalidNullPointerBuffer) {
@@ -64,24 +63,24 @@ TEST_P(urMemImageCreateTest, InvalidSize) {
 
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_IMAGE_SIZE,
                      urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                      &image_format, &invalid_image_desc, nullptr,
-                                      &image_handle));
+                                      &image_format, &invalid_image_desc,
+                                      nullptr, &image_handle));
 
     invalid_image_desc = image_desc;
     invalid_image_desc.height = std::numeric_limits<size_t>::max();
 
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_IMAGE_SIZE,
                      urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                      &image_format, &invalid_image_desc, nullptr,
-                                      &image_handle));
+                                      &image_format, &invalid_image_desc,
+                                      nullptr, &image_handle));
 
     invalid_image_desc = image_desc;
     invalid_image_desc.depth = std::numeric_limits<size_t>::max();
 
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_IMAGE_SIZE,
                      urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                      &image_format, &invalid_image_desc, nullptr,
-                                      &image_handle));
+                                      &image_format, &invalid_image_desc,
+                                      nullptr, &image_handle));
 }
 
 TEST_P(urMemImageCreateTest, InvalidImageDesc) {
@@ -142,8 +141,8 @@ TEST_P(urMemImageCreateTest, InvalidImageDesc) {
                                       nullptr, &image_handle));
 }
 
-using urMemImageCreateWithHostPtrFlagsTest = uur::urContextTestWithParam<
-    ur_mem_flag_t>;
+using urMemImageCreateWithHostPtrFlagsTest =
+    uur::urContextTestWithParam<ur_mem_flag_t>;
 
 UUR_TEST_SUITE_P(urMemImageCreateWithHostPtrFlagsTest,
                  ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
@@ -155,6 +154,6 @@ TEST_P(urMemImageCreateWithHostPtrFlagsTest, InvalidHostPtr) {
     ur_mem_handle_t image_handle = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_HOST_PTR,
                      urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                      &image_format,
-                                      &image_desc, nullptr, &image_handle));
+                                      &image_format, &image_desc, nullptr,
+                                      &image_handle));
 }

--- a/test/conformance/memory/urMemRelease.cpp
+++ b/test/conformance/memory/urMemRelease.cpp
@@ -10,4 +10,7 @@ TEST_P(urMemReleaseTest, Success) {
     ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
-TEST_P(urMemReleaseTest, InvalidNullHandleMem) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemRelease(nullptr)); }
+TEST_P(urMemReleaseTest, InvalidNullHandleMem) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urMemRelease(nullptr));
+}

--- a/test/conformance/memory/urMemRetain.cpp
+++ b/test/conformance/memory/urMemRetain.cpp
@@ -10,4 +10,6 @@ TEST_P(urMemRetainTest, Success) {
     EXPECT_SUCCESS(urMemRelease(buffer));
 }
 
-TEST_P(urMemRetainTest, InvalidNullHandleMem) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemRetain(nullptr)); }
+TEST_P(urMemRetainTest, InvalidNullHandleMem) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urMemRetain(nullptr));
+}

--- a/test/conformance/platform/urInit.cpp
+++ b/test/conformance/platform/urInit.cpp
@@ -11,6 +11,7 @@ TEST(urInitTest, Success) {
 }
 
 TEST(urInitTest, ErrorInvalidEnumerationDeviceFlags) {
-    const ur_device_init_flags_t device_flags = UR_DEVICE_INIT_FLAG_FORCE_UINT32;
+    const ur_device_init_flags_t device_flags =
+        UR_DEVICE_INIT_FLAG_FORCE_UINT32;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urInit(device_flags));
 }

--- a/test/conformance/platform/urPlatformGet.cpp
+++ b/test/conformance/platform/urPlatformGet.cpp
@@ -20,5 +20,6 @@ TEST_F(urPlatformGetTest, InvalidNumEntries) {
     uint32_t count;
     ASSERT_SUCCESS(urPlatformGet(0, nullptr, &count));
     std::vector<ur_platform_handle_t> platforms(count);
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE, urPlatformGet(0, platforms.data(), nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urPlatformGet(0, platforms.data(), nullptr));
 }

--- a/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/test/conformance/platform/urPlatformGetInfo.cpp
@@ -4,25 +4,30 @@
 #include "fixtures.h"
 #include <cstring>
 
-struct urPlatformGetInfoTest : uur::platform::urPlatformTest, ::testing::WithParamInterface<ur_platform_info_t> {
+struct urPlatformGetInfoTest
+    : uur::platform::urPlatformTest,
+      ::testing::WithParamInterface<ur_platform_info_t> {
 
-    void SetUp() { UUR_RETURN_ON_FATAL_FAILURE(uur::platform::urPlatformTest::SetUp()); }
+    void SetUp() {
+        UUR_RETURN_ON_FATAL_FAILURE(uur::platform::urPlatformTest::SetUp());
+    }
 };
 
-INSTANTIATE_TEST_SUITE_P(urPlatformGetInfo, urPlatformGetInfoTest,
-                         ::testing::Values(UR_PLATFORM_INFO_NAME
-                                           /*
-                        UR_PLATFORM_INFO_VENDOR_NAME,
-                        UR_PLATFORM_INFO_VERSION,
-                        UR_PLATFORM_INFO_EXTENSIONS,
-                        UR_PLATFORM_INFO_PROFILE
-                      */
-                                           ),
-                         [](const ::testing::TestParamInfo<ur_platform_info_t> &info) {
-                             std::stringstream ss;
-                             ss << info.param;
-                             return ss.str();
-                         });
+INSTANTIATE_TEST_SUITE_P(
+    urPlatformGetInfo, urPlatformGetInfoTest,
+    ::testing::Values(UR_PLATFORM_INFO_NAME
+                      /*
+   UR_PLATFORM_INFO_VENDOR_NAME,
+   UR_PLATFORM_INFO_VERSION,
+   UR_PLATFORM_INFO_EXTENSIONS,
+   UR_PLATFORM_INFO_PROFILE
+ */
+                      ),
+    [](const ::testing::TestParamInfo<ur_platform_info_t> &info) {
+        std::stringstream ss;
+        ss << info.param;
+        return ss.str();
+    });
 
 TEST_P(urPlatformGetInfoTest, Success) {
     size_t size = 0;
@@ -30,16 +35,20 @@ TEST_P(urPlatformGetInfoTest, Success) {
     ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<char> name(size);
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size, name.data(), nullptr));
+    ASSERT_SUCCESS(
+        urPlatformGetInfo(platform, info_type, size, name.data(), nullptr));
     ASSERT_EQ(size, std::strlen(name.data()) + 1);
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidNullHandlePlatform) {
     size_t size = 0;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urPlatformGetInfo(nullptr, GetParam(), 0, nullptr, &size));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urPlatformGetInfo(nullptr, GetParam(), 0, nullptr, &size));
 }
 
 TEST_F(urPlatformGetInfoTest, InvalidEnumerationPlatformInfoType) {
     size_t size = 0;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION, urPlatformGetInfo(platform, UR_PLATFORM_INFO_FORCE_UINT32, 0, nullptr, &size));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
+                     urPlatformGetInfo(platform, UR_PLATFORM_INFO_FORCE_UINT32,
+                                       0, nullptr, &size));
 }

--- a/test/conformance/platform/urTearDown.cpp
+++ b/test/conformance/platform/urTearDown.cpp
@@ -14,4 +14,6 @@ TEST_F(urTearDownTest, Success) {
     ASSERT_SUCCESS(urTearDown(&tear_down_params));
 }
 
-TEST_F(urTearDownTest, InvalidNullPointerParams) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urTearDown(nullptr)); }
+TEST_F(urTearDownTest, InvalidNullPointerParams) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER, urTearDown(nullptr));
+}

--- a/test/conformance/queue/urQueueFinish.cpp
+++ b/test/conformance/queue/urQueueFinish.cpp
@@ -8,18 +8,25 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFinishTest);
 TEST_P(urQueueFinishTest, Success) {
     constexpr size_t buffer_size = 1024;
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     buffer_size, nullptr, &buffer));
 
     ur_event_handle_t event = nullptr;
     std::vector<uint8_t> data(buffer_size, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false, 0, 1024, data.data(), 0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false,
+                                           0, 1024, data.data(), 0, nullptr,
+                                           &event));
 
     ASSERT_SUCCESS(urQueueFinish(queue));
 
     // check that enqueued commands have completed
     ur_event_status_t exec_status;
-    ASSERT_SUCCESS(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, sizeof(exec_status), &exec_status, nullptr));
+    ASSERT_SUCCESS(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+                                  sizeof(exec_status), &exec_status, nullptr));
     ASSERT_EQ(exec_status, UR_EXECUTION_INFO_EXECUTION_INFO_COMPLETE);
 }
 
-TEST_P(urQueueFinishTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueFinish(nullptr)); }
+TEST_P(urQueueFinishTest, InvalidNullHandleQueue) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urQueueFinish(nullptr));
+}

--- a/test/conformance/queue/urQueueFlush.cpp
+++ b/test/conformance/queue/urQueueFlush.cpp
@@ -8,12 +8,18 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFlushTest);
 TEST_P(urQueueFlushTest, Success) {
     constexpr size_t buffer_size = 1024;
     ur_mem_handle_t buffer = nullptr;
-    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, buffer_size, nullptr, &buffer));
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     buffer_size, nullptr, &buffer));
 
     std::vector<uint8_t> data(buffer_size, 42);
-    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false, 0, 1024, data.data(), 0, nullptr, nullptr));
+    ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false,
+                                           0, 1024, data.data(), 0, nullptr,
+                                           nullptr));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
 }
 
-TEST_P(urQueueFlushTest, InvalidNullHandleQueue) { ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE, urQueueFlush(nullptr)); }
+TEST_P(urQueueFlushTest, InvalidNullHandleQueue) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urQueueFlush(nullptr));
+}

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -19,7 +19,8 @@ TEST_P(urQueueGetInfoTestWithInfoParam, Success) {
     ASSERT_SUCCESS(urQueueGetInfo(queue, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
+    ASSERT_SUCCESS(
+        urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
 }
 
 using urQueueGetInfoTest = uur::urQueueTest;

--- a/test/conformance/source/main.cpp
+++ b/test/conformance/source/main.cpp
@@ -5,7 +5,8 @@
 
 int main(int argc, char **argv) {
 #ifdef KERNELS_ENVIRONMENT
-    auto *environment = new uur::KernelsEnvironment(argc, argv, KERNELS_DEFAULT_DIR);
+    auto *environment =
+        new uur::KernelsEnvironment(argc, argv, KERNELS_DEFAULT_DIR);
 #endif
 #ifdef DEVICES_ENVIRONMENT
     auto *environment = new uur::DevicesEnvironment(argc, argv);
@@ -14,7 +15,8 @@ int main(int argc, char **argv) {
     auto *environment = new uur::PlatformEnvironment(argc, argv);
 #endif
     ::testing::InitGoogleTest(&argc, argv);
-#if defined(DEVICES_ENVIRONMENT) || defined(PLATFORM_ENVIRONMENT) || defined(KERNELS_ENVIRONMENT)
+#if defined(DEVICES_ENVIRONMENT) || defined(PLATFORM_ENVIRONMENT) ||           \
+    defined(KERNELS_ENVIRONMENT)
     ::testing::AddGlobalTestEnvironment(environment);
 #endif
     return RUN_ALL_TESTS();

--- a/test/conformance/testing/include/uur/checks.h
+++ b/test/conformance/testing/include/uur/checks.h
@@ -10,9 +10,9 @@
 
 inline std::ostream &operator<<(std::ostream &out, const ur_result_t &result) {
     switch (result) {
-#define CASE(VALUE)    \
-    case VALUE:        \
-        out << #VALUE; \
+#define CASE(VALUE)                                                            \
+    case VALUE:                                                                \
+        out << #VALUE;                                                         \
         break;
 
         CASE(UR_RESULT_SUCCESS)
@@ -111,7 +111,7 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
 } // namespace uur
 
 #ifndef ASSERT_EQ_RESULT
-#define ASSERT_EQ_RESULT(EXPECTED, ACTUAL) \
+#define ASSERT_EQ_RESULT(EXPECTED, ACTUAL)                                     \
     ASSERT_EQ(uur::Result(EXPECTED), uur::Result(ACTUAL))
 #endif
 #ifndef ASSERT_SUCCESS
@@ -119,7 +119,7 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
 #endif
 
 #ifndef EXPECT_EQ_RESULT
-#define EXPECT_EQ_RESULT(EXPECTED, ACTUAL) \
+#define EXPECT_EQ_RESULT(EXPECTED, ACTUAL)                                     \
     EXPECT_EQ(uur::Result(EXPECTED), uur::Result(ACTUAL))
 #endif
 #ifndef EXPECT_SUCCESS
@@ -130,9 +130,9 @@ inline std::ostream &operator<<(std::ostream &out,
                                 const ur_device_info_t &info_type) {
     switch (info_type) {
 
-#define CASE(VALUE)    \
-    case VALUE:        \
-        out << #VALUE; \
+#define CASE(VALUE)                                                            \
+    case VALUE:                                                                \
+        out << #VALUE;                                                         \
         break;
 
         CASE(UR_DEVICE_INFO_TYPE)
@@ -245,9 +245,9 @@ inline std::ostream &operator<<(std::ostream &out,
                                 const ur_platform_info_t &info) {
 
     switch (info) {
-#define CASE(VALUE)    \
-    case VALUE:        \
-        out << #VALUE; \
+#define CASE(VALUE)                                                            \
+    case VALUE:                                                                \
+        out << #VALUE;                                                         \
         break;
         CASE(UR_PLATFORM_INFO_NAME)
         CASE(UR_PLATFORM_INFO_VENDOR_NAME)
@@ -267,9 +267,9 @@ inline std::ostream &operator<<(std::ostream &out,
                                 const ur_context_info_t &info) {
 
     switch (info) {
-#define CASE(VALUE)    \
-    case VALUE:        \
-        out << #VALUE; \
+#define CASE(VALUE)                                                            \
+    case VALUE:                                                                \
+        out << #VALUE;                                                         \
         break;
 
         CASE(UR_CONTEXT_INFO_NUM_DEVICES);
@@ -289,9 +289,9 @@ inline std::ostream &operator<<(std::ostream &out,
 inline std::ostream &operator<<(std::ostream &out,
                                 const ur_queue_info_t &info) {
     switch (info) {
-#define CASE(VALUE)    \
-    case VALUE:        \
-        out << #VALUE; \
+#define CASE(VALUE)                                                            \
+    case VALUE:                                                                \
+        out << #VALUE;                                                         \
         break;
 
         CASE(UR_QUEUE_INFO_CONTEXT)
@@ -312,9 +312,9 @@ inline std::ostream &operator<<(std::ostream &out,
 inline std::ostream &operator<<(std::ostream &out, const ur_mem_info_t &info) {
     switch (info) {
 
-#define CASE(name)    \
-    case name:        \
-        out << #name; \
+#define CASE(name)                                                             \
+    case name:                                                                 \
+        out << #name;                                                          \
         break;
 
         CASE(UR_MEM_INFO_SIZE)
@@ -330,9 +330,9 @@ inline std::ostream &operator<<(std::ostream &out, const ur_mem_info_t &info) {
 
 inline std::ostream &operator<<(std::ostream &out, const ur_mem_flag_t &flag) {
     switch (flag) {
-#define CASE(name)    \
-    case name:        \
-        out << #name; \
+#define CASE(name)                                                             \
+    case name:                                                                 \
+        out << #name;                                                          \
         break;
 
         CASE(UR_MEM_FLAG_READ_WRITE);
@@ -354,9 +354,9 @@ inline std::ostream &operator<<(std::ostream &out, const ur_mem_flag_t &flag) {
 inline std::ostream &operator<<(std::ostream &out,
                                 const ur_usm_alloc_info_t &info) {
     switch (info) {
-#define CASE(name)    \
-    case name:        \
-        out << #name; \
+#define CASE(name)                                                             \
+    case name:                                                                 \
+        out << #name;                                                          \
         break;
 
         CASE(UR_USM_ALLOC_INFO_TYPE);
@@ -376,9 +376,9 @@ inline std::ostream &operator<<(std::ostream &out,
 inline std::ostream &operator<<(std::ostream &out,
                                 const ur_event_info_t &info) {
     switch (info) {
-#define CASE(name)    \
-    case name:        \
-        out << #name; \
+#define CASE(name)                                                             \
+    case name:                                                                 \
+        out << #name;                                                          \
         break;
 
         CASE(UR_EVENT_INFO_COMMAND_QUEUE);
@@ -399,9 +399,9 @@ inline std::ostream &operator<<(std::ostream &out,
 inline std::ostream &operator<<(std::ostream &out,
                                 const ur_profiling_info_t &info) {
     switch (info) {
-#define CASE(name)    \
-    case name:        \
-        out << #name; \
+#define CASE(name)                                                             \
+    case name:                                                                 \
+        out << #name;                                                          \
         break;
 
         CASE(UR_PROFILING_INFO_COMMAND_QUEUED);

--- a/test/conformance/testing/include/uur/environment.h
+++ b/test/conformance/testing/include/uur/environment.h
@@ -67,12 +67,14 @@ struct KernelsEnvironment : DevicesEnvironment {
     virtual void SetUp() override;
     virtual void TearDown() override;
 
-    KernelSource LoadSource(const std::string &kernel_name, uint32_t device_index);
+    KernelSource LoadSource(const std::string &kernel_name,
+                            uint32_t device_index);
 
     static KernelsEnvironment *instance;
 
   private:
-    KernelOptions parseKernelOptions(int argc, char **argv, std::string kernels_default_dir);
+    KernelOptions parseKernelOptions(int argc, char **argv,
+                                     std::string kernels_default_dir);
     std::string getKernelDirectory() { return kernel_options.kernel_directory; }
     std::string getKernelSourcePath(const std::string &kernel_name,
                                     uint32_t device_index);

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -8,11 +8,11 @@
 #include <uur/environment.h>
 #include <uur/utils.h>
 
-#define UUR_RETURN_ON_FATAL_FAILURE(...)                \
-    __VA_ARGS__;                                        \
-    if (this->HasFatalFailure() || this->IsSkipped()) { \
-        return;                                         \
-    }                                                   \
+#define UUR_RETURN_ON_FATAL_FAILURE(...)                                       \
+    __VA_ARGS__;                                                               \
+    if (this->HasFatalFailure() || this->IsSkipped()) {                        \
+        return;                                                                \
+    }                                                                          \
     (void)0
 
 namespace uur {
@@ -76,12 +76,12 @@ struct urDeviceTest : urPlatformTest,
 };
 } // namespace uur
 
-#define UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(FIXTURE)                     \
-    INSTANTIATE_TEST_SUITE_P(                                            \
-        , FIXTURE,                                                       \
-        ::testing::ValuesIn(uur::DevicesEnvironment::instance->devices), \
-        [](const ::testing::TestParamInfo<ur_device_handle_t> &info) {   \
-            return uur::GetPlatformAndDeviceName(info.param);            \
+#define UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(FIXTURE)                           \
+    INSTANTIATE_TEST_SUITE_P(                                                  \
+        , FIXTURE,                                                             \
+        ::testing::ValuesIn(uur::DevicesEnvironment::instance->devices),       \
+        [](const ::testing::TestParamInfo<ur_device_handle_t> &info) {         \
+            return uur::GetPlatformAndDeviceName(info.param);                  \
         })
 
 namespace uur {
@@ -135,18 +135,17 @@ struct urMemBufferTest : urContextTest {
 
 } // namespace uur
 
-#define UUR_TEST_SUITE_P(FIXTURE, VALUES, PRINTER)                           \
-    INSTANTIATE_TEST_SUITE_P(                                                \
-        , FIXTURE,                                                           \
-        testing::Combine(                                                    \
-            ::testing::ValuesIn(uur::DevicesEnvironment::instance->devices), \
-            VALUES),                                                         \
+#define UUR_TEST_SUITE_P(FIXTURE, VALUES, PRINTER)                             \
+    INSTANTIATE_TEST_SUITE_P(                                                  \
+        , FIXTURE,                                                             \
+        testing::Combine(                                                      \
+            ::testing::ValuesIn(uur::DevicesEnvironment::instance->devices),   \
+            VALUES),                                                           \
         PRINTER)
 
 namespace uur {
 
-template <class T>
-struct urContextTestWithParam : urDeviceTestWithParam<T> {
+template <class T> struct urContextTestWithParam : urDeviceTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urDeviceTestWithParam<T>::SetUp());
         ASSERT_SUCCESS(urContextCreate(1, &this->device, nullptr, &context));
@@ -159,8 +158,7 @@ struct urContextTestWithParam : urDeviceTestWithParam<T> {
     ur_context_handle_t context;
 };
 
-template <class T>
-struct urMemBufferTestWithParam : urContextTestWithParam<T> {
+template <class T> struct urMemBufferTestWithParam : urContextTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_READ_WRITE,
@@ -194,8 +192,7 @@ struct urQueueTest : urContextTest {
     ur_queue_handle_t queue = nullptr;
 };
 
-template <class T>
-struct urQueueTestWithParam : urContextTestWithParam<T> {
+template <class T> struct urQueueTestWithParam : urContextTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
@@ -322,15 +319,14 @@ struct urUSMDeviceAllocTest : urQueueTest {
         if (!device_usm) {
             GTEST_SKIP() << "Device USM in not supported";
         }
-        ASSERT_SUCCESS(
-            urUSMDeviceAlloc(context, device, nullptr, nullptr, allocation_size,
-                             0, &ptr));
+        ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                        allocation_size, 0, &ptr));
         ur_event_handle_t event = nullptr;
 
         uint8_t fillPattern = 0;
-        ASSERT_SUCCESS(
-            urEnqueueUSMFill(queue, ptr, sizeof(fillPattern), &fillPattern,
-                             allocation_size, 0, nullptr, &event));
+        ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(fillPattern),
+                                        &fillPattern, allocation_size, 0,
+                                        nullptr, &event));
 
         EXPECT_SUCCESS(urQueueFlush(queue));
         ASSERT_SUCCESS(urEventWait(1, &event));
@@ -361,9 +357,9 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
         ur_event_handle_t event = nullptr;
 
         uint8_t fillPattern = 0;
-        ASSERT_SUCCESS(
-            urEnqueueUSMFill(this->queue, ptr, sizeof(fillPattern), &fillPattern,
-                             allocation_size, 0, nullptr, &event));
+        ASSERT_SUCCESS(urEnqueueUSMFill(this->queue, ptr, sizeof(fillPattern),
+                                        &fillPattern, allocation_size, 0,
+                                        nullptr, &event));
 
         EXPECT_SUCCESS(urQueueFlush(this->queue));
         ASSERT_SUCCESS(urEventWait(1, &event));

--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -58,77 +58,90 @@ ur_result_t GetInfo(ObjectTy object, InfoTy info, Callable cb, T &out_value) {
 }
 
 template <class T>
-auto GetPlatformInfo = [](ur_platform_handle_t platform, ur_platform_info_t info, T &out_value) {
-    return GetInfo(platform, info, urPlatformGetInfo, out_value);
-};
+auto GetPlatformInfo =
+    [](ur_platform_handle_t platform, ur_platform_info_t info, T &out_value) {
+        return GetInfo(platform, info, urPlatformGetInfo, out_value);
+    };
 
 template <class T>
-auto GetContextInfo = [](ur_context_handle_t context, ur_context_info_t info, T &out_value) {
-    return GetInfo(context, info, urContextGetInfo, out_value);
-};
+auto GetContextInfo =
+    [](ur_context_handle_t context, ur_context_info_t info, T &out_value) {
+        return GetInfo(context, info, urContextGetInfo, out_value);
+    };
 
 template <class T>
-auto GetDeviceInfo = [](ur_device_handle_t device, ur_device_info_t info, T &out_value) {
-    return GetInfo(device, info, urDeviceGetInfo, out_value);
-};
+auto GetDeviceInfo =
+    [](ur_device_handle_t device, ur_device_info_t info, T &out_value) {
+        return GetInfo(device, info, urDeviceGetInfo, out_value);
+    };
 
 template <class T>
-auto GetEventInfo = [](ur_event_handle_t event, ur_event_info_t info, T &out_value) {
-    return GetInfo(event, info, urEventGetInfo, out_value);
-};
+auto GetEventInfo =
+    [](ur_event_handle_t event, ur_event_info_t info, T &out_value) {
+        return GetInfo(event, info, urEventGetInfo, out_value);
+    };
 
 template <class T>
-auto GetQueueInfo = [](ur_queue_handle_t queue, ur_queue_info_t info, T &out_value) {
-    return GetInfo(queue, info, urQueueGetInfo, out_value);
-};
+auto GetQueueInfo =
+    [](ur_queue_handle_t queue, ur_queue_info_t info, T &out_value) {
+        return GetInfo(queue, info, urQueueGetInfo, out_value);
+    };
 
 template <class T>
-auto GetSamplerInfo = [](ur_sampler_handle_t sampler, ur_sampler_info_t info, T &out_value) {
-    return GetInfo(sampler, info, urSamplerGetInfo, out_value);
-};
+auto GetSamplerInfo =
+    [](ur_sampler_handle_t sampler, ur_sampler_info_t info, T &out_value) {
+        return GetInfo(sampler, info, urSamplerGetInfo, out_value);
+    };
 
 template <class T>
-auto GetKernelInfo = [](ur_kernel_handle_t kernel, ur_kernel_info_t info, T &out_value) {
-    return GetInfo(kernel, info, urKernelGetInfo, out_value);
-};
+auto GetKernelInfo =
+    [](ur_kernel_handle_t kernel, ur_kernel_info_t info, T &out_value) {
+        return GetInfo(kernel, info, urKernelGetInfo, out_value);
+    };
 
 template <class T>
-auto GetProgramInfo = [](ur_program_handle_t program, ur_program_info_t info, T &out_value) {
-    return GetInfo(program, info, urProgramGetInfo, out_value);
-};
+auto GetProgramInfo =
+    [](ur_program_handle_t program, ur_program_info_t info, T &out_value) {
+        return GetInfo(program, info, urProgramGetInfo, out_value);
+    };
 
 template <class T>
 ur_result_t GetObjectReferenceCount(T object, uint32_t &out_ref_count) {
     if constexpr (std::is_same_v<T, ur_context_handle_t>) {
-        return GetContextInfo<uint32_t>(object,
-                                        UR_CONTEXT_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetContextInfo<uint32_t>(object, UR_CONTEXT_INFO_REFERENCE_COUNT,
+                                        out_ref_count);
     }
     if constexpr (std::is_same_v<T, ur_device_handle_t>) {
-        return GetDeviceInfo<uint32_t>(object, UR_DEVICE_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetDeviceInfo<uint32_t>(object, UR_DEVICE_INFO_REFERENCE_COUNT,
+                                       out_ref_count);
     }
     if constexpr (std::is_same_v<T, ur_event_handle_t>) {
-        return GetEventInfo<uint32_t>(object, UR_EVENT_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetEventInfo<uint32_t>(object, UR_EVENT_INFO_REFERENCE_COUNT,
+                                      out_ref_count);
     }
     if constexpr (std::is_same_v<T, ur_queue_handle_t>) {
-        return GetQueueInfo<uint32_t>(object, UR_QUEUE_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetQueueInfo<uint32_t>(object, UR_QUEUE_INFO_REFERENCE_COUNT,
+                                      out_ref_count);
     }
     if constexpr (std::is_same_v<T, ur_sampler_handle_t>) {
-        return GetSamplerInfo<uint32_t>(object,
-                                        UR_SAMPLER_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetSamplerInfo<uint32_t>(object, UR_SAMPLER_INFO_REFERENCE_COUNT,
+                                        out_ref_count);
     }
     if constexpr (std::is_same_v<T, ur_kernel_handle_t>) {
-        return GetKernelInfo<uint32_t>(object, UR_KERNEL_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetKernelInfo<uint32_t>(object, UR_KERNEL_INFO_REFERENCE_COUNT,
+                                       out_ref_count);
     }
     if constexpr (std::is_same_v<T, ur_program_handle_t>) {
-        return GetProgramInfo<uint32_t>(object,
-                                        UR_PROGRAM_INFO_REFERENCE_COUNT, out_ref_count);
+        return GetProgramInfo<uint32_t>(object, UR_PROGRAM_INFO_REFERENCE_COUNT,
+                                        out_ref_count);
     }
     return UR_RESULT_ERROR_INVALID_VALUE;
 }
 
 inline std::string GetPlatformName(ur_platform_handle_t hPlatform) {
     std::string platform_name;
-    GetPlatformInfo<std::string>(hPlatform, UR_PLATFORM_INFO_NAME, platform_name);
+    GetPlatformInfo<std::string>(hPlatform, UR_PLATFORM_INFO_NAME,
+                                 platform_name);
     return GTestSanitizeString(
         std::string(platform_name.data(), platform_name.size()));
 }
@@ -143,104 +156,194 @@ inline std::string GetPlatformAndDeviceName(ur_device_handle_t device) {
     return GetPlatformName(GetPlatform()) + "__" + GetDeviceName(device);
 }
 
-ur_result_t GetDeviceType(ur_device_handle_t device, ur_device_type_t &device_type);
+ur_result_t GetDeviceType(ur_device_handle_t device,
+                          ur_device_type_t &device_type);
 ur_result_t GetDeviceVendorId(ur_device_handle_t device, uint32_t &vendor_id);
 ur_result_t GetDeviceId(ur_device_handle_t device, uint32_t &device_id);
-ur_result_t GetDeviceMaxComputeUnits(ur_device_handle_t device, uint32_t &max_compute_units);
-ur_result_t GetDeviceMaxWorkItemDimensions(ur_device_handle_t device, uint32_t &max_work_item_dimensions);
-ur_result_t GetDeviceMaxWorkItemSizes(ur_device_handle_t device, std::vector<size_t> &max_work_item_sizes);
-ur_result_t GetDeviceMaxWorkGroupSize(ur_device_handle_t device, size_t &max_work_group_size);
-ur_result_t GetDeviceSingleFPCapabilities(ur_device_handle_t device, ur_fp_capability_flags_t &fp_capabilities);
-ur_result_t GetDeviceHalfFPCapabilities(ur_device_handle_t device, ur_fp_capability_flags_t &fp_capabilities);
-ur_result_t GetDeviceDoubleFPCapabilities(ur_device_handle_t device, ur_fp_capability_flags_t &fp_capabilities);
-ur_result_t GetDeviceQueueProperties(ur_device_handle_t device, ur_queue_flags_t &flags);
-ur_result_t GetDevicePreferredVectorWidthChar(ur_device_handle_t device, uint32_t &pref_width);
-ur_result_t GetDevicePreferredVectorWidthInt(ur_device_handle_t device, uint32_t &pref_width);
-ur_result_t GetDevicePreferredVectorWidthLong(ur_device_handle_t device, uint32_t &pref_width);
-ur_result_t GetDevicePreferredVectorWidthFloat(ur_device_handle_t device, uint32_t &pref_width);
-ur_result_t GetDevicePreferredVectorWidthDouble(ur_device_handle_t device, uint32_t &pref_width);
-ur_result_t GetDevicePreferredVectorWidthHalf(ur_device_handle_t device, uint32_t &pref_width);
-ur_result_t GetDeviceNativeVectorWithChar(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceNativeVectorWithShort(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceNativeVectorWithInt(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceNativeVectorWithLong(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceNativeVectorWithFloat(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceNativeVectorWithDouble(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceNativeVectorWithHalf(ur_device_handle_t device, uint32_t &vec_width);
-ur_result_t GetDeviceMaxClockFrequency(ur_device_handle_t device, uint32_t &max_freq);
-ur_result_t GetDeviceMemoryClockRate(ur_device_handle_t device, uint32_t &mem_clock);
-ur_result_t GetDeviceAddressBits(ur_device_handle_t device, uint32_t &addr_bits);
-ur_result_t GetDeviceMaxMemAllocSize(ur_device_handle_t device, uint64_t &alloc_size);
-ur_result_t GetDeviceImageSupport(ur_device_handle_t device, bool &image_support);
-ur_result_t GetDeviceMaxReadImageArgs(ur_device_handle_t device, uint32_t &read_arg);
-ur_result_t GetDeviceMaxWriteImageArgs(ur_device_handle_t device, uint32_t &write_args);
-ur_result_t GetDeviceMaxReadWriteImageArgs(ur_device_handle_t device, uint32_t &read_write_args);
-ur_result_t GetDeviceImage2DMaxWidth(ur_device_handle_t device, size_t &max_width);
-ur_result_t GetDeviceImage2DMaxHeight(ur_device_handle_t device, size_t &max_height);
-ur_result_t GetDeviceImage3DMaxWidth(ur_device_handle_t device, size_t &max_width);
-ur_result_t GetDeviceImage3DMaxHeight(ur_device_handle_t device, size_t &max_height);
-ur_result_t GetDeviceImage3DMaxDepth(ur_device_handle_t device, size_t &max_depth);
-ur_result_t GetDeviceImageMaxBufferSize(ur_device_handle_t device, size_t &max_buf_size);
-ur_result_t GetDeviceImageMaxArraySize(ur_device_handle_t device, size_t &max_arr_size);
-ur_result_t GetDeviceMaxSamplers(ur_device_handle_t device, uint32_t &max_samplers);
-ur_result_t GetDeviceMaxParameterSize(ur_device_handle_t device, size_t &max_param_size);
-ur_result_t GetDeviceMemBaseAddressAlign(ur_device_handle_t device, uint32_t &align);
-ur_result_t GetDeviceMemCacheType(ur_device_handle_t device, ur_device_mem_cache_type_t &cache_type);
-ur_result_t GetDeviceMemCachelineSize(ur_device_handle_t device, uint32_t &cache_line_size);
-ur_result_t GetDeviceMemCacheSize(ur_device_handle_t device, uint64_t &cache_size);
-ur_result_t GetDeviceGlobalMemSize(ur_device_handle_t device, uint64_t &mem_size);
-ur_result_t GetDeviceGlobalMemFree(ur_device_handle_t device, uint64_t &mem_free);
-ur_result_t GetDeviceMaxConstantBufferSize(ur_device_handle_t device, uint64_t &buf_size);
+ur_result_t GetDeviceMaxComputeUnits(ur_device_handle_t device,
+                                     uint32_t &max_compute_units);
+ur_result_t GetDeviceMaxWorkItemDimensions(ur_device_handle_t device,
+                                           uint32_t &max_work_item_dimensions);
+ur_result_t GetDeviceMaxWorkItemSizes(ur_device_handle_t device,
+                                      std::vector<size_t> &max_work_item_sizes);
+ur_result_t GetDeviceMaxWorkGroupSize(ur_device_handle_t device,
+                                      size_t &max_work_group_size);
+ur_result_t
+GetDeviceSingleFPCapabilities(ur_device_handle_t device,
+                              ur_fp_capability_flags_t &fp_capabilities);
+ur_result_t
+GetDeviceHalfFPCapabilities(ur_device_handle_t device,
+                            ur_fp_capability_flags_t &fp_capabilities);
+ur_result_t
+GetDeviceDoubleFPCapabilities(ur_device_handle_t device,
+                              ur_fp_capability_flags_t &fp_capabilities);
+ur_result_t GetDeviceQueueProperties(ur_device_handle_t device,
+                                     ur_queue_flags_t &flags);
+ur_result_t GetDevicePreferredVectorWidthChar(ur_device_handle_t device,
+                                              uint32_t &pref_width);
+ur_result_t GetDevicePreferredVectorWidthInt(ur_device_handle_t device,
+                                             uint32_t &pref_width);
+ur_result_t GetDevicePreferredVectorWidthLong(ur_device_handle_t device,
+                                              uint32_t &pref_width);
+ur_result_t GetDevicePreferredVectorWidthFloat(ur_device_handle_t device,
+                                               uint32_t &pref_width);
+ur_result_t GetDevicePreferredVectorWidthDouble(ur_device_handle_t device,
+                                                uint32_t &pref_width);
+ur_result_t GetDevicePreferredVectorWidthHalf(ur_device_handle_t device,
+                                              uint32_t &pref_width);
+ur_result_t GetDeviceNativeVectorWithChar(ur_device_handle_t device,
+                                          uint32_t &vec_width);
+ur_result_t GetDeviceNativeVectorWithShort(ur_device_handle_t device,
+                                           uint32_t &vec_width);
+ur_result_t GetDeviceNativeVectorWithInt(ur_device_handle_t device,
+                                         uint32_t &vec_width);
+ur_result_t GetDeviceNativeVectorWithLong(ur_device_handle_t device,
+                                          uint32_t &vec_width);
+ur_result_t GetDeviceNativeVectorWithFloat(ur_device_handle_t device,
+                                           uint32_t &vec_width);
+ur_result_t GetDeviceNativeVectorWithDouble(ur_device_handle_t device,
+                                            uint32_t &vec_width);
+ur_result_t GetDeviceNativeVectorWithHalf(ur_device_handle_t device,
+                                          uint32_t &vec_width);
+ur_result_t GetDeviceMaxClockFrequency(ur_device_handle_t device,
+                                       uint32_t &max_freq);
+ur_result_t GetDeviceMemoryClockRate(ur_device_handle_t device,
+                                     uint32_t &mem_clock);
+ur_result_t GetDeviceAddressBits(ur_device_handle_t device,
+                                 uint32_t &addr_bits);
+ur_result_t GetDeviceMaxMemAllocSize(ur_device_handle_t device,
+                                     uint64_t &alloc_size);
+ur_result_t GetDeviceImageSupport(ur_device_handle_t device,
+                                  bool &image_support);
+ur_result_t GetDeviceMaxReadImageArgs(ur_device_handle_t device,
+                                      uint32_t &read_arg);
+ur_result_t GetDeviceMaxWriteImageArgs(ur_device_handle_t device,
+                                       uint32_t &write_args);
+ur_result_t GetDeviceMaxReadWriteImageArgs(ur_device_handle_t device,
+                                           uint32_t &read_write_args);
+ur_result_t GetDeviceImage2DMaxWidth(ur_device_handle_t device,
+                                     size_t &max_width);
+ur_result_t GetDeviceImage2DMaxHeight(ur_device_handle_t device,
+                                      size_t &max_height);
+ur_result_t GetDeviceImage3DMaxWidth(ur_device_handle_t device,
+                                     size_t &max_width);
+ur_result_t GetDeviceImage3DMaxHeight(ur_device_handle_t device,
+                                      size_t &max_height);
+ur_result_t GetDeviceImage3DMaxDepth(ur_device_handle_t device,
+                                     size_t &max_depth);
+ur_result_t GetDeviceImageMaxBufferSize(ur_device_handle_t device,
+                                        size_t &max_buf_size);
+ur_result_t GetDeviceImageMaxArraySize(ur_device_handle_t device,
+                                       size_t &max_arr_size);
+ur_result_t GetDeviceMaxSamplers(ur_device_handle_t device,
+                                 uint32_t &max_samplers);
+ur_result_t GetDeviceMaxParameterSize(ur_device_handle_t device,
+                                      size_t &max_param_size);
+ur_result_t GetDeviceMemBaseAddressAlign(ur_device_handle_t device,
+                                         uint32_t &align);
+ur_result_t GetDeviceMemCacheType(ur_device_handle_t device,
+                                  ur_device_mem_cache_type_t &cache_type);
+ur_result_t GetDeviceMemCachelineSize(ur_device_handle_t device,
+                                      uint32_t &cache_line_size);
+ur_result_t GetDeviceMemCacheSize(ur_device_handle_t device,
+                                  uint64_t &cache_size);
+ur_result_t GetDeviceGlobalMemSize(ur_device_handle_t device,
+                                   uint64_t &mem_size);
+ur_result_t GetDeviceGlobalMemFree(ur_device_handle_t device,
+                                   uint64_t &mem_free);
+ur_result_t GetDeviceMaxConstantBufferSize(ur_device_handle_t device,
+                                           uint64_t &buf_size);
 ur_result_t GetDeviceMaxConstantArgs(ur_device_handle_t device, uint32_t &args);
-ur_result_t GetDeviceLocalMemType(ur_device_handle_t device, ur_device_local_mem_type_t &type);
+ur_result_t GetDeviceLocalMemType(ur_device_handle_t device,
+                                  ur_device_local_mem_type_t &type);
 ur_result_t GetDeviceLocalMemSize(ur_device_handle_t device, uint64_t &size);
-ur_result_t GetDeviceErrorCorrectionSupport(ur_device_handle_t device, bool &ecc_support);
-ur_result_t GetDeviceProfilingTimerResolution(ur_device_handle_t device, size_t &resolution);
-ur_result_t GetDeviceLittleEndian(ur_device_handle_t device, bool &little_endian);
+ur_result_t GetDeviceErrorCorrectionSupport(ur_device_handle_t device,
+                                            bool &ecc_support);
+ur_result_t GetDeviceProfilingTimerResolution(ur_device_handle_t device,
+                                              size_t &resolution);
+ur_result_t GetDeviceLittleEndian(ur_device_handle_t device,
+                                  bool &little_endian);
 ur_result_t GetDeviceAvailable(ur_device_handle_t device, bool &available);
-ur_result_t GetDeviceCompilerAvailable(ur_device_handle_t device, bool &available);
-ur_result_t GetDeviceLinkerAvailable(ur_device_handle_t device, bool &available);
-ur_result_t GetDeviceExecutionCapabilities(ur_device_handle_t device, ur_device_exec_capability_flags_t &capabilities);
-ur_result_t GetDeviceQueueOnDeviceProperties(ur_device_handle_t device, ur_queue_flags_t &properties);
-ur_result_t GetDeviceQueueOnHostProperties(ur_device_handle_t device, ur_queue_flags_t &properties);
-ur_result_t GetDeviceBuiltInKernels(ur_device_handle_t device, std::vector<std::string> &names);
-ur_result_t GetDevicePlatform(ur_device_handle_t device, ur_platform_handle_t &platform);
-ur_result_t GetDeviceReferenceCount(ur_device_handle_t device, uint32_t &ref_count);
-ur_result_t GetDeviceILVersion(ur_device_handle_t device, std::string &il_version);
+ur_result_t GetDeviceCompilerAvailable(ur_device_handle_t device,
+                                       bool &available);
+ur_result_t GetDeviceLinkerAvailable(ur_device_handle_t device,
+                                     bool &available);
+ur_result_t
+GetDeviceExecutionCapabilities(ur_device_handle_t device,
+                               ur_device_exec_capability_flags_t &capabilities);
+ur_result_t GetDeviceQueueOnDeviceProperties(ur_device_handle_t device,
+                                             ur_queue_flags_t &properties);
+ur_result_t GetDeviceQueueOnHostProperties(ur_device_handle_t device,
+                                           ur_queue_flags_t &properties);
+ur_result_t GetDeviceBuiltInKernels(ur_device_handle_t device,
+                                    std::vector<std::string> &names);
+ur_result_t GetDevicePlatform(ur_device_handle_t device,
+                              ur_platform_handle_t &platform);
+ur_result_t GetDeviceReferenceCount(ur_device_handle_t device,
+                                    uint32_t &ref_count);
+ur_result_t GetDeviceILVersion(ur_device_handle_t device,
+                               std::string &il_version);
 ur_result_t GetDeviceVendor(ur_device_handle_t device, std::string &vendor);
-ur_result_t GetDeviceDriverVersion(ur_device_handle_t device, std::string &driver_version);
+ur_result_t GetDeviceDriverVersion(ur_device_handle_t device,
+                                   std::string &driver_version);
 ur_result_t GetDeviceProfile(ur_device_handle_t device, std::string &profile);
 ur_result_t GetDeviceVersion(ur_device_handle_t device, std::string &version);
-ur_result_t GetDeviceBackendRuntimeVersion(ur_device_handle_t device, std::string &runtime_version);
-ur_result_t GetDeviceExtensions(ur_device_handle_t device, std::vector<std::string> &extensions);
+ur_result_t GetDeviceBackendRuntimeVersion(ur_device_handle_t device,
+                                           std::string &runtime_version);
+ur_result_t GetDeviceExtensions(ur_device_handle_t device,
+                                std::vector<std::string> &extensions);
 ur_result_t GetDevicePrintfBufferSize(ur_device_handle_t device, size_t &size);
-ur_result_t GetDevicePreferredInteropUserSync(ur_device_handle_t device, bool &sync);
-ur_result_t GetDeviceParentDevice(ur_device_handle_t device, ur_device_handle_t &parent);
-ur_result_t GetDevicePartitionProperties(ur_device_handle_t device, std::vector<ur_device_partition_property_t> &properties);
-ur_result_t GetDevicePartitionMaxSubDevices(ur_device_handle_t device, uint32_t &max_sub_devices);
-ur_result_t GetDevicePartitionAffinityDomainFlags(ur_device_handle_t device, ur_device_affinity_domain_flags_t &flags);
-ur_result_t GetDevicePartitionType(ur_device_handle_t device, std::vector<ur_device_partition_property_t> &type);
-ur_result_t GetDeviceMaxNumberSubGroups(ur_device_handle_t device, uint32_t &max_sub_groups);
-ur_result_t GetDeviceSubGroupIndependentForwardProgress(ur_device_handle_t device, bool &progress);
-ur_result_t GetDeviceSubGroupSizesIntel(ur_device_handle_t device, std::vector<uint32_t> &sizes);
+ur_result_t GetDevicePreferredInteropUserSync(ur_device_handle_t device,
+                                              bool &sync);
+ur_result_t GetDeviceParentDevice(ur_device_handle_t device,
+                                  ur_device_handle_t &parent);
+ur_result_t GetDevicePartitionProperties(
+    ur_device_handle_t device,
+    std::vector<ur_device_partition_property_t> &properties);
+ur_result_t GetDevicePartitionMaxSubDevices(ur_device_handle_t device,
+                                            uint32_t &max_sub_devices);
+ur_result_t
+GetDevicePartitionAffinityDomainFlags(ur_device_handle_t device,
+                                      ur_device_affinity_domain_flags_t &flags);
+ur_result_t
+GetDevicePartitionType(ur_device_handle_t device,
+                       std::vector<ur_device_partition_property_t> &type);
+ur_result_t GetDeviceMaxNumberSubGroups(ur_device_handle_t device,
+                                        uint32_t &max_sub_groups);
+ur_result_t
+GetDeviceSubGroupIndependentForwardProgress(ur_device_handle_t device,
+                                            bool &progress);
+ur_result_t GetDeviceSubGroupSizesIntel(ur_device_handle_t device,
+                                        std::vector<uint32_t> &sizes);
 ur_result_t GetDeviceUSMHostSupport(ur_device_handle_t device, bool &support);
 ur_result_t GetDeviceUSMDeviceSupport(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceUSMSingleSharedSupport(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceUSMCrossSharedSupport(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceUSMSystemSharedSupport(ur_device_handle_t device, bool &support);
+ur_result_t GetDeviceUSMSingleSharedSupport(ur_device_handle_t device,
+                                            bool &support);
+ur_result_t GetDeviceUSMCrossSharedSupport(ur_device_handle_t device,
+                                           bool &support);
+ur_result_t GetDeviceUSMSystemSharedSupport(ur_device_handle_t device,
+                                            bool &support);
 ur_result_t GetDeviceUUID(ur_device_handle_t device, std::string &uuid);
-ur_result_t GetDevicePCIAddress(ur_device_handle_t device, std::string &address);
+ur_result_t GetDevicePCIAddress(ur_device_handle_t device,
+                                std::string &address);
 ur_result_t GetDeviceGPUEUCount(ur_device_handle_t device, uint32_t &count);
 ur_result_t GetDeviceGPUEUSIMDWidth(ur_device_handle_t device, uint32_t &width);
 ur_result_t GetDeviceGPUEUSlices(ur_device_handle_t device, uint32_t &slices);
-ur_result_t GetDeviceGPUSubslicesPerSlice(ur_device_handle_t device, uint32_t &subslices);
-ur_result_t GetDeviceMaxMemoryBandwidth(ur_device_handle_t device, uint32_t &bandwidth);
+ur_result_t GetDeviceGPUSubslicesPerSlice(ur_device_handle_t device,
+                                          uint32_t &subslices);
+ur_result_t GetDeviceMaxMemoryBandwidth(ur_device_handle_t device,
+                                        uint32_t &bandwidth);
 ur_result_t GetDeviceImageSRGB(ur_device_handle_t device, bool &support);
 ur_result_t GetDeviceAtomic64Support(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceMemoryOrderCapabilities(ur_device_handle_t device, ur_memory_order_capability_flags_t &flags);
-ur_result_t GetDeviceMemoryScopeCapabilities(ur_device_handle_t device, ur_memory_scope_capability_flags_t &flags);
+ur_result_t
+GetDeviceMemoryOrderCapabilities(ur_device_handle_t device,
+                                 ur_memory_order_capability_flags_t &flags);
+ur_result_t
+GetDeviceMemoryScopeCapabilities(ur_device_handle_t device,
+                                 ur_memory_scope_capability_flags_t &flags);
 ur_result_t GetDeviceBFloat16Support(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device, uint32_t &max_indices);
+ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device,
+                                            uint32_t &max_indices);
 
 } // namespace uur
 

--- a/test/conformance/testing/source/utils.cpp
+++ b/test/conformance/testing/source/utils.cpp
@@ -21,7 +21,8 @@ std::vector<std::string> split(const std::string &str, char delim) {
 }
 
 template <class T>
-ur_result_t GetDeviceVectorInfo(ur_device_handle_t device, ur_device_info_t info, std::vector<T> &out) {
+ur_result_t GetDeviceVectorInfo(ur_device_handle_t device,
+                                ur_device_info_t info, std::vector<T> &out) {
     size_t size = 0;
     ur_result_t result = urDeviceGetInfo(device, info, 0, nullptr, &size);
     if (result != UR_RESULT_SUCCESS || size == 0) {
@@ -37,8 +38,10 @@ ur_result_t GetDeviceVectorInfo(ur_device_handle_t device, ur_device_info_t info
 }
 } // namespace
 
-ur_result_t GetDeviceType(ur_device_handle_t device, ur_device_type_t &device_type) {
-    return GetDeviceInfo<ur_device_type_t>(device, UR_DEVICE_INFO_TYPE, device_type);
+ur_result_t GetDeviceType(ur_device_handle_t device,
+                          ur_device_type_t &device_type) {
+    return GetDeviceInfo<ur_device_type_t>(device, UR_DEVICE_INFO_TYPE,
+                                           device_type);
 }
 
 ur_result_t GetDeviceVendorId(ur_device_handle_t device, uint32_t &vendor_id) {
@@ -49,237 +52,355 @@ ur_result_t GetDeviceId(ur_device_handle_t device, uint32_t &device_id) {
     return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_DEVICE_ID, device_id);
 }
 
-ur_result_t GetDeviceMaxComputeUnits(ur_device_handle_t device, uint32_t &max_compute_units) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_COMPUTE_UNITS, max_compute_units);
+ur_result_t GetDeviceMaxComputeUnits(ur_device_handle_t device,
+                                     uint32_t &max_compute_units) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_COMPUTE_UNITS,
+                                   max_compute_units);
 }
 
-ur_result_t GetDeviceMaxWorkItemDimensions(ur_device_handle_t device, uint32_t &max_work_item_dimensions) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS, max_work_item_dimensions);
+ur_result_t GetDeviceMaxWorkItemDimensions(ur_device_handle_t device,
+                                           uint32_t &max_work_item_dimensions) {
+    return GetDeviceInfo<uint32_t>(device,
+                                   UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,
+                                   max_work_item_dimensions);
 }
 
-ur_result_t GetDeviceMaxWorkItemSizes(ur_device_handle_t device, std::vector<size_t> &max_work_item_sizes) {
-    return GetDeviceVectorInfo<size_t>(device, UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES, max_work_item_sizes);
+ur_result_t
+GetDeviceMaxWorkItemSizes(ur_device_handle_t device,
+                          std::vector<size_t> &max_work_item_sizes) {
+    return GetDeviceVectorInfo<size_t>(
+        device, UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES, max_work_item_sizes);
 }
 
-ur_result_t GetDeviceMaxWorkGroupSize(ur_device_handle_t device, size_t &max_work_group_size) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE, max_work_group_size);
+ur_result_t GetDeviceMaxWorkGroupSize(ur_device_handle_t device,
+                                      size_t &max_work_group_size) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
+                                 max_work_group_size);
 }
 
-ur_result_t GetDeviceSingleFPCapabilities(ur_device_handle_t device, ur_fp_capability_flags_t &fp_capabilities) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(device, UR_DEVICE_INFO_SINGLE_FP_CONFIG, fp_capabilities);
+ur_result_t
+GetDeviceSingleFPCapabilities(ur_device_handle_t device,
+                              ur_fp_capability_flags_t &fp_capabilities) {
+    return GetDeviceInfo<ur_fp_capability_flags_t>(
+        device, UR_DEVICE_INFO_SINGLE_FP_CONFIG, fp_capabilities);
 }
 
-ur_result_t GetDeviceHalfFPCapabilities(ur_device_handle_t device, ur_fp_capability_flags_t &fp_capabilities) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(device, UR_DEVICE_INFO_HALF_FP_CONFIG, fp_capabilities);
+ur_result_t
+GetDeviceHalfFPCapabilities(ur_device_handle_t device,
+                            ur_fp_capability_flags_t &fp_capabilities) {
+    return GetDeviceInfo<ur_fp_capability_flags_t>(
+        device, UR_DEVICE_INFO_HALF_FP_CONFIG, fp_capabilities);
 }
 
-ur_result_t GetDeviceDoubleFPCapabilities(ur_device_handle_t device, ur_fp_capability_flags_t &fp_capabilities) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(device, UR_DEVICE_INFO_DOUBLE_FP_CONFIG, fp_capabilities);
+ur_result_t
+GetDeviceDoubleFPCapabilities(ur_device_handle_t device,
+                              ur_fp_capability_flags_t &fp_capabilities) {
+    return GetDeviceInfo<ur_fp_capability_flags_t>(
+        device, UR_DEVICE_INFO_DOUBLE_FP_CONFIG, fp_capabilities);
 }
 
-ur_result_t GetDeviceQueueProperties(ur_device_handle_t device, ur_queue_flags_t &flags) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(device, UR_DEVICE_INFO_QUEUE_PROPERTIES, flags);
+ur_result_t GetDeviceQueueProperties(ur_device_handle_t device,
+                                     ur_queue_flags_t &flags) {
+    return GetDeviceInfo<ur_fp_capability_flags_t>(
+        device, UR_DEVICE_INFO_QUEUE_PROPERTIES, flags);
 }
 
-ur_result_t GetDevicePreferredVectorWidthChar(ur_device_handle_t device, uint32_t &pref_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR, pref_width);
+ur_result_t GetDevicePreferredVectorWidthChar(ur_device_handle_t device,
+                                              uint32_t &pref_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR, pref_width);
 }
 
-ur_result_t GetDevicePreferredVectorWidthInt(ur_device_handle_t device, uint32_t &pref_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT, pref_width);
+ur_result_t GetDevicePreferredVectorWidthInt(ur_device_handle_t device,
+                                             uint32_t &pref_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT, pref_width);
 }
 
-ur_result_t GetDevicePreferredVectorWidthLong(ur_device_handle_t device, uint32_t &pref_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG, pref_width);
+ur_result_t GetDevicePreferredVectorWidthLong(ur_device_handle_t device,
+                                              uint32_t &pref_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG, pref_width);
 }
 
-ur_result_t GetDevicePreferredVectorWidthFloat(ur_device_handle_t device, uint32_t &pref_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT, pref_width);
+ur_result_t GetDevicePreferredVectorWidthFloat(ur_device_handle_t device,
+                                               uint32_t &pref_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT, pref_width);
 }
 
-ur_result_t GetDevicePreferredVectorWidthDouble(ur_device_handle_t device, uint32_t &pref_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE, pref_width);
+ur_result_t GetDevicePreferredVectorWidthDouble(ur_device_handle_t device,
+                                                uint32_t &pref_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE, pref_width);
 }
 
-ur_result_t GetDevicePreferredVectorWidthHalf(ur_device_handle_t device, uint32_t &pref_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF, pref_width);
+ur_result_t GetDevicePreferredVectorWidthHalf(ur_device_handle_t device,
+                                              uint32_t &pref_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF, pref_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithChar(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR, vec_width);
+ur_result_t GetDeviceNativeVectorWithChar(ur_device_handle_t device,
+                                          uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR, vec_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithShort(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT, vec_width);
+ur_result_t GetDeviceNativeVectorWithShort(ur_device_handle_t device,
+                                           uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT, vec_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithInt(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT, vec_width);
+ur_result_t GetDeviceNativeVectorWithInt(ur_device_handle_t device,
+                                         uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT, vec_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithLong(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG, vec_width);
+ur_result_t GetDeviceNativeVectorWithLong(ur_device_handle_t device,
+                                          uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG, vec_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithFloat(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT, vec_width);
+ur_result_t GetDeviceNativeVectorWithFloat(ur_device_handle_t device,
+                                           uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT, vec_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithDouble(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE, vec_width);
+ur_result_t GetDeviceNativeVectorWithDouble(ur_device_handle_t device,
+                                            uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE, vec_width);
 }
 
-ur_result_t GetDeviceNativeVectorWithHalf(ur_device_handle_t device, uint32_t &vec_width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF, vec_width);
+ur_result_t GetDeviceNativeVectorWithHalf(ur_device_handle_t device,
+                                          uint32_t &vec_width) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF, vec_width);
 }
 
-ur_result_t GetDeviceMaxClockFrequency(ur_device_handle_t device, uint32_t &max_freq) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY, max_freq);
+ur_result_t GetDeviceMaxClockFrequency(ur_device_handle_t device,
+                                       uint32_t &max_freq) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY,
+                                   max_freq);
 }
 
-ur_result_t GetDeviceMemoryClockRate(ur_device_handle_t device, uint32_t &mem_clock) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MEMORY_CLOCK_RATE, mem_clock);
+ur_result_t GetDeviceMemoryClockRate(ur_device_handle_t device,
+                                     uint32_t &mem_clock) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MEMORY_CLOCK_RATE,
+                                   mem_clock);
 }
 
-ur_result_t GetDeviceAddressBits(ur_device_handle_t device, uint32_t &addr_bits) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_ADDRESS_BITS, addr_bits);
+ur_result_t GetDeviceAddressBits(ur_device_handle_t device,
+                                 uint32_t &addr_bits) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_ADDRESS_BITS,
+                                   addr_bits);
 }
 
-ur_result_t GetDeviceMaxMemAllocSize(ur_device_handle_t device, uint64_t &alloc_size) {
-    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE, alloc_size);
+ur_result_t GetDeviceMaxMemAllocSize(ur_device_handle_t device,
+                                     uint64_t &alloc_size) {
+    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,
+                                   alloc_size);
 }
 
-ur_result_t GetDeviceImageSupport(ur_device_handle_t device, bool &image_support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_IMAGE_SUPPORTED, image_support);
+ur_result_t GetDeviceImageSupport(ur_device_handle_t device,
+                                  bool &image_support) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_IMAGE_SUPPORTED,
+                               image_support);
 }
 
-ur_result_t GetDeviceMaxReadImageArgs(ur_device_handle_t device, uint32_t &read_arg) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS, read_arg);
+ur_result_t GetDeviceMaxReadImageArgs(ur_device_handle_t device,
+                                      uint32_t &read_arg) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS,
+                                   read_arg);
 }
 
-ur_result_t GetDeviceMaxWriteImageArgs(ur_device_handle_t device, uint32_t &write_args) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS, write_args);
+ur_result_t GetDeviceMaxWriteImageArgs(ur_device_handle_t device,
+                                       uint32_t &write_args) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS,
+                                   write_args);
 }
 
-ur_result_t GetDeviceMaxReadWriteImageArgs(ur_device_handle_t device, uint32_t &read_write_args) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS, read_write_args);
+ur_result_t GetDeviceMaxReadWriteImageArgs(ur_device_handle_t device,
+                                           uint32_t &read_write_args) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS, read_write_args);
 }
 
-ur_result_t GetDeviceImage2DMaxWidth(ur_device_handle_t device, size_t &max_width) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH, max_width);
+ur_result_t GetDeviceImage2DMaxWidth(ur_device_handle_t device,
+                                     size_t &max_width) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH,
+                                 max_width);
 }
 
-ur_result_t GetDeviceImage2DMaxHeight(ur_device_handle_t device, size_t &max_height) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT, max_height);
+ur_result_t GetDeviceImage2DMaxHeight(ur_device_handle_t device,
+                                      size_t &max_height) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT,
+                                 max_height);
 }
 
-ur_result_t GetDeviceImage3DMaxWidth(ur_device_handle_t device, size_t &max_width) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH, max_width);
+ur_result_t GetDeviceImage3DMaxWidth(ur_device_handle_t device,
+                                     size_t &max_width) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH,
+                                 max_width);
 }
 
-ur_result_t GetDeviceImage3DMaxHeight(ur_device_handle_t device, size_t &max_height) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT, max_height);
+ur_result_t GetDeviceImage3DMaxHeight(ur_device_handle_t device,
+                                      size_t &max_height) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT,
+                                 max_height);
 }
 
-ur_result_t GetDeviceImage3DMaxDepth(ur_device_handle_t device, size_t &max_depth) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH, max_depth);
+ur_result_t GetDeviceImage3DMaxDepth(ur_device_handle_t device,
+                                     size_t &max_depth) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH,
+                                 max_depth);
 }
 
-ur_result_t GetDeviceImageMaxBufferSize(ur_device_handle_t device, size_t &max_buf_size) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE, max_buf_size);
+ur_result_t GetDeviceImageMaxBufferSize(ur_device_handle_t device,
+                                        size_t &max_buf_size) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE,
+                                 max_buf_size);
 }
 
-ur_result_t GetDeviceImageMaxArraySize(ur_device_handle_t device, size_t &max_arr_size) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE, max_arr_size);
+ur_result_t GetDeviceImageMaxArraySize(ur_device_handle_t device,
+                                       size_t &max_arr_size) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE,
+                                 max_arr_size);
 }
 
-ur_result_t GetDeviceMaxSamplers(ur_device_handle_t device, uint32_t &max_samplers) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_SAMPLERS, max_samplers);
+ur_result_t GetDeviceMaxSamplers(ur_device_handle_t device,
+                                 uint32_t &max_samplers) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_SAMPLERS,
+                                   max_samplers);
 }
 
-ur_result_t GetDeviceMaxParameterSize(ur_device_handle_t device, size_t &max_param_size) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_MAX_PARAMETER_SIZE, max_param_size);
+ur_result_t GetDeviceMaxParameterSize(ur_device_handle_t device,
+                                      size_t &max_param_size) {
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_MAX_PARAMETER_SIZE,
+                                 max_param_size);
 }
 
-ur_result_t GetDeviceMemBaseAddressAlign(ur_device_handle_t device, uint32_t &align) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN, align);
+ur_result_t GetDeviceMemBaseAddressAlign(ur_device_handle_t device,
+                                         uint32_t &align) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN,
+                                   align);
 }
 
-ur_result_t GetDeviceMemCacheType(ur_device_handle_t device, ur_device_mem_cache_type_t &cache_type) {
-    return GetDeviceInfo<ur_device_mem_cache_type_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE, cache_type);
+ur_result_t GetDeviceMemCacheType(ur_device_handle_t device,
+                                  ur_device_mem_cache_type_t &cache_type) {
+    return GetDeviceInfo<ur_device_mem_cache_type_t>(
+        device, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE, cache_type);
 }
 
-ur_result_t GetDeviceMemCachelineSize(ur_device_handle_t device, uint32_t &cache_line_size) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE, cache_line_size);
+ur_result_t GetDeviceMemCachelineSize(ur_device_handle_t device,
+                                      uint32_t &cache_line_size) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE, cache_line_size);
 }
 
-ur_result_t GetDeviceMemCacheSize(ur_device_handle_t device, uint64_t &cache_size) {
-    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE, cache_size);
+ur_result_t GetDeviceMemCacheSize(ur_device_handle_t device,
+                                  uint64_t &cache_size) {
+    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE,
+                                   cache_size);
 }
 
-ur_result_t GetDeviceGlobalMemSize(ur_device_handle_t device, uint64_t &mem_size) {
-    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_SIZE, mem_size);
+ur_result_t GetDeviceGlobalMemSize(ur_device_handle_t device,
+                                   uint64_t &mem_size) {
+    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_SIZE,
+                                   mem_size);
 }
 
-ur_result_t GetDeviceGlobalMemFree(ur_device_handle_t device, uint64_t &mem_free) {
-    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_FREE, mem_free);
+ur_result_t GetDeviceGlobalMemFree(ur_device_handle_t device,
+                                   uint64_t &mem_free) {
+    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_GLOBAL_MEM_FREE,
+                                   mem_free);
 }
 
-ur_result_t GetDeviceMaxConstantBufferSize(ur_device_handle_t device, uint64_t &buf_size) {
-    return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE, buf_size);
+ur_result_t GetDeviceMaxConstantBufferSize(ur_device_handle_t device,
+                                           uint64_t &buf_size) {
+    return GetDeviceInfo<uint64_t>(
+        device, UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE, buf_size);
 }
 
-ur_result_t GetDeviceMaxConstantArgs(ur_device_handle_t device, uint32_t &args) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_CONSTANT_ARGS, args);
+ur_result_t GetDeviceMaxConstantArgs(ur_device_handle_t device,
+                                     uint32_t &args) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_CONSTANT_ARGS,
+                                   args);
 }
 
-ur_result_t GetDeviceLocalMemType(ur_device_handle_t device, ur_device_local_mem_type_t &type) {
-    return GetDeviceInfo<ur_device_local_mem_type_t>(device, UR_DEVICE_INFO_LOCAL_MEM_TYPE, type);
+ur_result_t GetDeviceLocalMemType(ur_device_handle_t device,
+                                  ur_device_local_mem_type_t &type) {
+    return GetDeviceInfo<ur_device_local_mem_type_t>(
+        device, UR_DEVICE_INFO_LOCAL_MEM_TYPE, type);
 }
 
 ur_result_t GetDeviceLocalMemSize(ur_device_handle_t device, uint64_t &size) {
     return GetDeviceInfo<uint64_t>(device, UR_DEVICE_INFO_LOCAL_MEM_SIZE, size);
 }
 
-ur_result_t GetDeviceErrorCorrectionSupport(ur_device_handle_t device, bool &ecc_support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT, ecc_support);
+ur_result_t GetDeviceErrorCorrectionSupport(ur_device_handle_t device,
+                                            bool &ecc_support) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT,
+                               ecc_support);
 }
 
-ur_result_t GetDeviceProfilingTimerResolution(ur_device_handle_t device, size_t &resolution) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION, resolution);
+ur_result_t GetDeviceProfilingTimerResolution(ur_device_handle_t device,
+                                              size_t &resolution) {
+    return GetDeviceInfo<size_t>(
+        device, UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION, resolution);
 }
 
-ur_result_t GetDeviceLittleEndian(ur_device_handle_t device, bool &little_endian) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_ENDIAN_LITTLE, little_endian);
+ur_result_t GetDeviceLittleEndian(ur_device_handle_t device,
+                                  bool &little_endian) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_ENDIAN_LITTLE,
+                               little_endian);
 }
 
 ur_result_t GetDeviceAvailable(ur_device_handle_t device, bool &available) {
     return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_AVAILABLE, available);
 }
 
-ur_result_t GetDeviceCompilerAvailable(ur_device_handle_t device, bool &available) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_COMPILER_AVAILABLE, available);
+ur_result_t GetDeviceCompilerAvailable(ur_device_handle_t device,
+                                       bool &available) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_COMPILER_AVAILABLE,
+                               available);
 }
 
-ur_result_t GetDeviceLinkerAvailable(ur_device_handle_t device, bool &available) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_LINKER_AVAILABLE, available);
+ur_result_t GetDeviceLinkerAvailable(ur_device_handle_t device,
+                                     bool &available) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_LINKER_AVAILABLE,
+                               available);
 }
 
-ur_result_t GetDeviceExecutionCapabilities(ur_device_handle_t device, ur_device_exec_capability_flags_t &capabilities) {
-    return GetDeviceInfo<ur_device_exec_capability_flags_t>(device, UR_DEVICE_INFO_EXECUTION_CAPABILITIES, capabilities);
+ur_result_t GetDeviceExecutionCapabilities(
+    ur_device_handle_t device,
+    ur_device_exec_capability_flags_t &capabilities) {
+    return GetDeviceInfo<ur_device_exec_capability_flags_t>(
+        device, UR_DEVICE_INFO_EXECUTION_CAPABILITIES, capabilities);
 }
 
-ur_result_t GetDeviceQueueOnDeviceProperties(ur_device_handle_t device, ur_queue_flags_t &properties) {
-    return GetDeviceInfo<ur_queue_flags_t>(device, UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES, properties);
+ur_result_t GetDeviceQueueOnDeviceProperties(ur_device_handle_t device,
+                                             ur_queue_flags_t &properties) {
+    return GetDeviceInfo<ur_queue_flags_t>(
+        device, UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES, properties);
 }
 
-ur_result_t GetDeviceQueueOnHostProperties(ur_device_handle_t device, ur_queue_flags_t &properties) {
-    return GetDeviceInfo<ur_queue_flags_t>(device, UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES, properties);
+ur_result_t GetDeviceQueueOnHostProperties(ur_device_handle_t device,
+                                           ur_queue_flags_t &properties) {
+    return GetDeviceInfo<ur_queue_flags_t>(
+        device, UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES, properties);
 }
 
-ur_result_t GetDeviceBuiltInKernels(ur_device_handle_t device, std::vector<std::string> &names) {
+ur_result_t GetDeviceBuiltInKernels(ur_device_handle_t device,
+                                    std::vector<std::string> &names) {
     std::string kernels_str;
-    ur_result_t result = GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_BUILT_IN_KERNELS, kernels_str);
+    ur_result_t result = GetDeviceInfo<std::string>(
+        device, UR_DEVICE_INFO_BUILT_IN_KERNELS, kernels_str);
     if (result != UR_RESULT_SUCCESS) {
         return result;
     }
@@ -287,24 +408,32 @@ ur_result_t GetDeviceBuiltInKernels(ur_device_handle_t device, std::vector<std::
     return UR_RESULT_SUCCESS;
 }
 
-ur_result_t GetDevicePlatform(ur_device_handle_t device, ur_platform_handle_t &platform) {
-    return GetDeviceInfo<ur_platform_handle_t>(device, UR_DEVICE_INFO_PLATFORM, platform);
+ur_result_t GetDevicePlatform(ur_device_handle_t device,
+                              ur_platform_handle_t &platform) {
+    return GetDeviceInfo<ur_platform_handle_t>(device, UR_DEVICE_INFO_PLATFORM,
+                                               platform);
 }
 
-ur_result_t GetDeviceReferenceCount(ur_device_handle_t device, uint32_t &ref_count) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_REFERENCE_COUNT, ref_count);
+ur_result_t GetDeviceReferenceCount(ur_device_handle_t device,
+                                    uint32_t &ref_count) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_REFERENCE_COUNT,
+                                   ref_count);
 }
 
-ur_result_t GetDeviceILVersion(ur_device_handle_t device, std::string &il_version) {
-    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_IL_VERSION, il_version);
+ur_result_t GetDeviceILVersion(ur_device_handle_t device,
+                               std::string &il_version) {
+    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_IL_VERSION,
+                                      il_version);
 }
 
 ur_result_t GetDeviceVendor(ur_device_handle_t device, std::string &vendor) {
     return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_VENDOR, vendor);
 }
 
-ur_result_t GetDeviceDriverVersion(ur_device_handle_t device, std::string &driver_version) {
-    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_DRIVER_VERSION, driver_version);
+ur_result_t GetDeviceDriverVersion(ur_device_handle_t device,
+                                   std::string &driver_version) {
+    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_DRIVER_VERSION,
+                                      driver_version);
 }
 
 ur_result_t GetDeviceProfile(ur_device_handle_t device, std::string &profile) {
@@ -315,13 +444,17 @@ ur_result_t GetDeviceVersion(ur_device_handle_t device, std::string &version) {
     return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_VERSION, version);
 }
 
-ur_result_t GetDeviceBackendRuntimeVersion(ur_device_handle_t device, std::string &runtime_version) {
-    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION, runtime_version);
+ur_result_t GetDeviceBackendRuntimeVersion(ur_device_handle_t device,
+                                           std::string &runtime_version) {
+    return GetDeviceInfo<std::string>(
+        device, UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION, runtime_version);
 }
 
-ur_result_t GetDeviceExtensions(ur_device_handle_t device, std::vector<std::string> &extensions) {
+ur_result_t GetDeviceExtensions(ur_device_handle_t device,
+                                std::vector<std::string> &extensions) {
     std::string extensions_str;
-    ur_result_t result = GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_EXTENSIONS, extensions_str);
+    ur_result_t result = GetDeviceInfo<std::string>(
+        device, UR_DEVICE_INFO_EXTENSIONS, extensions_str);
     if (result != UR_RESULT_SUCCESS) {
         return result;
     }
@@ -330,89 +463,130 @@ ur_result_t GetDeviceExtensions(ur_device_handle_t device, std::vector<std::stri
 }
 
 ur_result_t GetDevicePrintfBufferSize(ur_device_handle_t device, size_t &size) {
-    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_PRINTF_BUFFER_SIZE, size);
+    return GetDeviceInfo<size_t>(device, UR_DEVICE_INFO_PRINTF_BUFFER_SIZE,
+                                 size);
 }
 
-ur_result_t GetDevicePreferredInteropUserSync(ur_device_handle_t device, bool &sync) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC, sync);
+ur_result_t GetDevicePreferredInteropUserSync(ur_device_handle_t device,
+                                              bool &sync) {
+    return GetDeviceInfo<bool>(
+        device, UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC, sync);
 }
 
-ur_result_t GetDeviceParentDevice(ur_device_handle_t device, ur_device_handle_t &parent) {
-    return GetDeviceInfo<ur_device_handle_t>(device, UR_DEVICE_INFO_PARENT_DEVICE, parent);
+ur_result_t GetDeviceParentDevice(ur_device_handle_t device,
+                                  ur_device_handle_t &parent) {
+    return GetDeviceInfo<ur_device_handle_t>(
+        device, UR_DEVICE_INFO_PARENT_DEVICE, parent);
 }
 
-ur_result_t GetDevicePartitionProperties(ur_device_handle_t device, std::vector<ur_device_partition_property_t> &properties) {
-    return GetDeviceVectorInfo<ur_device_partition_property_t>(device, UR_DEVICE_INFO_PARTITION_PROPERTIES, properties);
+ur_result_t GetDevicePartitionProperties(
+    ur_device_handle_t device,
+    std::vector<ur_device_partition_property_t> &properties) {
+    return GetDeviceVectorInfo<ur_device_partition_property_t>(
+        device, UR_DEVICE_INFO_PARTITION_PROPERTIES, properties);
 }
 
-ur_result_t GetDevicePartitionMaxSubDevices(ur_device_handle_t device, uint32_t &max_sub_devices) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES, max_sub_devices);
+ur_result_t GetDevicePartitionMaxSubDevices(ur_device_handle_t device,
+                                            uint32_t &max_sub_devices) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES, max_sub_devices);
 }
 
-ur_result_t GetDevicePartitionAffinityDomainFlags(ur_device_handle_t device, ur_device_affinity_domain_flags_t &flags) {
-    return GetDeviceInfo<ur_device_affinity_domain_flags_t>(device, UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN, flags);
+ur_result_t GetDevicePartitionAffinityDomainFlags(
+    ur_device_handle_t device, ur_device_affinity_domain_flags_t &flags) {
+    return GetDeviceInfo<ur_device_affinity_domain_flags_t>(
+        device, UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN, flags);
 }
 
-ur_result_t GetDevicePartitionType(ur_device_handle_t device, std::vector<ur_device_partition_property_t> &type) {
-    return GetDeviceVectorInfo<ur_device_partition_property_t>(device, UR_DEVICE_INFO_PARTITION_TYPE, type);
+ur_result_t
+GetDevicePartitionType(ur_device_handle_t device,
+                       std::vector<ur_device_partition_property_t> &type) {
+    return GetDeviceVectorInfo<ur_device_partition_property_t>(
+        device, UR_DEVICE_INFO_PARTITION_TYPE, type);
 }
 
-ur_result_t GetDeviceMaxNumberSubGroups(ur_device_handle_t device, uint32_t &max_sub_groups) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS, max_sub_groups);
+ur_result_t GetDeviceMaxNumberSubGroups(ur_device_handle_t device,
+                                        uint32_t &max_sub_groups) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS,
+                                   max_sub_groups);
 }
 
-ur_result_t GetDeviceSubGroupIndependentForwardProgress(ur_device_handle_t device, bool &progress) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, progress);
+ur_result_t
+GetDeviceSubGroupIndependentForwardProgress(ur_device_handle_t device,
+                                            bool &progress) {
+    return GetDeviceInfo<bool>(
+        device, UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
+        progress);
 }
 
-ur_result_t GetDeviceSubGroupSizesIntel(ur_device_handle_t device, std::vector<uint32_t> &sizes) {
-    return GetDeviceVectorInfo<uint32_t>(device, UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL, sizes);
+ur_result_t GetDeviceSubGroupSizesIntel(ur_device_handle_t device,
+                                        std::vector<uint32_t> &sizes) {
+    return GetDeviceVectorInfo<uint32_t>(
+        device, UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL, sizes);
 }
 
 ur_result_t GetDeviceUSMHostSupport(ur_device_handle_t device, bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_HOST_SUPPORT, support);
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_HOST_SUPPORT,
+                               support);
 }
 
-ur_result_t GetDeviceUSMDeviceSupport(ur_device_handle_t device, bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_DEVICE_SUPPORT, support);
+ur_result_t GetDeviceUSMDeviceSupport(ur_device_handle_t device,
+                                      bool &support) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_DEVICE_SUPPORT,
+                               support);
 }
 
-ur_result_t GetDeviceUSMSingleSharedSupport(ur_device_handle_t device, bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT, support);
+ur_result_t GetDeviceUSMSingleSharedSupport(ur_device_handle_t device,
+                                            bool &support) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,
+                               support);
 }
 
-ur_result_t GetDeviceUSMCrossSharedSupport(ur_device_handle_t device, bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT, support);
+ur_result_t GetDeviceUSMCrossSharedSupport(ur_device_handle_t device,
+                                           bool &support) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,
+                               support);
 }
 
-ur_result_t GetDeviceUSMSystemSharedSupport(ur_device_handle_t device, bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT, support);
+ur_result_t GetDeviceUSMSystemSharedSupport(ur_device_handle_t device,
+                                            bool &support) {
+    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,
+                               support);
 }
 
 ur_result_t GetDeviceUUID(ur_device_handle_t device, std::string &uuid) {
     return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_UUID, uuid);
 }
-ur_result_t GetDevicePCIAddress(ur_device_handle_t device, std::string &address) {
-    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_PCI_ADDRESS, address);
+ur_result_t GetDevicePCIAddress(ur_device_handle_t device,
+                                std::string &address) {
+    return GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_PCI_ADDRESS,
+                                      address);
 }
 
 ur_result_t GetDeviceGPUEUCount(ur_device_handle_t device, uint32_t &count) {
     return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GPU_EU_COUNT, count);
 }
-ur_result_t GetDeviceGPUEUSIMDWidth(ur_device_handle_t device, uint32_t &width) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH, width);
+ur_result_t GetDeviceGPUEUSIMDWidth(ur_device_handle_t device,
+                                    uint32_t &width) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,
+                                   width);
 }
 
 ur_result_t GetDeviceGPUEUSlices(ur_device_handle_t device, uint32_t &slices) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GPU_EU_SLICES, slices);
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GPU_EU_SLICES,
+                                   slices);
 }
 
-ur_result_t GetDeviceGPUSubslicesPerSlice(ur_device_handle_t device, uint32_t &subslices) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE, subslices);
+ur_result_t GetDeviceGPUSubslicesPerSlice(ur_device_handle_t device,
+                                          uint32_t &subslices) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE, subslices);
 }
 
-ur_result_t GetDeviceMaxMemoryBandwidth(ur_device_handle_t device, uint32_t &bandwidth) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH, bandwidth);
+ur_result_t GetDeviceMaxMemoryBandwidth(ur_device_handle_t device,
+                                        uint32_t &bandwidth) {
+    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,
+                                   bandwidth);
 }
 
 ur_result_t GetDeviceImageSRGB(ur_device_handle_t device, bool &support) {
@@ -423,20 +597,28 @@ ur_result_t GetDeviceAtomic64Support(ur_device_handle_t device, bool &support) {
     return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_ATOMIC_64, support);
 }
 
-ur_result_t GetDeviceMemoryOrderCapabilities(ur_device_handle_t device, ur_memory_order_capability_flags_t &flags) {
-    return GetDeviceInfo<ur_memory_order_capability_flags_t>(device, UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES, flags);
+ur_result_t
+GetDeviceMemoryOrderCapabilities(ur_device_handle_t device,
+                                 ur_memory_order_capability_flags_t &flags) {
+    return GetDeviceInfo<ur_memory_order_capability_flags_t>(
+        device, UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES, flags);
 }
 
-ur_result_t GetDeviceMemoryScopeCapabilities(ur_device_handle_t device, ur_memory_scope_capability_flags_t &flags) {
-    return GetDeviceInfo<ur_memory_scope_capability_flags_t>(device, UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES, flags);
+ur_result_t
+GetDeviceMemoryScopeCapabilities(ur_device_handle_t device,
+                                 ur_memory_scope_capability_flags_t &flags) {
+    return GetDeviceInfo<ur_memory_scope_capability_flags_t>(
+        device, UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES, flags);
 }
 
 ur_result_t GetDeviceBFloat16Support(ur_device_handle_t device, bool &support) {
     return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_BFLOAT16, support);
 }
 
-ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device, uint32_t &max_indices) {
-    return GetDeviceInfo<uint32_t>(device, UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, max_indices);
+ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device,
+                                            uint32_t &max_indices) {
+    return GetDeviceInfo<uint32_t>(
+        device, UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, max_indices);
 }
 
 } // namespace uur

--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -7,7 +7,8 @@ struct urUSMDeviceAllocTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
         bool deviceUSMSupport = false;
-        ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, deviceUSMSupport));
+        ASSERT_SUCCESS(
+            uur::GetDeviceUSMDeviceSupport(device, deviceUSMSupport));
         if (!deviceUSMSupport) {
             GTEST_SKIP() << "Device USM is not supported.";
         }
@@ -18,16 +19,14 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMDeviceAllocTest);
 TEST_P(urUSMDeviceAllocTest, Success) {
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
-    ASSERT_SUCCESS(
-        urUSMDeviceAlloc(context, device, nullptr, nullptr, allocation_size, 0,
-                         &ptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                    allocation_size, 0, &ptr));
     ASSERT_NE(ptr, nullptr);
 
     ur_event_handle_t event = nullptr;
     uint8_t pattern = 0;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
@@ -57,15 +56,14 @@ TEST_P(urUSMDeviceAllocTest, InvalidNullPtrResult) {
 
 TEST_P(urUSMDeviceAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_USM_SIZE,
-                     urUSMDeviceAlloc(context, device, nullptr, nullptr, 13, 0,
-                                      &ptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_USM_SIZE,
+        urUSMDeviceAlloc(context, device, nullptr, nullptr, 13, 0, &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidValueAlignPowerOfTwo) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_VALUE,
-        urUSMDeviceAlloc(context, device, nullptr, nullptr, sizeof(int), 1,
-                         &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+                     urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                      sizeof(int), 1, &ptr));
 }

--- a/test/conformance/usm/urUSMFree.cpp
+++ b/test/conformance/usm/urUSMFree.cpp
@@ -15,16 +15,14 @@ TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
 
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
-    ASSERT_SUCCESS(
-        urUSMDeviceAlloc(context, device, nullptr, nullptr, allocation_size, 0,
-                         &ptr));
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+                                    allocation_size, 0, &ptr));
 
     ur_event_handle_t event = nullptr;
 
     uint8_t pattern = 0;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
@@ -45,9 +43,8 @@ TEST_P(urUSMFreeTest, SuccessHostAlloc) {
 
     ur_event_handle_t event = nullptr;
     uint8_t pattern = 0;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
@@ -59,8 +56,10 @@ TEST_P(urUSMFreeTest, SuccessSharedAlloc) {
     bool shared_usm_cross = false;
     bool shared_usm_single = false;
 
-    ASSERT_SUCCESS(uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));
-    ASSERT_SUCCESS(uur::GetDeviceUSMSingleSharedSupport(device, shared_usm_single));
+    ASSERT_SUCCESS(
+        uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));
+    ASSERT_SUCCESS(
+        uur::GetDeviceUSMSingleSharedSupport(device, shared_usm_single));
 
     if (!(shared_usm_cross || shared_usm_single)) {
         GTEST_SKIP() << "Shared USM is not supported by the device.";
@@ -68,15 +67,13 @@ TEST_P(urUSMFreeTest, SuccessSharedAlloc) {
 
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
-    ASSERT_SUCCESS(
-        urUSMSharedAlloc(context, device, nullptr, nullptr, allocation_size, 0,
-                         &ptr));
+    ASSERT_SUCCESS(urUSMSharedAlloc(context, device, nullptr, nullptr,
+                                    allocation_size, 0, &ptr));
 
     ur_event_handle_t event = nullptr;
     uint8_t pattern = 0;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
 

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -3,19 +3,25 @@
 
 #include <uur/fixtures.h>
 
-using urUSMAllocInfoTest = uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t>;
+using urUSMAllocInfoTest =
+    uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t>;
 
 UUR_TEST_SUITE_P(urUSMAllocInfoTest,
-                 ::testing::Values(UR_USM_ALLOC_INFO_TYPE, UR_USM_ALLOC_INFO_BASE_PTR, UR_USM_ALLOC_INFO_SIZE, UR_USM_ALLOC_INFO_DEVICE),
+                 ::testing::Values(UR_USM_ALLOC_INFO_TYPE,
+                                   UR_USM_ALLOC_INFO_BASE_PTR,
+                                   UR_USM_ALLOC_INFO_SIZE,
+                                   UR_USM_ALLOC_INFO_DEVICE),
                  uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
 
 TEST_P(urUSMAllocInfoTest, Success) {
     size_t size = 0;
     auto alloc_info = getParam();
-    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, 0, nullptr, &size));
+    ASSERT_SUCCESS(
+        urUSMGetMemAllocInfo(context, ptr, alloc_info, 0, nullptr, &size));
     ASSERT_NE(size, 0);
     std::vector<uint8_t> info_data(size);
-    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size, info_data.data(), nullptr));
+    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size,
+                                        info_data.data(), nullptr));
 }
 
 using urUSMGetMemAllocInfoTest = uur::urUSMDeviceAllocTest;
@@ -24,19 +30,25 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMGetMemAllocInfoTest);
 TEST_P(urUSMGetMemAllocInfoTest, InvalidNullHandleContext) {
     ur_usm_type_t USMType;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urUSMGetMemAllocInfo(nullptr, ptr, UR_USM_ALLOC_INFO_TYPE, sizeof(ur_usm_type_t), &USMType, nullptr));
+                     urUSMGetMemAllocInfo(nullptr, ptr, UR_USM_ALLOC_INFO_TYPE,
+                                          sizeof(ur_usm_type_t), &USMType,
+                                          nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidNullPointerMem) {
     ur_usm_type_t USMType;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urUSMGetMemAllocInfo(context, nullptr, UR_USM_ALLOC_INFO_TYPE, sizeof(ur_usm_type_t), &USMType, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urUSMGetMemAllocInfo(context, nullptr, UR_USM_ALLOC_INFO_TYPE,
+                             sizeof(ur_usm_type_t), &USMType, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidEnumeration) {
     ur_usm_type_t USMType;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
-                     urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_FORCE_UINT32, sizeof(ur_usm_type_t), &USMType, nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_ENUMERATION,
+        urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_FORCE_UINT32,
+                             sizeof(ur_usm_type_t), &USMType, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidValuePropValueSize) {

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -33,9 +33,8 @@ TEST_P(urUSMHostAllocTest, Success) {
     ur_event_handle_t event = nullptr;
 
     uint8_t pattern = 0;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
     EXPECT_SUCCESS(urEventRelease(event));
@@ -43,9 +42,8 @@ TEST_P(urUSMHostAllocTest, Success) {
 
     // Set 1, in all bytes of int
     pattern = 1;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     EXPECT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &event));
     EXPECT_SUCCESS(urEventRelease(event));
@@ -59,15 +57,15 @@ TEST_P(urUSMHostAllocTest, Success) {
 
 TEST_P(urUSMHostAllocTest, InvalidNullHandleContext) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urUSMHostAlloc(nullptr, nullptr, nullptr, sizeof(int), 0,
-                                    &ptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urUSMHostAlloc(nullptr, nullptr, nullptr, sizeof(int), 0, &ptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidNullPtrMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urUSMHostAlloc(context, nullptr, nullptr, sizeof(int), 0,
-                                    nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urUSMHostAlloc(context, nullptr, nullptr, sizeof(int), 0, nullptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidUSMSize) {
@@ -78,7 +76,7 @@ TEST_P(urUSMHostAllocTest, InvalidUSMSize) {
 
 TEST_P(urUSMHostAllocTest, InvalidValueAlignPowerOfTwo) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
-                     urUSMHostAlloc(context, nullptr, nullptr, sizeof(int), 1,
-                                    &ptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_VALUE,
+        urUSMHostAlloc(context, nullptr, nullptr, sizeof(int), 1, &ptr));
 }

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -9,8 +9,10 @@ struct urUSMSharedAllocTest : uur::urQueueTest {
         bool shared_usm_cross = false;
         bool shared_usm_single = false;
 
-        ASSERT_SUCCESS(uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));
-        ASSERT_SUCCESS(uur::GetDeviceUSMSingleSharedSupport(device, shared_usm_single));
+        ASSERT_SUCCESS(
+            uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));
+        ASSERT_SUCCESS(
+            uur::GetDeviceUSMSingleSharedSupport(device, shared_usm_single));
 
         if (!(shared_usm_cross || shared_usm_single)) {
             GTEST_SKIP() << "Shared USM is not supported by the device.";
@@ -22,15 +24,13 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMSharedAllocTest);
 TEST_P(urUSMSharedAllocTest, Success) {
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
-    ASSERT_SUCCESS(
-        urUSMSharedAlloc(context, device, nullptr, nullptr, allocation_size, 0,
-                         &ptr));
+    ASSERT_SUCCESS(urUSMSharedAlloc(context, device, nullptr, nullptr,
+                                    allocation_size, 0, &ptr));
 
     ur_event_handle_t event = nullptr;
     uint8_t pattern = 0;
-    ASSERT_SUCCESS(
-        urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern, allocation_size,
-                         0, nullptr, &event));
+    ASSERT_SUCCESS(urEnqueueUSMFill(queue, ptr, sizeof(pattern), &pattern,
+                                    allocation_size, 0, nullptr, &event));
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     ASSERT_SUCCESS(urUSMFree(context, ptr));
@@ -59,15 +59,14 @@ TEST_P(urUSMSharedAllocTest, InvalidNullPtrMem) {
 
 TEST_P(urUSMSharedAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_USM_SIZE,
-                     urUSMSharedAlloc(context, device, nullptr, nullptr, 13, 0,
-                                      &ptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_USM_SIZE,
+        urUSMSharedAlloc(context, device, nullptr, nullptr, 13, 0, &ptr));
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidValueAlignPowerOfTwo) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_VALUE,
-        urUSMSharedAlloc(context, device, nullptr, nullptr, sizeof(int), 1,
-                         &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+                     urUSMSharedAlloc(context, device, nullptr, nullptr,
+                                      sizeof(int), 1, &ptr));
 }

--- a/test/layers/validation/fixtures.hpp
+++ b/test/layers/validation/fixtures.hpp
@@ -28,7 +28,8 @@ struct valPlatformsTest : urTest {
         ASSERT_EQ(urPlatformGet(0, nullptr, &count), UR_RESULT_SUCCESS);
         ASSERT_NE(count, 0);
         platforms.resize(count);
-        ASSERT_EQ(urPlatformGet(count, platforms.data(), nullptr), UR_RESULT_SUCCESS);
+        ASSERT_EQ(urPlatformGet(count, platforms.data(), nullptr),
+                  UR_RESULT_SUCCESS);
     }
 
     std::vector<ur_platform_handle_t> platforms;

--- a/test/layers/validation/parameters.cpp
+++ b/test/layers/validation/parameters.cpp
@@ -4,16 +4,19 @@
 #include "fixtures.hpp"
 
 TEST(valTest, urInit) {
-    const ur_device_init_flags_t device_flags = UR_DEVICE_INIT_FLAG_FORCE_UINT32;
+    const ur_device_init_flags_t device_flags =
+        UR_DEVICE_INIT_FLAG_FORCE_UINT32;
     ASSERT_EQ(UR_RESULT_ERROR_INVALID_ENUMERATION, urInit(device_flags));
 }
 
 TEST_F(valPlatformsTest, testUrPlatformGetApiVersion) {
     ur_api_version_t api_version = {};
 
-    ASSERT_EQ(urPlatformGetApiVersion(nullptr, &api_version), UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ(urPlatformGetApiVersion(nullptr, &api_version),
+              UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
     for (auto p : platforms) {
-        ASSERT_EQ(urPlatformGetApiVersion(p, nullptr), UR_RESULT_ERROR_INVALID_NULL_POINTER);
+        ASSERT_EQ(urPlatformGetApiVersion(p, nullptr),
+                  UR_RESULT_ERROR_INVALID_NULL_POINTER);
     }
 }

--- a/test/unified_memory_allocation/common/base.hpp
+++ b/test/unified_memory_allocation/common/base.hpp
@@ -13,12 +13,8 @@
 
 namespace uma_test {
 struct test : ::testing::Test {
-    void SetUp() {
-        ::testing::Test::SetUp();
-    }
-    void TearDown() override {
-        ::testing::Test::TearDown();
-    }
+    void SetUp() { ::testing::Test::SetUp(); }
+    void TearDown() override { ::testing::Test::TearDown(); }
 };
 } // namespace uma_test
 

--- a/test/unified_memory_allocation/common/pool.c
+++ b/test/unified_memory_allocation/common/pool.c
@@ -14,9 +14,7 @@ static enum uma_result_t nullInitialize(void *params, void **pool) {
     return UMA_RESULT_SUCCESS;
 }
 
-static void nullFinalize(void *pool) {
-    (void)pool;
-}
+static void nullFinalize(void *pool) { (void)pool; }
 
 static void *nullMalloc(void *pool, size_t size) {
     (void)pool;
@@ -63,21 +61,20 @@ enum uma_result_t nullGetLastResult(void *pool, const char **ppMsg) {
 }
 
 uma_memory_pool_handle_t nullPoolCreate(void) {
-    struct uma_memory_pool_ops_t ops = {
-        .version = UMA_VERSION_CURRENT,
-        .initialize = nullInitialize,
-        .finalize = nullFinalize,
-        .malloc = nullMalloc,
-        .realloc = nullRealloc,
-        .calloc = nullCalloc,
-        .aligned_malloc = nullAlignedMalloc,
-        .malloc_usable_size = nullMallocUsableSize,
-        .free = nullFree,
-        .get_last_result = nullGetLastResult};
+    struct uma_memory_pool_ops_t ops = {.version = UMA_VERSION_CURRENT,
+                                        .initialize = nullInitialize,
+                                        .finalize = nullFinalize,
+                                        .malloc = nullMalloc,
+                                        .realloc = nullRealloc,
+                                        .calloc = nullCalloc,
+                                        .aligned_malloc = nullAlignedMalloc,
+                                        .malloc_usable_size =
+                                            nullMallocUsableSize,
+                                        .free = nullFree,
+                                        .get_last_result = nullGetLastResult};
 
     uma_memory_pool_handle_t hPool;
-    enum uma_result_t ret = umaPoolCreate(&ops, NULL,
-                                          &hPool);
+    enum uma_result_t ret = umaPoolCreate(&ops, NULL, &hPool);
 
     (void)ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);
@@ -90,16 +87,15 @@ struct traceParams {
 };
 
 static enum uma_result_t traceInitialize(void *params, void **pool) {
-    struct traceParams *tracePool = (struct traceParams *)malloc(sizeof(struct traceParams));
+    struct traceParams *tracePool =
+        (struct traceParams *)malloc(sizeof(struct traceParams));
     *tracePool = *((struct traceParams *)params);
     *pool = tracePool;
 
     return UMA_RESULT_SUCCESS;
 }
 
-static void traceFinalize(void *pool) {
-    free(pool);
-}
+static void traceFinalize(void *pool) { free(pool); }
 
 static void *traceMalloc(void *pool, size_t size) {
     struct traceParams *tracePool = (struct traceParams *)pool;
@@ -150,26 +146,25 @@ enum uma_result_t traceGetLastResult(void *pool, const char **ppMsg) {
     return umaPoolGetLastResult(tracePool->hUpstreamPool, ppMsg);
 }
 
-uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool, void (*trace)(const char *)) {
-    struct uma_memory_pool_ops_t ops = {
-        .version = UMA_VERSION_CURRENT,
-        .initialize = traceInitialize,
-        .finalize = traceFinalize,
-        .malloc = traceMalloc,
-        .realloc = traceRealloc,
-        .calloc = traceCalloc,
-        .aligned_malloc = traceAlignedMalloc,
-        .malloc_usable_size = traceMallocUsableSize,
-        .free = traceFree,
-        .get_last_result = traceGetLastResult};
+uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,
+                                         void (*trace)(const char *)) {
+    struct uma_memory_pool_ops_t ops = {.version = UMA_VERSION_CURRENT,
+                                        .initialize = traceInitialize,
+                                        .finalize = traceFinalize,
+                                        .malloc = traceMalloc,
+                                        .realloc = traceRealloc,
+                                        .calloc = traceCalloc,
+                                        .aligned_malloc = traceAlignedMalloc,
+                                        .malloc_usable_size =
+                                            traceMallocUsableSize,
+                                        .free = traceFree,
+                                        .get_last_result = traceGetLastResult};
 
-    struct traceParams params = {
-        .hUpstreamPool = hUpstreamPool,
-        .trace = trace};
+    struct traceParams params = {.hUpstreamPool = hUpstreamPool,
+                                 .trace = trace};
 
     uma_memory_pool_handle_t hPool;
-    enum uma_result_t ret = umaPoolCreate(&ops, &params,
-                                          &hPool);
+    enum uma_result_t ret = umaPoolCreate(&ops, &params, &hPool);
 
     (void)ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);

--- a/test/unified_memory_allocation/common/pool.h
+++ b/test/unified_memory_allocation/common/pool.h
@@ -11,7 +11,8 @@ extern "C" {
 #endif
 
 uma_memory_pool_handle_t nullPoolCreate(void);
-uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool, void (*trace)(const char *));
+uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,
+                                         void (*trace)(const char *));
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/common/pool.hpp
+++ b/test/unified_memory_allocation/common/pool.hpp
@@ -26,35 +26,20 @@ auto wrapPoolUnique(uma_memory_pool_handle_t hPool) {
 }
 
 struct pool_base {
-    uma_result_t initialize() noexcept {
-        return UMA_RESULT_SUCCESS;
-    };
-    void *malloc(size_t size) noexcept {
-        return nullptr;
-    }
-    void *calloc(size_t, size_t) noexcept {
-        return nullptr;
-    }
-    void *realloc(void *, size_t) noexcept {
-        return nullptr;
-    }
-    void *aligned_malloc(size_t, size_t) noexcept {
-        return nullptr;
-    }
-    size_t malloc_usable_size(void *) noexcept {
-        return 0;
-    }
-    void free(void *) noexcept {
-    }
+    uma_result_t initialize() noexcept { return UMA_RESULT_SUCCESS; };
+    void *malloc(size_t size) noexcept { return nullptr; }
+    void *calloc(size_t, size_t) noexcept { return nullptr; }
+    void *realloc(void *, size_t) noexcept { return nullptr; }
+    void *aligned_malloc(size_t, size_t) noexcept { return nullptr; }
+    size_t malloc_usable_size(void *) noexcept { return 0; }
+    void free(void *) noexcept {}
     enum uma_result_t get_last_result(const char **ppMessage) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }
 };
 
 struct malloc_pool : public pool_base {
-    void *malloc(size_t size) noexcept {
-        return ::malloc(size);
-    }
+    void *malloc(size_t size) noexcept { return ::malloc(size); }
     void *calloc(size_t num, size_t size) noexcept {
         return ::calloc(num, size);
     }
@@ -76,9 +61,7 @@ struct malloc_pool : public pool_base {
         return ::malloc_usable_size(ptr);
 #endif
     }
-    void free(void *ptr) noexcept {
-        return ::free(ptr);
-    }
+    void free(void *ptr) noexcept { return ::free(ptr); }
 };
 
 } // namespace uma_test

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -14,11 +14,10 @@ static enum uma_result_t nullInitialize(void *params, void **pool) {
     return UMA_RESULT_SUCCESS;
 }
 
-static void nullFinalize(void *pool) {
-    (void)pool;
-}
+static void nullFinalize(void *pool) { (void)pool; }
 
-static enum uma_result_t nullAlloc(void *provider, size_t size, size_t alignment, void **ptr) {
+static enum uma_result_t nullAlloc(void *provider, size_t size,
+                                   size_t alignment, void **ptr) {
     (void)provider;
     (void)size;
     (void)alignment;
@@ -40,17 +39,16 @@ enum uma_result_t nullGetLastResult(void *provider, const char **ppMsg) {
 }
 
 uma_memory_provider_handle_t nullProviderCreate(void) {
-    struct uma_memory_provider_ops_t ops = {
-        .version = UMA_VERSION_CURRENT,
-        .initialize = nullInitialize,
-        .finalize = nullFinalize,
-        .alloc = nullAlloc,
-        .free = nullFree,
-        .get_last_result = nullGetLastResult};
+    struct uma_memory_provider_ops_t ops = {.version = UMA_VERSION_CURRENT,
+                                            .initialize = nullInitialize,
+                                            .finalize = nullFinalize,
+                                            .alloc = nullAlloc,
+                                            .free = nullFree,
+                                            .get_last_result =
+                                                nullGetLastResult};
 
     uma_memory_provider_handle_t hProvider;
-    enum uma_result_t ret = umaMemoryProviderCreate(&ops, NULL,
-                                                    &hProvider);
+    enum uma_result_t ret = umaMemoryProviderCreate(&ops, NULL, &hProvider);
 
     (void)ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);
@@ -63,22 +61,23 @@ struct traceParams {
 };
 
 static enum uma_result_t traceInitialize(void *params, void **pool) {
-    struct traceParams *tracePool = (struct traceParams *)malloc(sizeof(struct traceParams));
+    struct traceParams *tracePool =
+        (struct traceParams *)malloc(sizeof(struct traceParams));
     *tracePool = *((struct traceParams *)params);
     *pool = tracePool;
 
     return UMA_RESULT_SUCCESS;
 }
 
-static void traceFinalize(void *pool) {
-    free(pool);
-}
+static void traceFinalize(void *pool) { free(pool); }
 
-static enum uma_result_t traceAlloc(void *provider, size_t size, size_t alignment, void **ptr) {
+static enum uma_result_t traceAlloc(void *provider, size_t size,
+                                    size_t alignment, void **ptr) {
     struct traceParams *traceProvider = (struct traceParams *)provider;
 
     traceProvider->trace("alloc");
-    return umaMemoryProviderAlloc(traceProvider->hUpstreamProvider, size, alignment, ptr);
+    return umaMemoryProviderAlloc(traceProvider->hUpstreamProvider, size,
+                                  alignment, ptr);
 }
 
 static enum uma_result_t traceFree(void *provider, void *ptr, size_t size) {
@@ -92,25 +91,26 @@ enum uma_result_t traceGetLastResult(void *provider, const char **ppMsg) {
     struct traceParams *traceProvider = (struct traceParams *)provider;
 
     traceProvider->trace("get_last_result");
-    return umaMemoryProviderGetLastResult(traceProvider->hUpstreamProvider, ppMsg);
+    return umaMemoryProviderGetLastResult(traceProvider->hUpstreamProvider,
+                                          ppMsg);
 }
 
-uma_memory_provider_handle_t traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider, void (*trace)(const char *)) {
-    struct uma_memory_provider_ops_t ops = {
-        .version = UMA_VERSION_CURRENT,
-        .initialize = traceInitialize,
-        .finalize = traceFinalize,
-        .alloc = traceAlloc,
-        .free = traceFree,
-        .get_last_result = traceGetLastResult};
+uma_memory_provider_handle_t
+traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
+                    void (*trace)(const char *)) {
+    struct uma_memory_provider_ops_t ops = {.version = UMA_VERSION_CURRENT,
+                                            .initialize = traceInitialize,
+                                            .finalize = traceFinalize,
+                                            .alloc = traceAlloc,
+                                            .free = traceFree,
+                                            .get_last_result =
+                                                traceGetLastResult};
 
-    struct traceParams params = {
-        .hUpstreamProvider = hUpstreamProvider,
-        .trace = trace};
+    struct traceParams params = {.hUpstreamProvider = hUpstreamProvider,
+                                 .trace = trace};
 
     uma_memory_provider_handle_t hProvider;
-    enum uma_result_t ret = umaMemoryProviderCreate(&ops, &params,
-                                                    &hProvider);
+    enum uma_result_t ret = umaMemoryProviderCreate(&ops, &params, &hProvider);
 
     (void)ret; /* silence unused variable warning */
     assert(ret == UMA_RESULT_SUCCESS);

--- a/test/unified_memory_allocation/common/provider.h
+++ b/test/unified_memory_allocation/common/provider.h
@@ -11,7 +11,9 @@ extern "C" {
 #endif
 
 uma_memory_provider_handle_t nullProviderCreate(void);
-uma_memory_provider_handle_t traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider, void (*trace)(const char *));
+uma_memory_provider_handle_t
+traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
+                    void (*trace)(const char *));
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -24,9 +24,7 @@ auto wrapProviderUnique(uma_memory_provider_handle_t hProvider) {
 }
 
 struct provider_base {
-    uma_result_t initialize() noexcept {
-        return UMA_RESULT_SUCCESS;
-    };
+    uma_result_t initialize() noexcept { return UMA_RESULT_SUCCESS; };
     enum uma_result_t alloc(size_t, size_t, void **) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }

--- a/test/unified_memory_allocation/memoryPool.hpp
+++ b/test/unified_memory_allocation/memoryPool.hpp
@@ -9,7 +9,10 @@
 #ifndef UMA_TEST_MEMORY_POOL_OPS_HPP
 #define UMA_TEST_MEMORY_POOL_OPS_HPP
 
-struct umaPoolTest : uma_test::test, ::testing::WithParamInterface<std::function<std::pair<uma_result_t, uma::pool_unique_handle_t>()>> {
+struct umaPoolTest
+    : uma_test::test,
+      ::testing::WithParamInterface<
+          std::function<std::pair<uma_result_t, uma::pool_unique_handle_t>()>> {
     umaPoolTest() : pool(nullptr, nullptr) {}
     void SetUp() {
         test::SetUp();
@@ -18,9 +21,7 @@ struct umaPoolTest : uma_test::test, ::testing::WithParamInterface<std::function
         EXPECT_NE(pool, nullptr);
         this->pool = std::move(pool);
     }
-    void TearDown() override {
-        test::TearDown();
-    }
+    void TearDown() override { test::TearDown(); }
     uma::pool_unique_handle_t pool;
 };
 

--- a/test/unified_memory_allocation/memoryPoolAPI.cpp
+++ b/test/unified_memory_allocation/memoryPoolAPI.cpp
@@ -17,7 +17,8 @@ TEST_F(test, memoryPoolTrace) {
     auto trace = [](const char *name) { calls[name]++; };
 
     auto nullPool = uma_test::wrapPoolUnique(nullPoolCreate());
-    auto tracingPool = uma_test::wrapPoolUnique(tracePoolCreate(nullPool.get(), trace));
+    auto tracingPool =
+        uma_test::wrapPoolUnique(tracePoolCreate(nullPool.get(), trace));
 
     size_t call_count = 0;
 
@@ -51,22 +52,24 @@ TEST_F(test, memoryPoolTrace) {
     ASSERT_EQ(calls.size(), ++call_count);
 }
 
-INSTANTIATE_TEST_SUITE_P(mallocPoolTest, umaPoolTest,
-                         ::testing::Values(
-                             [] { return uma::poolMakeUnique<uma_test::malloc_pool>(); }));
+INSTANTIATE_TEST_SUITE_P(
+    mallocPoolTest, umaPoolTest, ::testing::Values([] {
+        return uma::poolMakeUnique<uma_test::malloc_pool>();
+    }));
 
-//////////////////////////// Negative test cases ////////////////////////////////
+//////////////////////////// Negative test cases
+///////////////////////////////////
 
-struct poolInitializeTest : uma_test::test, ::testing::WithParamInterface<uma_result_t> {};
+struct poolInitializeTest : uma_test::test,
+                            ::testing::WithParamInterface<uma_result_t> {};
 
-INSTANTIATE_TEST_SUITE_P(poolInitializeTest,
-                         poolInitializeTest,
-                         ::testing::Values(
-                             UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY,
-                             UMA_RESULT_ERROR_POOL_SPECIFIC,
-                             UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC,
-                             UMA_RESULT_ERROR_INVALID_ARGUMENT,
-                             UMA_RESULT_ERROR_UNKNOWN));
+INSTANTIATE_TEST_SUITE_P(
+    poolInitializeTest, poolInitializeTest,
+    ::testing::Values(UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY,
+                      UMA_RESULT_ERROR_POOL_SPECIFIC,
+                      UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC,
+                      UMA_RESULT_ERROR_INVALID_ARGUMENT,
+                      UMA_RESULT_ERROR_UNKNOWN));
 
 TEST_P(poolInitializeTest, errorPropagation) {
     struct pool : public uma_test::pool_base {

--- a/test/unified_memory_allocation/memoryProvider.hpp
+++ b/test/unified_memory_allocation/memoryProvider.hpp
@@ -9,7 +9,10 @@
 #ifndef UMA_TEST_MEMORY_PROVIDER_OPS_HPP
 #define UMA_TEST_MEMORY_PROVIDER_OPS_HPP
 
-struct umaProviderTest : uma_test::test, ::testing::WithParamInterface<std::function<std::pair<uma_result_t, uma::provider_unique_handle_t>()>> {
+struct umaProviderTest
+    : uma_test::test,
+      ::testing::WithParamInterface<std::function<
+          std::pair<uma_result_t, uma::provider_unique_handle_t>()>> {
     umaProviderTest() : provider(nullptr, nullptr) {}
     void SetUp() {
         test::SetUp();
@@ -18,9 +21,7 @@ struct umaProviderTest : uma_test::test, ::testing::WithParamInterface<std::func
         EXPECT_NE(provider, nullptr);
         this->provider = std::move(provider);
     }
-    void TearDown() override {
-        test::TearDown();
-    }
+    void TearDown() override { test::TearDown(); }
     uma::provider_unique_handle_t provider;
 };
 

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -16,7 +16,8 @@ TEST_F(test, memoryProviderTrace) {
     auto trace = [](const char *name) { calls[name]++; };
 
     auto nullProvider = uma_test::wrapProviderUnique(nullProviderCreate());
-    auto tracingProvider = uma_test::wrapProviderUnique(traceProviderCreate(nullProvider.get(), trace));
+    auto tracingProvider = uma_test::wrapProviderUnique(
+        traceProviderCreate(nullProvider.get(), trace));
 
     size_t call_count = 0;
 
@@ -36,18 +37,19 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(calls.size(), ++call_count);
 }
 
-//////////////////////////// Negative test cases ////////////////////////////////
+//////////////////////////// Negative test cases
+///////////////////////////////////
 
-struct providerInitializeTest : uma_test::test, ::testing::WithParamInterface<uma_result_t> {};
+struct providerInitializeTest : uma_test::test,
+                                ::testing::WithParamInterface<uma_result_t> {};
 
-INSTANTIATE_TEST_SUITE_P(providerInitializeTest,
-                         providerInitializeTest,
-                         ::testing::Values(
-                             UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY,
-                             UMA_RESULT_ERROR_POOL_SPECIFIC,
-                             UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC,
-                             UMA_RESULT_ERROR_INVALID_ARGUMENT,
-                             UMA_RESULT_ERROR_UNKNOWN));
+INSTANTIATE_TEST_SUITE_P(
+    providerInitializeTest, providerInitializeTest,
+    ::testing::Values(UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY,
+                      UMA_RESULT_ERROR_POOL_SPECIFIC,
+                      UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC,
+                      UMA_RESULT_ERROR_INVALID_ARGUMENT,
+                      UMA_RESULT_ERROR_UNKNOWN));
 
 TEST_P(providerInitializeTest, errorPropagation) {
     struct provider : public uma_test::provider_base {

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -85,7 +85,8 @@ class FileSinkDefaultLevel : public FileSink {
 
 TEST_F(FileSink, MultipleLines) {
     logger::Level level = logger::Level::WARN;
-    logger::Logger logger(level, std::make_unique<logger::FileSink>(logger_name, file_path));
+    logger::Logger logger(
+        level, std::make_unique<logger::FileSink>(logger_name, file_path));
 
     logger.warning("Test message: {}", "success");
     logger.debug("This should not be printed: {}", 42);
@@ -97,7 +98,8 @@ TEST_F(FileSink, MultipleLines) {
 
 TEST_F(FileSink, ThreeParams) {
     logger::Level level = logger::Level::DEBUG;
-    logger::Logger logger(level, std::make_unique<logger::FileSink>(logger_name, file_path));
+    logger::Logger logger(
+        level, std::make_unique<logger::FileSink>(logger_name, file_path));
 
     logger.setFlushLevel(level);
     logger.debug("{} {}: {}", "Test", 42, 3.8);
@@ -105,32 +107,36 @@ TEST_F(FileSink, ThreeParams) {
 }
 
 TEST_F(FileSink, DoubleBraces) {
-    logger::Logger logger(logger::Level::ERR,
-                          std::make_unique<logger::FileSink>(logger_name, file_path));
+    logger::Logger logger(
+        logger::Level::ERR,
+        std::make_unique<logger::FileSink>(logger_name, file_path));
 
     logger.error("{{}} {}: {}", "Test", 42);
     test_msg += "[ERROR]: {} Test: 42\n";
 }
 
 TEST_F(FileSink, DoubleBraces2) {
-    logger::Logger logger(logger::Level::ERR,
-                          std::make_unique<logger::FileSink>(logger_name, file_path));
+    logger::Logger logger(
+        logger::Level::ERR,
+        std::make_unique<logger::FileSink>(logger_name, file_path));
 
     logger.error("200 {{ {}: {{{}}} 3.8", "Test", 42);
     test_msg += "[ERROR]: 200 { Test: {42} 3.8\n";
 }
 
 TEST_F(FileSink, DoubleBraces3) {
-    logger::Logger logger(logger::Level::ERR,
-                          std::make_unique<logger::FileSink>(logger_name, file_path));
+    logger::Logger logger(
+        logger::Level::ERR,
+        std::make_unique<logger::FileSink>(logger_name, file_path));
 
     logger.error("{{ {}:}} {}}}", "Test", 42);
     test_msg += "[ERROR]: { Test:} 42}\n";
 }
 
 TEST_F(FileSink, NoBraces) {
-    logger::Logger logger(logger::Level::ERR,
-                          std::make_unique<logger::FileSink>(logger_name, file_path));
+    logger::Logger logger(
+        logger::Level::ERR,
+        std::make_unique<logger::FileSink>(logger_name, file_path));
 
     logger.error(" Test: 42");
     test_msg += "[ERROR]:  Test: 42\n";
@@ -138,7 +144,8 @@ TEST_F(FileSink, NoBraces) {
 
 TEST_F(FileSink, SetFlushLevelDebugCtor) {
     auto level = logger::Level::DEBUG;
-    logger::Logger logger(level, std::make_unique<logger::FileSink>(logger_name, file_path, level));
+    logger::Logger logger(level, std::make_unique<logger::FileSink>(
+                                     logger_name, file_path, level));
 
     logger.debug("Test message: {}", "success");
     test_msg += "[DEBUG]: Test message: success\n";

--- a/test/unit/utils/getenv.cpp
+++ b/test/unit/utils/getenv.cpp
@@ -160,20 +160,15 @@ class GetenvToMap : public GetEnvFailureWithParam {};
 
 class GetenvToVec : public GetEnvFailureWithParam {};
 
-INSTANTIATE_TEST_SUITE_P(WrongValuesForMap, GetenvToMap,
-                         testing::Values("value_1;value_2",
-                                         "param_1:value_1,value_2;param_2:",
-                                         "param_1:value_1,value_2;:value_1",
-                                         ",;:", ",;", "rvrawerv)(*&)($@#93939854;;)",
-                                         "simple", ",", ":", ";", "value,value",
-                                         "param:value;param:value",
-                                         "param,value;param:value",
-                                         "param:value;param_2,value",
-                                         "param:value;param_2",
-                                         "param:value;param_2;param_3",
-                                         "param:value:value_2",
-                                         "param:value;:",
-                                         "param:value;,"));
+INSTANTIATE_TEST_SUITE_P(
+    WrongValuesForMap, GetenvToMap,
+    testing::Values("value_1;value_2", "param_1:value_1,value_2;param_2:",
+                    "param_1:value_1,value_2;:value_1", ",;:", ",;",
+                    "rvrawerv)(*&)($@#93939854;;)", "simple", ",", ":", ";",
+                    "value,value", "param:value;param:value",
+                    "param,value;param:value", "param:value;param_2,value",
+                    "param:value;param_2", "param:value;param_2;param_3",
+                    "param:value:value_2", "param:value;:", "param:value;,"));
 
 TEST_P(GetenvToMap, WrongEnvVarValues) {
     ASSERT_THROW(getenv_to_map("UR_TEST_ENV_VAR"), std::invalid_argument);
@@ -181,8 +176,8 @@ TEST_P(GetenvToMap, WrongEnvVarValues) {
 
 INSTANTIATE_TEST_SUITE_P(WrongValuesForVec, GetenvToVec,
                          testing::Values("value_1;value_2",
-                                         "param_1:value_1,value_2;param_2",
-                                         ",", ";", ":", ",,,",
+                                         "param_1:value_1,value_2;param_2", ",",
+                                         ";", ":", ",,,",
                                          "rvrawerv)(*&)($@#93939854,,)",
                                          "value,,", "value;"));
 


### PR DESCRIPTION
This PR:
* Removes `ColumnLimit: 0` from the root `.clang-format`.
* Adds override `.clang-format` file for autogenerated files in `/include`
* Applies all remaining formating changes

Important files [`.clang-format`](https://github.com/oneapi-src/unified-runtime/pull/329/files#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2) [`include/.clang-format`](https://github.com/oneapi-src/unified-runtime/pull/329/files#diff-f7bc9dbee0ee89027baab27fda48147ed6a4f5abc7998a9042f9ad3c6e133bae)