### PR TITLE
ur: Add parameter valid usage for enqueue buffer commands

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4204,6 +4204,8 @@ urEnqueueEventsWaitWithBarrier(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4250,6 +4252,8 @@ urEnqueueMemBufferRead(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4299,6 +4303,15 @@ urEnqueueMemBufferWrite(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.width == 0`
+///         + `bufferRowPitch != 0 && bufferRowPitch < region.width`
+///         + `hostRowPitch != 0 && hostRowPitch < region.width`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`
+///         + `hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`
+///         + `hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`
+///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4306,8 +4319,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -4355,6 +4368,15 @@ urEnqueueMemBufferReadRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.width == 0`
+///         + `bufferRowPitch != 0 && bufferRowPitch < region.width`
+///         + `hostRowPitch != 0 && hostRowPitch < region.width`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`
+///         + `hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`
+///         + `hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`
+///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4362,8 +4384,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -4404,6 +4426,9 @@ urEnqueueMemBufferWriteRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `srcOffset + size` results in an out-of-bounds access.
+///         + If `dstOffset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4446,6 +4471,16 @@ urEnqueueMemBufferCopy(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.depth == 0`
+///         + `srcRowPitch != 0 && srcRowPitch < region.height`
+///         + `dstRowPitch != 0 && dstRowPitch < region.height`
+///         + `srcSlicePitch != 0 && srcSlicePitch < region.height * srcRowPitch`
+///         + `srcSlicePitch != 0 && srcSlicePitch % srcRowPitch != 0`
+///         + `dstSlicePitch != 0 && dstSlicePitch < region.height * dstRowPitch`
+///         + `dstSlicePitch != 0 && dstSlicePitch % dstRowPitch != 0`
+///         + If the combination of `srcOrigin`, `region`, `srcRowPitch`, and `srcSlicePitch` results in an out-of-bounds access.
+///         + If the combination of `dstOrigin`, `region`, `dstRowPitch`, and `dstSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4455,7 +4490,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -4493,6 +4528,8 @@ urEnqueueMemBufferCopyRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -4712,6 +4749,8 @@ typedef enum ur_usm_migration_flag_t {
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -6739,8 +6778,8 @@ typedef struct ur_enqueue_mem_buffer_read_rect_params_t {
     ur_queue_handle_t *phQueue;
     ur_mem_handle_t *phBuffer;
     bool *pblockingRead;
-    ur_rect_offset_t *pbufferOffset;
-    ur_rect_offset_t *phostOffset;
+    ur_rect_offset_t *pbufferOrigin;
+    ur_rect_offset_t *phostOrigin;
     ur_rect_region_t *pregion;
     size_t *pbufferRowPitch;
     size_t *pbufferSlicePitch;
@@ -6772,8 +6811,8 @@ typedef struct ur_enqueue_mem_buffer_write_rect_params_t {
     ur_queue_handle_t *phQueue;
     ur_mem_handle_t *phBuffer;
     bool *pblockingWrite;
-    ur_rect_offset_t *pbufferOffset;
-    ur_rect_offset_t *phostOffset;
+    ur_rect_offset_t *pbufferOrigin;
+    ur_rect_offset_t *phostOrigin;
     ur_rect_region_t *pregion;
     size_t *pbufferRowPitch;
     size_t *pbufferSlicePitch;
@@ -6835,7 +6874,7 @@ typedef struct ur_enqueue_mem_buffer_copy_rect_params_t {
     ur_mem_handle_t *phBufferDst;
     ur_rect_offset_t *psrcOrigin;
     ur_rect_offset_t *pdstOrigin;
-    ur_rect_region_t *psrcRegion;
+    ur_rect_region_t *pregion;
     size_t *psrcRowPitch;
     size_t *psrcSlicePitch;
     size_t *pdstRowPitch;

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -189,6 +189,8 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "If `offset + size` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -240,6 +242,8 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "If `offset + size` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -264,10 +268,10 @@ params:
       name: blockingRead
       desc: "[in] indicates blocking (true), non-blocking (false)"
     - type: $x_rect_offset_t
-      name: bufferOffset
+      name: bufferOrigin
       desc: "[in] 3D offset in the buffer"
     - type: $x_rect_offset_t
-      name: hostOffset
+      name: hostOrigin
       desc: "[in] 3D offset in the host region"
     - type: $x_rect_region_t
       name: region
@@ -307,6 +311,15 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`region.width == 0 || region.height == 0 || region.width == 0`"
+        - "`bufferRowPitch != 0 && bufferRowPitch < region.width`"
+        - "`hostRowPitch != 0 && hostRowPitch < region.width`"
+        - "`bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`"
+        - "`bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`"
+        - "`hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`"
+        - "`hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`"
+        - "If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -331,10 +344,10 @@ params:
       name: blockingWrite
       desc: "[in] indicates blocking (true), non-blocking (false)"
     - type: $x_rect_offset_t
-      name: bufferOffset
+      name: bufferOrigin
       desc: "[in] 3D offset in the buffer"
     - type: $x_rect_offset_t
-      name: hostOffset
+      name: hostOrigin
       desc: "[in] 3D offset in the host region"
     - type: $x_rect_region_t
       name: region
@@ -374,6 +387,15 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`region.width == 0 || region.height == 0 || region.width == 0`"
+        - "`bufferRowPitch != 0 && bufferRowPitch < region.width`"
+        - "`hostRowPitch != 0 && hostRowPitch < region.width`"
+        - "`bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`"
+        - "`bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`"
+        - "`hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`"
+        - "`hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`"
+        - "If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -423,6 +445,9 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "If `srcOffset + size` results in an out-of-bounds access."
+        - "If `dstOffset + size` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -450,7 +475,7 @@ params:
       name: dstOrigin
       desc: "[in] 3D offset in the destination buffer"
     - type: $x_rect_region_t
-      name: srcRegion
+      name: region
       desc: "[in] source 3D rectangular region descriptor: width, height, depth"
     - type: size_t
       name: srcRowPitch
@@ -484,6 +509,16 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`region.width == 0 || region.height == 0 || region.depth == 0`"
+        - "`srcRowPitch != 0 && srcRowPitch < region.height`"
+        - "`dstRowPitch != 0 && dstRowPitch < region.height`"
+        - "`srcSlicePitch != 0 && srcSlicePitch < region.height * srcRowPitch`"
+        - "`srcSlicePitch != 0 && srcSlicePitch % srcRowPitch != 0`"
+        - "`dstSlicePitch != 0 && dstSlicePitch < region.height * dstRowPitch`"
+        - "`dstSlicePitch != 0 && dstSlicePitch % dstRowPitch != 0`"
+        - "If the combination of `srcOrigin`, `region`, `srcRowPitch`, and `srcSlicePitch` results in an out-of-bounds access."
+        - "If the combination of `dstOrigin`, `region`, `dstRowPitch`, and `dstSlicePitch` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -533,6 +568,8 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "If `offset + size` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -825,6 +862,8 @@ returns:
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
         - "If event objects in phEventWaitList are not valid events."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "If `offset + size` results in an out-of-bounds access."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------

--- a/scripts/generate_ids.py
+++ b/scripts/generate_ids.py
@@ -25,7 +25,7 @@ def generate_registry(path, specs):
     for s in specs:
         for i, obj in enumerate(s['objects']):
             if obj['type'] == 'function':
-                functions.append(obj['class'].removeprefix('$x') + obj['name'])
+                functions.append(obj['class'][len('$x'):] + obj['name'])
 
     try:
         existing_registry = list(util.yamlRead(path))[1]['etors']

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2208,8 +2208,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -2231,7 +2231,7 @@ urEnqueueMemBufferReadRect(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferReadRect = d_context.urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr != pfnMemBufferReadRect) {
-        result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2249,8 +2249,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -2273,7 +2273,7 @@ urEnqueueMemBufferWriteRect(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferWriteRect = d_context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr != pfnMemBufferWriteRect) {
-        result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -2327,7 +2327,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -2345,7 +2345,7 @@ urEnqueueMemBufferCopyRect(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnMemBufferCopyRect = d_context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr != pfnMemBufferCopyRect) {
-        result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -2443,8 +2443,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -2467,10 +2467,10 @@ urEnqueueMemBufferReadRect(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_read_rect_params_t params = {&hQueue, &hBuffer, &blockingRead, &bufferOffset, &hostOffset, &region, &bufferRowPitch, &bufferSlicePitch, &hostRowPitch, &hostSlicePitch, &pDst, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    ur_enqueue_mem_buffer_read_rect_params_t params = {&hQueue, &hBuffer, &blockingRead, &bufferOrigin, &hostOrigin, &region, &bufferRowPitch, &bufferSlicePitch, &hostRowPitch, &hostSlicePitch, &pDst, &numEventsInWaitList, &phEventWaitList, &phEvent};
     uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, "urEnqueueMemBufferReadRect", &params);
 
-    ur_result_t result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, "urEnqueueMemBufferReadRect", &params, &result, instance);
 
@@ -2484,8 +2484,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -2509,10 +2509,10 @@ urEnqueueMemBufferWriteRect(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_write_rect_params_t params = {&hQueue, &hBuffer, &blockingWrite, &bufferOffset, &hostOffset, &region, &bufferRowPitch, &bufferSlicePitch, &hostRowPitch, &hostSlicePitch, &pSrc, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    ur_enqueue_mem_buffer_write_rect_params_t params = {&hQueue, &hBuffer, &blockingWrite, &bufferOrigin, &hostOrigin, &region, &bufferRowPitch, &bufferSlicePitch, &hostRowPitch, &hostSlicePitch, &pSrc, &numEventsInWaitList, &phEventWaitList, &phEvent};
     uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, "urEnqueueMemBufferWriteRect", &params);
 
-    ur_result_t result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, "urEnqueueMemBufferWriteRect", &params, &result, instance);
 
@@ -2562,7 +2562,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -2581,10 +2581,10 @@ urEnqueueMemBufferCopyRect(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_mem_buffer_copy_rect_params_t params = {&hQueue, &hBufferSrc, &hBufferDst, &srcOrigin, &dstOrigin, &srcRegion, &srcRowPitch, &srcSlicePitch, &dstRowPitch, &dstSlicePitch, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    ur_enqueue_mem_buffer_copy_rect_params_t params = {&hQueue, &hBufferSrc, &hBufferDst, &srcOrigin, &dstOrigin, &region, &srcRowPitch, &srcSlicePitch, &dstRowPitch, &dstSlicePitch, &numEventsInWaitList, &phEventWaitList, &phEvent};
     uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, "urEnqueueMemBufferCopyRect", &params);
 
-    ur_result_t result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    ur_result_t result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, "urEnqueueMemBufferCopyRect", &params, &result, instance);
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2878,8 +2878,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -2922,9 +2922,37 @@ urEnqueueMemBufferReadRect(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (region.width == 0 || region.height == 0 || region.width == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (bufferRowPitch != 0 && bufferRowPitch < region.width) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (hostRowPitch != 0 && hostRowPitch < region.width) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2934,8 +2962,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -2979,9 +3007,37 @@ urEnqueueMemBufferWriteRect(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (region.width == 0 || region.height == 0 || region.width == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (bufferRowPitch != 0 && bufferRowPitch < region.width) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (hostRowPitch != 0 && hostRowPitch < region.width) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3042,7 +3098,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -3081,9 +3137,37 @@ urEnqueueMemBufferCopyRect(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (region.width == 0 || region.height == 0 || region.depth == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (srcRowPitch != 0 && srcRowPitch < region.height) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (dstRowPitch != 0 && dstRowPitch < region.height) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (srcSlicePitch != 0 && srcSlicePitch < region.height * srcRowPitch) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (srcSlicePitch != 0 && srcSlicePitch % srcRowPitch != 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (dstSlicePitch != 0 && dstSlicePitch < region.height * dstRowPitch) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (dstSlicePitch != 0 && dstSlicePitch % dstRowPitch != 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3242,8 +3242,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -3282,7 +3282,7 @@ urEnqueueMemBufferReadRect(
     }
 
     // forward to device-platform
-    result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3309,8 +3309,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -3350,7 +3350,7 @@ urEnqueueMemBufferWriteRect(
     }
 
     // forward to device-platform
-    result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {
@@ -3442,7 +3442,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -3480,7 +3480,7 @@ urEnqueueMemBufferCopyRect(
     }
 
     // forward to device-platform
-    result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    result = pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3396,6 +3396,8 @@ urEnqueueEventsWaitWithBarrier(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3449,6 +3451,8 @@ urEnqueueMemBufferRead(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3505,6 +3509,15 @@ urEnqueueMemBufferWrite(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.width == 0`
+///         + `bufferRowPitch != 0 && bufferRowPitch < region.width`
+///         + `hostRowPitch != 0 && hostRowPitch < region.width`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`
+///         + `hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`
+///         + `hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`
+///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3512,8 +3525,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -3535,7 +3548,7 @@ urEnqueueMemBufferReadRect(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferReadRect(hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3568,6 +3581,15 @@ urEnqueueMemBufferReadRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.width == 0`
+///         + `bufferRowPitch != 0 && bufferRowPitch < region.width`
+///         + `hostRowPitch != 0 && hostRowPitch < region.width`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`
+///         + `hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`
+///         + `hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`
+///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3575,8 +3597,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -3599,7 +3621,7 @@ urEnqueueMemBufferWriteRect(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOffset, hostOffset, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferWriteRect(hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3624,6 +3646,9 @@ urEnqueueMemBufferWriteRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `srcOffset + size` results in an out-of-bounds access.
+///         + If `dstOffset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3673,6 +3698,16 @@ urEnqueueMemBufferCopy(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.depth == 0`
+///         + `srcRowPitch != 0 && srcRowPitch < region.height`
+///         + `dstRowPitch != 0 && dstRowPitch < region.height`
+///         + `srcSlicePitch != 0 && srcSlicePitch < region.height * srcRowPitch`
+///         + `srcSlicePitch != 0 && srcSlicePitch % srcRowPitch != 0`
+///         + `dstSlicePitch != 0 && dstSlicePitch < region.height * dstRowPitch`
+///         + `dstSlicePitch != 0 && dstSlicePitch % dstRowPitch != 0`
+///         + If the combination of `srcOrigin`, `region`, `srcRowPitch`, and `srcSlicePitch` results in an out-of-bounds access.
+///         + If the combination of `dstOrigin`, `region`, `dstRowPitch`, and `dstSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3682,7 +3717,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -3700,7 +3735,7 @@ urEnqueueMemBufferCopyRect(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, srcRegion, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnMemBufferCopyRect(hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch, numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3727,6 +3762,8 @@ urEnqueueMemBufferCopyRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3951,6 +3988,8 @@ urEnqueueMemImageCopy(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3012,6 +3012,8 @@ urEnqueueEventsWaitWithBarrier(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3061,6 +3063,8 @@ urEnqueueMemBufferRead(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3113,6 +3117,15 @@ urEnqueueMemBufferWrite(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.width == 0`
+///         + `bufferRowPitch != 0 && bufferRowPitch < region.width`
+///         + `hostRowPitch != 0 && hostRowPitch < region.width`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`
+///         + `hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`
+///         + `hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`
+///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3120,8 +3133,8 @@ urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingRead,                        ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being read
@@ -3172,6 +3185,15 @@ urEnqueueMemBufferReadRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.width == 0`
+///         + `bufferRowPitch != 0 && bufferRowPitch < region.width`
+///         + `hostRowPitch != 0 && hostRowPitch < region.width`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch < region.height * bufferRowPitch`
+///         + `bufferSlicePitch != 0 && bufferSlicePitch % bufferRowPitch != 0`
+///         + `hostSlicePitch != 0 && hostSlicePitch < region.height * hostRowPitch`
+///         + `hostSlicePitch != 0 && hostSlicePitch % hostRowPitch != 0`
+///         + If the combination of `bufferOrigin`, `region`, `bufferRowPitch`, and `bufferSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3179,8 +3201,8 @@ urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     ur_mem_handle_t hBuffer,                  ///< [in] handle of the buffer object
     bool blockingWrite,                       ///< [in] indicates blocking (true), non-blocking (false)
-    ur_rect_offset_t bufferOffset,            ///< [in] 3D offset in the buffer
-    ur_rect_offset_t hostOffset,              ///< [in] 3D offset in the host region
+    ur_rect_offset_t bufferOrigin,            ///< [in] 3D offset in the buffer
+    ur_rect_offset_t hostOrigin,              ///< [in] 3D offset in the host region
     ur_rect_region_t region,                  ///< [in] 3D rectangular region descriptor: width, height, depth
     size_t bufferRowPitch,                    ///< [in] length of each row in bytes in the buffer object
     size_t bufferSlicePitch,                  ///< [in] length of each 2D slice in bytes in the buffer object being
@@ -3224,6 +3246,9 @@ urEnqueueMemBufferWriteRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `srcOffset + size` results in an out-of-bounds access.
+///         + If `dstOffset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3269,6 +3294,16 @@ urEnqueueMemBufferCopy(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `region.width == 0 || region.height == 0 || region.depth == 0`
+///         + `srcRowPitch != 0 && srcRowPitch < region.height`
+///         + `dstRowPitch != 0 && dstRowPitch < region.height`
+///         + `srcSlicePitch != 0 && srcSlicePitch < region.height * srcRowPitch`
+///         + `srcSlicePitch != 0 && srcSlicePitch % srcRowPitch != 0`
+///         + `dstSlicePitch != 0 && dstSlicePitch < region.height * dstRowPitch`
+///         + `dstSlicePitch != 0 && dstSlicePitch % dstRowPitch != 0`
+///         + If the combination of `srcOrigin`, `region`, `srcRowPitch`, and `srcSlicePitch` results in an out-of-bounds access.
+///         + If the combination of `dstOrigin`, `region`, `dstRowPitch`, and `dstSlicePitch` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3278,7 +3313,7 @@ urEnqueueMemBufferCopyRect(
     ur_mem_handle_t hBufferDst,               ///< [in] handle of the dest buffer object
     ur_rect_offset_t srcOrigin,               ///< [in] 3D offset in the source buffer
     ur_rect_offset_t dstOrigin,               ///< [in] 3D offset in the destination buffer
-    ur_rect_region_t srcRegion,               ///< [in] source 3D rectangular region descriptor: width, height, depth
+    ur_rect_region_t region,                  ///< [in] source 3D rectangular region descriptor: width, height, depth
     size_t srcRowPitch,                       ///< [in] length of each row in bytes in the source buffer object
     size_t srcSlicePitch,                     ///< [in] length of each 2D slice in bytes in the source buffer object
     size_t dstRowPitch,                       ///< [in] length of each row in bytes in the destination buffer object
@@ -3319,6 +3354,8 @@ urEnqueueMemBufferCopyRect(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL
@@ -3527,6 +3564,8 @@ urEnqueueMemImageCopy(
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ///         + If event objects in phEventWaitList are not valid events.
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `offset + size` results in an out-of-bounds access.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL

--- a/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -65,6 +65,15 @@ TEST_P(urEnqueueMemBufferCopyTest, InvalidNullPtrEventWaitList) {
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
+TEST_P(urEnqueueMemBufferCopyTest, InvalidSize) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer,
+                                            1, 0, size, 0, nullptr, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer,
+                                            0, 1, size, 0, nullptr, nullptr));
+}
+
 using urEnqueueMemBufferCopyMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {

--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -84,6 +84,14 @@ TEST_P(urEnqueueMemBufferFillTest, InvalidNullPtrEventWaitList) {
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
+TEST_P(urEnqueueMemBufferFillTest, InvalidSize) {
+    const uint32_t pattern = 0xdeadbeef;
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueMemBufferFill(queue, buffer, &pattern,
+                                            sizeof(pattern), 1, size, 0,
+                                            nullptr, nullptr));
+}
+
 using urEnqueueMemBufferFillMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {

--- a/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -157,6 +157,13 @@ TEST_P(urEnqueueMemBufferMapTest, InvalidNullPtrEventWaitList) {
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
+TEST_P(urEnqueueMemBufferMapTest, InvalidSize) {
+    void *map = nullptr;
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueMemBufferMap(queue, buffer, true, 0, 1, size, 0,
+                                           nullptr, nullptr, &map));
+}
+
 using urEnqueueMemBufferMapMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferMapMultiDeviceTest, WriteMapDifferentQueues) {

--- a/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -43,6 +43,13 @@ TEST_P(urEnqueueMemBufferReadTest, InvalidNullPtrEventWaitList) {
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
+TEST_P(urEnqueueMemBufferReadTest, InvalidSize) {
+    std::vector<uint32_t> output(count, 42);
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueMemBufferRead(queue, buffer, true, 1, size,
+                                            output.data(), 0, nullptr, nullptr));
+}
+
 using urEnqueueMemBufferReadMultiDeviceTest = uur::urMultiDeviceMemBufferQueueTest;
 
 TEST_F(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {

--- a/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -52,3 +52,10 @@ TEST_P(urEnqueueMemBufferWriteTest, InvalidNullPtrEventWaitList) {
                                              nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
+
+TEST_P(urEnqueueMemBufferWriteTest, InvalidSize) {
+    std::vector<uint32_t> output(count, 42);
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueMemBufferWrite(queue, buffer, true, 1, size,
+                                             output.data(), 0, nullptr, nullptr));
+}


### PR DESCRIPTION
Define the conditions under which the `UR_RESULT_ERROR_INVALID_SIZE`
error code should be returned for the following entry points:

* `urEnqueueMemBufferRead`
* `urEnqueueMemBufferReadRect`
* `urEnqueueMemBufferWrite`
* `urEnqueueMemBufferWriteRect`
* `urEnqueueMemBufferCopy`
* `urEnqueueMemBufferCopyRect`
* `urEnqueueMemBufferFill`
* `urEnqueueMemBufferMap`

Fixes #19