### PR TITLE
Remove non-generic paramers from ur_usm_pool_limits_desc_t

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1051,9 +1051,7 @@ class ur_usm_pool_limits_desc_t(Structure):
         ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
                                                                         ## ::UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
-        ("maxPoolSize", c_size_t),                                      ## [in] Maximum size of a memory pool
         ("maxPoolableSize", c_size_t),                                  ## [in] Allocations up to this limit will be subject to pooling
-        ("capacity", c_size_t),                                         ## [in] When pooling, each bucket will hold a max of 4 unfreed slabs
         ("slabMinSize", c_size_t)                                       ## [in] Minimum allocation size that will be requested from the driver
     ]
 

--- a/include/ur.py
+++ b/include/ur.py
@@ -1052,7 +1052,7 @@ class ur_usm_pool_limits_desc_t(Structure):
                                                                         ## ::UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("maxPoolableSize", c_size_t),                                  ## [in] Allocations up to this limit will be subject to pooling
-        ("slabMinSize", c_size_t)                                       ## [in] Minimum allocation size that will be requested from the driver
+        ("minDriverAllocSize", c_size_t)                                ## [in] Minimum allocation size that will be requested from the driver
     ]
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2258,7 +2258,7 @@ typedef struct ur_usm_pool_limits_desc_t {
                                ///< ::UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     size_t maxPoolableSize;    ///< [in] Allocations up to this limit will be subject to pooling
-    size_t slabMinSize;        ///< [in] Minimum allocation size that will be requested from the driver
+    size_t minDriverAllocSize; ///< [in] Minimum allocation size that will be requested from the driver
 
 } ur_usm_pool_limits_desc_t;
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2257,9 +2257,7 @@ typedef struct ur_usm_pool_limits_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
-    size_t maxPoolSize;        ///< [in] Maximum size of a memory pool
     size_t maxPoolableSize;    ///< [in] Allocations up to this limit will be subject to pooling
-    size_t capacity;           ///< [in] When pooling, each bucket will hold a max of 4 unfreed slabs
     size_t slabMinSize;        ///< [in] Minimum allocation size that will be requested from the driver
 
 } ur_usm_pool_limits_desc_t;

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -174,7 +174,7 @@ members:
       name:  maxPoolableSize
       desc: "[in] Allocations up to this limit will be subject to pooling"
     - type: "size_t"
-      name:  slabMinSize
+      name:  minDriverAllocSize
       desc: "[in] Minimum allocation size that will be requested from the driver"
 --- #--------------------------------------------------------------------------
 type: function

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -171,14 +171,8 @@ name: $x_usm_pool_limits_desc_t
 base: $x_base_desc_t
 members:
     - type: "size_t"
-      name:  maxPoolSize
-      desc: "[in] Maximum size of a memory pool"
-    - type: "size_t"
       name:  maxPoolableSize
       desc: "[in] Allocations up to this limit will be subject to pooling"
-    - type: "size_t"
-      name:  capacity
-      desc: "[in] When pooling, each bucket will hold a max of 4 unfreed slabs"
     - type: "size_t"
       name:  slabMinSize
       desc: "[in] Minimum allocation size that will be requested from the driver"


### PR DESCRIPTION
The structure should be extended in future, accordingly to: https://github.com/oneapi-src/unified-runtime/issues/369

