### PR TITLE
[ur] Fix formatting of logging section in docs

### DIFF
--- a/scripts/core/INTRO.rst
+++ b/scripts/core/INTRO.rst
@@ -207,7 +207,7 @@ By default, there is a guarantee that *error* messages are flushed immediately. 
 Loggers redirect messages to *stdout*, *stderr*, or a file (default: *stderr*).
 
 All of these logging options can be set with **UR_LOG_LOADER** and **UR_LOG_NULL** environment variables described in the **Environment Variables** section below.
-Both of these environment variables have the same syntax for setting logger options::
+Both of these environment variables have the same syntax for setting logger options:
 
   "[level:debug|info|warning|error];[flush:<debug|info|warning|error>];[output:stdout|stderr|file,<path>]"
   


### PR DESCRIPTION
During building pages, the following warning occurs:
```
/home/runner/work/unified-runtime/unified-runtime/docs/source/core/INTRO.rst:202: WARNING: Could not lex literal_block as "cpp". Highlighting skipped.
```
Reformatted Logging section to get rid of this warning.