### PR TITLE
[ur][CTS] Refactor *CreateWithNativeHandle CTS

### DIFF
--- a/test/conformance/context/urContextGetNativeHandle.cpp
+++ b/test/conformance/context/urContextGetNativeHandle.cpp
@@ -8,9 +8,22 @@ using urContextGetNativeHandleTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetNativeHandleTest);
 
 TEST_P(urContextGetNativeHandleTest, Success) {
-    ur_native_handle_t native_handle = nullptr;
-    ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_handle));
-    ASSERT_NE(native_handle, nullptr);
+    ur_native_handle_t native_context = nullptr;
+    ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_context_handle_t ctx = nullptr;
+    ASSERT_SUCCESS(urContextCreateWithNativeHandle(native_context, &ctx));
+    ASSERT_NE(ctx, nullptr);
+
+    uint32_t n_devices = 0;
+    ASSERT_SUCCESS(urContextGetInfo(ctx, UR_CONTEXT_INFO_NUM_DEVICES,
+                                    sizeof(uint32_t), &n_devices, nullptr));
+
+    ASSERT_SUCCESS(urContextRelease(ctx));
 }
 
 TEST_P(urContextGetNativeHandleTest, InvalidNullHandleContext) {

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -8,7 +8,21 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
     for (auto device : devices) {
         ur_native_handle_t native_handle = nullptr;
         ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
-        ASSERT_NE(native_handle, nullptr);
+
+        // We cannot assume anything about a native_handle, not even if it's
+        // `nullptr` since this could be a valid representation within a backend.
+        // We can however convert the native_handle back into a unified-runtime handle
+        // and perform some query on it to verify that it works.
+        ur_device_handle_t dev = nullptr;
+        ASSERT_SUCCESS(
+            urDeviceCreateWithNativeHandle(native_handle, platform, &dev));
+        ASSERT_NE(dev, nullptr);
+
+        uint32_t dev_id = 0;
+        ASSERT_SUCCESS(urDeviceGetInfo(dev, UR_DEVICE_INFO_DEVICE_ID,
+                                       sizeof(uint32_t), &dev_id, nullptr));
+
+        ASSERT_SUCCESS(urDeviceRelease(dev));
     }
 }
 

--- a/test/conformance/event/urEventGetNativeHandle.cpp
+++ b/test/conformance/event/urEventGetNativeHandle.cpp
@@ -9,7 +9,21 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetNativeHandleTest);
 TEST_P(urEventGetNativeHandleTest, Success) {
     ur_native_handle_t native_event = nullptr;
     ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
-    ASSERT_NE(native_event, nullptr);
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_event_handle_t evt = nullptr;
+    ASSERT_SUCCESS(urEventCreateWithNativeHandle(native_event, context, &evt));
+    ASSERT_NE(evt, nullptr);
+
+    ur_execution_info_t exec_info;
+    ASSERT_SUCCESS(urEventGetInfo(evt, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+                                  sizeof(ur_execution_info_t), &exec_info,
+                                  nullptr));
+
+    ASSERT_SUCCESS(urEventRelease(evt));
 }
 
 TEST_P(urEventGetNativeHandleTest, InvalidNullHandleEvent) {

--- a/test/conformance/memory/urMemGetNativeHandle.cpp
+++ b/test/conformance/memory/urMemGetNativeHandle.cpp
@@ -6,9 +6,22 @@ using urMemGetNativeHandleTest = uur::urMemBufferTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetNativeHandleTest);
 
 TEST_P(urMemGetNativeHandleTest, Success) {
-    ur_native_handle_t phNativeMem = nullptr;
-    ASSERT_SUCCESS(urMemGetNativeHandle(buffer, &phNativeMem));
-    ASSERT_NE(phNativeMem, nullptr);
+    ur_native_handle_t hNativeMem = nullptr;
+    ASSERT_SUCCESS(urMemGetNativeHandle(buffer, &hNativeMem));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_mem_handle_t mem = nullptr;
+    ASSERT_SUCCESS(urMemCreateWithNativeHandle(hNativeMem, context, &mem));
+    ASSERT_NE(mem, nullptr);
+
+    size_t alloc_size = 0;
+    ASSERT_SUCCESS(urMemGetInfo(mem, UR_MEM_INFO_SIZE, sizeof(size_t),
+                                &alloc_size, nullptr));
+
+    ASSERT_SUCCESS(urMemRelease(mem));
 }
 
 TEST_P(urMemGetNativeHandleTest, InvalidNullHandleMem) {

--- a/test/conformance/queue/urQueueGetNativeHandle.cpp
+++ b/test/conformance/queue/urQueueGetNativeHandle.cpp
@@ -8,7 +8,20 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetNativeHandleTest);
 TEST_P(urQueueGetNativeHandleTest, Success) {
     ur_native_handle_t native_handle = nullptr;
     ASSERT_SUCCESS(urQueueGetNativeHandle(queue, &native_handle));
-    ASSERT_NE(native_handle, nullptr);
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_queue_handle_t q = nullptr;
+    ASSERT_SUCCESS(urQueueCreateWithNativeHandle(native_handle, context, &q));
+    ASSERT_NE(q, nullptr);
+
+    uint32_t q_size = 0;
+    ASSERT_SUCCESS(urQueueGetInfo(q, UR_QUEUE_INFO_SIZE, sizeof(uint32_t),
+                                  &q_size, nullptr));
+
+    ASSERT_SUCCESS(urQueueRelease(q));
 }
 
 TEST_P(urQueueGetNativeHandleTest, InvalidNullHandleQueue) {


### PR DESCRIPTION
We cannot assume anything about a native_handle, not even if it's `nullptr` since this could be a valid representation within a backend. We can however convert the native_handle back into a unified-runtime handle and perform some query on it to verify that it works.

Closes #370 