### PR TITLE
[ur] extend ur_usm_alloc_info_t with pool info

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -841,6 +841,7 @@ class ur_usm_alloc_info_v(IntEnum):
     BASE_PTR = 1                                    ## Memory allocation base pointer info
     SIZE = 2                                        ## Memory allocation size info
     DEVICE = 3                                      ## Memory allocation device info
+    POOL = 4                                        ## Memory allocation pool info
 
 class ur_usm_alloc_info_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2025,6 +2025,7 @@ typedef enum ur_usm_alloc_info_t {
     UR_USM_ALLOC_INFO_BASE_PTR = 1, ///< Memory allocation base pointer info
     UR_USM_ALLOC_INFO_SIZE = 2,     ///< Memory allocation size info
     UR_USM_ALLOC_INFO_DEVICE = 3,   ///< Memory allocation device info
+    UR_USM_ALLOC_INFO_POOL = 4,     ///< Memory allocation pool info
     /// @cond
     UR_USM_ALLOC_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2255,7 +2256,7 @@ urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_USM_ALLOC_INFO_DEVICE < propName`
+///         + `::UR_USM_ALLOC_INFO_POOL < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -70,6 +70,8 @@ etors:
       desc: "Memory allocation size info"
     - name: DEVICE
       desc: "Memory allocation device info"
+    - name: POOL
+      desc: "Memory allocation pool info"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "USM memory advice"

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1353,7 +1353,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_USM_ALLOC_INFO_DEVICE < propName) {
+        if (UR_USM_ALLOC_INFO_POOL < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1640,7 +1640,7 @@ ur_result_t UR_APICALL urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_USM_ALLOC_INFO_DEVICE < propName`
+///         + `::UR_USM_ALLOC_INFO_POOL < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1433,7 +1433,7 @@ ur_result_t UR_APICALL urUSMFree(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_USM_ALLOC_INFO_DEVICE < propName`
+///         + `::UR_USM_ALLOC_INFO_POOL < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/test/conformance/testing/include/uur/checks.h
+++ b/test/conformance/testing/include/uur/checks.h
@@ -363,6 +363,7 @@ inline std::ostream &operator<<(std::ostream &out,
         CASE(UR_USM_ALLOC_INFO_BASE_PTR);
         CASE(UR_USM_ALLOC_INFO_SIZE);
         CASE(UR_USM_ALLOC_INFO_DEVICE);
+        CASE(UR_USM_ALLOC_INFO_POOL);
 
 #undef CASE
 

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -10,7 +10,8 @@ UUR_TEST_SUITE_P(urUSMAllocInfoTest,
                  ::testing::Values(UR_USM_ALLOC_INFO_TYPE,
                                    UR_USM_ALLOC_INFO_BASE_PTR,
                                    UR_USM_ALLOC_INFO_SIZE,
-                                   UR_USM_ALLOC_INFO_DEVICE),
+                                   UR_USM_ALLOC_INFO_DEVICE,
+                                   UR_USM_ALLOC_INFO_POOL),
                  uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
 
 TEST_P(urUSMAllocInfoTest, Success) {


### PR DESCRIPTION
Closes: https://github.com/oneapi-src/unified-runtime/issues/326