### PR TITLE
[ur] Fix part of logger tests not running properly + cleanup

### DIFF
--- a/source/common/logger/ur_logger_details.hpp
+++ b/source/common/logger/ur_logger_details.hpp
@@ -27,14 +27,6 @@ class Logger {
         }
     }
 
-    Logger(const Logger &other) : level(other.level), sink(std::move(sink)) {}
-
-    Logger &operator=(Logger other) {
-        std::swap(level, other.level);
-        sink.swap(other.sink);
-        return *this;
-    }
-
     ~Logger() = default;
 
     void setLevel(logger::Level level) { this->level = level; }

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -4,6 +4,7 @@
 #ifndef UR_SINKS_HPP
 #define UR_SINKS_HPP 1
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -122,18 +123,20 @@ class StderrSink : public Sink {
 
 class FileSink : public Sink {
   public:
-    FileSink(std::string logger_name, std::string file_path)
+    FileSink(std::string logger_name, std::filesystem::path file_path)
         : Sink(logger_name) {
         ofstream = std::ofstream(file_path, std::ofstream::out);
         if (!ofstream.good()) {
             throw std::invalid_argument(
-                std::string("Failure while opening log file: ") + file_path +
+                std::string("Failure while opening log file: ") +
+                file_path.string() +
                 std::string(" Check if given path exists."));
         }
         this->ostream = &ofstream;
     }
 
-    FileSink(std::string logger_name, std::string file_path, Level flush_lvl)
+    FileSink(std::string logger_name, std::filesystem::path file_path,
+             Level flush_lvl)
         : FileSink(logger_name, file_path) {
         this->flush_level = flush_lvl;
     }

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -61,32 +61,6 @@ class Sink {
         }
     }
 
-    template <typename Arg> void format(const char *fmt, Arg &&arg) {
-        while (*fmt != '\0') {
-            while (*fmt != '{' && *fmt != '}' && *fmt != '\0') {
-                *ostream << *fmt++;
-            }
-
-            if (*fmt == '{') {
-                if (*(++fmt) == '{') {
-                    *ostream << *fmt++;
-                } else if (*fmt != '}') {
-                    throw std::runtime_error("Only empty braces are allowed!");
-                } else {
-                    *ostream << arg;
-                    fmt++;
-                }
-            } else if (*fmt == '}') {
-                if (*(++fmt) == '}') {
-                    *ostream << *fmt++;
-                } else {
-                    throw std::runtime_error(
-                        "Closing curly brace not escaped!");
-                }
-            }
-        }
-    }
-
     template <typename Arg, typename... Args>
     void format(const char *fmt, Arg &&arg, Args &&...args) {
         bool arg_printed = false;
@@ -151,7 +125,7 @@ class FileSink : public Sink {
     FileSink(std::string logger_name, std::string file_path)
         : Sink(logger_name) {
         ofstream = std::ofstream(file_path, std::ofstream::out);
-        if (ofstream.rdstate() != std::ofstream::goodbit) {
+        if (!ofstream.good()) {
             throw std::invalid_argument(
                 std::string("Failure while opening log file: ") + file_path +
                 std::string(" Check if given path exists."));

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -30,16 +30,11 @@ class LoggerFromEnvVar : public ::testing::Test {
 
 class LoggerWithFileSink : public ::testing::Test {
   protected:
-    std::filesystem::path file_path = "ur_test_logger.log";
+    std::filesystem::path file_name = "ur_test_logger.log";
+    std::filesystem::path file_path = file_name;
     std::string logger_name = "test";
     std::string test_msg = "<" + logger_name + ">";
     std::unique_ptr<logger::Logger> logger;
-
-    void SetUp() override {
-        logger = std::make_unique<logger::Logger>(
-            logger::Level::WARN,
-            std::make_unique<logger::FileSink>(logger_name, file_path));
-    }
 
     void TearDown() override {
         logger.reset();
@@ -50,8 +45,17 @@ class LoggerWithFileSink : public ::testing::Test {
         printed_msg << test_log.rdbuf();
         test_log.close();
 
-        std::filesystem::remove(file_path);
+        ASSERT_GT(std::filesystem::remove_all(*file_path.begin()), 0);
         ASSERT_EQ(printed_msg.str(), test_msg);
+    }
+};
+
+class DefaultLoggerWithFileSink : public LoggerWithFileSink {
+  protected:
+    void SetUp() override {
+        logger = std::make_unique<logger::Logger>(
+            logger::Level::WARN,
+            std::make_unique<logger::FileSink>(logger_name, file_path));
     }
 };
 

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -4,7 +4,6 @@
 #ifndef UR_UNIT_LOGGER_TEST_FIXTURES_HPP
 #define UR_UNIT_LOGGER_TEST_FIXTURES_HPP
 
-#include <filesystem>
 #include <gtest/gtest.h>
 
 #include "helpers.h"

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: MIT
+
+#ifndef UR_UNIT_LOGGER_TEST_FIXTURES_HPP
+#define UR_UNIT_LOGGER_TEST_FIXTURES_HPP
+
+#include <gtest/gtest.h>
+
+#include "helpers.h"
+#include "logger/ur_logger.hpp"
+
+class CreateLoggerWithEnvVar : public ::testing::TestWithParam<std::string> {
+  protected:
+    int ret = -1;
+    std::string env_var_value;
+
+    void SetUp() override {
+        env_var_value = GetParam();
+        ret = setenv("UR_LOG_TEST_ADAPTER", env_var_value.c_str(), 1);
+        ASSERT_EQ(ret, 0);
+        logger::init("test_adapter");
+        logger::info("{} initialized successfully!", "test_adapter");
+    }
+
+    void TearDown() override {
+        ret = unsetenv("UR_LOG_TEST_ADAPTER");
+        ASSERT_EQ(ret, 0);
+    }
+};
+
+class FileSink : public ::testing::Test {
+  protected:
+    std::string file_path = "ur_test_logger.log";
+    std::string logger_name = "test";
+    std::string test_msg = "<" + logger_name + ">";
+
+    void TearDown() override {
+        auto test_log = std::ifstream(file_path, std::ios::in);
+        ASSERT_TRUE(test_log.good());
+        std::stringstream printed_msg;
+        printed_msg << test_log.rdbuf();
+        test_log.close();
+
+        std::remove(file_path.c_str());
+        ASSERT_EQ(printed_msg.str(), test_msg);
+    }
+};
+
+class FileSinkDefaultLevel : public FileSink {
+  protected:
+    int ret = -1;
+    std::string env_var_value = "output:file," + file_path;
+
+    void SetUp() override {
+        ret = setenv("UR_LOG_TEST_ADAPTER", env_var_value.c_str(), 1);
+        ASSERT_EQ(ret, 0);
+        logger::init("test_adapter");
+        logger::info("{} initialized successfully!", "test_adapter");
+    }
+
+    void TearDown() override {
+        ret = unsetenv("UR_LOG_TEST_ADAPTER");
+        ASSERT_EQ(ret, 0);
+    }
+};
+
+#endif // UR_UNIT_LOGGER_TEST_FIXTURES_HPP

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -9,13 +9,12 @@
 #include "helpers.h"
 #include "logger/ur_logger.hpp"
 
-class CreateLoggerWithEnvVar : public ::testing::TestWithParam<std::string> {
+class LoggerFromEnvVar : public ::testing::Test {
   protected:
     int ret = -1;
-    std::string env_var_value;
 
     void SetUp() override {
-        env_var_value = GetParam();
+        std::string env_var_value = "level:info;output:stderr";
         ret = setenv("UR_LOG_TEST_ADAPTER", env_var_value.c_str(), 1);
         ASSERT_EQ(ret, 0);
         logger::init("test_adapter");
@@ -48,21 +47,14 @@ class FileSink : public ::testing::Test {
 
 class FileSinkDefaultLevel : public FileSink {
   protected:
-    int ret = -1;
-    std::string env_var_value = "output:file," + file_path;
+    std::unique_ptr<logger::Logger> logger;
 
     void SetUp() override {
-        ret = setenv("UR_LOG_TEST_ADAPTER", env_var_value.c_str(), 1);
-        ASSERT_EQ(ret, 0);
-        logger::init("test_adapter");
-        logger::info("{} initialized successfully!", "test_adapter");
+        logger = std::make_unique<logger::Logger>(
+            std::make_unique<logger::FileSink>("test", file_path));
     }
 
-    void TearDown() override {
-        FileSink::TearDown();
-        ret = unsetenv("UR_LOG_TEST_ADAPTER");
-        ASSERT_EQ(ret, 0);
-    }
+    void TearDown() override { FileSink::TearDown(); }
 };
 
 #endif // UR_UNIT_LOGGER_TEST_FIXTURES_HPP

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -59,6 +59,7 @@ class FileSinkDefaultLevel : public FileSink {
     }
 
     void TearDown() override {
+        FileSink::TearDown();
         ret = unsetenv("UR_LOG_TEST_ADAPTER");
         ASSERT_EQ(ret, 0);
     }

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -7,94 +7,73 @@
 #include "fixtures.hpp"
 #include "logger/ur_logger_details.hpp"
 
-TEST(logger, NullSinkOneParam) {
+//////////////////////////////////////////////////////////////////////////////
+TEST(LoggerFailure, NullSinkOneParam) {
     ASSERT_THROW(logger::Logger(nullptr), std::invalid_argument);
 }
 
-TEST(logger, NullSinkTwoParams) {
+TEST(LoggerFailure, NullSinkTwoParams) {
     ASSERT_THROW(logger::Logger(logger::Level::ERR, nullptr),
                  std::invalid_argument);
 }
 
-TEST_F(LoggerFromEnvVar, EnvVarSetupStd) {
+//////////////////////////////////////////////////////////////////////////////
+TEST_F(LoggerFromEnvVar, BasicMessage) {
     logger::info("Test message: {}", "success");
     logger::debug("This should not be printed: {}", 42);
 }
 
-TEST_F(FileSink, MultipleLines) {
-    logger::Level level = logger::Level::WARN;
-    logger::Logger logger(
-        level, std::make_unique<logger::FileSink>(logger_name, file_path));
+//////////////////////////////////////////////////////////////////////////////
+TEST_F(LoggerWithFileSink, DefaultLevelNoOutput) {
+    logger->info("This should not be printed: {}", 42);
+    test_msg.clear();
+}
 
-    logger.warning("Test message: {}", "success");
-    logger.debug("This should not be printed: {}", 42);
-    logger.error("Test message: {}", "success");
+TEST_F(LoggerWithFileSink, MultipleLines) {
+    logger->warning("Test message: {}", "success");
+    logger->debug("This should not be printed: {}", 42);
+    logger->error("Test message: {}", "success");
 
     test_msg += "[WARNING]: Test message: success\n"
                 "<test>[ERROR]: Test message: success\n";
 }
 
-TEST_F(FileSink, ThreeParams) {
-    logger::Level level = logger::Level::DEBUG;
-    logger::Logger logger(
-        level, std::make_unique<logger::FileSink>(logger_name, file_path));
-
-    logger.setFlushLevel(level);
-    logger.debug("{} {}: {}", "Test", 42, 3.8);
-    test_msg += "[DEBUG]: Test 42: 3.8\n";
+TEST_F(LoggerWithFileSink, ThreeParams) {
+    logger->error("{} {}: {}", "Test", 42, 3.8);
+    test_msg += "[ERROR]: Test 42: 3.8\n";
 }
 
-TEST_F(FileSink, DoubleBraces) {
-    logger::Logger logger(
-        logger::Level::ERR,
-        std::make_unique<logger::FileSink>(logger_name, file_path));
-
-    logger.error("{{}} {}: {}", "Test", 42);
+TEST_F(LoggerWithFileSink, DoubleBraces) {
+    logger->error("{{}} {}: {}", "Test", 42);
     test_msg += "[ERROR]: {} Test: 42\n";
 }
 
-TEST_F(FileSink, DoubleBraces2) {
-    logger::Logger logger(
-        logger::Level::ERR,
-        std::make_unique<logger::FileSink>(logger_name, file_path));
-
-    logger.error("200 {{ {}: {{{}}} 3.8", "Test", 42);
+TEST_F(LoggerWithFileSink, DoubleBraces2) {
+    logger->error("200 {{ {}: {{{}}} 3.8", "Test", 42);
     test_msg += "[ERROR]: 200 { Test: {42} 3.8\n";
 }
 
-TEST_F(FileSink, DoubleBraces3) {
-    logger::Logger logger(
-        logger::Level::ERR,
-        std::make_unique<logger::FileSink>(logger_name, file_path));
-
-    logger.error("{{ {}:}} {}}}", "Test", 42);
+TEST_F(LoggerWithFileSink, DoubleBraces3) {
+    logger->error("{{ {}:}} {}}}", "Test", 42);
     test_msg += "[ERROR]: { Test:} 42}\n";
 }
 
-TEST_F(FileSink, NoBraces) {
-    logger::Logger logger(
-        logger::Level::ERR,
-        std::make_unique<logger::FileSink>(logger_name, file_path));
-
-    logger.error(" Test: 42");
+TEST_F(LoggerWithFileSink, NoBraces) {
+    logger->error(" Test: 42");
     test_msg += "[ERROR]:  Test: 42\n";
 }
 
-TEST_F(FileSink, SetFlushLevelDebugCtor) {
+TEST_F(LoggerWithFileSink, SetLogLevelAndFlushLevelDebugWithCtor) {
     auto level = logger::Level::DEBUG;
-    logger::Logger logger(level, std::make_unique<logger::FileSink>(
-                                     logger_name, file_path, level));
+    logger = std::make_unique<logger::Logger>(
+        level,
+        std::make_unique<logger::FileSink>(logger_name, file_path, level));
 
-    logger.debug("Test message: {}", "success");
+    logger->debug("Test message: {}", "success");
     test_msg += "[DEBUG]: Test message: success\n";
 }
 
-TEST_F(FileSinkDefaultLevel, DefaultLevelNoOutput) {
-    logger->debug("This should not be printed: {}", 42);
-    test_msg.clear();
-}
-
-TEST_F(FileSinkDefaultLevel, SetLevelDebug) {
+TEST_F(LoggerWithFileSink, SetLevelDebug) {
     auto level = logger::Level::DEBUG;
     logger->setLevel(level);
     logger->setFlushLevel(level);
@@ -103,7 +82,7 @@ TEST_F(FileSinkDefaultLevel, SetLevelDebug) {
     test_msg += "[DEBUG]: Test message: success\n";
 }
 
-TEST_F(FileSinkDefaultLevel, SetLevelInfo) {
+TEST_F(LoggerWithFileSink, SetLevelInfo) {
     auto level = logger::Level::INFO;
     logger->setLevel(level);
     logger->setFlushLevel(level);
@@ -113,17 +92,16 @@ TEST_F(FileSinkDefaultLevel, SetLevelInfo) {
     test_msg += "[INFO]: Test message: success\n";
 }
 
-TEST_F(FileSinkDefaultLevel, SetLevelWarning) {
+TEST_F(LoggerWithFileSink, SetLevelWarning) {
     auto level = logger::Level::WARN;
     logger->setLevel(level);
-    logger->setFlushLevel(level);
     logger->warning("Test message: {}", "success");
     logger->info("This should not be printed: {}", 42);
 
     test_msg += "[WARNING]: Test message: success\n";
 }
 
-TEST_F(FileSinkDefaultLevel, SetLevelError) {
+TEST_F(LoggerWithFileSink, SetLevelError) {
     logger->setLevel(logger::Level::ERR);
     logger->error("Test message: {}", "success");
     logger->warning("This should not be printed: {}", 42);

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -16,11 +16,7 @@ TEST(logger, NullSinkTwoParams) {
                  std::invalid_argument);
 }
 
-INSTANTIATE_TEST_SUITE_P(EnvVarSetupStdParams, CreateLoggerWithEnvVar,
-                         ::testing::Values("level:info",
-                                           "level:info;output:stderr"));
-
-TEST_P(CreateLoggerWithEnvVar, EnvVarSetupStd) {
+TEST_F(LoggerFromEnvVar, EnvVarSetupStd) {
     logger::info("Test message: {}", "success");
     logger::debug("This should not be printed: {}", 42);
 }
@@ -94,42 +90,43 @@ TEST_F(FileSink, SetFlushLevelDebugCtor) {
 }
 
 TEST_F(FileSinkDefaultLevel, DefaultLevelNoOutput) {
-    logger::debug("This should not be printed: {}", 42);
+    logger->debug("This should not be printed: {}", 42);
+    test_msg.clear();
 }
 
 TEST_F(FileSinkDefaultLevel, SetLevelDebug) {
     auto level = logger::Level::DEBUG;
-    logger::setLevel(level);
-    logger::setFlushLevel(level);
-    logger::debug("Test message: {}", "success");
+    logger->setLevel(level);
+    logger->setFlushLevel(level);
+    logger->debug("Test message: {}", "success");
 
     test_msg += "[DEBUG]: Test message: success\n";
 }
 
 TEST_F(FileSinkDefaultLevel, SetLevelInfo) {
     auto level = logger::Level::INFO;
-    logger::setLevel(level);
-    logger::setFlushLevel(level);
-    logger::info("Test message: {}", "success");
-    logger::debug("This should not be printed: {}", 42);
+    logger->setLevel(level);
+    logger->setFlushLevel(level);
+    logger->info("Test message: {}", "success");
+    logger->debug("This should not be printed: {}", 42);
 
     test_msg += "[INFO]: Test message: success\n";
 }
 
 TEST_F(FileSinkDefaultLevel, SetLevelWarning) {
     auto level = logger::Level::WARN;
-    logger::setLevel(level);
-    logger::setFlushLevel(level);
-    logger::warning("Test message: {}", "success");
-    logger::info("This should not be printed: {}", 42);
+    logger->setLevel(level);
+    logger->setFlushLevel(level);
+    logger->warning("Test message: {}", "success");
+    logger->info("This should not be printed: {}", 42);
 
     test_msg += "[WARNING]: Test message: success\n";
 }
 
 TEST_F(FileSinkDefaultLevel, SetLevelError) {
-    logger::setLevel(logger::Level::ERR);
-    logger::error("Test message: {}", "success");
-    logger::warning("This should not be printed: {}", 42);
+    logger->setLevel(logger::Level::ERR);
+    logger->error("Test message: {}", "success");
+    logger->warning("This should not be printed: {}", 42);
 
     test_msg += "[ERROR]: Test message: success\n";
 }

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -4,10 +4,7 @@
 #include <fstream>
 #include <sstream>
 
-#include <gtest/gtest.h>
-
-#include "helpers.h"
-#include "logger/ur_logger.hpp"
+#include "fixtures.hpp"
 #include "logger/ur_logger_details.hpp"
 
 TEST(logger, NullSinkOneParam) {
@@ -19,25 +16,6 @@ TEST(logger, NullSinkTwoParams) {
                  std::invalid_argument);
 }
 
-class CreateLoggerWithEnvVar : public ::testing::TestWithParam<std::string> {
-  protected:
-    int ret = -1;
-    std::string env_var_value;
-
-    void SetUp() override {
-        env_var_value = GetParam();
-        ret = setenv("UR_LOG_TEST_ADAPTER", env_var_value.c_str(), 1);
-        ASSERT_EQ(ret, 0);
-        logger::init("test_adapter");
-        logger::info("{} initialized successfully!", "test_adapter");
-    }
-
-    void TearDown() override {
-        ret = unsetenv("UR_LOG_TEST_ADAPTER");
-        ASSERT_EQ(ret, 0);
-    }
-};
-
 INSTANTIATE_TEST_SUITE_P(EnvVarSetupStdParams, CreateLoggerWithEnvVar,
                          ::testing::Values("level:info",
                                            "level:info;output:stderr"));
@@ -46,42 +24,6 @@ TEST_P(CreateLoggerWithEnvVar, EnvVarSetupStd) {
     logger::info("Test message: {}", "success");
     logger::debug("This should not be printed: {}", 42);
 }
-
-class FileSink : public ::testing::Test {
-  protected:
-    std::string file_path = "ur_test_logger.log";
-    std::string logger_name = "test";
-    std::string test_msg = "<" + logger_name + ">";
-
-    void TearDown() override {
-        auto test_log = std::ifstream(file_path, std::ios::in);
-        ASSERT_TRUE(test_log.good());
-        std::stringstream printed_msg;
-        printed_msg << test_log.rdbuf();
-        test_log.close();
-
-        std::remove(file_path.c_str());
-        ASSERT_EQ(printed_msg.str(), test_msg);
-    }
-};
-
-class FileSinkDefaultLevel : public FileSink {
-  protected:
-    int ret = -1;
-    std::string env_var_value = "output:file," + file_path;
-
-    void SetUp() override {
-        ret = setenv("UR_LOG_TEST_ADAPTER", env_var_value.c_str(), 1);
-        ASSERT_EQ(ret, 0);
-        logger::init("test_adapter");
-        logger::info("{} initialized successfully!", "test_adapter");
-    }
-
-    void TearDown() override {
-        ret = unsetenv("UR_LOG_TEST_ADAPTER");
-        ASSERT_EQ(ret, 0);
-    }
-};
 
 TEST_F(FileSink, MultipleLines) {
     logger::Level level = logger::Level::WARN;

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -24,12 +24,12 @@ TEST_F(LoggerFromEnvVar, BasicMessage) {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-TEST_F(LoggerWithFileSink, DefaultLevelNoOutput) {
+TEST_F(DefaultLoggerWithFileSink, DefaultLevelNoOutput) {
     logger->info("This should not be printed: {}", 42);
     test_msg.clear();
 }
 
-TEST_F(LoggerWithFileSink, MultipleLines) {
+TEST_F(DefaultLoggerWithFileSink, MultipleLines) {
     logger->warning("Test message: {}", "success");
     logger->debug("This should not be printed: {}", 42);
     logger->error("Test message: {}", "success");
@@ -38,31 +38,68 @@ TEST_F(LoggerWithFileSink, MultipleLines) {
                 "<test>[ERROR]: Test message: success\n";
 }
 
-TEST_F(LoggerWithFileSink, ThreeParams) {
+TEST_F(DefaultLoggerWithFileSink, ThreeParams) {
     logger->error("{} {}: {}", "Test", 42, 3.8);
     test_msg += "[ERROR]: Test 42: 3.8\n";
 }
 
-TEST_F(LoggerWithFileSink, DoubleBraces) {
+TEST_F(DefaultLoggerWithFileSink, DoubleBraces) {
     logger->error("{{}} {}: {}", "Test", 42);
     test_msg += "[ERROR]: {} Test: 42\n";
 }
 
-TEST_F(LoggerWithFileSink, DoubleBraces2) {
+TEST_F(DefaultLoggerWithFileSink, DoubleBraces2) {
     logger->error("200 {{ {}: {{{}}} 3.8", "Test", 42);
     test_msg += "[ERROR]: 200 { Test: {42} 3.8\n";
 }
 
-TEST_F(LoggerWithFileSink, DoubleBraces3) {
+TEST_F(DefaultLoggerWithFileSink, DoubleBraces3) {
     logger->error("{{ {}:}} {}}}", "Test", 42);
     test_msg += "[ERROR]: { Test:} 42}\n";
 }
 
-TEST_F(LoggerWithFileSink, NoBraces) {
+TEST_F(DefaultLoggerWithFileSink, NoBraces) {
     logger->error(" Test: 42");
     test_msg += "[ERROR]:  Test: 42\n";
 }
 
+TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
+    auto level = logger::Level::DEBUG;
+    logger->setLevel(level);
+    logger->setFlushLevel(level);
+    logger->debug("Test message: {}", "success");
+
+    test_msg += "[DEBUG]: Test message: success\n";
+}
+
+TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
+    auto level = logger::Level::INFO;
+    logger->setLevel(level);
+    logger->setFlushLevel(level);
+    logger->info("Test message: {}", "success");
+    logger->debug("This should not be printed: {}", 42);
+
+    test_msg += "[INFO]: Test message: success\n";
+}
+
+TEST_F(DefaultLoggerWithFileSink, SetLevelWarning) {
+    auto level = logger::Level::WARN;
+    logger->setLevel(level);
+    logger->warning("Test message: {}", "success");
+    logger->info("This should not be printed: {}", 42);
+
+    test_msg += "[WARNING]: Test message: success\n";
+}
+
+TEST_F(DefaultLoggerWithFileSink, SetLevelError) {
+    logger->setLevel(logger::Level::ERR);
+    logger->error("Test message: {}", "success");
+    logger->warning("This should not be printed: {}", 42);
+
+    test_msg += "[ERROR]: Test message: success\n";
+}
+
+//////////////////////////////////////////////////////////////////////////////
 TEST_F(LoggerWithFileSink, SetLogLevelAndFlushLevelDebugWithCtor) {
     auto level = logger::Level::DEBUG;
     logger = std::make_unique<logger::Logger>(
@@ -73,38 +110,18 @@ TEST_F(LoggerWithFileSink, SetLogLevelAndFlushLevelDebugWithCtor) {
     test_msg += "[DEBUG]: Test message: success\n";
 }
 
-TEST_F(LoggerWithFileSink, SetLevelDebug) {
-    auto level = logger::Level::DEBUG;
-    logger->setLevel(level);
-    logger->setFlushLevel(level);
-    logger->debug("Test message: {}", "success");
+TEST_F(LoggerWithFileSink, NestedFilePath) {
+    auto dir_name = "tmp_dir";
+    file_path = dir_name;
+    for (int i = 0; i < 20; ++i) {
+        file_path /= dir_name;
+    }
+    std::filesystem::create_directories(file_path);
+    file_path /= file_name;
+    logger = std::make_unique<logger::Logger>(
+        logger::Level::WARN,
+        std::make_unique<logger::FileSink>(logger_name, file_path));
 
-    test_msg += "[DEBUG]: Test message: success\n";
-}
-
-TEST_F(LoggerWithFileSink, SetLevelInfo) {
-    auto level = logger::Level::INFO;
-    logger->setLevel(level);
-    logger->setFlushLevel(level);
-    logger->info("Test message: {}", "success");
-    logger->debug("This should not be printed: {}", 42);
-
-    test_msg += "[INFO]: Test message: success\n";
-}
-
-TEST_F(LoggerWithFileSink, SetLevelWarning) {
-    auto level = logger::Level::WARN;
-    logger->setLevel(level);
     logger->warning("Test message: {}", "success");
-    logger->info("This should not be printed: {}", 42);
-
     test_msg += "[WARNING]: Test message: success\n";
-}
-
-TEST_F(LoggerWithFileSink, SetLevelError) {
-    logger->setLevel(logger::Level::ERR);
-    logger->error("Test message: {}", "success");
-    logger->warning("This should not be printed: {}", 42);
-
-    test_msg += "[ERROR]: Test message: success\n";
 }


### PR DESCRIPTION
Fix FileSink logger tests checks not running. These checks detected failures in setting up logger with the `setenv()` function. This was due to the fact that the global logger object is a static singleton, therefore it's configuration can be provided only once per test binary run. Replaced global logger in these tests with local logger objects. New tests for validation of logger configured with the env var are not part of this PR.

Cleaned up logger and logger tests code a bit. 