### PR TITLE
[CTS] Implement size checks for info queries

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -635,7 +635,7 @@ class ur_context_properties_t(Structure):
 ## @brief Supported context info
 class ur_context_info_v(IntEnum):
     NUM_DEVICES = 0                                 ## [uint32_t] The number of the devices in the context
-    DEVICES = 1                                     ## [::ur_context_handle_t...] The array of the device handles in the
+    DEVICES = 1                                     ## [::ur_device_handle_t ...] The array of the device handles in the
                                                     ## context
     REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the context object.
                                                     ## The reference count returned should be considered immediately stale. 
@@ -979,11 +979,11 @@ class ur_usm_type_t(c_int):
 ###############################################################################
 ## @brief USM memory allocation information type
 class ur_usm_alloc_info_v(IntEnum):
-    TYPE = 0                                        ## Memory allocation type info
-    BASE_PTR = 1                                    ## Memory allocation base pointer info
-    SIZE = 2                                        ## Memory allocation size info
-    DEVICE = 3                                      ## Memory allocation device info
-    POOL = 4                                        ## Memory allocation pool info
+    TYPE = 0                                        ## [::ur_usm_type_t] Memory allocation type info
+    BASE_PTR = 1                                    ## [void *] Memory allocation base pointer info
+    SIZE = 2                                        ## [size_t] Memory allocation size info
+    DEVICE = 3                                      ## [::ur_device_handle_t] Memory allocation device info
+    POOL = 4                                        ## [::ur_usm_pool_handle_t] Memory allocation pool info
 
 class ur_usm_alloc_info_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1255,7 +1255,7 @@ urContextRetain(
 /// @brief Supported context info
 typedef enum ur_context_info_t {
     UR_CONTEXT_INFO_NUM_DEVICES = 0,          ///< [uint32_t] The number of the devices in the context
-    UR_CONTEXT_INFO_DEVICES = 1,              ///< [::ur_context_handle_t...] The array of the device handles in the
+    UR_CONTEXT_INFO_DEVICES = 1,              ///< [::ur_device_handle_t ...] The array of the device handles in the
                                               ///< context
     UR_CONTEXT_INFO_REFERENCE_COUNT = 2,      ///< [uint32_t] Reference count of the context object.
                                               ///< The reference count returned should be considered immediately stale.
@@ -2187,11 +2187,11 @@ typedef enum ur_usm_type_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory allocation information type
 typedef enum ur_usm_alloc_info_t {
-    UR_USM_ALLOC_INFO_TYPE = 0,     ///< Memory allocation type info
-    UR_USM_ALLOC_INFO_BASE_PTR = 1, ///< Memory allocation base pointer info
-    UR_USM_ALLOC_INFO_SIZE = 2,     ///< Memory allocation size info
-    UR_USM_ALLOC_INFO_DEVICE = 3,   ///< Memory allocation device info
-    UR_USM_ALLOC_INFO_POOL = 4,     ///< Memory allocation pool info
+    UR_USM_ALLOC_INFO_TYPE = 0,     ///< [::ur_usm_type_t] Memory allocation type info
+    UR_USM_ALLOC_INFO_BASE_PTR = 1, ///< [void *] Memory allocation base pointer info
+    UR_USM_ALLOC_INFO_SIZE = 2,     ///< [size_t] Memory allocation size info
+    UR_USM_ALLOC_INFO_DEVICE = 3,   ///< [::ur_device_handle_t] Memory allocation device info
+    UR_USM_ALLOC_INFO_POOL = 4,     ///< [::ur_usm_pool_handle_t] Memory allocation pool info
     /// @cond
     UR_USM_ALLOC_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -88,7 +88,7 @@ etors:
     - name: NUM_DEVICES
       desc: "[uint32_t] The number of the devices in the context"
     - name: DEVICES
-      desc: "[$x_context_handle_t...] The array of the device handles in the context"
+      desc: "[$x_device_handle_t ...] The array of the device handles in the context"
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the context object.

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -75,15 +75,15 @@ class: $xUSM
 name: $x_usm_alloc_info_t
 etors:
     - name: TYPE
-      desc: "Memory allocation type info"
+      desc: "[$x_usm_type_t] Memory allocation type info"
     - name: BASE_PTR
-      desc: "Memory allocation base pointer info"
+      desc: "[void *] Memory allocation base pointer info"
     - name: SIZE
-      desc: "Memory allocation size info"
+      desc: "[size_t] Memory allocation size info"
     - name: DEVICE
-      desc: "Memory allocation device info"
+      desc: "[$x_device_handle_t] Memory allocation device info"
     - name: POOL
-      desc: "Memory allocation pool info"
+      desc: "[$x_usm_pool_handle_t] Memory allocation pool info"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "USM memory advice"

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -1,7 +1,102 @@
 // Copyright (C) 2022-2023 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+#include <map>
 #include <uur/fixtures.h>
+
+static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
+    {UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t)},
+    {UR_DEVICE_INFO_VENDOR_ID, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_DEVICE_ID, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_COMPUTE_UNITS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE, sizeof(size_t)},
+    {UR_DEVICE_INFO_SINGLE_FP_CONFIG, sizeof(ur_fp_capability_flag_t)},
+    {UR_DEVICE_INFO_HALF_FP_CONFIG, sizeof(ur_fp_capability_flag_t)},
+    {UR_DEVICE_INFO_DOUBLE_FP_CONFIG, sizeof(ur_fp_capability_flag_t)},
+    {UR_DEVICE_INFO_QUEUE_PROPERTIES, sizeof(ur_queue_flags_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MEMORY_CLOCK_RATE, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_ADDRESS_BITS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE, sizeof(uint64_t)},
+    {UR_DEVICE_INFO_IMAGE_SUPPORTED, sizeof(bool)},
+    {UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH, sizeof(size_t)},
+    {UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT, sizeof(size_t)},
+    {UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH, sizeof(size_t)},
+    {UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT, sizeof(size_t)},
+    {UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH, sizeof(size_t)},
+    {UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE, sizeof(size_t)},
+    {UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE, sizeof(size_t)},
+    {UR_DEVICE_INFO_MAX_SAMPLERS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_PARAMETER_SIZE, sizeof(size_t)},
+    {UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE, sizeof(ur_device_mem_cache_type_t)},
+    {UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE, sizeof(uint64_t)},
+    {UR_DEVICE_INFO_GLOBAL_MEM_SIZE, sizeof(uint64_t)},
+    {UR_DEVICE_INFO_GLOBAL_MEM_FREE, sizeof(uint64_t)},
+    {UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE, sizeof(uint64_t)},
+    {UR_DEVICE_INFO_MAX_CONSTANT_ARGS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_LOCAL_MEM_TYPE, sizeof(ur_device_local_mem_type_t)},
+    {UR_DEVICE_INFO_LOCAL_MEM_SIZE, sizeof(uint64_t)},
+    {UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT, sizeof(bool)},
+    {UR_DEVICE_INFO_HOST_UNIFIED_MEMORY, sizeof(bool)},
+    {UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION, sizeof(size_t)},
+    {UR_DEVICE_INFO_ENDIAN_LITTLE, sizeof(bool)},
+    {UR_DEVICE_INFO_AVAILABLE, sizeof(bool)},
+    {UR_DEVICE_INFO_COMPILER_AVAILABLE, sizeof(bool)},
+    {UR_DEVICE_INFO_LINKER_AVAILABLE, sizeof(bool)},
+    {UR_DEVICE_INFO_EXECUTION_CAPABILITIES,
+     sizeof(ur_device_exec_capability_flags_t)},
+    {UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES, sizeof(ur_queue_flags_t)},
+    {UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES, sizeof(ur_queue_flags_t)},
+    {UR_DEVICE_INFO_PLATFORM, sizeof(ur_platform_handle_t)},
+    {UR_DEVICE_INFO_REFERENCE_COUNT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PRINTF_BUFFER_SIZE, sizeof(size_t)},
+    {UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC, sizeof(bool)},
+    {UR_DEVICE_INFO_PARENT_DEVICE, sizeof(ur_device_handle_t)},
+    {UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,
+     sizeof(ur_device_affinity_domain_flags_t)},
+    {UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, sizeof(bool)},
+    {UR_DEVICE_INFO_USM_HOST_SUPPORT, sizeof(bool)},
+    {UR_DEVICE_INFO_USM_DEVICE_SUPPORT, sizeof(bool)},
+    {UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT, sizeof(bool)},
+    {UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT, sizeof(bool)},
+    {UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT, sizeof(bool)},
+    {UR_DEVICE_INFO_GPU_EU_COUNT, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_GPU_EU_SLICES, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_IMAGE_SRGB, sizeof(bool)},
+    {UR_DEVICE_INFO_ATOMIC_64, sizeof(bool)},
+    {UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,
+     sizeof(ur_memory_order_capability_flags_t)},
+    {UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES,
+     sizeof(ur_memory_scope_capability_flags_t)},
+    {UR_DEVICE_INFO_BFLOAT16, sizeof(bool)},
+    {UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS, sizeof(bool)},
+};
 
 struct urDeviceGetInfoTest : uur::urAllDevicesTest,
                              ::testing::WithParamInterface<ur_device_info_t> {
@@ -125,6 +220,10 @@ TEST_P(urDeviceGetInfoTest, Success) {
         size_t size = 0;
         ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, 0, nullptr, &size));
         ASSERT_NE(size, 0);
+        if (const auto expected_size = device_info_size_map.find(info_type);
+            expected_size != device_info_size_map.end()) {
+            ASSERT_EQ(expected_size->second, size);
+        }
         void *info_data = alloca(size);
         ASSERT_SUCCESS(
             urDeviceGetInfo(device, info_type, size, info_data, nullptr));

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -1,8 +1,14 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: MIT
+#include <map>
 #include <uur/fixtures.h>
 
 using urMemGetInfoTest = uur::urMemBufferTestWithParam<ur_mem_info_t>;
+
+static std::unordered_map<ur_mem_info_t, size_t> mem_info_size_map = {
+    {UR_MEM_INFO_SIZE, sizeof(size_t)},
+    {UR_MEM_INFO_CONTEXT, sizeof(ur_context_handle_t)},
+};
 
 UUR_TEST_SUITE_P(urMemGetInfoTest,
                  ::testing::Values(UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT),
@@ -13,6 +19,12 @@ TEST_P(urMemGetInfoTest, Success) {
     size_t size;
     ASSERT_SUCCESS(urMemGetInfo(buffer, info, 0, nullptr, &size));
     ASSERT_NE(size, 0);
+
+    if (const auto expected_size = mem_info_size_map.find(info);
+        expected_size != mem_info_size_map.end()) {
+        ASSERT_EQ(expected_size->second, size);
+    }
+
     std::vector<uint8_t> info_data(size);
     ASSERT_SUCCESS(urMemGetInfo(buffer, info, size, info_data.data(), nullptr));
 }

--- a/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/test/conformance/platform/urPlatformGetInfo.cpp
@@ -15,14 +15,9 @@ struct urPlatformGetInfoTest
 
 INSTANTIATE_TEST_SUITE_P(
     urPlatformGetInfo, urPlatformGetInfoTest,
-    ::testing::Values(UR_PLATFORM_INFO_NAME
-                      /*
-   UR_PLATFORM_INFO_VENDOR_NAME,
-   UR_PLATFORM_INFO_VERSION,
-   UR_PLATFORM_INFO_EXTENSIONS,
-   UR_PLATFORM_INFO_PROFILE
- */
-                      ),
+    ::testing::Values(UR_PLATFORM_INFO_NAME, UR_PLATFORM_INFO_VENDOR_NAME,
+                      UR_PLATFORM_INFO_VERSION, UR_PLATFORM_INFO_EXTENSIONS,
+                      UR_PLATFORM_INFO_PROFILE),
     [](const ::testing::TestParamInfo<ur_platform_info_t> &info) {
         std::stringstream ss;
         ss << info.param;

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -1,6 +1,16 @@
 // Copyright (C) 2023 Intel Corporation
 // SPDX-License-Identifier: MIT
+#include <map>
 #include <uur/fixtures.h>
+
+std::unordered_map<ur_queue_info_t, size_t> queue_info_size_map = {
+    {UR_QUEUE_INFO_CONTEXT, sizeof(ur_context_handle_t)},
+    {UR_QUEUE_INFO_DEVICE, sizeof(ur_device_handle_t)},
+    {UR_QUEUE_INFO_DEVICE_DEFAULT, sizeof(ur_queue_handle_t)},
+    {UR_QUEUE_INFO_PROPERTIES, sizeof(ur_queue_flags_t)},
+    {UR_QUEUE_INFO_REFERENCE_COUNT, sizeof(uint32_t)},
+    {UR_QUEUE_INFO_SIZE, sizeof(uint32_t)},
+};
 
 using urQueueGetInfoTestWithInfoParam =
     uur::urQueueTestWithParam<ur_queue_info_t>;
@@ -18,6 +28,12 @@ TEST_P(urQueueGetInfoTestWithInfoParam, Success) {
     size_t size = 0;
     ASSERT_SUCCESS(urQueueGetInfo(queue, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
+
+    if (const auto expected_size = queue_info_size_map.find(info_type);
+        expected_size != queue_info_size_map.end()) {
+        ASSERT_EQ(expected_size->second, size);
+    }
+
     std::vector<uint8_t> data(size);
     ASSERT_SUCCESS(
         urQueueGetInfo(queue, info_type, size, data.data(), nullptr));


### PR DESCRIPTION
This PR:
* Adds checks to the CTS *GetInfo tests that we return the expected size for certain info queries. Some are not possible to assert on as they can return variable length values depending on the backend.
* Some small spec description fixes, which clarify the return type of the query.


Closes #379 