### PR TITLE
[ur] Make creation of buffer objects extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -201,10 +201,14 @@ class ur_result_t(c_int):
 class ur_structure_type_v(IntEnum):
     CONTEXT_PROPERTIES = 0                          ## ::ur_context_properties_t
     IMAGE_DESC = 1                                  ## ::ur_image_desc_t
-    PROGRAM_PROPERTIES = 2                          ## ::ur_program_properties_t
-    USM_DESC = 3                                    ## ::ur_usm_desc_t
-    USM_POOL_DESC = 4                               ## ::ur_usm_pool_desc_t
-    USM_POOL_LIMITS_DESC = 5                        ## ::ur_usm_pool_limits_desc_t
+    BUFFER_PROPERTIES = 2                           ## ::ur_buffer_properties_t
+    BUFFER_REGION = 3                               ## ::ur_buffer_region_t
+    BUFFER_CHANNEL_PROPERTIES = 4                   ## ::ur_buffer_channel_properties_t
+    BUFFER_ALLOC_LOCATION_PROPERTIES = 5            ## ::ur_buffer_alloc_location_properties_t
+    PROGRAM_PROPERTIES = 6                          ## ::ur_program_properties_t
+    USM_DESC = 7                                    ## ::ur_usm_desc_t
+    USM_POOL_DESC = 8                               ## ::ur_usm_pool_desc_t
+    USM_POOL_LIMITS_DESC = 9                        ## ::ur_usm_pool_limits_desc_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -726,9 +730,58 @@ class ur_image_desc_t(Structure):
     ]
 
 ###############################################################################
+## @brief Buffer creation properties
+class ur_buffer_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_BUFFER_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("pHost", c_void_p)                                             ## [in][optional] pointer to the buffer data
+    ]
+
+###############################################################################
+## @brief Buffer memory channel creation properties
+## 
+## @details
+##     - Specify these properties in ::urMemBufferCreate via
+##       ::ur_buffer_properties_t as part of a `pNext` chain.
+## 
+## @remarks
+##   _Analogues_
+##     - cl_intel_mem_channel_property
+class ur_buffer_channel_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("channel", c_ulong)                                            ## [in] Identifies the channel/region to which the buffer should be mapped.
+    ]
+
+###############################################################################
+## @brief Buffer allocation location creation properties
+## 
+## @details
+##     - Specify these properties in ::urMemBufferCreate via
+##       ::ur_buffer_properties_t as part of a `pNext` chain.
+## 
+## @remarks
+##   _Analogues_
+##     - cl_intel_mem_alloc_buffer_location
+class ur_buffer_alloc_location_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("location", c_ulong)                                           ## [in] Identifies the ID of global memory partition to which the memory
+                                                                        ## should be allocated.
+    ]
+
+###############################################################################
 ## @brief Buffer region type, used to describe a sub buffer
 class ur_buffer_region_t(Structure):
     _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_BUFFER_REGION
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("origin", c_size_t),                                           ## [in] buffer origin offset
         ("size", c_size_t)                                              ## [in] size of the buffer region
     ]
@@ -1869,9 +1922,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urMemBufferCreate
 if __use_win_types:
-    _urMemBufferCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, c_void_p, POINTER(ur_mem_handle_t) )
+    _urMemBufferCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, POINTER(ur_buffer_properties_t), POINTER(ur_mem_handle_t) )
 else:
-    _urMemBufferCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, c_void_p, POINTER(ur_mem_handle_t) )
+    _urMemBufferCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_mem_flags_t, c_size_t, POINTER(ur_buffer_properties_t), POINTER(ur_mem_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urMemRetain

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -628,7 +628,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnMemBufferCreate_t)(
     ur_context_handle_t,
     ur_mem_flags_t,
     size_t,
-    void *,
+    const ur_buffer_properties_t *,
     ur_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -647,7 +647,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnMemBufferPartition_t)(
     ur_mem_handle_t,
     ur_mem_flags_t,
     ur_buffer_create_type_t,
-    ur_buffer_region_t *,
+    const ur_buffer_region_t *,
     ur_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -266,6 +266,14 @@ etors:
       desc: $x_context_properties_t
     - name: IMAGE_DESC
       desc: $x_image_desc_t
+    - name: BUFFER_PROPERTIES
+      desc: $x_buffer_properties_t
+    - name: BUFFER_REGION
+      desc: $x_buffer_region_t
+    - name: BUFFER_CHANNEL_PROPERTIES
+      desc: $x_buffer_channel_properties_t
+    - name: BUFFER_ALLOC_LOCATION_PROPERTIES
+      desc: $x_buffer_alloc_location_properties_t
     - name: PROGRAM_PROPERTIES
       desc: $x_program_properties_t
     - name: USM_DESC

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -224,9 +224,9 @@ params:
       name: pHost
       desc: "[in][optional] pointer to the buffer data"
     - type: $x_mem_handle_t*
-      name: phMem      
+      name: phMem
       desc: "[out] pointer to handle of image object created"
-returns:      
+returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
@@ -238,10 +238,58 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Buffer creation properties"
+class: $xMem
+name: $x_buffer_properties_t
+base: $x_base_properties_t
+members:
+    - type: void*
+      name: pHost
+      desc: >
+          [in][optional] pointer to the buffer data
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Buffer memory channel creation properties"
+details:
+    - Specify these properties in $xMemBufferCreate via $x_buffer_properties_t
+      as part of a `pNext` chain.
+analogue:
+    - "cl_intel_mem_channel_property"
+class: $xMem
+name: $x_buffer_channel_properties_t
+base: $x_base_properties_t
+members:
+    - type: uint32_t
+      name: channel
+      desc: >
+          [in] Identifies the channel/region to which the buffer should be
+          mapped.
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Buffer allocation location creation properties"
+details:
+    - Specify these properties in $xMemBufferCreate via $x_buffer_properties_t
+      as part of a `pNext` chain.
+analogue:
+    - "cl_intel_mem_alloc_buffer_location"
+class: $xMem
+name: $x_buffer_alloc_location_properties_t
+base: $x_base_properties_t
+members:
+    - type: uint32_t
+      name: location
+      desc: >
+          [in] Identifies the ID of global memory partition to which the memory
+          should be allocated.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create a memory buffer"
 class: $xMem
 name: BufferCreate
+details:
+    - See also $x_buffer_channel_properties_t.
+    - See also $x_buffer_alloc_location_properties_t.
 ordinal: "0"
 analogue:
     - "**clCreateBuffer**"
@@ -255,19 +303,20 @@ params:
     - type: "size_t"
       name: size
       desc: "[in] size in bytes of the memory object to be allocated"
-    - type: "void*"
-      name: pHost
-      desc: "[in][optional] pointer to the buffer data"
+    - type: const $x_buffer_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to buffer creation properties"
     - type: $x_mem_handle_t*
-      name: phBuffer     
+      name: phBuffer
       desc: "[out] pointer to handle of the memory buffer created"
-returns:      
+returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_BUFFER_SIZE
     - $X_RESULT_ERROR_INVALID_HOST_PTR:
-      - "`pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`"
-      - "`pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`"
+      - "`pProperties == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`"
+      - "`pProperties->pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`"
+      - "`pProperties->pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`"
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
@@ -310,6 +359,7 @@ type: struct
 desc: "Buffer region type, used to describe a sub buffer"
 class: $xMem
 name: $x_buffer_region_t
+base: $x_base_desc_t
 members:
     - type: size_t
       name: origin
@@ -344,13 +394,13 @@ params:
     - type: $x_buffer_create_type_t
       name: bufferCreateType
       desc: "[in] buffer creation type"
-    - type: "$x_buffer_region_t*"
-      name: pBufferCreateInfo
+    - type: const $x_buffer_region_t*
+      name: pRegion
       desc: "[in] pointer to buffer create region information"
     - type: $x_mem_handle_t*
-      name: phMem      
+      name: phMem
       desc: "[out] pointer to the handle of sub buffer created"
-returns:      
+returns:
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
     - $X_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -427,7 +477,7 @@ params:
       name: pMemInfo
       desc: |
             [out][optional] array of bytes holding the info.
-            If propSize is less than the real number of bytes needed to return 
+            If propSize is less than the real number of bytes needed to return
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pMemInfo is not used.
     - type: "size_t*"
       name: pPropSizeRet

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -612,7 +612,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
+    const ur_buffer_properties_t
+        *pProperties, ///< [in][optional] pointer to buffer creation properties
     ur_mem_handle_t
         *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
@@ -621,7 +622,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnBufferCreate = d_context.urDdiTable.Mem.pfnBufferCreate;
     if (nullptr != pfnBufferCreate) {
-        result = pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
+        result = pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
     } else {
         // generic implementation
         *phBuffer = reinterpret_cast<ur_mem_handle_t>(d_context.get());
@@ -673,8 +674,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    const ur_buffer_region_t
+        *pRegion, ///< [in] pointer to buffer create region information
     ur_mem_handle_t
         *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
@@ -683,8 +684,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnBufferPartition = d_context.urDdiTable.Mem.pfnBufferPartition;
     if (nullptr != pfnBufferPartition) {
-        result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                                    pBufferCreateInfo, phMem);
+        result = pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion,
+                                    phMem);
     } else {
         // generic implementation
         *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -749,7 +749,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
+    const ur_buffer_properties_t
+        *pProperties, ///< [in][optional] pointer to buffer creation properties
     ur_mem_handle_t
         *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
@@ -759,13 +760,13 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_buffer_create_params_t params = {&hContext, &flags, &size, &pHost,
-                                            &phBuffer};
+    ur_mem_buffer_create_params_t params = {&hContext, &flags, &size,
+                                            &pProperties, &phBuffer};
     uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_BUFFER_CREATE,
                                              "urMemBufferCreate", &params);
 
     ur_result_t result =
-        pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
+        pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
 
     context.notify_end(UR_FUNCTION_MEM_BUFFER_CREATE, "urMemBufferCreate",
                        &params, &result, instance);
@@ -826,8 +827,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    const ur_buffer_region_t
+        *pRegion, ///< [in] pointer to buffer create region information
     ur_mem_handle_t
         *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
@@ -838,12 +839,12 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     }
 
     ur_mem_buffer_partition_params_t params = {
-        &hBuffer, &flags, &bufferCreateType, &pBufferCreateInfo, &phMem};
+        &hBuffer, &flags, &bufferCreateType, &pRegion, &phMem};
     uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_BUFFER_PARTITION,
                                              "urMemBufferPartition", &params);
 
-    ur_result_t result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                                            pBufferCreateInfo, phMem);
+    ur_result_t result =
+        pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion, phMem);
 
     context.notify_end(UR_FUNCTION_MEM_BUFFER_PARTITION, "urMemBufferPartition",
                        &params, &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -737,7 +737,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
+    const ur_buffer_properties_t
+        *pProperties, ///< [in][optional] pointer to buffer creation properties
     ur_mem_handle_t
         *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
@@ -760,20 +761,26 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pHost == NULL &&
+        if (pProperties == NULL &&
             (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
                       UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {
             return UR_RESULT_ERROR_INVALID_HOST_PTR;
         }
 
-        if (pHost != NULL &&
+        if (pProperties->pHost == NULL &&
+            (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
+                      UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {
+            return UR_RESULT_ERROR_INVALID_HOST_PTR;
+        }
+
+        if (pProperties->pHost != NULL &&
             (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
                       UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0) {
             return UR_RESULT_ERROR_INVALID_HOST_PTR;
         }
     }
 
-    return pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
+    return pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -823,8 +830,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    const ur_buffer_region_t
+        *pRegion, ///< [in] pointer to buffer create region information
     ur_mem_handle_t
         *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
@@ -847,7 +854,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
-        if (NULL == pBufferCreateInfo) {
+        if (NULL == pRegion) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -856,8 +863,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
         }
     }
 
-    return pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                              pBufferCreateInfo, phMem);
+    return pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -898,7 +898,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
+    const ur_buffer_properties_t
+        *pProperties, ///< [in][optional] pointer to buffer creation properties
     ur_mem_handle_t
         *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
@@ -915,7 +916,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
+    result = pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -985,8 +986,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    const ur_buffer_region_t
+        *pRegion, ///< [in] pointer to buffer create region information
     ur_mem_handle_t
         *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
@@ -1003,8 +1004,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
 
     // forward to device-platform
-    result = pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                                pBufferCreateInfo, phMem);
+    result =
+        pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion, phMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -938,6 +938,10 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a memory buffer
 ///
+/// @details
+///     - See also ::ur_buffer_channel_properties_t.
+///     - See also ::ur_buffer_alloc_location_properties_t.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateBuffer**
@@ -956,15 +960,17 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_BUFFER_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
-///         + `pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`
-///         + `pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
+///         + `pProperties == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`
+///         + `pProperties->pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`
+///         + `pProperties->pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
+    const ur_buffer_properties_t
+        *pProperties, ///< [in][optional] pointer to buffer creation properties
     ur_mem_handle_t
         *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
@@ -973,7 +979,7 @@ ur_result_t UR_APICALL urMemBufferCreate(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnBufferCreate(hContext, flags, size, pHost, phBuffer);
+    return pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1052,7 +1058,7 @@ ur_result_t UR_APICALL urMemRelease(
 ///         + `0x3f < flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pBufferCreateInfo`
+///         + `NULL == pRegion`
 ///         + `NULL == phMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE
@@ -1066,8 +1072,8 @@ ur_result_t UR_APICALL urMemBufferPartition(
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    const ur_buffer_region_t
+        *pRegion, ///< [in] pointer to buffer create region information
     ur_mem_handle_t
         *phMem ///< [out] pointer to the handle of sub buffer created
 ) {
@@ -1077,8 +1083,7 @@ ur_result_t UR_APICALL urMemBufferPartition(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnBufferPartition(hBuffer, flags, bufferCreateType,
-                              pBufferCreateInfo, phMem);
+    return pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion, phMem);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -813,6 +813,10 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a memory buffer
 ///
+/// @details
+///     - See also ::ur_buffer_channel_properties_t.
+///     - See also ::ur_buffer_alloc_location_properties_t.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateBuffer**
@@ -831,15 +835,17 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_BUFFER_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR
-///         + `pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`
-///         + `pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
+///         + `pProperties == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`
+///         + `pProperties->pHost == NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0`
+///         + `pProperties->pHost != NULL && (flags & (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
-    void *pHost, ///< [in][optional] pointer to the buffer data
+    const ur_buffer_properties_t
+        *pProperties, ///< [in][optional] pointer to buffer creation properties
     ur_mem_handle_t
         *phBuffer ///< [out] pointer to handle of the memory buffer created
 ) {
@@ -915,7 +921,7 @@ ur_result_t UR_APICALL urMemRelease(
 ///         + `0x3f < flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pBufferCreateInfo`
+///         + `NULL == pRegion`
 ///         + `NULL == phMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE
@@ -929,8 +935,8 @@ ur_result_t UR_APICALL urMemBufferPartition(
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     ur_buffer_create_type_t bufferCreateType, ///< [in] buffer creation type
-    ur_buffer_region_t *
-        pBufferCreateInfo, ///< [in] pointer to buffer create region information
+    const ur_buffer_region_t
+        *pRegion, ///< [in] pointer to buffer create region information
     ur_mem_handle_t
         *phMem ///< [out] pointer to the handle of sub buffer created
 ) {

--- a/test/conformance/memory/urMemBufferPartition.cpp
+++ b/test/conformance/memory/urMemBufferPartition.cpp
@@ -7,7 +7,8 @@ using urMemBufferPartitionTest = uur::urMemBufferTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferPartitionTest);
 
 TEST_P(urMemBufferPartitionTest, Success) {
-    ur_buffer_region_t region{0, 1024};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              1024};
     ur_mem_handle_t partition = nullptr;
     ASSERT_SUCCESS(urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                         UR_BUFFER_CREATE_TYPE_REGION, &region,
@@ -16,7 +17,8 @@ TEST_P(urMemBufferPartitionTest, Success) {
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidNullHandleBuffer) {
-    ur_buffer_region_t region{0, 1024};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              1024};
     ur_mem_handle_t partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urMemBufferPartition(nullptr, UR_MEM_FLAG_READ_WRITE,
@@ -25,7 +27,8 @@ TEST_P(urMemBufferPartitionTest, InvalidNullHandleBuffer) {
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidEnumerationFlags) {
-    ur_buffer_region_t region{0, 1024};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              1024};
     ur_mem_handle_t partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_FORCE_UINT32,
@@ -34,7 +37,8 @@ TEST_P(urMemBufferPartitionTest, InvalidEnumerationFlags) {
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidEnumerationBufferCreateType) {
-    ur_buffer_region_t region{0, 1024};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              1024};
     ur_mem_handle_t partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
@@ -51,7 +55,8 @@ TEST_P(urMemBufferPartitionTest, InvalidNullPointerBufferCreateInfo) {
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidNullPointerMem) {
-    ur_buffer_region_t region{0, 1024};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              1024};
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
@@ -59,7 +64,7 @@ TEST_P(urMemBufferPartitionTest, InvalidNullPointerMem) {
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidBufferSize) {
-    ur_buffer_region_t region{0, 0};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0, 0};
     ur_mem_handle_t partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
@@ -74,7 +79,8 @@ TEST_P(urMemBufferPartitionTest, InvalidValueCreateType) {
                                      nullptr, &ro_buffer));
 
     // attempting to partition it into a RW buffer should fail
-    ur_buffer_region_t region{0, 1024};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              1024};
     ur_mem_handle_t partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
                      urMemBufferPartition(ro_buffer, UR_MEM_FLAG_READ_WRITE,
@@ -83,7 +89,8 @@ TEST_P(urMemBufferPartitionTest, InvalidValueCreateType) {
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidValueBufferCreateInfoOutOfBounds) {
-    ur_buffer_region_t region{0, 8192};
+    ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
+                              8192};
     ur_mem_handle_t partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,


### PR DESCRIPTION
Enable extensibility of `urMemBufferCreate` and `urMemBufferPartition`
via `pNext` chained property structures. This also enables existing
functionality in PI relating to the `cl_intel_mem_channel_property` and
`cl_intel_mem_alloc_buffer_location` OpenCL extensions while also
enabling future extensions without ABI changes.

Fixes #98
