### PR TITLE
[ur] Replace extern logger object with a singleton

### DIFF
--- a/source/drivers/null/ur_null.cpp
+++ b/source/drivers/null/ur_null.cpp
@@ -8,11 +8,6 @@
  *
  */
 #include "ur_null.hpp"
-#include "logger/ur_logger.hpp"
-
-namespace logger {
-Logger logger = create_logger("null");
-}
 
 namespace driver {
 //////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -17,10 +17,6 @@
 #include "tracing/ur_tracing_layer.hpp"
 #endif
 
-namespace logger {
-Logger logger = create_logger("loader");
-}
-
 namespace ur_lib {
 ///////////////////////////////////////////////////////////////////////////////
 context_t *context;
@@ -34,6 +30,10 @@ context_t::~context_t() {}
 //////////////////////////////////////////////////////////////////////////
 __urdlllocal ur_result_t context_t::Init(ur_device_init_flags_t device_flags) {
     ur_result_t result;
+    const char *logger_name = "loader";
+    logger::init(logger_name);
+    logger::info("Logger {} initialized successfully!", logger_name);
+
     result = loader::context->init();
 
     if (UR_RESULT_SUCCESS == result) {


### PR DESCRIPTION
Replace extern logger object with a singleton one. Remove the need for initializing logger when logger is not used.

Add printing logger name at the beginning of messages.