### PR TITLE
[cmake] add quotes to cmd output, make it robust

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -10,7 +10,7 @@ function(get_program_version_major_minor name ret)
     execute_process(COMMAND ${name} --version
         OUTPUT_VARIABLE cmd_ret
         ERROR_QUIET)
-    STRING(REGEX MATCH "([0-9]+)\.([0-9]+)" VERSION ${cmd_ret})
+    STRING(REGEX MATCH "([0-9]+)\.([0-9]+)" VERSION "${cmd_ret}")
     SET(${ret} ${VERSION} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
I encounter the problem when having local clang-format but it fails to run because of some missing library. Then in https://github.com/oneapi-src/unified-runtime/blob/main/CMakeLists.txt#L119 it calls https://github.com/oneapi-src/unified-runtime/blob/main/cmake/helpers.cmake#L9, which use the output of `clang-format --version`, which in my case is empty.

Then the empty output make `${cmd_ret}` empty, and without the quotes, it would be a missing argument to `STRING REGEX`(instead of a empty string with quotes).