### PR TITLE
[ur] normalize prop names

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -834,19 +834,19 @@ typedef enum ur_device_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < infoType`
+///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,            ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo,          ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,            ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue,           ///< [out][optional] array of bytes holding the info.
                                 ///< If propSize is not equal to or greater than the real number of bytes
                                 ///< needed to return the info
                                 ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-                                ///< pDeviceInfo is not used.
-    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+                                ///< pPropValue is not used.
+    size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1314,18 +1314,18 @@ urContextRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < ContextInfoType`
+///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
-    size_t propSize,                   ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo,                ///< [out][optional] array of bytes holding the info.
-                                       ///< if propSize is not equal to or greater than the real number of bytes
-                                       ///< needed to return
-                                       ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                       ///< pContextInfo is not used.
-    size_t *pPropSizeRet               ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
+    size_t propSize,              ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue,             ///< [out][optional] array of bytes holding the info.
+                                  ///< if propSize is not equal to or greater than the real number of bytes
+                                  ///< needed to return
+                                  ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                                  ///< pPropValue is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1848,17 +1848,17 @@ urMemCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
+///         + `::UR_MEM_INFO_CONTEXT < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemGetInfo(
-    ur_mem_handle_t hMemory,   ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
-    size_t propSize,           ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo,            ///< [out][optional] array of bytes holding the info.
-                               ///< If propSize is less than the real number of bytes needed to return
-                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                               ///< pMemInfo is not used.
-    size_t *pPropSizeRet       ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+    ur_mem_handle_t hMemory, ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName,  ///< [in] type of the info to retrieve.
+    size_t propSize,         ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue,        ///< [out][optional] array of bytes holding the info.
+                             ///< If propSize is less than the real number of bytes needed to return
+                             ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                             ///< pPropValue is not used.
+    size_t *pPropSizeRet     ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1878,17 +1878,17 @@ urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
+///         + `::UR_IMAGE_INFO_DEPTH < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemImageGetInfo(
-    ur_mem_handle_t hMemory,     ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
-    size_t propSize,             ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo,              ///< [out][optional] array of bytes holding the info.
-                                 ///< If propSize is less than the real number of bytes needed to return
-                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                 ///< pImgInfo is not used.
-    size_t *pPropSizeRet         ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+    ur_mem_handle_t hMemory,  ///< [in] handle to the image object being queried.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
+    size_t propSize,          ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue,         ///< [out][optional] array of bytes holding the info.
+                              ///< If propSize is less than the real number of bytes needed to return
+                              ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
+                              ///< pPropValue is not used.
+    size_t *pPropSizeRet      ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 );
 
 #if !defined(__GNUC__)
@@ -2847,12 +2847,12 @@ urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName,   ///< [in] name of the Program property to query
     size_t propSize,              ///< [in] the size of the Program property.
-    void *pProgramInfo,           ///< [in,out][optional] array of bytes of holding the program info property.
+    void *pPropValue,             ///< [in,out][optional] array of bytes of holding the program info property.
                                   ///< If propSize is not equal to or greater than the real number of bytes
                                   ///< needed to return
                                   ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                  ///< pProgramInfo is not used.
-    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+                                  ///< pPropValue is not used.
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2920,7 +2920,7 @@ urProgramGetBuildInfo(
     void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
                                       ///< If propSize is not equal to or greater than the real number of bytes
                                       ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-                                      ///< error is returned and pKernelInfo is not used.
+                                      ///< error is returned and pPropValue is not used.
     size_t *pPropSizeRet              ///< [out][optional] pointer to the actual size in bytes of data being
                                       ///< queried by propName.
 );
@@ -3178,11 +3178,11 @@ urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pKernelInfo,          ///< [in,out][optional] array of bytes holding the kernel info property.
+    void *pPropValue,           ///< [in,out][optional] array of bytes holding the kernel info property.
                                 ///< If propSize is not equal to or greater than the real number of bytes
                                 ///< needed to return
                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-                                ///< pKernelInfo is not used.
+                                ///< pPropValue is not used.
     size_t *pPropSizeRet        ///< [out][optional] pointer to the actual size in bytes of data being
                                 ///< queried by propName.
 );
@@ -5505,9 +5505,9 @@ typedef void(UR_APICALL *ur_pfnContextReleaseCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_context_get_info_params_t {
     ur_context_handle_t *phContext;
-    ur_context_info_t *pContextInfoType;
+    ur_context_info_t *ppropName;
     size_t *ppropSize;
-    void **ppContextInfo;
+    void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_context_get_info_params_t;
 
@@ -5975,7 +5975,7 @@ typedef struct ur_program_get_info_params_t {
     ur_program_handle_t *phProgram;
     ur_program_info_t *ppropName;
     size_t *ppropSize;
-    void **ppProgramInfo;
+    void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_program_get_info_params_t;
 
@@ -6129,7 +6129,7 @@ typedef struct ur_kernel_get_info_params_t {
     ur_kernel_handle_t *phKernel;
     ur_kernel_info_t *ppropName;
     size_t *ppropSize;
-    void **ppKernelInfo;
+    void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_kernel_get_info_params_t;
 
@@ -6756,9 +6756,9 @@ typedef void(UR_APICALL *ur_pfnMemCreateWithNativeHandleCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_mem_get_info_params_t {
     ur_mem_handle_t *phMemory;
-    ur_mem_info_t *pMemInfoType;
+    ur_mem_info_t *ppropName;
     size_t *ppropSize;
-    void **ppMemInfo;
+    void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_mem_get_info_params_t;
 
@@ -6780,9 +6780,9 @@ typedef void(UR_APICALL *ur_pfnMemGetInfoCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_mem_image_get_info_params_t {
     ur_mem_handle_t *phMemory;
-    ur_image_info_t *pImgInfoType;
+    ur_image_info_t *ppropName;
     size_t *ppropSize;
-    void **ppImgInfo;
+    void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_mem_image_get_info_params_t;
 
@@ -7944,9 +7944,9 @@ typedef void(UR_APICALL *ur_pfnDeviceGetCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_device_get_info_params_t {
     ur_device_handle_t *phDevice;
-    ur_device_info_t *pinfoType;
+    ur_device_info_t *ppropName;
     size_t *ppropSize;
-    void **ppDeviceInfo;
+    void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_device_get_info_params_t;
 

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -132,22 +132,22 @@ params:
       name: hContext
       desc: "[in] handle of the context"
     - type: $x_context_info_t
-      name: ContextInfoType
+      name: propName
       desc: "[in] type of the info to retrieve"
     - type: "size_t"
       name: propSize
       desc: |
-            [in] the number of bytes of memory pointed to by pContextInfo.
+            [in] the number of bytes of memory pointed to by pPropValue.
     - type: "void*"
-      name: pContextInfo
+      name: pPropValue
       desc: |
             [out][optional] array of bytes holding the info.
             if propSize is not equal to or greater than the real number of bytes needed to return 
-            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pContextInfo is not used.
+            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
-            [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+            [out][optional] pointer to the actual size in bytes of the queried propName.
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Return platform native context handle."

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -371,22 +371,22 @@ params:
       name: hDevice
       desc: "[in] handle of the device instance"
     - type: $x_device_info_t
-      name: infoType
+      name: propName
       desc: "[in] type of the info to retrieve"
     - type: "size_t"
       name: propSize
       desc: |
-            [in] the number of bytes pointed to by pDeviceInfo.
+            [in] the number of bytes pointed to by pPropValue.
     - type: "void*"
-      name: pDeviceInfo
+      name: pPropValue
       desc: |
             [out][optional] array of bytes holding the info.
             If propSize is not equal to or greater than the real number of bytes needed to return the info
-            then the $X_RESULT_ERROR_INVALID_VALUE error is returned and pDeviceInfo is not used.
+            then the $X_RESULT_ERROR_INVALID_VALUE error is returned and pPropValue is not used.
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
-            [out][optional] pointer to the actual size in bytes of the queried infoType.
+            [out][optional] pointer to the actual size in bytes of the queried propName.
 returns:
     - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -158,11 +158,11 @@ params:
       desc: |
             [in] the size of the Kernel property value.           
     - type: "void*"
-      name: pKernelInfo
+      name: pPropValue
       desc: |
             [in,out][optional] array of bytes holding the kernel info property.
             If propSize is not equal to or greater than the real number of bytes needed to return 
-            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pKernelInfo is not used.
+            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
       name: "pPropSizeRet"
       desc: |

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -470,21 +470,21 @@ params:
       name: hMemory
       desc: "[in] handle to the memory object being queried."
     - type: $x_mem_info_t
-      name: MemInfoType
+      name: propName
       desc: "[in] type of the info to retrieve."
     - type: "size_t"
       name: propSize
-      desc: "[in] the number of bytes of memory pointed to by pMemInfo."
+      desc: "[in] the number of bytes of memory pointed to by pPropValue."
     - type: "void*"
-      name: pMemInfo
+      name: pPropValue
       desc: |
             [out][optional] array of bytes holding the info.
             If propSize is less than the real number of bytes needed to return
-            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pMemInfo is not used.
+            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
-            [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+            [out][optional] pointer to the actual size in bytes of the queried propName.
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieve information about an image object."
@@ -501,18 +501,18 @@ params:
       name: hMemory
       desc: "[in] handle to the image object being queried."
     - type: $x_image_info_t
-      name: ImgInfoType
+      name: propName
       desc: "[in] type of image info to retrieve."
     - type: "size_t"
       name: propSize
-      desc: "[in] the number of bytes of memory pointer to by pImgInfo."
+      desc: "[in] the number of bytes of memory pointer to by pPropValue."
     - type: "void*"
-      name: pImgInfo
+      name: pPropValue
       desc: |
             [out][optional] array of bytes holding the info.
             If propSize is less than the real number of bytes needed to return
-            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pImgInfo is not used.
+            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
-            [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+            [out][optional] pointer to the actual size in bytes of the queried propName.

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -347,15 +347,15 @@ params:
       desc: |
             [in] the size of the Program property.
     - type: "void*"
-      name: pProgramInfo
+      name: pPropValue
       desc: |
             [in,out][optional] array of bytes of holding the program info property.
             If propSize is not equal to or greater than the real number of bytes needed to return 
-            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pProgramInfo is not used.
+            the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
       name: "pPropSizeRet"
       desc: |
-            [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+            [out][optional] pointer to the actual size in bytes of the queried propName.
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Program object build status"
@@ -426,7 +426,7 @@ params:
             [in,out][optional] value of the Program build property.
             If propSize is not equal to or greater than the real number of bytes
             needed to return the info then the $X_RESULT_ERROR_INVALID_SIZE
-            error is returned and pKernelInfo is not used.
+            error is returned and pPropValue is not used.
     - type: "size_t*"
       name: pPropSizeRet
       desc: |

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -230,15 +230,15 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 /// @brief Intercept function for urDeviceGetInfo
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -246,7 +246,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     auto pfnGetInfo = d_context.urDdiTable.Device.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result =
-            pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+            pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -487,25 +487,25 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Context.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                            pPropSizeRet);
+        result =
+            pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -743,16 +743,16 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 /// @brief Intercept function for urMemGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+        hMemory,            ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -760,7 +760,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     auto pfnGetInfo = d_context.urDdiTable.Mem.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result =
-            pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+            pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -772,22 +772,22 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 /// @brief Intercept function for urMemImageGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnImageGetInfo = d_context.urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr != pfnImageGetInfo) {
-        result = pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
+        result = pfnImageGetInfo(hMemory, propName, propSize, pPropValue,
                                  pPropSizeRet);
     } else {
         // generic implementation
@@ -1286,21 +1286,21 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Program.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hProgram, propName, propSize, pProgramInfo,
-                            pPropSizeRet);
+        result =
+            pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1320,7 +1320,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         pPropValue, ///< [in,out][optional] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
+    ///< error is returned and pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1480,11 +1480,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
+    ///< pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1495,7 +1495,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     auto pfnGetInfo = d_context.urDdiTable.Kernel.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
         result =
-            pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+            pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -275,15 +275,15 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 /// @brief Intercept function for urDeviceGetInfo
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
 
@@ -291,13 +291,13 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_device_get_info_params_t params = {&hDevice, &infoType, &propSize,
-                                          &pDeviceInfo, &pPropSizeRet};
+    ur_device_get_info_params_t params = {&hDevice, &propName, &propSize,
+                                          &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_DEVICE_GET_INFO,
                                              "urDeviceGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+        pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_DEVICE_GET_INFO, "urDeviceGetInfo", &params,
                        &result, instance);
@@ -593,17 +593,17 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
 
@@ -611,13 +611,13 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_context_get_info_params_t params = {
-        &hContext, &ContextInfoType, &propSize, &pContextInfo, &pPropSizeRet};
+    ur_context_get_info_params_t params = {&hContext, &propName, &propSize,
+                                           &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_CONTEXT_GET_INFO,
                                              "urContextGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hContext, ContextInfoType, propSize,
-                                    pContextInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_CONTEXT_GET_INFO, "urContextGetInfo",
                        &params, &result, instance);
@@ -912,16 +912,16 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 /// @brief Intercept function for urMemGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+        hMemory,            ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
 
@@ -929,13 +929,13 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_get_info_params_t params = {&hMemory, &MemInfoType, &propSize,
-                                       &pMemInfo, &pPropSizeRet};
+    ur_mem_get_info_params_t params = {&hMemory, &propName, &propSize,
+                                       &pPropValue, &pPropSizeRet};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+        pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params,
                        &result, instance);
@@ -947,15 +947,15 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 /// @brief Intercept function for urMemImageGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
 
@@ -963,13 +963,13 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_mem_image_get_info_params_t params = {&hMemory, &ImgInfoType, &propSize,
-                                             &pImgInfo, &pPropSizeRet};
+    ur_mem_image_get_info_params_t params = {&hMemory, &propName, &propSize,
+                                             &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_MEM_IMAGE_GET_INFO,
                                              "urMemImageGetInfo", &params);
 
     ur_result_t result =
-        pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+        pfnImageGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_MEM_IMAGE_GET_INFO, "urMemImageGetInfo",
                        &params, &result, instance);
@@ -1587,13 +1587,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
 
@@ -1602,12 +1602,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     }
 
     ur_program_get_info_params_t params = {&hProgram, &propName, &propSize,
-                                           &pProgramInfo, &pPropSizeRet};
+                                           &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_PROGRAM_GET_INFO,
                                              "urProgramGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+        pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_PROGRAM_GET_INFO, "urProgramGetInfo",
                        &params, &result, instance);
@@ -1627,7 +1627,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         pPropValue, ///< [in,out][optional] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
+    ///< error is returned and pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1830,11 +1830,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
+    ///< pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1846,12 +1846,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     }
 
     ur_kernel_get_info_params_t params = {&hKernel, &propName, &propSize,
-                                          &pKernelInfo, &pPropSizeRet};
+                                          &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_KERNEL_GET_INFO,
                                              "urKernelGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+        pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_KERNEL_GET_INFO, "urKernelGetInfo", &params,
                        &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -283,15 +283,15 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 /// @brief Intercept function for urDeviceGetInfo
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Device.pfnGetInfo;
 
@@ -304,13 +304,13 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < infoType) {
+        if (UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
 
     ur_result_t result =
-        pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+        pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -639,17 +639,17 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Context.pfnGetInfo;
 
@@ -662,13 +662,13 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < ContextInfoType) {
+        if (UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
 
-    ur_result_t result = pfnGetInfo(hContext, ContextInfoType, propSize,
-                                    pContextInfo, pPropSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1050,16 +1050,16 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 /// @brief Intercept function for urMemGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+        hMemory,            ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Mem.pfnGetInfo;
 
@@ -1072,13 +1072,13 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (UR_MEM_INFO_CONTEXT < MemInfoType) {
+        if (UR_MEM_INFO_CONTEXT < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
 
     ur_result_t result =
-        pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+        pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1087,15 +1087,15 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 /// @brief Intercept function for urMemImageGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnImageGetInfo = context.urDdiTable.Mem.pfnImageGetInfo;
 
@@ -1108,13 +1108,13 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (UR_IMAGE_INFO_DEPTH < ImgInfoType) {
+        if (UR_IMAGE_INFO_DEPTH < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
 
     ur_result_t result =
-        pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+        pfnImageGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1909,13 +1909,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = context.urDdiTable.Program.pfnGetInfo;
 
@@ -1934,7 +1934,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     }
 
     ur_result_t result =
-        pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+        pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1951,7 +1951,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         pPropValue, ///< [in,out][optional] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
+    ///< error is returned and pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2185,11 +2185,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
+    ///< pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2211,7 +2211,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     }
 
     ur_result_t result =
-        pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+        pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -354,15 +354,15 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 /// @brief Intercept function for urDeviceGetInfo
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -377,7 +377,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+    result = pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -716,17 +716,17 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
 __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -741,8 +741,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                        pPropSizeRet);
+    result = pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1107,16 +1106,16 @@ __urdlllocal ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 /// @brief Intercept function for urMemGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+        hMemory,            ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1131,7 +1130,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     hMemory = reinterpret_cast<ur_mem_object_t *>(hMemory)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+    result = pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1140,15 +1139,15 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 /// @brief Intercept function for urMemImageGetInfo
 __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1164,7 +1163,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
     // forward to device-platform
     result =
-        pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo, pPropSizeRet);
+        pfnImageGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1885,13 +1884,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1906,8 +1905,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+    result = pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1924,7 +1922,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         pPropValue, ///< [in,out][optional] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
+    ///< error is returned and pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2159,11 +2157,11 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
+    ///< pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2181,7 +2179,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+    result = pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -359,26 +359,26 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < infoType`
+///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Device.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hDevice, infoType, propSize, pDeviceInfo, pPropSizeRet);
+    return pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -763,27 +763,26 @@ ur_result_t UR_APICALL urContextRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < ContextInfoType`
+///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < propName`
 ur_result_t UR_APICALL urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Context.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hContext, ContextInfoType, propSize, pContextInfo,
-                      pPropSizeRet);
+    return pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1172,26 +1171,26 @@ ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
+///         + `::UR_MEM_INFO_CONTEXT < propName`
 ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+        hMemory,            ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Mem.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hMemory, MemInfoType, propSize, pMemInfo, pPropSizeRet);
+    return pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1211,25 +1210,25 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
+///         + `::UR_IMAGE_INFO_DEPTH < propName`
 ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnImageGetInfo = ur_lib::context->urDdiTable.Mem.pfnImageGetInfo;
     if (nullptr == pfnImageGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageGetInfo(hMemory, ImgInfoType, propSize, pImgInfo,
+    return pfnImageGetInfo(hMemory, propName, propSize, pPropValue,
                            pPropSizeRet);
 }
 
@@ -2065,20 +2064,20 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Program.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hProgram, propName, propSize, pProgramInfo, pPropSizeRet);
+    return pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2107,7 +2106,7 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
         pPropValue, ///< [in,out][optional] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
+    ///< error is returned and pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2342,11 +2341,11 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
+    ///< pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2356,7 +2355,7 @@ ur_result_t UR_APICALL urKernelGetInfo(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hKernel, propName, propSize, pKernelInfo, pPropSizeRet);
+    return pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -307,19 +307,19 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < infoType`
+///         + `::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
-    ur_device_info_t infoType,  ///< [in] type of the info to retrieve
-    size_t propSize,   ///< [in] the number of bytes pointed to by pDeviceInfo.
-    void *pDeviceInfo, ///< [out][optional] array of bytes holding the info.
+    ur_device_info_t propName,  ///< [in] type of the info to retrieve
+    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
-    ///< pDeviceInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried infoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -663,19 +663,19 @@ ur_result_t UR_APICALL urContextRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < ContextInfoType`
+///         + `::UR_CONTEXT_INFO_USM_FILL2D_SUPPORT < propName`
 ur_result_t UR_APICALL urContextGetInfo(
-    ur_context_handle_t hContext,      ///< [in] handle of the context
-    ur_context_info_t ContextInfoType, ///< [in] type of the info to retrieve
+    ur_context_handle_t hContext, ///< [in] handle of the context
+    ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pContextInfo.
-    void *pContextInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pContextInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by ContextInfoType.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1020,19 +1020,19 @@ ur_result_t UR_APICALL urMemCreateWithNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_MEM_INFO_CONTEXT < MemInfoType`
+///         + `::UR_MEM_INFO_CONTEXT < propName`
 ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
-        hMemory, ///< [in] handle to the memory object being queried.
-    ur_mem_info_t MemInfoType, ///< [in] type of the info to retrieve.
+        hMemory,            ///< [in] handle to the memory object being queried.
+    ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointed to by pMemInfo.
-    void *pMemInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pMemInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pMemInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1055,18 +1055,18 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < ImgInfoType`
+///         + `::UR_IMAGE_INFO_DEPTH < propName`
 ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
-    ur_image_info_t ImgInfoType, ///< [in] type of image info to retrieve.
+    ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
-        propSize, ///< [in] the number of bytes of memory pointer to by pImgInfo.
-    void *pImgInfo, ///< [out][optional] array of bytes holding the info.
+        propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
+    void *pPropValue, ///< [out][optional] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pImgInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data queried by pImgInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1811,13 +1811,13 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pProgramInfo, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pProgramInfo is not used.
+    ///< pPropValue is not used.
     size_t *
-        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data copied to pProgramInfo.
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of the queried propName.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1849,7 +1849,7 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
         pPropValue, ///< [in,out][optional] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
-    ///< error is returned and pKernelInfo is not used.
+    ///< error is returned and pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2052,11 +2052,11 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pKernelInfo, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
-    ///< pKernelInfo is not used.
+    ///< pPropValue is not used.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.


### PR DESCRIPTION
The names of properties-related (e.g., device info, context info, and similar) arguments in functions are all over the place. This makes it guesswork for developers to correctly use these APIs, but, maybe more importantly, it means it's impossible to programmatically find all property-related variables in mako templates.