### PR TITLE
[UR] Prevent loader from segfaulting

### DIFF
--- a/source/loader/ur_adapter_registry.hpp
+++ b/source/loader/ur_adapter_registry.hpp
@@ -28,13 +28,13 @@ class AdapterRegistry {
         }
         if (!altPlatforms) {
             discoverKnownAdapters();
-        }
-
-        std::stringstream ss(*altPlatforms);
-        while (ss.good()) {
-            std::string substr;
-            getline(ss, substr, ',');
-            discovered_adapters.emplace_back(substr);
+        } else {
+            std::stringstream ss(*altPlatforms);
+            while (ss.good()) {
+                std::string substr;
+                getline(ss, substr, ',');
+                discovered_adapters.emplace_back(substr);
+            }
         }
     }
 


### PR DESCRIPTION
The loader will segfault due to `altPlatforms` not having any values - this resulted in an empty string added to the list on known platforms which resulted in a segfault.