### PR TITLE
Use root CMakeLists.txt as the default version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Documentation
         working-directory: ${{github.workspace}}/scripts
         run: python3 run.py --core
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ set(API_JSON_FILE ${PROJECT_BINARY_DIR}/unified_runtime.json)
 # Generate source from the specification
 add_custom_target(generate-code USES_TERMINAL
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
-    COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE} --ver ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE}
     COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
Following on from !331 this patch fixes an issue where running
`scripts/run.py` without the `--ver` argument would result in the wrong
version number being generated in the spec HTML. The default value for
the `--ver` argument is now read from the `project()` command in root
`CMakeLists.txt` file, making it the single source of truth for the
version.
