### PR TITLE
Remove [in] from doxygen documentation of phEvent parameter on enqueu…

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4089,8 +4089,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4130,8 +4130,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4173,8 +4173,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4219,8 +4219,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4265,8 +4265,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4321,8 +4321,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4378,8 +4378,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4419,8 +4419,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4465,8 +4465,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4508,8 +4508,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4558,8 +4558,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4608,8 +4608,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4652,8 +4652,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4727,9 +4727,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 );
 
@@ -4769,8 +4769,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4814,8 +4814,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4854,8 +4854,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4894,8 +4894,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4925,8 +4925,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4975,8 +4975,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5022,8 +5022,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5058,8 +5058,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5094,8 +5094,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 );
 
 #if !defined(__GNUC__)

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -49,7 +49,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular kernel execution instance.
+            [out][optional] return an event object that identifies this particular kernel execution instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_KERNEL
@@ -90,7 +90,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -129,7 +129,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -180,7 +180,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -231,7 +231,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -298,7 +298,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -365,7 +365,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance. 
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -414,7 +414,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance. 
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -475,7 +475,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -524,7 +524,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -581,7 +581,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance. 
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -638,7 +638,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -687,7 +687,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance. 
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -739,7 +739,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance. 
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -813,10 +813,10 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
     - type: void**
       name: ppRetMap
-      desc: "[in,out] return mapped pointer.  TODO: move it before numEventsInWaitList?"
+      desc: "[out] return mapped pointer.  TODO: move it before numEventsInWaitList?"
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -879,7 +879,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -919,7 +919,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -963,7 +963,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1014,7 +1014,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1058,7 +1058,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1094,7 +1094,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular command instance.
+            [out][optional] return an event object that identifies this particular command instance.
 returns:      
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1143,7 +1143,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular kernel execution instance.
+            [out][optional] return an event object that identifies this particular kernel execution instance.
 returns:
   - $X_RESULT_ERROR_INVALID_SIZE:
       - "`pitch == 0`"
@@ -1205,7 +1205,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular kernel execution instance.
+            [out][optional] return an event object that identifies this particular kernel execution instance.
 returns:
   - $X_RESULT_ERROR_INVALID_SIZE:
       - "`srcPitch == 0`"
@@ -1262,7 +1262,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular kernel execution instance.
+            [out][optional] return an event object that identifies this particular kernel execution instance.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
@@ -1307,7 +1307,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [in,out][optional] return an event object that identifies this particular kernel execution instance.
+            [out][optional] return an event object that identifies this particular kernel execution instance.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -2054,8 +2054,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2084,8 +2084,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2114,8 +2114,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2148,8 +2148,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2182,8 +2182,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2223,8 +2223,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2265,8 +2265,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2299,8 +2299,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2337,8 +2337,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2371,8 +2371,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2408,8 +2408,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2445,8 +2445,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2482,8 +2482,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2516,9 +2516,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2549,8 +2549,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2583,8 +2583,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2616,8 +2616,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2648,8 +2648,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2675,8 +2675,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2712,8 +2712,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2748,8 +2748,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2783,8 +2783,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2818,8 +2818,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -2289,8 +2289,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -2319,8 +2319,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
 
@@ -2349,8 +2349,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnEventsWaitWithBarrier = context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
 
@@ -2383,8 +2383,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -2417,8 +2417,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -2458,8 +2458,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
 
@@ -2500,8 +2500,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferWriteRect = context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
 
@@ -2534,8 +2534,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -2572,8 +2572,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
@@ -2606,8 +2606,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -2643,8 +2643,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -2680,8 +2680,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -2717,8 +2717,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -2751,9 +2751,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = context.urDdiTable.Enqueue.pfnMemBufferMap;
@@ -2784,8 +2784,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -2818,8 +2818,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMFill = context.urDdiTable.Enqueue.pfnUSMFill;
 
@@ -2851,8 +2851,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -2883,8 +2883,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -2910,8 +2910,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 ) {
     auto pfnUSMMemAdvise = context.urDdiTable.Enqueue.pfnUSMMemAdvise;
 
@@ -2947,8 +2947,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -2983,8 +2983,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -3018,8 +3018,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableWrite = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
 
@@ -3053,8 +3053,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableRead = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2661,8 +2661,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnKernelLaunch = context.urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -2710,8 +2710,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnEventsWait = context.urDdiTable.Enqueue.pfnEventsWait;
 
@@ -2747,8 +2747,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnEventsWaitWithBarrier = context.urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
 
@@ -2788,8 +2788,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferRead = context.urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -2837,8 +2837,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferWrite = context.urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -2893,8 +2893,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferReadRect = context.urDdiTable.Enqueue.pfnMemBufferReadRect;
 
@@ -2950,8 +2950,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferWriteRect = context.urDdiTable.Enqueue.pfnMemBufferWriteRect;
 
@@ -2999,8 +2999,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferCopy = context.urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -3052,8 +3052,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferCopyRect = context.urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
@@ -3101,8 +3101,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferFill = context.urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -3153,8 +3153,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageRead = context.urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -3205,8 +3205,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageWrite = context.urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -3257,8 +3257,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageCopy = context.urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -3306,9 +3306,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = context.urDdiTable.Enqueue.pfnMemBufferMap;
@@ -3358,8 +3358,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemUnmap = context.urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -3407,8 +3407,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMFill = context.urDdiTable.Enqueue.pfnUSMFill;
 
@@ -3475,8 +3475,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMMemcpy = context.urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -3526,8 +3526,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMPrefetch = context.urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -3572,8 +3572,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 ) {
     auto pfnUSMMemAdvise = context.urDdiTable.Enqueue.pfnUSMMemAdvise;
 
@@ -3620,8 +3620,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnUSMFill2D = context.urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -3703,8 +3703,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = context.urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -3773,8 +3773,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableWrite = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
 
@@ -3827,8 +3827,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableRead = context.urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2964,8 +2964,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3020,8 +3020,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3073,8 +3073,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3130,8 +3130,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3190,8 +3190,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3257,8 +3257,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3325,8 +3325,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3385,8 +3385,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3452,8 +3452,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3515,8 +3515,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3578,8 +3578,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3641,8 +3641,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3704,8 +3704,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3767,9 +3767,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3826,8 +3826,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3886,8 +3886,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3942,8 +3942,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3997,8 +3997,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4047,8 +4047,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4100,8 +4100,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4159,8 +4159,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4217,8 +4217,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4278,8 +4278,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3260,8 +3260,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnKernelLaunch = ur_lib::context->urDdiTable.Enqueue.pfnKernelLaunch;
     if (nullptr == pfnKernelLaunch) {
@@ -3308,8 +3308,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnEventsWait = ur_lib::context->urDdiTable.Enqueue.pfnEventsWait;
     if (nullptr == pfnEventsWait) {
@@ -3358,8 +3358,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnEventsWaitWithBarrier = ur_lib::context->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
     if (nullptr == pfnEventsWaitWithBarrier) {
@@ -3411,8 +3411,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferRead = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferRead;
     if (nullptr == pfnMemBufferRead) {
@@ -3464,8 +3464,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWrite;
     if (nullptr == pfnMemBufferWrite) {
@@ -3527,8 +3527,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferReadRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferReadRect;
     if (nullptr == pfnMemBufferReadRect) {
@@ -3591,8 +3591,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferWriteRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferWriteRect;
     if (nullptr == pfnMemBufferWriteRect) {
@@ -3639,8 +3639,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopy;
     if (nullptr == pfnMemBufferCopy) {
@@ -3692,8 +3692,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferCopyRect = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferCopyRect;
     if (nullptr == pfnMemBufferCopyRect) {
@@ -3742,8 +3742,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemBufferFill = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferFill;
     if (nullptr == pfnMemBufferFill) {
@@ -3799,8 +3799,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageRead = ur_lib::context->urDdiTable.Enqueue.pfnMemImageRead;
     if (nullptr == pfnMemImageRead) {
@@ -3856,8 +3856,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageWrite = ur_lib::context->urDdiTable.Enqueue.pfnMemImageWrite;
     if (nullptr == pfnMemImageWrite) {
@@ -3907,8 +3907,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemImageCopy = ur_lib::context->urDdiTable.Enqueue.pfnMemImageCopy;
     if (nullptr == pfnMemImageCopy) {
@@ -3966,9 +3966,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 ) {
     auto pfnMemBufferMap = ur_lib::context->urDdiTable.Enqueue.pfnMemBufferMap;
@@ -4015,8 +4015,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnMemUnmap = ur_lib::context->urDdiTable.Enqueue.pfnMemUnmap;
     if (nullptr == pfnMemUnmap) {
@@ -4067,8 +4067,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMFill = ur_lib::context->urDdiTable.Enqueue.pfnUSMFill;
     if (nullptr == pfnUSMFill) {
@@ -4114,8 +4114,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMMemcpy = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy;
     if (nullptr == pfnUSMMemcpy) {
@@ -4161,8 +4161,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     auto pfnUSMPrefetch = ur_lib::context->urDdiTable.Enqueue.pfnUSMPrefetch;
     if (nullptr == pfnUSMPrefetch) {
@@ -4199,8 +4199,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 ) {
     auto pfnUSMMemAdvise = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemAdvise;
     if (nullptr == pfnUSMMemAdvise) {
@@ -4256,8 +4256,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnUSMFill2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMFill2D;
     if (nullptr == pfnUSMFill2D) {
@@ -4310,8 +4310,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnUSMMemcpy2D = ur_lib::context->urDdiTable.Enqueue.pfnUSMMemcpy2D;
     if (nullptr == pfnUSMMemcpy2D) {
@@ -4353,8 +4353,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableWrite = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
     if (nullptr == pfnDeviceGlobalVariableWrite) {
@@ -4396,8 +4396,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     auto pfnDeviceGlobalVariableRead = ur_lib::context->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
     if (nullptr == pfnDeviceGlobalVariableRead) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2888,8 +2888,8 @@ urEnqueueKernelLaunch(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2932,8 +2932,8 @@ urEnqueueEventsWait(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2978,8 +2978,8 @@ urEnqueueEventsWaitWithBarrier(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
                                               ///< previously enqueued commands
                                               ///< must be complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3027,8 +3027,8 @@ urEnqueueMemBufferRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3076,8 +3076,8 @@ urEnqueueMemBufferWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3135,8 +3135,8 @@ urEnqueueMemBufferReadRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3195,8 +3195,8 @@ urEnqueueMemBufferWriteRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3239,8 +3239,8 @@ urEnqueueMemBufferCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3288,8 +3288,8 @@ urEnqueueMemBufferCopyRect(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3334,8 +3334,8 @@ urEnqueueMemBufferFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3387,8 +3387,8 @@ urEnqueueMemImageRead(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3440,8 +3440,8 @@ urEnqueueMemImageWrite(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3487,8 +3487,8 @@ urEnqueueMemImageCopy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3542,9 +3542,9 @@ urEnqueueMemBufferMap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent,               ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
-    void **ppRetMap                           ///< [in,out] return mapped pointer.  TODO: move it before
+    ur_event_handle_t *phEvent,               ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+    void **ppRetMap                           ///< [out] return mapped pointer.  TODO: move it before
                                               ///< numEventsInWaitList?
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3587,8 +3587,8 @@ urEnqueueMemUnmap(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3635,8 +3635,8 @@ urEnqueueUSMFill(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3678,8 +3678,8 @@ urEnqueueUSMMemcpy(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3721,8 +3721,8 @@ urEnqueueUSMPrefetch(
                                               ///< events that must be complete before this command can be executed.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
                                               ///< command does not wait on any event to complete.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular command instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3755,8 +3755,8 @@ urEnqueueUSMMemAdvise(
     const void *pMem,          ///< [in] pointer to the USM memory object
     size_t size,               ///< [in] size in bytes to be advised
     ur_mem_advice_t advice,    ///< [in] USM memory advice
-    ur_event_handle_t *phEvent ///< [in,out][optional] return an event object that identifies this
-                               ///< particular command instance.
+    ur_event_handle_t *phEvent ///< [out][optional] return an event object that identifies this particular
+                               ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3808,8 +3808,8 @@ urEnqueueUSMFill2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3858,8 +3858,8 @@ urEnqueueUSMMemcpy2D(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3897,8 +3897,8 @@ urEnqueueDeviceGlobalVariableWrite(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -3936,8 +3936,8 @@ urEnqueueDeviceGlobalVariableRead(
                                               ///< events that must be complete before the kernel execution.
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
                                               ///< event.
-    ur_event_handle_t *phEvent                ///< [in,out][optional] return an event object that identifies this
-                                              ///< particular kernel execution instance.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< kernel execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
Remove [in] from doxygen documentation of phEvent parameter on enqueue entrypoints
Remove [in] from doxygen documentation of ppRetMap parameter of urEnqueueMemBufferMap

Closes #346 