### PR TITLE
Add libunwind validation backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(UR_USE_UBSAN "enable UndefinedBehaviorSanitizer" OFF)
 option(UR_USE_MSAN "enable MemorySanitizer" OFF)
 option(UMA_BUILD_SHARED_LIBRARY "Build UMA as shared library" OFF)
 option(UR_ENABLE_TRACING "enable api tracing through xpti" OFF)
+option(VAL_USE_LIBUNWIND_BACKTRACE "enable libunwind validation backtrace" OFF)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/cmake/FindLibunwind.cmake
+++ b/cmake/FindLibunwind.cmake
@@ -1,0 +1,25 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+#
+# FindLibunwind.cmake -- module searching for libunwind library.
+#                        LIBUNWIND_FOUND is set to true if libunwind is found.
+#
+
+find_library(LIBUNWIND_LIBRARIES NAMES unwind)
+find_path(LIBUNWIND_INCLUDE_DIR NAMES libunwind.h)
+
+if (LIBUNWIND_LIBRARIES AND LIBUNWIND_INCLUDE_DIR)
+    set(LIBUNWIND_FOUND TRUE)
+endif()
+
+if (LIBUNWIND_FOUND)
+    add_library(Libunwind INTERFACE IMPORTED)
+    set_target_properties(Libunwind PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${LIBUNWIND_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES "${LIBUNWIND_LIBRARIES}"
+    )
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libunwind DEFAULT_MSG LIBUNWIND_LIBRARIES LIBUNWIND_INCLUDE_DIR)

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -49,7 +49,7 @@ if (UNIX)
 endif()
 
 if(WIN32)
-    target_link_libraries(loader PRIVATE cfgmgr32.lib dbghelp)
+    target_link_libraries(loader PRIVATE cfgmgr32.lib)
 endif()
 
 if(UNIX)
@@ -90,18 +90,39 @@ if(UR_ENABLE_TRACING)
     )
 endif()
 
+
+# link validation backtrace dependencies
+find_package(Libunwind)
+if (VAL_USE_LIBUNWIND_BACKTRACE AND LIBUNWIND_FOUND)
+    message(STATUS "Using libunwind backtrace for validation")
+
+    target_sources(loader PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_unwind.cpp)
+    target_link_libraries(loader PRIVATE Libunwind)
+else()
+    message(STATUS "Using default backtrace for validation")
+
+    if(WIN32)
+        target_sources(loader PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_win.cpp)
+    target_link_libraries(loader PRIVATE dbghelp)
+    else()
+        target_sources(loader PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_lin.cpp)
+    endif()
+endif()
+
 if(WIN32)
     target_sources(loader
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/windows/lib_init.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/windows/loader_init.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_win.cpp
+
     )
 else()
     target_sources(loader
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/linux/lib_init.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/linux/loader_init.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_lin.cpp
     )
 endif()

--- a/source/loader/layers/validation/backtrace_unwind.cpp
+++ b/source/loader/layers/validation/backtrace_unwind.cpp
@@ -1,0 +1,59 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+#include "backtrace.hpp"
+
+#include <cxxabi.h>
+#include <execinfo.h>
+#include <vector>
+
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+
+namespace validation_layer {
+
+std::vector<BacktraceLine> getCurrentBacktrace() {
+    unw_cursor_t cursor;
+    unw_context_t context;
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+
+    if (unw_step(&cursor) <= 0) {
+        return std::vector<BacktraceLine>(1, "Failed to acquire a backtrace");
+    }
+
+    std::vector<BacktraceLine> backtrace;
+    try {
+        char proc_name[256];
+        unw_word_t ip, offset;
+        std::stringstream backtraceLine;
+
+        do {
+            if (unw_get_proc_name(&cursor, proc_name, sizeof(proc_name),
+                                  &offset) != 0) {
+                backtrace.push_back("????????");
+            } else if (unw_get_reg(&cursor, UNW_REG_IP, &ip) != 0) {
+                backtraceLine.str("");
+                backtraceLine << "(" << proc_name << "+"
+                              << std::to_string(offset) << ") [????????]";
+                backtrace.push_back(backtraceLine.str());
+            } else {
+                backtraceLine.str("");
+                backtraceLine << "(" << proc_name << "+"
+                              << std::to_string(offset) << ") [0x" << std::hex
+                              << ip << "]";
+                backtrace.push_back(backtraceLine.str());
+            }
+        } while (unw_step(&cursor) > 0);
+    } catch (std::bad_alloc &) {
+        return std::vector<BacktraceLine>(1, "Failed to acquire a backtrace");
+    }
+
+    return backtrace;
+}
+
+} // namespace validation_layer


### PR DESCRIPTION
Libunwind backtrace can be enabled using cmake option `VAL_USE_LIBUNWIND_BACKTRACE`, it is set to `OFF` by default.

Addresses: https://github.com/oneapi-src/unified-runtime/issues/368

An example output from backtrace implementation using libunwind looks like this:
```
<VALIDATION>[ERROR]: (_ZN16validation_layer15RefCountContext14updateRefCountEPvNS0_18RefCountUpdateTypeE+241) [0x7f95f3809731]
<VALIDATION>[ERROR]: (_ZN16validation_layer15RefCountContext14createRefCountEPv+31) [0x7f95f380807f]
<VALIDATION>[ERROR]: (_ZN16validation_layer15urContextCreateEjPKP19ur_device_handle_t_PK23ur_context_properties_tPP20ur_context_handle_t_+190) [0x7f95f380094e]
<VALIDATION>[ERROR]: (urContextCreate+86) [0x7f95f37f3566]
<VALIDATION>[ERROR]: (_ZN64valDeviceTestMultithreaded_testUrContextRetainReleaseLeakMt_Test8TestBodyEv+56) [0x560275107258]
<VALIDATION>[ERROR]: (_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+123) [0x56027516af8b]
<VALIDATION>[ERROR]: (_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+106) [0x56027514e02a]
<VALIDATION>[ERROR]: (_ZN7testing4Test3RunEv+195) [0x56027512f0e3]
<VALIDATION>[ERROR]: (_ZN7testing8TestInfo3RunEv+304) [0x56027512fc70]
<VALIDATION>[ERROR]: (_ZN7testing9TestSuite3RunEv+317) [0x5602751304bd]
<VALIDATION>[ERROR]: (_ZN7testing8internal12UnitTestImpl11RunAllTestsEv+1108) [0x560275140eb4]
<VALIDATION>[ERROR]: (_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+123) [0x56027516dbeb]
<VALIDATION>[ERROR]: (_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+106) [0x56027515047a]
<VALIDATION>[ERROR]: (_ZN7testing8UnitTest3RunEv+203) [0x560275140a0b]
<VALIDATION>[ERROR]: (_Z13RUN_ALL_TESTSv+17) [0x5602751192a1]
<VALIDATION>[ERROR]: (main+61) [0x56027511927d]
<VALIDATION>[ERROR]: (__libc_init_first+144) [0x7f95f3261d90]
<VALIDATION>[ERROR]: (__libc_start_main+128) [0x7f95f3261e40]
<VALIDATION>[ERROR]: (_start+37) [0x560275106a05]
```