### PR TITLE
[ur] Make sampler creation extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -212,6 +212,7 @@ class ur_structure_type_v(IntEnum):
     USM_POOL_DESC = 10                              ## ::ur_usm_pool_desc_t
     USM_POOL_LIMITS_DESC = 11                       ## ::ur_usm_pool_limits_desc_t
     DEVICE_BINARY = 12                              ## ::ur_device_binary_t
+    SAMPLER_DESC = 13                               ## ::ur_sampler_desc_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -902,21 +903,15 @@ class ur_sampler_info_t(c_int):
 
 
 ###############################################################################
-## @brief Sampler properties
-class ur_sampler_properties_v(IntEnum):
-    NORMALIZED_COORDS = 0                           ## Sampler normalized coordinates
-    ADDRESSING_MODE = 1                             ## Sampler addressing mode
-    FILTER_MODE = 2                                 ## Sampler filter mode
-
-class ur_sampler_properties_t(c_int):
-    def __str__(self):
-        return str(ur_sampler_properties_v(self.value))
-
-
-###############################################################################
-## @brief Sampler Properties type
-class ur_sampler_property_t(c_intptr_t):
-    pass
+## @brief Sampler description.
+class ur_sampler_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_SAMPLER_DESC
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("normalizedCoords", c_bool),                                   ## [in] Specify if image coordinates are normalized (true) or not (false)
+        ("addressingMode", ur_sampler_addressing_mode_t),               ## [in] Specify the address mode of the sampler
+        ("filterMode", ur_sampler_filter_mode_t)                        ## [in] Specify the filter mode of the sampler
+    ]
 
 ###############################################################################
 ## @brief USM memory property flags
@@ -1968,9 +1963,9 @@ class ur_kernel_dditable_t(Structure):
 ###############################################################################
 ## @brief Function-pointer for urSamplerCreate
 if __use_win_types:
-    _urSamplerCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_t), POINTER(ur_sampler_handle_t) )
+    _urSamplerCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_desc_t), POINTER(ur_sampler_handle_t) )
 else:
-    _urSamplerCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_property_t), POINTER(ur_sampler_handle_t) )
+    _urSamplerCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_sampler_desc_t), POINTER(ur_sampler_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urSamplerRetain

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -236,6 +236,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_USM_POOL_DESC = 10,                   ///< ::ur_usm_pool_desc_t
     UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 11,            ///< ::ur_usm_pool_limits_desc_t
     UR_STRUCTURE_TYPE_DEVICE_BINARY = 12,                   ///< ::ur_device_binary_t
+    UR_STRUCTURE_TYPE_SAMPLER_DESC = 13,                    ///< ::ur_sampler_desc_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1939,20 +1940,15 @@ typedef enum ur_sampler_info_t {
 } ur_sampler_info_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Sampler properties
-typedef enum ur_sampler_properties_t {
-    UR_SAMPLER_PROPERTIES_NORMALIZED_COORDS = 0, ///< Sampler normalized coordinates
-    UR_SAMPLER_PROPERTIES_ADDRESSING_MODE = 1,   ///< Sampler addressing mode
-    UR_SAMPLER_PROPERTIES_FILTER_MODE = 2,       ///< Sampler filter mode
-    /// @cond
-    UR_SAMPLER_PROPERTIES_FORCE_UINT32 = 0x7fffffff
-    /// @endcond
+/// @brief Sampler description.
+typedef struct ur_sampler_desc_t {
+    ur_structure_type_t stype;                   ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_SAMPLER_DESC
+    const void *pNext;                           ///< [in][optional] pointer to extension-specific structure
+    bool normalizedCoords;                       ///< [in] Specify if image coordinates are normalized (true) or not (false)
+    ur_sampler_addressing_mode_t addressingMode; ///< [in] Specify the address mode of the sampler
+    ur_sampler_filter_mode_t filterMode;         ///< [in] Specify the filter mode of the sampler
 
-} ur_sampler_properties_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Sampler Properties type
-typedef intptr_t ur_sampler_property_t;
+} ur_sampler_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sampler object in a context
@@ -1974,8 +1970,11 @@ typedef intptr_t ur_sampler_property_t;
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pProps`
+///         + `NULL == pDesc`
 ///         + `NULL == phSampler`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode`
+///         + `::UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
@@ -1983,10 +1982,9 @@ typedef intptr_t ur_sampler_property_t;
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerCreate(
-    ur_context_handle_t hContext,        ///< [in] handle of the context object
-    const ur_sampler_property_t *pProps, ///< [in] specifies a list of sampler property names and their
-                                         ///< corresponding values.
-    ur_sampler_handle_t *phSampler       ///< [out] pointer to handle of sampler object created
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
+    ur_sampler_handle_t *phSampler  ///< [out] pointer to handle of sampler object created
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6461,7 +6459,7 @@ typedef struct ur_kernel_callbacks_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_sampler_create_params_t {
     ur_context_handle_t *phContext;
-    const ur_sampler_property_t **ppProps;
+    const ur_sampler_desc_t **ppDesc;
     ur_sampler_handle_t **pphSampler;
 } ur_sampler_create_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -545,7 +545,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetKernelProcAddrTable_t)(
 /// @brief Function-pointer for urSamplerCreate
 typedef ur_result_t(UR_APICALL *ur_pfnSamplerCreate_t)(
     ur_context_handle_t,
-    const ur_sampler_property_t *,
+    const ur_sampler_desc_t *,
     ur_sampler_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -287,7 +287,9 @@ etors:
     - name: USM_POOL_LIMITS_DESC
       desc: $x_usm_pool_limits_desc_t
     - name: DEVICE_BINARY
-      desc: "$x_device_binary_t"
+      desc: $x_device_binary_t
+    - name: SAMPLER_DESC
+      desc: $x_sampler_desc_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -55,22 +55,21 @@ etors:
     - name: FILTER_MODE
       desc: "[$x_sampler_filter_mode_t] Sampler filter mode setting"
 --- #--------------------------------------------------------------------------
-type: enum
-desc: "Sampler properties"
+type: struct
+desc: "Sampler description."
 class: $xSampler
-name: $x_sampler_properties_t
-etors:
-    - name: NORMALIZED_COORDS
-      desc: "Sampler normalized coordinates"
-    - name: ADDRESSING_MODE
-      desc: "Sampler addressing mode"
-    - name: FILTER_MODE
-      desc: "Sampler filter mode"
---- #--------------------------------------------------------------------------
-type: typedef
-desc: "Sampler Properties type"
-name: $x_sampler_property_t
-value: intptr_t
+name: $x_sampler_desc_t
+base: $x_base_desc_t
+members:
+    - type: bool
+      name: normalizedCoords
+      desc: "[in] Specify if image coordinates are normalized (true) or not (false)"
+    - type: $x_sampler_addressing_mode_t
+      name: addressingMode
+      desc: "[in] Specify the address mode of the sampler"
+    - type: $x_sampler_filter_mode_t
+      name: filterMode
+      desc: "[in] Specify the filter mode of the sampler"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Create a sampler object in a context"
@@ -86,10 +85,9 @@ params:
     - type: $x_context_handle_t
       name: hContext
       desc: "[in] handle of the context object"
-    - type: "const $x_sampler_property_t*"
-      name: pProps
-      desc: |
-            [in] specifies a list of sampler property names and their corresponding values.
+    - type: const $x_sampler_desc_t*
+      name: pDesc
+      desc: "[in] pointer to the sampler description"
     - type: $x_sampler_handle_t*
       name: phSampler
       desc: "[out] pointer to handle of sampler object created"

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -799,10 +799,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
 __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
         *phSampler ///< [out] pointer to handle of sampler object created
 ) {
@@ -811,7 +809,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Sampler.pfnCreate;
     if (nullptr != pfnCreate) {
-        result = pfnCreate(hContext, pProps, phSampler);
+        result = pfnCreate(hContext, pDesc, phSampler);
     } else {
         // generic implementation
         *phSampler = reinterpret_cast<ur_sampler_handle_t>(d_context.get());

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -980,10 +980,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
 __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
         *phSampler ///< [out] pointer to handle of sampler object created
 ) {
@@ -993,11 +991,11 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_sampler_create_params_t params = {&hContext, &pProps, &phSampler};
+    ur_sampler_create_params_t params = {&hContext, &pDesc, &phSampler};
     uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_CREATE,
                                              "urSamplerCreate", &params);
 
-    ur_result_t result = pfnCreate(hContext, pProps, phSampler);
+    ur_result_t result = pfnCreate(hContext, pDesc, phSampler);
 
     context.notify_end(UR_FUNCTION_SAMPLER_CREATE, "urSamplerCreate", &params,
                        &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1122,10 +1122,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
 __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
         *phSampler ///< [out] pointer to handle of sampler object created
 ) {
@@ -1140,16 +1138,24 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == pProps) {
+        if (NULL == pDesc) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
         if (NULL == phSampler) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
+
+        if (UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
     }
 
-    ur_result_t result = pfnCreate(hContext, pProps, phSampler);
+    ur_result_t result = pfnCreate(hContext, pDesc, phSampler);
 
     if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
         refCountContext.createRefCount(*phSampler);

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1172,10 +1172,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
 __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
         *phSampler ///< [out] pointer to handle of sampler object created
 ) {
@@ -1192,7 +1190,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnCreate(hContext, pProps, phSampler);
+    result = pfnCreate(hContext, pDesc, phSampler);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1253,18 +1253,19 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pProps`
+///         + `NULL == pDesc`
 ///         + `NULL == phSampler`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode`
+///         + `::UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
         *phSampler ///< [out] pointer to handle of sampler object created
 ) {
@@ -1273,7 +1274,7 @@ ur_result_t UR_APICALL urSamplerCreate(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreate(hContext, pProps, phSampler);
+    return pfnCreate(hContext, pDesc, phSampler);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1092,18 +1092,19 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pProps`
+///         + `NULL == pDesc`
 ///         + `NULL == phSampler`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode`
+///         + `::UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urSamplerCreate(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    const ur_sampler_property_t
-        *pProps, ///< [in] specifies a list of sampler property names and their
-                 ///< corresponding values.
+    ur_context_handle_t hContext,   ///< [in] handle of the context object
+    const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
         *phSampler ///< [out] pointer to handle of sampler object created
 ) {


### PR DESCRIPTION
Replace the `pProps` pointer to null-terminated list of key, value pairs
with a pointer `ur_sampler_desc_t` with the relevant required values as
data members. This also enables extensibility of `ur_sampler_handle_t`
creation. Fixes #373.
