### PR TITLE
[ur] Unify naming for usm related types.

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -796,7 +796,7 @@ class ur_sampler_addressing_mode_t(c_int):
 
 ###############################################################################
 ## @brief USM memory property flags
-class ur_usm_mem_flags_v(IntEnum):
+class ur_usm_flags_v(IntEnum):
     BIAS_CACHED = UR_BIT(0)                         ## Allocation should be cached
     BIAS_UNCACHED = UR_BIT(1)                       ## Allocation should not be cached
     WRITE_COMBINED = UR_BIT(2)                      ## Memory should be allocated write-combined (WC)
@@ -805,7 +805,7 @@ class ur_usm_mem_flags_v(IntEnum):
     DEVICE_READ_ONLY = UR_BIT(5)                    ## Memory is only possibly modified from the host, but read-only in all
                                                     ## device code
 
-class ur_usm_mem_flags_t(c_int):
+class ur_usm_flags_t(c_int):
     def __str__(self):
         return hex(self.value)
 
@@ -876,7 +876,7 @@ class ur_usm_desc_t(Structure):
     _fields_ = [
         ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
-        ("flags", ur_usm_mem_flags_t),                                  ## [in] memory allocation flags
+        ("flags", ur_usm_flags_t),                                      ## [in] Memory allocation flags
         ("hints", ur_mem_advice_t)                                      ## [in] Memory advice hints
     ]
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1978,20 +1978,20 @@ urSamplerCreateWithNativeHandle(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory property flags
-typedef uint32_t ur_usm_mem_flags_t;
-typedef enum ur_usm_mem_flag_t {
-    UR_USM_MEM_FLAG_BIAS_CACHED = UR_BIT(0),              ///< Allocation should be cached
-    UR_USM_MEM_FLAG_BIAS_UNCACHED = UR_BIT(1),            ///< Allocation should not be cached
-    UR_USM_MEM_FLAG_WRITE_COMBINED = UR_BIT(2),           ///< Memory should be allocated write-combined (WC)
-    UR_USM_MEM_FLAG_INITIAL_PLACEMENT_DEVICE = UR_BIT(3), ///< Optimize shared allocation for first access on the device
-    UR_USM_MEM_FLAG_INITIAL_PLACEMENT_HOST = UR_BIT(4),   ///< Optimize shared allocation for first access on the host
-    UR_USM_MEM_FLAG_DEVICE_READ_ONLY = UR_BIT(5),         ///< Memory is only possibly modified from the host, but read-only in all
-                                                          ///< device code
+typedef uint32_t ur_usm_flags_t;
+typedef enum ur_usm_flag_t {
+    UR_USM_FLAG_BIAS_CACHED = UR_BIT(0),              ///< Allocation should be cached
+    UR_USM_FLAG_BIAS_UNCACHED = UR_BIT(1),            ///< Allocation should not be cached
+    UR_USM_FLAG_WRITE_COMBINED = UR_BIT(2),           ///< Memory should be allocated write-combined (WC)
+    UR_USM_FLAG_INITIAL_PLACEMENT_DEVICE = UR_BIT(3), ///< Optimize shared allocation for first access on the device
+    UR_USM_FLAG_INITIAL_PLACEMENT_HOST = UR_BIT(4),   ///< Optimize shared allocation for first access on the host
+    UR_USM_FLAG_DEVICE_READ_ONLY = UR_BIT(5),         ///< Memory is only possibly modified from the host, but read-only in all
+                                                      ///< device code
     /// @cond
-    UR_USM_MEM_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_USM_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
-} ur_usm_mem_flag_t;
+} ur_usm_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory property flags
@@ -2058,7 +2058,7 @@ typedef struct ur_usm_pool_handle_t_ *ur_usm_pool_handle_t;
 typedef struct ur_usm_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
-    ur_usm_mem_flags_t flags;  ///< [in] memory allocation flags
+    ur_usm_flags_t flags;      ///< [in] Memory allocation flags
     ur_mem_advice_t hints;     ///< [in] Memory advice hints
 
 } ur_usm_desc_t;

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -13,7 +13,7 @@ ordinal: "4"
 type: enum
 desc: "USM memory property flags"
 class: $xUSM
-name: $x_usm_mem_flags_t
+name: $x_usm_flags_t
 etors:
     - name: BIAS_CACHED
       value: "$X_BIT(0)"
@@ -106,9 +106,9 @@ class: $xUSM
 name: $x_usm_desc_t
 base: $x_base_desc_t
 members:
-    - type: $x_usm_mem_flags_t
+    - type: $x_usm_flags_t
       name:  flags
-      desc: "[in] memory allocation flags"
+      desc: "[in] Memory allocation flags"
     - type: $x_mem_advice_t
       name: hints
       desc: "[in] Memory advice hints"


### PR DESCRIPTION
Right now, we have types that start with: `usm`, `usm_mem` and `mem`.

I think we should also rename `ur_mem_advice_t` to have `usm` prefix but I'm not sure if we want `ur_usm_mem_advice_t` or `ur_usm_advice_t`. `usm_mem` duplicates 'memory' but we already have USMMemAdvise functions.