### PR TITLE
[ur] Add soft float device capability

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -381,12 +381,12 @@ class ur_device_info_v(IntEnum):
     MAX_WORK_ITEM_DIMENSIONS = 4                    ## uint32_t: max work item dimensions
     MAX_WORK_ITEM_SIZES = 5                         ## size_t[]: return an array of max work item sizes
     MAX_WORK_GROUP_SIZE = 6                         ## size_t: max work group size
-    SINGLE_FP_CONFIG = 7                            ## Return a bit field of ::ur_fp_capability_flags_t: single precision
-                                                    ## floating point capability
-    HALF_FP_CONFIG = 8                              ## Return a bit field of ::ur_fp_capability_flags_t: half precision
-                                                    ## floating point capability
-    DOUBLE_FP_CONFIG = 9                            ## Return a bit field of ::ur_fp_capability_flags_t: double precision
-                                                    ## floating point capability
+    SINGLE_FP_CONFIG = 7                            ## Return a bit field of ::ur_device_fp_capability_flags_t: single
+                                                    ## precision floating point capability
+    HALF_FP_CONFIG = 8                              ## Return a bit field of ::ur_device_fp_capability_flags_t: half
+                                                    ## precision floating point capability
+    DOUBLE_FP_CONFIG = 9                            ## Return a bit field of ::ur_device_fp_capability_flags_t: double
+                                                    ## precision floating point capability
     QUEUE_PROPERTIES = 10                           ## Return a bit field of ::ur_queue_flags_t: command queue properties
                                                     ## supported by the device
     PREFERRED_VECTOR_WIDTH_CHAR = 11                ## uint32_t: preferred vector width for char
@@ -523,7 +523,7 @@ class ur_device_partition_t(c_int):
 
 ###############################################################################
 ## @brief FP capabilities
-class ur_fp_capability_flags_v(IntEnum):
+class ur_device_fp_capability_flags_v(IntEnum):
     CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0)       ## Support correctly rounded divide and sqrt
     ROUND_TO_NEAREST = UR_BIT(1)                    ## Support round to nearest
     ROUND_TO_ZERO = UR_BIT(2)                       ## Support round to zero
@@ -531,8 +531,9 @@ class ur_fp_capability_flags_v(IntEnum):
     INF_NAN = UR_BIT(4)                             ## Support INF to NAN
     DENORM = UR_BIT(5)                              ## Support denorm
     FMA = UR_BIT(6)                                 ## Support FMA
+    SOFT_FLOAT = UR_BIT(7)                          ## Basic floating point operations implemented in software.
 
-class ur_fp_capability_flags_t(c_int):
+class ur_device_fp_capability_flags_t(c_int):
     def __str__(self):
         return hex(self.value)
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -694,12 +694,12 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                ///< uint32_t: max work item dimensions
     UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< size_t[]: return an array of max work item sizes
     UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                     ///< size_t: max work group size
-    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< Return a bit field of ::ur_fp_capability_flags_t: single precision
-                                                                ///< floating point capability
-    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                          ///< Return a bit field of ::ur_fp_capability_flags_t: half precision
-                                                                ///< floating point capability
-    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                        ///< Return a bit field of ::ur_fp_capability_flags_t: double precision
-                                                                ///< floating point capability
+    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< Return a bit field of ::ur_device_fp_capability_flags_t: single
+                                                                ///< precision floating point capability
+    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                          ///< Return a bit field of ::ur_device_fp_capability_flags_t: half
+                                                                ///< precision floating point capability
+    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                        ///< Return a bit field of ::ur_device_fp_capability_flags_t: double
+                                                                ///< precision floating point capability
     UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,                       ///< Return a bit field of ::ur_queue_flags_t: command queue properties
                                                                 ///< supported by the device
     UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,            ///< uint32_t: preferred vector width for char
@@ -991,20 +991,21 @@ urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief FP capabilities
-typedef uint32_t ur_fp_capability_flags_t;
-typedef enum ur_fp_capability_flag_t {
-    UR_FP_CAPABILITY_FLAG_CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0), ///< Support correctly rounded divide and sqrt
-    UR_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST = UR_BIT(1),              ///< Support round to nearest
-    UR_FP_CAPABILITY_FLAG_ROUND_TO_ZERO = UR_BIT(2),                 ///< Support round to zero
-    UR_FP_CAPABILITY_FLAG_ROUND_TO_INF = UR_BIT(3),                  ///< Support round to infinity
-    UR_FP_CAPABILITY_FLAG_INF_NAN = UR_BIT(4),                       ///< Support INF to NAN
-    UR_FP_CAPABILITY_FLAG_DENORM = UR_BIT(5),                        ///< Support denorm
-    UR_FP_CAPABILITY_FLAG_FMA = UR_BIT(6),                           ///< Support FMA
+typedef uint32_t ur_device_fp_capability_flags_t;
+typedef enum ur_device_fp_capability_flag_t {
+    UR_DEVICE_FP_CAPABILITY_FLAG_CORRECTLY_ROUNDED_DIVIDE_SQRT = UR_BIT(0), ///< Support correctly rounded divide and sqrt
+    UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST = UR_BIT(1),              ///< Support round to nearest
+    UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_ZERO = UR_BIT(2),                 ///< Support round to zero
+    UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_INF = UR_BIT(3),                  ///< Support round to infinity
+    UR_DEVICE_FP_CAPABILITY_FLAG_INF_NAN = UR_BIT(4),                       ///< Support INF to NAN
+    UR_DEVICE_FP_CAPABILITY_FLAG_DENORM = UR_BIT(5),                        ///< Support denorm
+    UR_DEVICE_FP_CAPABILITY_FLAG_FMA = UR_BIT(6),                           ///< Support FMA
+    UR_DEVICE_FP_CAPABILITY_FLAG_SOFT_FLOAT = UR_BIT(7),                    ///< Basic floating point operations implemented in software.
     /// @cond
-    UR_FP_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
+    UR_DEVICE_FP_CAPABILITY_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
-} ur_fp_capability_flag_t;
+} ur_device_fp_capability_flag_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device memory cache type

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -159,11 +159,11 @@ etors:
     - name: MAX_WORK_GROUP_SIZE
       desc: "size_t: max work group size"
     - name: SINGLE_FP_CONFIG
-      desc: "Return a bit field of $x_fp_capability_flags_t: single precision floating point capability"
+      desc: "Return a bit field of $x_device_fp_capability_flags_t: single precision floating point capability"
     - name: HALF_FP_CONFIG
-      desc: "Return a bit field of $x_fp_capability_flags_t: half precision floating point capability"
+      desc: "Return a bit field of $x_device_fp_capability_flags_t: half precision floating point capability"
     - name: DOUBLE_FP_CONFIG
-      desc: "Return a bit field of $x_fp_capability_flags_t: double precision floating point capability"
+      desc: "Return a bit field of $x_device_fp_capability_flags_t: double precision floating point capability"
     - name: QUEUE_PROPERTIES
       desc: "Return a bit field of $x_queue_flags_t: command queue properties supported by the device"
     - name: PREFERRED_VECTOR_WIDTH_CHAR
@@ -528,7 +528,7 @@ returns:
 type: enum
 desc: "FP capabilities"
 class: $xDevice
-name: $x_fp_capability_flags_t
+name: $x_device_fp_capability_flags_t
 etors:
     - name: CORRECTLY_ROUNDED_DIVIDE_SQRT
       desc: "Support correctly rounded divide and sqrt"
@@ -551,6 +551,9 @@ etors:
     - name: FMA
       desc: "Support FMA"
       value: "$X_BIT(6)"
+    - name: SOFT_FLOAT
+      desc: "Basic floating point operations implemented in software."
+      value: "$X_BIT(7)"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Device memory cache type"

--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -170,13 +170,13 @@ ur_result_t GetDeviceMaxWorkGroupSize(ur_device_handle_t device,
                                       size_t &max_work_group_size);
 ur_result_t
 GetDeviceSingleFPCapabilities(ur_device_handle_t device,
-                              ur_fp_capability_flags_t &fp_capabilities);
+                              ur_device_fp_capability_flags_t &fp_capabilities);
 ur_result_t
 GetDeviceHalfFPCapabilities(ur_device_handle_t device,
-                            ur_fp_capability_flags_t &fp_capabilities);
+                            ur_device_fp_capability_flags_t &fp_capabilities);
 ur_result_t
 GetDeviceDoubleFPCapabilities(ur_device_handle_t device,
-                              ur_fp_capability_flags_t &fp_capabilities);
+                              ur_device_fp_capability_flags_t &fp_capabilities);
 ur_result_t GetDeviceQueueProperties(ur_device_handle_t device,
                                      ur_queue_flags_t &flags);
 ur_result_t GetDevicePreferredVectorWidthChar(ur_device_handle_t device,

--- a/test/conformance/testing/source/utils.cpp
+++ b/test/conformance/testing/source/utils.cpp
@@ -78,30 +78,30 @@ ur_result_t GetDeviceMaxWorkGroupSize(ur_device_handle_t device,
                                  max_work_group_size);
 }
 
-ur_result_t
-GetDeviceSingleFPCapabilities(ur_device_handle_t device,
-                              ur_fp_capability_flags_t &fp_capabilities) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(
+ur_result_t GetDeviceSingleFPCapabilities(
+    ur_device_handle_t device,
+    ur_device_fp_capability_flags_t &fp_capabilities) {
+    return GetDeviceInfo<ur_device_fp_capability_flags_t>(
         device, UR_DEVICE_INFO_SINGLE_FP_CONFIG, fp_capabilities);
 }
 
 ur_result_t
 GetDeviceHalfFPCapabilities(ur_device_handle_t device,
-                            ur_fp_capability_flags_t &fp_capabilities) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(
+                            ur_device_fp_capability_flags_t &fp_capabilities) {
+    return GetDeviceInfo<ur_device_fp_capability_flags_t>(
         device, UR_DEVICE_INFO_HALF_FP_CONFIG, fp_capabilities);
 }
 
-ur_result_t
-GetDeviceDoubleFPCapabilities(ur_device_handle_t device,
-                              ur_fp_capability_flags_t &fp_capabilities) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(
+ur_result_t GetDeviceDoubleFPCapabilities(
+    ur_device_handle_t device,
+    ur_device_fp_capability_flags_t &fp_capabilities) {
+    return GetDeviceInfo<ur_device_fp_capability_flags_t>(
         device, UR_DEVICE_INFO_DOUBLE_FP_CONFIG, fp_capabilities);
 }
 
 ur_result_t GetDeviceQueueProperties(ur_device_handle_t device,
                                      ur_queue_flags_t &flags) {
-    return GetDeviceInfo<ur_fp_capability_flags_t>(
+    return GetDeviceInfo<ur_device_fp_capability_flags_t>(
         device, UR_DEVICE_INFO_QUEUE_PROPERTIES, flags);
 }
 


### PR DESCRIPTION
* Fixes #113 by introducing the `UR_DEVICE_FP_CAPABILITY_FLAG_SOFT_FLOAT`
  enumeration to support `sycl::info::device::fp_config::soft_float`.
* Rename `ur_fp_capability_flag_t` to `ur_device_fp_capability_flag_t`
  to be consistent with the other types describing device capabilities.
