### PR TITLE
[CTS] Fix event tests to use queue with profiling enabled

### DIFF
--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -15,10 +15,12 @@ namespace event {
  * - Execution Status: UR_EVENT_STATUS_COMPLETE
  * - Reference Count: 1
  */
-template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
+template <class T>
+struct urEventTestWithParam : uur::urProfilingQueueTestWithParam<T> {
 
     void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
+        UUR_RETURN_ON_FATAL_FAILURE(
+            uur::urProfilingQueueTestWithParam<T>::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_WRITE_ONLY,
                                          size, nullptr, &buffer));
 
@@ -36,7 +38,7 @@ template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
         if (event) {
             EXPECT_SUCCESS(urEventRelease(event));
         }
-        uur::urQueueTestWithParam<T>::TearDown();
+        uur::urProfilingQueueTestWithParam<T>::TearDown();
     }
 
     const size_t count = 1024;
@@ -51,10 +53,10 @@ template <class T> struct urEventTestWithParam : uur::urQueueTestWithParam<T> {
  * (i.e. urEventRelease and urEventRetain). Does not handle destruction of the
  * event.
  */
-struct urEventReferenceTest : uur::urQueueTest {
+struct urEventReferenceTest : uur::urProfilingQueueTest {
 
     void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
+        UUR_RETURN_ON_FATAL_FAILURE(urProfilingQueueTest::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_WRITE_ONLY, size,
                                          nullptr, &buffer));
 
@@ -67,7 +69,7 @@ struct urEventReferenceTest : uur::urQueueTest {
         if (buffer) {
             EXPECT_SUCCESS(urMemRelease(buffer));
         }
-        urQueueTest::TearDown();
+        urProfilingQueueTest::TearDown();
     }
 
     const size_t count = 1024;

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -209,6 +209,45 @@ template <class T> struct urQueueTestWithParam : urContextTestWithParam<T> {
     ur_queue_handle_t queue;
 };
 
+struct urProfilingQueueTest : urContextTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
+        ur_queue_property_t props[] = {UR_QUEUE_PROPERTIES_FLAGS,
+                                       UR_QUEUE_FLAG_PROFILING_ENABLE, 0};
+        ASSERT_SUCCESS(
+            urQueueCreate(this->context, this->device, props, &queue));
+    }
+
+    void TearDown() override {
+        if (queue) {
+            EXPECT_SUCCESS(urQueueRelease(queue));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTest::TearDown());
+    };
+
+    ur_queue_handle_t queue = nullptr;
+};
+
+template <class T>
+struct urProfilingQueueTestWithParam : urContextTestWithParam<T> {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
+        ur_queue_property_t props[] = {UR_QUEUE_PROPERTIES_FLAGS,
+                                       UR_QUEUE_FLAG_PROFILING_ENABLE, 0};
+        ASSERT_SUCCESS(
+            urQueueCreate(this->context, this->device, props, &queue));
+    }
+
+    void TearDown() override {
+        if (queue) {
+            EXPECT_SUCCESS(urQueueRelease(queue));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::TearDown());
+    };
+
+    ur_queue_handle_t queue = nullptr;
+};
+
 struct urMultiQueueTest : urContextTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());


### PR DESCRIPTION
The event testsuite has an entrypoint `urEventGetProfilingInfo` which requires a queue that has the `UR_QUEUE_FLAG_PROFILING_ENABLE` set when it's created.

Closes #377 