### PR TITLE
Add validation backtrace libbacktrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(UR_USE_UBSAN "enable UndefinedBehaviorSanitizer" OFF)
 option(UR_USE_MSAN "enable MemorySanitizer" OFF)
 option(UMA_BUILD_SHARED_LIBRARY "Build UMA as shared library" OFF)
 option(UR_ENABLE_TRACING "enable api tracing through xpti" OFF)
+option(VAL_USE_LIBBACKTRACE_BACKTRACE "enable libbacktrace validation backtrace for linux" OFF)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/cmake/FindLibbacktrace.cmake
+++ b/cmake/FindLibbacktrace.cmake
@@ -1,0 +1,25 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+#
+# FindLIBBACKTRACE.cmake -- module searching for libbacktrace library.
+#                           LIBBACKTRACE_FOUND is set to true if libbacktrace is found.
+#
+
+find_library(LIBBACKTRACE_LIBRARIES NAMES backtrace)
+find_path(LIBBACKTRACE_INCLUDE_DIR NAMES backtrace.h)
+
+if (LIBBACKTRACE_LIBRARIES AND LIBBACKTRACE_INCLUDE_DIR)
+    set(LIBBACKTRACE_FOUND TRUE)
+endif()
+
+if (LIBBACKTRACE_FOUND)
+    add_library(Libbacktrace INTERFACE IMPORTED)
+    set_target_properties(Libbacktrace PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${LIBBACKTRACE_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES "${LIBBACKTRACE_LIBRARIES}"
+    )
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libbacktrace DEFAULT_MSG LIBBACKTRACE_LIBRARIES LIBBACKTRACE_INCLUDE_DIR)

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -49,7 +49,7 @@ if (UNIX)
 endif()
 
 if(WIN32)
-    target_link_libraries(loader PRIVATE cfgmgr32.lib dbghelp)
+    target_link_libraries(loader PRIVATE cfgmgr32.lib)
 endif()
 
 if(UNIX)
@@ -90,18 +90,39 @@ if(UR_ENABLE_TRACING)
     )
 endif()
 
+
+# link validation backtrace dependencies
+find_package(Libbacktrace)
+if (VAL_USE_LIBBACKTRACE_BACKTRACE AND LIBBACKTRACE_FOUND AND UNIX)
+    message(STATUS "Using libbacktrace backtrace for validation")
+
+    target_sources(loader PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_libbacktrace.cpp)
+    target_link_libraries(loader PRIVATE Libbacktrace)
+else()
+    message(STATUS "Using default backtrace for validation")
+
+    if(WIN32)
+        target_sources(loader PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_win.cpp)
+        target_link_libraries(loader PRIVATE dbghelp)
+    else()
+        target_sources(loader PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_lin.cpp)
+    endif()
+endif()
+
 if(WIN32)
     target_sources(loader
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/windows/lib_init.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/windows/loader_init.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_win.cpp
+
     )
 else()
     target_sources(loader
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/linux/lib_init.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/linux/loader_init.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/backtrace_lin.cpp
     )
 endif()

--- a/source/loader/layers/validation/backtrace_libbacktrace.cpp
+++ b/source/loader/layers/validation/backtrace_libbacktrace.cpp
@@ -14,6 +14,18 @@
 
 namespace validation_layer {
 
+void filter_after_occurence(std::vector<BacktraceLine> &backtrace,
+                            std::string substring) {
+    auto it = std::find_if(backtrace.begin(), backtrace.end(),
+                           [&substring](const std::string &s) {
+                               return s.find(substring) != std::string::npos;
+                           });
+
+    if (it != backtrace.end()) {
+        backtrace.erase(backtrace.begin(), it);
+    }
+}
+
 int backtrace_cb(void *data, uintptr_t pc, const char *filename, int lineno,
                  const char *function) {
     if (filename == NULL && function == NULL) {
@@ -56,17 +68,19 @@ int backtrace_cb(void *data, uintptr_t pc, const char *filename, int lineno,
     return 0;
 }
 
-std::vector<std::string> getCurrentBacktrace() {
+std::vector<BacktraceLine> getCurrentBacktrace() {
     backtrace_state *state = backtrace_create_state(NULL, 0, NULL, NULL);
     if (state == NULL) {
         return std::vector<std::string>(1, "Failed to acquire a backtrace");
     }
 
-    std::vector<std::string> backtrace;
+    std::vector<BacktraceLine> backtrace;
     backtrace_full(state, 0, backtrace_cb, NULL, &backtrace);
     if (backtrace.empty()) {
         return std::vector<std::string>(1, "Failed to acquire a backtrace");
     }
+
+    filter_after_occurence(backtrace, "ur_libapi.cpp");
 
     return backtrace;
 }

--- a/source/loader/layers/validation/backtrace_libbacktrace.cpp
+++ b/source/loader/layers/validation/backtrace_libbacktrace.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+#include "backtrace.hpp"
+
+#include <backtrace.h>
+#include <cxxabi.h>
+#include <limits.h>
+#include <vector>
+
+namespace validation_layer {
+
+int backtrace_cb(void *data, uintptr_t pc, const char *filename, int lineno,
+                 const char *function) {
+    if (filename == NULL && function == NULL) {
+        return 0;
+    }
+
+    std::stringstream backtraceLine;
+    backtraceLine << "0x" << std::hex << pc << " in ";
+
+    int status;
+    char *demangled = abi::__cxa_demangle(function, NULL, NULL, &status);
+    if (status == 0) {
+        backtraceLine << "(" << demangled << ") ";
+    } else if (function != NULL) {
+        backtraceLine << "(" << function << ") ";
+    } else {
+        backtraceLine << "(????????) ";
+    }
+
+    char filepath[PATH_MAX];
+    if (realpath(filename, filepath) != NULL) {
+        backtraceLine << "(" << filepath << ":" << std::dec << lineno << ")";
+    } else {
+        backtraceLine << "(????????)";
+    }
+
+    std::vector<std::string> *backtrace =
+        reinterpret_cast<std::vector<std::string> *>(data);
+    try {
+        if (backtraceLine.str().empty()) {
+            backtrace->push_back("????????");
+        } else {
+            backtrace->push_back(backtraceLine.str());
+        }
+    } catch (std::bad_alloc &) {
+    }
+
+    free(demangled);
+
+    return 0;
+}
+
+std::vector<std::string> getCurrentBacktrace() {
+    backtrace_state *state = backtrace_create_state(NULL, 0, NULL, NULL);
+    if (state == NULL) {
+        return std::vector<std::string>(1, "Failed to acquire a backtrace");
+    }
+
+    std::vector<std::string> backtrace;
+    backtrace_full(state, 0, backtrace_cb, NULL, &backtrace);
+    if (backtrace.empty()) {
+        return std::vector<std::string>(1, "Failed to acquire a backtrace");
+    }
+
+    return backtrace;
+}
+
+} // namespace validation_layer

--- a/source/loader/layers/validation/ur_leak_check.hpp
+++ b/source/loader/layers/validation/ur_leak_check.hpp
@@ -95,7 +95,8 @@ struct RefCountContext {
             context.logger.error("Handle {} was recorded for first time here:",
                                  ptr);
             for (size_t i = 0; i < refRuntimeInfo.backtrace.size(); i++) {
-                context.logger.error(refRuntimeInfo.backtrace[i].c_str());
+                context.logger.error("#{} {}", i,
+                                     refRuntimeInfo.backtrace[i].c_str());
             }
         }
     }


### PR DESCRIPTION
Libbacktrace backtrace can be enabled using cmake option `VAL_USE_LIBBACKTRACE_BACKTRACE`, it is set to OFF by default.

Addresses: https://github.com/oneapi-src/unified-runtime/issues/368
Supersedes: https://github.com/oneapi-src/unified-runtime/pull/388

An example output from backtrace implementation using libbacktrace looks like this:

```
<VALIDATION>[ERROR]: #0 0x7fb0800bbf37 in (urContextRelease) (/home/kswiecic/dev/sycl_workspace/unified-runtime/source/loader/ur_libapi.cpp:745)
<VALIDATION>[ERROR]: #1 0x55d4bacd942f in (valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1::operator()() const) (/home/kswiecic/dev/sycl_workspace/unified-runtime/test/layers/validation/leaks_mt.cpp:40)
<VALIDATION>[ERROR]: #2 0x55d4bacd92ac in (void std::__invoke_impl<void, valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1>(std::__invoke_other, valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1&&)) (/usr/include/c++/11/bits/invoke.h:61)
<VALIDATION>[ERROR]: #3 0x55d4bacd923c in (std::__invoke_result<valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1>::type std::__invoke<valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1>(valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1&&)) (/usr/include/c++/11/bits/invoke.h:96)
<VALIDATION>[ERROR]: #4 0x55d4bacd9214 in (void std::thread::_Invoker<std::tuple<valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1> >::_M_invoke<0ul>(std::_Index_tuple<0ul>)) (/usr/include/c++/11/bits/std_thread.h:253)
<VALIDATION>[ERROR]: #5 0x55d4bacd91e4 in (std::thread::_Invoker<std::tuple<valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1> >::operator()()) (/usr/include/c++/11/bits/std_thread.h:260)
<VALIDATION>[ERROR]: #6 0x55d4bacd9148 in (std::thread::_State_impl<std::thread::_Invoker<std::tuple<valDeviceTestMultithreaded_testUrContextReleaseLeakMt_Test::TestBody()::$_1> > >::_M_run()) (/usr/include/c++/11/bits/std_thread.h:211)
<VALIDATION>[ERROR]: #7 0x7fb07fb4fb42 in (start_thread) (????????)
<VALIDATION>[ERROR]: #8 0x7fb07fbe19ff in (????????) (????????)
```