### PR TITLE
ur: Update spec to v0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
-project(unified-runtime VERSION 0.5.0)
+project(unified-runtime VERSION 0.6.0)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -205,7 +205,7 @@ set(API_JSON_FILE ${PROJECT_BINARY_DIR}/unified_runtime.json)
 # Generate source from the specification
 add_custom_target(generate-code USES_TERMINAL
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
-    COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE}
+    COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE} --ver ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
 )
 

--- a/include/ur.py
+++ b/include/ur.py
@@ -4,7 +4,7 @@
  SPDX-License-Identifier: MIT
 
  @file ur.py
- @version v0.5-r0.5
+ @version v0.6-r0
 
  """
 import platform

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  *
  * @file ur_api.h
- * @version v0.5-r0.5
+ * @version v0.6-r0
  *
  */
 #ifndef UR_API_H_INCLUDED

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  *
  * @file ur_ddi.h
- * @version v0.5-r0.5
+ * @version v0.6-r0
  *
  */
 #ifndef UR_DDI_H_INCLUDED

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -223,7 +223,8 @@ def generate_common(dstpath, sections, ver, rev):
         loc += util.makoWrite(
             "./templates/%s.mako" % fn,
             os.path.join(sourcepath, fn),
-            ver=rev,
+            ver=ver,
+            rev=rev,
             sourcepath=sourcepath,
             sections=sections)
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -60,7 +60,7 @@ def build():
     revision is number of commits since tag 'v0'
 """
 def revision():
-    return '0.5'
+    return '0'
     result = subprocess.run(['git', 'describe', '--tags', '--dirty'], cwd=os.path.dirname(os.path.abspath(__file__)), stdout=subprocess.PIPE)
     if result.returncode:
         print('ERROR: Could not get revision number from git', file=sys.stderr)
@@ -178,4 +178,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-# END OF FILE

--- a/scripts/templates/api_listing.mako
+++ b/scripts/templates/api_listing.mako
@@ -7,7 +7,7 @@ from templates import helper as th
 ==============================
 ${groupname} API
 ==============================
-oneAPI Runtime Specification - Version ${rev}
+|full_name| Specification - Version |spec_version|
 
 %for s in specs:
 <%

--- a/scripts/templates/conf.py.mako
+++ b/scripts/templates/conf.py.mako
@@ -219,8 +219,8 @@ primary_domain = 'cpp'
 highlight_language = 'cpp'
 
 rst_prolog = """
-.. |l0_full_name| replace:: oneAPI Unified Runtime
-.. |l0_spec_version| replace:: ${ver}
+.. |full_name| replace:: oneAPI Unified Runtime
+.. |spec_version| replace:: ${ver}
 """
 
 def setup(app):

--- a/scripts/templates/index.rst.mako
+++ b/scripts/templates/index.rst.mako
@@ -6,7 +6,7 @@
 .. _l0-section:
 
 ===================================
- |l0_full_name|: |l0_spec_version|
+|full_name|: |spec_version|
 ===================================
 
 .. toctree::

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  *
  * @file ur_api.cpp
- * @version v0.5-r0.5
+ * @version v0.6-r0
  *
  */
 #include "ur_api.h"


### PR DESCRIPTION
Change version in preparation for oneAPI HW SIG to differentiate the current state of the specification from previous meetings.