### PR TITLE
ci: Automatically deploy weekly prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,21 @@
+---
+name: Deploy weekly prerelease
+
+on:
+  schedule:
+    # At 23:00 on Friday, GitHub actions schedule is in UTC time.
+    - cron: 0 23 * * 5
+
+jobs:
+  weekly-prerelease:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create weekly prerelease
+        run:
+          gh release create --prerelease --title "Weekly Stable Snapshot $(date +%Y/%m/%d)" weekly-$(date +%Y-%m-%d)
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ add_executable(example example.cpp)
 target_link_libraries(example PUBLIC unified-runtime::headers)
 ```
 
+### Weekly Tags
+
+Each Friday at 23:00 UTC time a [prerelease
+tag](https://github.com/oneapi-src/unified-runtime/releases) is created which
+takes the form `weekly-YYYY-MM-DD`. These tags should be used by downstream
+projects which intend to track development closely but maintain a fixed point in
+history to avoid pulling potentially breaking changes from the `main` branch.
+
 ## Source Code Generation
 
 Code is generated using included [Python scripts](/scripts/README.md).


### PR DESCRIPTION
Fixes #288 by adding a new GitHub Actions workflow to create a weekly
prerelease tag as a snapshot of the main branch.
