### PR TITLE
[UR] Generate a bit mask for `flags_t` parameter validation

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -219,6 +219,7 @@ typedef enum ur_result_t {
     /// @endcond
 
 } ur_result_t;
+#define UR_RESULT_MAX_VALUE UR_RESULT_ERROR_UNKNOWN
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
@@ -242,6 +243,7 @@ typedef enum ur_structure_type_t {
     /// @endcond
 
 } ur_structure_type_t;
+#define UR_STRUCTURE_TYPE_MAX_VALUE UR_STRUCTURE_TYPE_SAMPLER_DESC
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Base for all properties types
@@ -298,6 +300,7 @@ typedef enum ur_device_init_flag_t {
     /// @endcond
 
 } ur_device_init_flag_t;
+#define UR_DEVICE_INIT_FLAGS_MAX_VALUE 0x1f
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' driver(s)
@@ -399,6 +402,7 @@ typedef enum ur_platform_info_t {
     /// @endcond
 
 } ur_platform_info_t;
+#define UR_PLATFORM_INFO_MAX_VALUE UR_PLATFORM_INFO_PROFILE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about platform
@@ -445,6 +449,7 @@ typedef enum ur_api_version_t {
     /// @endcond
 
 } ur_api_version_t;
+#define UR_API_VERSION_MAX_VALUE UR_API_VERSION_CURRENT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Returns the API version supported by the specified platform
@@ -642,6 +647,7 @@ typedef enum ur_device_type_t {
     /// @endcond
 
 } ur_device_type_t;
+#define UR_DEVICE_TYPE_MAX_VALUE UR_DEVICE_TYPE_VPU
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves devices within a platform
@@ -815,6 +821,7 @@ typedef enum ur_device_info_t {
     /// @endcond
 
 } ur_device_info_t;
+#define UR_DEVICE_INFO_MAX_VALUE UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about device
@@ -915,6 +922,7 @@ typedef enum ur_device_partition_t {
     /// @endcond
 
 } ur_device_partition_t;
+#define UR_DEVICE_PARTITION_MAX_VALUE UR_DEVICE_PARTITION_BY_CSLICE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition the device into sub-devices
@@ -1007,6 +1015,7 @@ typedef enum ur_device_fp_capability_flag_t {
     /// @endcond
 
 } ur_device_fp_capability_flag_t;
+#define UR_DEVICE_FP_CAPABILITY_FLAGS_MAX_VALUE 0xff
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device memory cache type
@@ -1019,6 +1028,7 @@ typedef enum ur_device_mem_cache_type_t {
     /// @endcond
 
 } ur_device_mem_cache_type_t;
+#define UR_DEVICE_MEM_CACHE_TYPE_MAX_VALUE UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device local memory type
@@ -1031,6 +1041,7 @@ typedef enum ur_device_local_mem_type_t {
     /// @endcond
 
 } ur_device_local_mem_type_t;
+#define UR_DEVICE_LOCAL_MEM_TYPE_MAX_VALUE UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device kernel execution capability
@@ -1043,6 +1054,7 @@ typedef enum ur_device_exec_capability_flag_t {
     /// @endcond
 
 } ur_device_exec_capability_flag_t;
+#define UR_DEVICE_EXEC_CAPABILITY_FLAGS_MAX_VALUE 0x3
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device affinity domain
@@ -1055,6 +1067,7 @@ typedef enum ur_device_affinity_domain_flag_t {
     /// @endcond
 
 } ur_device_affinity_domain_flag_t;
+#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MAX_VALUE 0x3
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native device handle.
@@ -1148,6 +1161,7 @@ typedef enum ur_memory_order_capability_flag_t {
     /// @endcond
 
 } ur_memory_order_capability_flag_t;
+#define UR_MEMORY_ORDER_CAPABILITY_FLAGS_MAX_VALUE 0x1f
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory scope capabilities
@@ -1163,6 +1177,7 @@ typedef enum ur_memory_scope_capability_flag_t {
     /// @endcond
 
 } ur_memory_scope_capability_flag_t;
+#define UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MAX_VALUE 0x1f
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -1181,6 +1196,7 @@ typedef enum ur_context_flag_t {
     /// @endcond
 
 } ur_context_flag_t;
+#define UR_CONTEXT_FLAGS_MAX_VALUE 0x1
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Context creation properties
@@ -1272,6 +1288,7 @@ typedef enum ur_context_info_t {
     /// @endcond
 
 } ur_context_info_t;
+#define UR_CONTEXT_INFO_MAX_VALUE UR_CONTEXT_INFO_USM_FILL2D_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Releases the context handle reference indicating end of its usage
@@ -1435,6 +1452,7 @@ typedef enum ur_mem_flag_t {
     /// @endcond
 
 } ur_mem_flag_t;
+#define UR_MEM_FLAGS_MAX_VALUE 0x3f
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory types
@@ -1451,6 +1469,7 @@ typedef enum ur_mem_type_t {
     /// @endcond
 
 } ur_mem_type_t;
+#define UR_MEM_TYPE_MAX_VALUE UR_MEM_TYPE_IMAGE1D_BUFFER
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory Information type
@@ -1462,6 +1481,7 @@ typedef enum ur_mem_info_t {
     /// @endcond
 
 } ur_mem_info_t;
+#define UR_MEM_INFO_MAX_VALUE UR_MEM_INFO_CONTEXT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel order info: number of channels and the channel layout
@@ -1486,6 +1506,7 @@ typedef enum ur_image_channel_order_t {
     /// @endcond
 
 } ur_image_channel_order_t;
+#define UR_IMAGE_CHANNEL_ORDER_MAX_VALUE UR_IMAGE_CHANNEL_ORDER_SRGBA
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel type info: describe the size of the channel data type
@@ -1510,6 +1531,7 @@ typedef enum ur_image_channel_type_t {
     /// @endcond
 
 } ur_image_channel_type_t;
+#define UR_IMAGE_CHANNEL_TYPE_MAX_VALUE UR_IMAGE_CHANNEL_TYPE_FLOAT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image information types
@@ -1526,6 +1548,7 @@ typedef enum ur_image_info_t {
     /// @endcond
 
 } ur_image_info_t;
+#define UR_IMAGE_INFO_MAX_VALUE UR_IMAGE_INFO_DEPTH
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image format including channel layout and data type
@@ -1744,6 +1767,7 @@ typedef enum ur_buffer_create_type_t {
     /// @endcond
 
 } ur_buffer_create_type_t;
+#define UR_BUFFER_CREATE_TYPE_MAX_VALUE UR_BUFFER_CREATE_TYPE_REGION
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sub buffer representing a region in an existing buffer
@@ -1908,6 +1932,7 @@ typedef enum ur_sampler_filter_mode_t {
     /// @endcond
 
 } ur_sampler_filter_mode_t;
+#define UR_SAMPLER_FILTER_MODE_MAX_VALUE UR_SAMPLER_FILTER_MODE_LINEAR
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler addressing mode
@@ -1922,6 +1947,7 @@ typedef enum ur_sampler_addressing_mode_t {
     /// @endcond
 
 } ur_sampler_addressing_mode_t;
+#define UR_SAMPLER_ADDRESSING_MODE_MAX_VALUE UR_SAMPLER_ADDRESSING_MODE_NONE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get sample object information
@@ -1939,6 +1965,7 @@ typedef enum ur_sampler_info_t {
     /// @endcond
 
 } ur_sampler_info_t;
+#define UR_SAMPLER_INFO_MAX_VALUE UR_SAMPLER_INFO_FILTER_MODE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler description.
@@ -2132,6 +2159,7 @@ typedef enum ur_usm_flag_t {
     /// @endcond
 
 } ur_usm_flag_t;
+#define UR_USM_FLAGS_MAX_VALUE 0x3
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM host memory property flags
@@ -2143,6 +2171,7 @@ typedef enum ur_usm_host_mem_flag_t {
     /// @endcond
 
 } ur_usm_host_mem_flag_t;
+#define UR_USM_HOST_MEM_FLAGS_MAX_VALUE 0x1
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM device memory property flags
@@ -2157,6 +2186,7 @@ typedef enum ur_usm_device_mem_flag_t {
     /// @endcond
 
 } ur_usm_device_mem_flag_t;
+#define UR_USM_DEVICE_MEM_FLAGS_MAX_VALUE 0x7
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory property flags
@@ -2169,6 +2199,7 @@ typedef enum ur_usm_pool_flag_t {
     /// @endcond
 
 } ur_usm_pool_flag_t;
+#define UR_USM_POOL_FLAGS_MAX_VALUE 0x1
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocation type
@@ -2182,6 +2213,7 @@ typedef enum ur_usm_type_t {
     /// @endcond
 
 } ur_usm_type_t;
+#define UR_USM_TYPE_MAX_VALUE UR_USM_TYPE_SHARED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory allocation information type
@@ -2196,6 +2228,7 @@ typedef enum ur_usm_alloc_info_t {
     /// @endcond
 
 } ur_usm_alloc_info_t;
+#define UR_USM_ALLOC_INFO_MAX_VALUE UR_USM_ALLOC_INFO_POOL
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory advice
@@ -2214,7 +2247,8 @@ typedef enum ur_usm_advice_flag_t {
     UR_USM_ADVICE_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
-} ur_usm_advice_flag_t;
+} ur_usm_advice_t;
+#define UR_USM_ADVICE_MAX_VALUE UR_USM_ADVICE_BIAS_UNCACHED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of USM pool
@@ -2515,6 +2549,7 @@ typedef enum ur_program_metadata_type_t {
     /// @endcond
 
 } ur_program_metadata_type_t;
+#define UR_PROGRAM_METADATA_TYPE_MAX_VALUE UR_PROGRAM_METADATA_TYPE_STRING
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program metadata value union.
@@ -2830,6 +2865,7 @@ typedef enum ur_program_info_t {
     /// @endcond
 
 } ur_program_info_t;
+#define UR_PROGRAM_INFO_MAX_VALUE UR_PROGRAM_INFO_KERNEL_NAMES
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Program object
@@ -2871,6 +2907,7 @@ typedef enum ur_program_build_status_t {
     /// @endcond
 
 } ur_program_build_status_t;
+#define UR_PROGRAM_BUILD_STATUS_MAX_VALUE UR_PROGRAM_BUILD_STATUS_IN_PROGRESS
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program object binary type
@@ -2884,6 +2921,7 @@ typedef enum ur_program_binary_type_t {
     /// @endcond
 
 } ur_program_binary_type_t;
+#define UR_PROGRAM_BINARY_TYPE_MAX_VALUE UR_PROGRAM_BINARY_TYPE_EXECUTABLE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object build information
@@ -2898,6 +2936,7 @@ typedef enum ur_program_build_info_t {
     /// @endcond
 
 } ur_program_build_info_t;
+#define UR_PROGRAM_BUILD_INFO_MAX_VALUE UR_PROGRAM_BUILD_INFO_BINARY_TYPE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query build information about a Program object for a Device
@@ -3117,6 +3156,7 @@ typedef enum ur_kernel_info_t {
     /// @endcond
 
 } ur_kernel_info_t;
+#define UR_KERNEL_INFO_MAX_VALUE UR_KERNEL_INFO_ATTRIBUTES
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel Work Group information
@@ -3135,6 +3175,7 @@ typedef enum ur_kernel_group_info_t {
     /// @endcond
 
 } ur_kernel_group_info_t;
+#define UR_KERNEL_GROUP_INFO_MAX_VALUE UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel SubGroup information
@@ -3149,6 +3190,7 @@ typedef enum ur_kernel_sub_group_info_t {
     /// @endcond
 
 } ur_kernel_sub_group_info_t;
+#define UR_KERNEL_SUB_GROUP_INFO_MAX_VALUE UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set additional Kernel execution information
@@ -3161,6 +3203,7 @@ typedef enum ur_kernel_exec_info_t {
     /// @endcond
 
 } ur_kernel_exec_info_t;
+#define UR_KERNEL_EXEC_INFO_MAX_VALUE UR_KERNEL_EXEC_INFO_USM_PTRS
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Kernel object
@@ -3508,6 +3551,7 @@ typedef enum ur_queue_info_t {
     /// @endcond
 
 } ur_queue_info_t;
+#define UR_QUEUE_INFO_MAX_VALUE UR_QUEUE_INFO_SIZE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue property flags
@@ -3525,6 +3569,7 @@ typedef enum ur_queue_flag_t {
     /// @endcond
 
 } ur_queue_flag_t;
+#define UR_QUEUE_FLAGS_MAX_VALUE 0x7f
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue property type
@@ -3540,6 +3585,7 @@ typedef enum ur_queue_properties_t {
     /// @endcond
 
 } ur_queue_properties_t;
+#define UR_QUEUE_PROPERTIES_MAX_VALUE UR_QUEUE_PROPERTIES_COMPUTE_INDEX
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
@@ -3802,6 +3848,7 @@ typedef enum ur_command_t {
     /// @endcond
 
 } ur_command_t;
+#define UR_COMMAND_MAX_VALUE UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event Status
@@ -3815,6 +3862,7 @@ typedef enum ur_event_status_t {
     /// @endcond
 
 } ur_event_status_t;
+#define UR_EVENT_STATUS_MAX_VALUE UR_EVENT_STATUS_QUEUED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event query information type
@@ -3832,6 +3880,7 @@ typedef enum ur_event_info_t {
     /// @endcond
 
 } ur_event_info_t;
+#define UR_EVENT_INFO_MAX_VALUE UR_EVENT_INFO_REFERENCE_COUNT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Profiling query information type
@@ -3849,6 +3898,7 @@ typedef enum ur_profiling_info_t {
     /// @endcond
 
 } ur_profiling_info_t;
+#define UR_PROFILING_INFO_MAX_VALUE UR_PROFILING_INFO_COMMAND_END
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
@@ -4044,6 +4094,7 @@ typedef enum ur_execution_info_t {
     /// @endcond
 
 } ur_execution_info_t;
+#define UR_EXECUTION_INFO_MAX_VALUE UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event callback function that can be registered by the application.
@@ -4211,6 +4262,7 @@ typedef enum ur_function_t {
     /// @endcond
 
 } ur_function_t;
+#define UR_FUNCTION_MAX_VALUE UR_FUNCTION_USM_POOL_DESTROY
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -4884,6 +4936,7 @@ typedef enum ur_map_flag_t {
     /// @endcond
 
 } ur_map_flag_t;
+#define UR_MAP_FLAGS_MAX_VALUE 0x3
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map flags
@@ -4895,6 +4948,7 @@ typedef enum ur_usm_migration_flag_t {
     /// @endcond
 
 } ur_usm_migration_flag_t;
+#define UR_USM_MIGRATION_FLAGS_MAX_VALUE 0x1
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to map a region of the buffer object into the host

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -298,7 +298,7 @@ typedef enum ur_device_init_flag_t {
     /// @endcond
 
 } ur_device_init_flag_t;
-#define UR_DEVICE_INIT_FLAGS_MAX_VALUE 0x1f
+#define UR_DEVICE_INIT_FLAGS_MASK 0xffffffe0
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' driver(s)
@@ -322,7 +322,7 @@ typedef enum ur_device_init_flag_t {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1f < device_flags`
+///         + `0xffffffe0 & device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urInit(
@@ -1008,7 +1008,7 @@ typedef enum ur_device_fp_capability_flag_t {
     /// @endcond
 
 } ur_device_fp_capability_flag_t;
-#define UR_DEVICE_FP_CAPABILITY_FLAGS_MAX_VALUE 0xff
+#define UR_DEVICE_FP_CAPABILITY_FLAGS_MASK 0xffffff00
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device memory cache type
@@ -1045,7 +1045,7 @@ typedef enum ur_device_exec_capability_flag_t {
     /// @endcond
 
 } ur_device_exec_capability_flag_t;
-#define UR_DEVICE_EXEC_CAPABILITY_FLAGS_MAX_VALUE 0x3
+#define UR_DEVICE_EXEC_CAPABILITY_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device affinity domain
@@ -1058,7 +1058,7 @@ typedef enum ur_device_affinity_domain_flag_t {
     /// @endcond
 
 } ur_device_affinity_domain_flag_t;
-#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MAX_VALUE 0x3
+#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native device handle.
@@ -1152,7 +1152,7 @@ typedef enum ur_memory_order_capability_flag_t {
     /// @endcond
 
 } ur_memory_order_capability_flag_t;
-#define UR_MEMORY_ORDER_CAPABILITY_FLAGS_MAX_VALUE 0x1f
+#define UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK 0xffffffe0
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory scope capabilities
@@ -1168,7 +1168,7 @@ typedef enum ur_memory_scope_capability_flag_t {
     /// @endcond
 
 } ur_memory_scope_capability_flag_t;
-#define UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MAX_VALUE 0x1f
+#define UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK 0xffffffe0
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -1187,7 +1187,7 @@ typedef enum ur_context_flag_t {
     /// @endcond
 
 } ur_context_flag_t;
-#define UR_CONTEXT_FLAGS_MAX_VALUE 0x1
+#define UR_CONTEXT_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Context creation properties
@@ -1442,7 +1442,7 @@ typedef enum ur_mem_flag_t {
     /// @endcond
 
 } ur_mem_flag_t;
-#define UR_MEM_FLAGS_MAX_VALUE 0x3f
+#define UR_MEM_FLAGS_MASK 0xffffffc0
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory types
@@ -1574,7 +1574,7 @@ typedef struct ur_image_desc_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///         + `::UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -1665,7 +1665,7 @@ typedef struct ur_buffer_alloc_location_properties_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -1767,7 +1767,7 @@ typedef enum ur_buffer_create_type_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pRegion`
@@ -2140,7 +2140,7 @@ typedef enum ur_usm_flag_t {
     /// @endcond
 
 } ur_usm_flag_t;
-#define UR_USM_FLAGS_MAX_VALUE 0x3
+#define UR_USM_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM host memory property flags
@@ -2152,7 +2152,7 @@ typedef enum ur_usm_host_mem_flag_t {
     /// @endcond
 
 } ur_usm_host_mem_flag_t;
-#define UR_USM_HOST_MEM_FLAGS_MAX_VALUE 0x1
+#define UR_USM_HOST_MEM_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM device memory property flags
@@ -2167,7 +2167,7 @@ typedef enum ur_usm_device_mem_flag_t {
     /// @endcond
 
 } ur_usm_device_mem_flag_t;
-#define UR_USM_DEVICE_MEM_FLAGS_MAX_VALUE 0x7
+#define UR_USM_DEVICE_MEM_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory property flags
@@ -2180,7 +2180,7 @@ typedef enum ur_usm_pool_flag_t {
     /// @endcond
 
 } ur_usm_pool_flag_t;
-#define UR_USM_POOL_FLAGS_MAX_VALUE 0x1
+#define UR_USM_POOL_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocation type
@@ -2475,7 +2475,7 @@ urUSMGetMemAllocInfo(
 ///         + `NULL == pPoolDesc`
 ///         + `NULL == ppPool`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < pPoolDesc->flags`
+///         + `0xfffffffe & pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -3537,7 +3537,7 @@ typedef enum ur_queue_flag_t {
     /// @endcond
 
 } ur_queue_flag_t;
-#define UR_QUEUE_FLAGS_MAX_VALUE 0x7f
+#define UR_QUEUE_FLAGS_MASK 0xffffff80
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue property type
@@ -4897,7 +4897,7 @@ typedef enum ur_map_flag_t {
     /// @endcond
 
 } ur_map_flag_t;
-#define UR_MAP_FLAGS_MAX_VALUE 0x3
+#define UR_MAP_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map flags
@@ -4909,7 +4909,7 @@ typedef enum ur_usm_migration_flag_t {
     /// @endcond
 
 } ur_usm_migration_flag_t;
-#define UR_USM_MIGRATION_FLAGS_MAX_VALUE 0x1
+#define UR_USM_MIGRATION_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to map a region of the buffer object into the host
@@ -4934,7 +4934,7 @@ typedef enum ur_usm_migration_flag_t {
 ///         + `NULL == hQueue`
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3 < mapFlags`
+///         + `0xfffffffc & mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -5104,7 +5104,7 @@ urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < flags`
+///         + `0xfffffffe & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -219,7 +219,6 @@ typedef enum ur_result_t {
     /// @endcond
 
 } ur_result_t;
-#define UR_RESULT_MAX_VALUE UR_RESULT_ERROR_UNKNOWN
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
@@ -243,7 +242,6 @@ typedef enum ur_structure_type_t {
     /// @endcond
 
 } ur_structure_type_t;
-#define UR_STRUCTURE_TYPE_MAX_VALUE UR_STRUCTURE_TYPE_SAMPLER_DESC
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Base for all properties types
@@ -402,7 +400,6 @@ typedef enum ur_platform_info_t {
     /// @endcond
 
 } ur_platform_info_t;
-#define UR_PLATFORM_INFO_MAX_VALUE UR_PLATFORM_INFO_PROFILE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about platform
@@ -449,7 +446,6 @@ typedef enum ur_api_version_t {
     /// @endcond
 
 } ur_api_version_t;
-#define UR_API_VERSION_MAX_VALUE UR_API_VERSION_CURRENT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Returns the API version supported by the specified platform
@@ -647,7 +643,6 @@ typedef enum ur_device_type_t {
     /// @endcond
 
 } ur_device_type_t;
-#define UR_DEVICE_TYPE_MAX_VALUE UR_DEVICE_TYPE_VPU
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves devices within a platform
@@ -821,7 +816,6 @@ typedef enum ur_device_info_t {
     /// @endcond
 
 } ur_device_info_t;
-#define UR_DEVICE_INFO_MAX_VALUE UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves various information about device
@@ -922,7 +916,6 @@ typedef enum ur_device_partition_t {
     /// @endcond
 
 } ur_device_partition_t;
-#define UR_DEVICE_PARTITION_MAX_VALUE UR_DEVICE_PARTITION_BY_CSLICE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition the device into sub-devices
@@ -1028,7 +1021,6 @@ typedef enum ur_device_mem_cache_type_t {
     /// @endcond
 
 } ur_device_mem_cache_type_t;
-#define UR_DEVICE_MEM_CACHE_TYPE_MAX_VALUE UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device local memory type
@@ -1041,7 +1033,6 @@ typedef enum ur_device_local_mem_type_t {
     /// @endcond
 
 } ur_device_local_mem_type_t;
-#define UR_DEVICE_LOCAL_MEM_TYPE_MAX_VALUE UR_DEVICE_LOCAL_MEM_TYPE_GLOBAL
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Device kernel execution capability
@@ -1288,7 +1279,6 @@ typedef enum ur_context_info_t {
     /// @endcond
 
 } ur_context_info_t;
-#define UR_CONTEXT_INFO_MAX_VALUE UR_CONTEXT_INFO_USM_FILL2D_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Releases the context handle reference indicating end of its usage
@@ -1469,7 +1459,6 @@ typedef enum ur_mem_type_t {
     /// @endcond
 
 } ur_mem_type_t;
-#define UR_MEM_TYPE_MAX_VALUE UR_MEM_TYPE_IMAGE1D_BUFFER
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory Information type
@@ -1481,7 +1470,6 @@ typedef enum ur_mem_info_t {
     /// @endcond
 
 } ur_mem_info_t;
-#define UR_MEM_INFO_MAX_VALUE UR_MEM_INFO_CONTEXT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel order info: number of channels and the channel layout
@@ -1506,7 +1494,6 @@ typedef enum ur_image_channel_order_t {
     /// @endcond
 
 } ur_image_channel_order_t;
-#define UR_IMAGE_CHANNEL_ORDER_MAX_VALUE UR_IMAGE_CHANNEL_ORDER_SRGBA
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image channel type info: describe the size of the channel data type
@@ -1531,7 +1518,6 @@ typedef enum ur_image_channel_type_t {
     /// @endcond
 
 } ur_image_channel_type_t;
-#define UR_IMAGE_CHANNEL_TYPE_MAX_VALUE UR_IMAGE_CHANNEL_TYPE_FLOAT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image information types
@@ -1548,7 +1534,6 @@ typedef enum ur_image_info_t {
     /// @endcond
 
 } ur_image_info_t;
-#define UR_IMAGE_INFO_MAX_VALUE UR_IMAGE_INFO_DEPTH
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image format including channel layout and data type
@@ -1767,7 +1752,6 @@ typedef enum ur_buffer_create_type_t {
     /// @endcond
 
 } ur_buffer_create_type_t;
-#define UR_BUFFER_CREATE_TYPE_MAX_VALUE UR_BUFFER_CREATE_TYPE_REGION
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a sub buffer representing a region in an existing buffer
@@ -1932,7 +1916,6 @@ typedef enum ur_sampler_filter_mode_t {
     /// @endcond
 
 } ur_sampler_filter_mode_t;
-#define UR_SAMPLER_FILTER_MODE_MAX_VALUE UR_SAMPLER_FILTER_MODE_LINEAR
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler addressing mode
@@ -1947,7 +1930,6 @@ typedef enum ur_sampler_addressing_mode_t {
     /// @endcond
 
 } ur_sampler_addressing_mode_t;
-#define UR_SAMPLER_ADDRESSING_MODE_MAX_VALUE UR_SAMPLER_ADDRESSING_MODE_NONE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get sample object information
@@ -1965,7 +1947,6 @@ typedef enum ur_sampler_info_t {
     /// @endcond
 
 } ur_sampler_info_t;
-#define UR_SAMPLER_INFO_MAX_VALUE UR_SAMPLER_INFO_FILTER_MODE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler description.
@@ -2213,7 +2194,6 @@ typedef enum ur_usm_type_t {
     /// @endcond
 
 } ur_usm_type_t;
-#define UR_USM_TYPE_MAX_VALUE UR_USM_TYPE_SHARED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory allocation information type
@@ -2228,7 +2208,6 @@ typedef enum ur_usm_alloc_info_t {
     /// @endcond
 
 } ur_usm_alloc_info_t;
-#define UR_USM_ALLOC_INFO_MAX_VALUE UR_USM_ALLOC_INFO_POOL
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM memory advice
@@ -2248,7 +2227,6 @@ typedef enum ur_usm_advice_flag_t {
     /// @endcond
 
 } ur_usm_advice_t;
-#define UR_USM_ADVICE_MAX_VALUE UR_USM_ADVICE_BIAS_UNCACHED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of USM pool
@@ -2549,7 +2527,6 @@ typedef enum ur_program_metadata_type_t {
     /// @endcond
 
 } ur_program_metadata_type_t;
-#define UR_PROGRAM_METADATA_TYPE_MAX_VALUE UR_PROGRAM_METADATA_TYPE_STRING
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program metadata value union.
@@ -2865,7 +2842,6 @@ typedef enum ur_program_info_t {
     /// @endcond
 
 } ur_program_info_t;
-#define UR_PROGRAM_INFO_MAX_VALUE UR_PROGRAM_INFO_KERNEL_NAMES
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Program object
@@ -2907,7 +2883,6 @@ typedef enum ur_program_build_status_t {
     /// @endcond
 
 } ur_program_build_status_t;
-#define UR_PROGRAM_BUILD_STATUS_MAX_VALUE UR_PROGRAM_BUILD_STATUS_IN_PROGRESS
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program object binary type
@@ -2921,7 +2896,6 @@ typedef enum ur_program_binary_type_t {
     /// @endcond
 
 } ur_program_binary_type_t;
-#define UR_PROGRAM_BINARY_TYPE_MAX_VALUE UR_PROGRAM_BINARY_TYPE_EXECUTABLE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object build information
@@ -2936,7 +2910,6 @@ typedef enum ur_program_build_info_t {
     /// @endcond
 
 } ur_program_build_info_t;
-#define UR_PROGRAM_BUILD_INFO_MAX_VALUE UR_PROGRAM_BUILD_INFO_BINARY_TYPE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query build information about a Program object for a Device
@@ -3156,7 +3129,6 @@ typedef enum ur_kernel_info_t {
     /// @endcond
 
 } ur_kernel_info_t;
-#define UR_KERNEL_INFO_MAX_VALUE UR_KERNEL_INFO_ATTRIBUTES
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel Work Group information
@@ -3175,7 +3147,6 @@ typedef enum ur_kernel_group_info_t {
     /// @endcond
 
 } ur_kernel_group_info_t;
-#define UR_KERNEL_GROUP_INFO_MAX_VALUE UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel SubGroup information
@@ -3190,7 +3161,6 @@ typedef enum ur_kernel_sub_group_info_t {
     /// @endcond
 
 } ur_kernel_sub_group_info_t;
-#define UR_KERNEL_SUB_GROUP_INFO_MAX_VALUE UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set additional Kernel execution information
@@ -3203,7 +3173,6 @@ typedef enum ur_kernel_exec_info_t {
     /// @endcond
 
 } ur_kernel_exec_info_t;
-#define UR_KERNEL_EXEC_INFO_MAX_VALUE UR_KERNEL_EXEC_INFO_USM_PTRS
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Kernel object
@@ -3551,7 +3520,6 @@ typedef enum ur_queue_info_t {
     /// @endcond
 
 } ur_queue_info_t;
-#define UR_QUEUE_INFO_MAX_VALUE UR_QUEUE_INFO_SIZE
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue property flags
@@ -3585,7 +3553,6 @@ typedef enum ur_queue_properties_t {
     /// @endcond
 
 } ur_queue_properties_t;
-#define UR_QUEUE_PROPERTIES_MAX_VALUE UR_QUEUE_PROPERTIES_COMPUTE_INDEX
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
@@ -3848,7 +3815,6 @@ typedef enum ur_command_t {
     /// @endcond
 
 } ur_command_t;
-#define UR_COMMAND_MAX_VALUE UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event Status
@@ -3862,7 +3828,6 @@ typedef enum ur_event_status_t {
     /// @endcond
 
 } ur_event_status_t;
-#define UR_EVENT_STATUS_MAX_VALUE UR_EVENT_STATUS_QUEUED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event query information type
@@ -3880,7 +3845,6 @@ typedef enum ur_event_info_t {
     /// @endcond
 
 } ur_event_info_t;
-#define UR_EVENT_INFO_MAX_VALUE UR_EVENT_INFO_REFERENCE_COUNT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Profiling query information type
@@ -3898,7 +3862,6 @@ typedef enum ur_profiling_info_t {
     /// @endcond
 
 } ur_profiling_info_t;
-#define UR_PROFILING_INFO_MAX_VALUE UR_PROFILING_INFO_COMMAND_END
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get event object information
@@ -4094,7 +4057,6 @@ typedef enum ur_execution_info_t {
     /// @endcond
 
 } ur_execution_info_t;
-#define UR_EXECUTION_INFO_MAX_VALUE UR_EXECUTION_INFO_EXECUTION_INFO_QUEUED
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Event callback function that can be registered by the application.
@@ -4262,7 +4224,6 @@ typedef enum ur_function_t {
     /// @endcond
 
 } ur_function_t;
-#define UR_FUNCTION_MAX_VALUE UR_FUNCTION_USM_POOL_DESTROY
 
 #if !defined(__GNUC__)
 #pragma endregion

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -298,6 +298,7 @@ typedef enum ur_device_init_flag_t {
     /// @endcond
 
 } ur_device_init_flag_t;
+/// @brief Bit Mask for validating ur_device_init_flags_t
 #define UR_DEVICE_INIT_FLAGS_MASK 0xffffffe0
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -322,7 +323,7 @@ typedef enum ur_device_init_flag_t {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffe0 & device_flags`
+///         + `::UR_DEVICE_INIT_FLAGS_MASK & device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urInit(
@@ -1008,6 +1009,7 @@ typedef enum ur_device_fp_capability_flag_t {
     /// @endcond
 
 } ur_device_fp_capability_flag_t;
+/// @brief Bit Mask for validating ur_device_fp_capability_flags_t
 #define UR_DEVICE_FP_CAPABILITY_FLAGS_MASK 0xffffff00
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1045,6 +1047,7 @@ typedef enum ur_device_exec_capability_flag_t {
     /// @endcond
 
 } ur_device_exec_capability_flag_t;
+/// @brief Bit Mask for validating ur_device_exec_capability_flags_t
 #define UR_DEVICE_EXEC_CAPABILITY_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1058,6 +1061,7 @@ typedef enum ur_device_affinity_domain_flag_t {
     /// @endcond
 
 } ur_device_affinity_domain_flag_t;
+/// @brief Bit Mask for validating ur_device_affinity_domain_flags_t
 #define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1152,6 +1156,7 @@ typedef enum ur_memory_order_capability_flag_t {
     /// @endcond
 
 } ur_memory_order_capability_flag_t;
+/// @brief Bit Mask for validating ur_memory_order_capability_flags_t
 #define UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK 0xffffffe0
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1168,6 +1173,7 @@ typedef enum ur_memory_scope_capability_flag_t {
     /// @endcond
 
 } ur_memory_scope_capability_flag_t;
+/// @brief Bit Mask for validating ur_memory_scope_capability_flags_t
 #define UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK 0xffffffe0
 
 #if !defined(__GNUC__)
@@ -1187,6 +1193,7 @@ typedef enum ur_context_flag_t {
     /// @endcond
 
 } ur_context_flag_t;
+/// @brief Bit Mask for validating ur_context_flags_t
 #define UR_CONTEXT_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1442,6 +1449,7 @@ typedef enum ur_mem_flag_t {
     /// @endcond
 
 } ur_mem_flag_t;
+/// @brief Bit Mask for validating ur_mem_flags_t
 #define UR_MEM_FLAGS_MASK 0xffffffc0
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1574,7 +1582,7 @@ typedef struct ur_image_desc_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///         + `::UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -1665,7 +1673,7 @@ typedef struct ur_buffer_alloc_location_properties_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -1767,7 +1775,7 @@ typedef enum ur_buffer_create_type_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pRegion`
@@ -2140,6 +2148,7 @@ typedef enum ur_usm_flag_t {
     /// @endcond
 
 } ur_usm_flag_t;
+/// @brief Bit Mask for validating ur_usm_flags_t
 #define UR_USM_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2152,6 +2161,7 @@ typedef enum ur_usm_host_mem_flag_t {
     /// @endcond
 
 } ur_usm_host_mem_flag_t;
+/// @brief Bit Mask for validating ur_usm_host_mem_flags_t
 #define UR_USM_HOST_MEM_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2167,6 +2177,7 @@ typedef enum ur_usm_device_mem_flag_t {
     /// @endcond
 
 } ur_usm_device_mem_flag_t;
+/// @brief Bit Mask for validating ur_usm_device_mem_flags_t
 #define UR_USM_DEVICE_MEM_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2180,6 +2191,7 @@ typedef enum ur_usm_pool_flag_t {
     /// @endcond
 
 } ur_usm_pool_flag_t;
+/// @brief Bit Mask for validating ur_usm_pool_flags_t
 #define UR_USM_POOL_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2226,7 +2238,9 @@ typedef enum ur_usm_advice_flag_t {
     UR_USM_ADVICE_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
-} ur_usm_advice_t;
+} ur_usm_advice_flag_t;
+/// @brief Bit Mask for validating ur_usm_advice_flags_t
+#define UR_USM_ADVICE_FLAGS_MASK 0xfffffe00
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of USM pool
@@ -2475,7 +2489,7 @@ urUSMGetMemAllocInfo(
 ///         + `NULL == pPoolDesc`
 ///         + `NULL == ppPool`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffe & pPoolDesc->flags`
+///         + `::UR_USM_POOL_FLAGS_MASK & pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -3537,6 +3551,7 @@ typedef enum ur_queue_flag_t {
     /// @endcond
 
 } ur_queue_flag_t;
+/// @brief Bit Mask for validating ur_queue_flags_t
 #define UR_QUEUE_FLAGS_MASK 0xffffff80
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4897,6 +4912,7 @@ typedef enum ur_map_flag_t {
     /// @endcond
 
 } ur_map_flag_t;
+/// @brief Bit Mask for validating ur_map_flags_t
 #define UR_MAP_FLAGS_MASK 0xfffffffc
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4909,6 +4925,7 @@ typedef enum ur_usm_migration_flag_t {
     /// @endcond
 
 } ur_usm_migration_flag_t;
+/// @brief Bit Mask for validating ur_usm_migration_flags_t
 #define UR_USM_MIGRATION_FLAGS_MASK 0xfffffffe
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4934,7 +4951,7 @@ typedef enum ur_usm_migration_flag_t {
 ///         + `NULL == hQueue`
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffc & mapFlags`
+///         + `::UR_MAP_FLAGS_MASK & mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -5104,7 +5121,7 @@ urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffe & flags`
+///         + `::UR_USM_MIGRATION_FLAGS_MASK & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -5144,7 +5161,7 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1ff < advice`
+///         + `::UR_USM_ADVICE_FLAGS_MASK & advice`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -683,7 +683,7 @@ def _generate_returns(obj, meta):
 
                 elif type_traits.is_enum(item['type'], meta):
                     if type_traits.is_flags(item['type']) and 'bit_mask' in meta['enum'][typename].keys():
-                        _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s & %s`"%(meta['enum'][typename]['bit_mask'], item['name']))
+                        _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s & %s`"%(typename.upper()[:-2]+ "_MASK", item['name']))
                     else:
                         _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s < %s`"%(meta['enum'][typename]['max'], item['name']))
 
@@ -702,7 +702,7 @@ def _generate_returns(obj, meta):
                                 _append(rets, "$X_RESULT_ERROR_UNSUPPORTED_VERSION", "`%s != %s->stype`"%(re.sub(r"(\$\w)_(.*)_t.*", r"\1_STRUCTURE_TYPE_\2", typename).upper(), item['name']))
                             else:
                                 if type_traits.is_flags(m['type']) and 'bit_mask' in meta['enum'][mtypename].keys():
-                                    _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s & %s->%s`"%(meta['enum'][mtypename]['bit_mask'], item['name'], m['name']))
+                                    _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s & %s->%s`"%(mtypename.upper()[:-2]+ "_MASK", item['name'], m['name']))
                                 else:
                                     _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s < %s->%s`"%(meta['enum'][mtypename]['max'], item['name'], m['name']))
 

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -13,6 +13,7 @@ import json
 import yaml
 import copy
 from templates.helper import param_traits, type_traits, value_traits
+import ctypes
 
 default_version = "0.5"
 all_versions = ["0.5", "1.0", "1.1", "2.0"]
@@ -529,15 +530,20 @@ def _generate_meta(d, ordinal, meta):
         if 'enum' == type:
             value = -1
             max_value = -1
+            bit_mask = 0
             meta[type][name]['etors'] = []
             for idx, etor in enumerate(d['etors']):
                 meta[type][name]['etors'].append(etor['name'])
                 value = _get_etor_value(etor.get('value'), value)
+                if type_traits.is_flags(name):
+                    bit_mask |= value
                 if value > max_value:
                     max_value = value
                     max_index = idx
             if type_traits.is_flags(name):
                 meta[type][name]['max'] = hex((max_value << 1)-1) if max_value else '0'
+                if bit_mask != 0:
+                    meta[type][name]['bit_mask'] = hex(ctypes.c_uint32(~bit_mask).value)
             else:
                 meta[type][name]['max'] = d['etors'][idx]['name']
 
@@ -676,7 +682,10 @@ def _generate_returns(obj, meta):
                     _append(rets, "$X_RESULT_ERROR_INVALID_NULL_HANDLE", "`NULL == %s`"%item['name'])
 
                 elif type_traits.is_enum(item['type'], meta):
-                    _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s < %s`"%(meta['enum'][typename]['max'], item['name']))
+                    if type_traits.is_flags(item['type']) and 'bit_mask' in meta['enum'][typename].keys():
+                        _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s & %s`"%(meta['enum'][typename]['bit_mask'], item['name']))
+                    else:
+                        _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s < %s`"%(meta['enum'][typename]['max'], item['name']))
 
                 if type_traits.is_descriptor(item['type']):
                     # walk each entry in the desc for pointers and enums
@@ -692,7 +701,10 @@ def _generate_returns(obj, meta):
                             if re.match(r"stype", m['name']):
                                 _append(rets, "$X_RESULT_ERROR_UNSUPPORTED_VERSION", "`%s != %s->stype`"%(re.sub(r"(\$\w)_(.*)_t.*", r"\1_STRUCTURE_TYPE_\2", typename).upper(), item['name']))
                             else:
-                                _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s < %s->%s`"%(meta['enum'][mtypename]['max'], item['name'], m['name']))
+                                if type_traits.is_flags(m['type']) and 'bit_mask' in meta['enum'][mtypename].keys():
+                                    _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s & %s->%s`"%(meta['enum'][mtypename]['bit_mask'], item['name'], m['name']))
+                                else:
+                                    _append(rets, "$X_RESULT_ERROR_INVALID_ENUMERATION", "`%s < %s->%s`"%(meta['enum'][mtypename]['max'], item['name'], m['name']))
 
                 elif type_traits.is_properties(item['type']):
                     # walk each entry in the properties

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -92,6 +92,7 @@ typedef enum ${th.make_enum_name(n, tags, obj)}
     %endfor
 
 } ${th.make_enum_name(n, tags, obj)};
+${th.make_enum_max_def(n, tags, obj, meta)}
 ## STRUCT/UNION ###############################################################
 %elif re.match(r"struct|union", obj['type']):
 typedef ${obj['type']} ${th.make_type_name(n, tags, obj)}

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -92,7 +92,9 @@ typedef enum ${th.make_enum_name(n, tags, obj)}
     %endfor
 
 } ${th.make_enum_name(n, tags, obj)};
+%if th.type_traits.is_flags(obj['name']):
 ${th.make_enum_max_def(n, tags, obj, meta)}
+%endif
 ## STRUCT/UNION ###############################################################
 %elif re.match(r"struct|union", obj['type']):
 typedef ${obj['type']} ${th.make_type_name(n, tags, obj)}

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -93,6 +93,7 @@ typedef enum ${th.make_enum_name(n, tags, obj)}
 
 } ${th.make_enum_name(n, tags, obj)};
 %if th.type_traits.is_flags(obj['name']):
+/// @brief Bit Mask for validating ${th.make_type_name(n, tags, obj)}
 ${th.make_flags_bitmask(n, tags, obj, meta)}
 %endif
 ## STRUCT/UNION ###############################################################

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -93,7 +93,7 @@ typedef enum ${th.make_enum_name(n, tags, obj)}
 
 } ${th.make_enum_name(n, tags, obj)};
 %if th.type_traits.is_flags(obj['name']):
-${th.make_enum_max_def(n, tags, obj, meta)}
+${th.make_flags_bitmask(n, tags, obj, meta)}
 %endif
 ## STRUCT/UNION ###############################################################
 %elif re.match(r"struct|union", obj['type']):

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -554,13 +554,16 @@ def make_enum_name(namespace, tags, obj):
     return name
 
 """
-    returns c/c++ definition of enums max value.
+    returns c/c++ definition of flags_t bit mask.
 """
-def make_enum_max_def(namespace, tags, obj, meta):
+def make_flags_bitmask(namespace, tags, obj, meta):
+    etor_meta = meta[obj['type']][obj['name']]
+    if 'bit_mask' not in etor_meta.keys():
+        return ""
     macro_def = "#define"
-    macro_name = make_type_name(namespace, tags, obj).upper()[:-2] + "_MAX_VALUE"
-    max_value = subt(namespace, tags, meta['enum'][obj['name']]['max'])
-    return "%s %s %s"%(macro_def, macro_name, max_value)    
+    macro_name = make_type_name(namespace, tags, obj).upper()[:-2] + "_MASK"
+    mask = etor_meta['bit_mask']
+    return "%s %s %s"%(macro_def, macro_name, mask)
 
 """
 Public:

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -554,6 +554,15 @@ def make_enum_name(namespace, tags, obj):
     return name
 
 """
+    returns c/c++ definition of enums max value.
+"""
+def make_enum_max_def(namespace, tags, obj, meta):
+    macro_def = "#define"
+    macro_name = make_type_name(namespace, tags, obj).upper()[:-2] + "_MAX_VALUE"
+    max_value = subt(namespace, tags, meta['enum'][obj['name']]['max'])
+    return "%s %s %s"%(macro_def, macro_name, max_value)    
+
+"""
 Public:
     returns c/c++ name of etor
 """

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -25,7 +25,7 @@ __urdlllocal ur_result_t UR_APICALL urInit(
     }
 
     if (context.enableParameterValidation) {
-        if (0x1f < device_flags) {
+        if (0xffffffe0 & device_flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
@@ -788,7 +788,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0x3f < flags) {
+        if (0xffffffc0 & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -849,7 +849,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0x3f < flags) {
+        if (0xffffffc0 & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -957,7 +957,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0x3f < flags) {
+        if (0xffffffc0 & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -1559,7 +1559,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (0x1 < pPoolDesc->flags) {
+        if (0xfffffffe & pPoolDesc->flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
@@ -3940,7 +3940,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0x3 < mapFlags) {
+        if (0xfffffffc & mapFlags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -4182,7 +4182,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (0x1 < flags) {
+        if (0xfffffffe & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -25,7 +25,7 @@ __urdlllocal ur_result_t UR_APICALL urInit(
     }
 
     if (context.enableParameterValidation) {
-        if (0xffffffe0 & device_flags) {
+        if (UR_DEVICE_INIT_FLAGS_MASK & device_flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
@@ -788,7 +788,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0xffffffc0 & flags) {
+        if (UR_MEM_FLAGS_MASK & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -849,7 +849,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0xffffffc0 & flags) {
+        if (UR_MEM_FLAGS_MASK & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -957,7 +957,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0xffffffc0 & flags) {
+        if (UR_MEM_FLAGS_MASK & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -1559,7 +1559,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (0xfffffffe & pPoolDesc->flags) {
+        if (UR_USM_POOL_FLAGS_MASK & pPoolDesc->flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
@@ -3940,7 +3940,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (0xfffffffc & mapFlags) {
+        if (UR_MAP_FLAGS_MASK & mapFlags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -4182,7 +4182,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (0xfffffffe & flags) {
+        if (UR_USM_MIGRATION_FLAGS_MASK & flags) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -4232,7 +4232,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (0x1ff < advice) {
+        if (UR_USM_ADVICE_FLAGS_MASK & advice) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -35,7 +35,7 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1f < device_flags`
+///         + `0xffffffe0 & device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -902,7 +902,7 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///         + `::UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -954,7 +954,7 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -1056,7 +1056,7 @@ ur_result_t UR_APICALL urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pRegion`
@@ -1676,7 +1676,7 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ///         + `NULL == pPoolDesc`
 ///         + `NULL == ppPool`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < pPoolDesc->flags`
+///         + `0xfffffffe & pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urUSMPoolCreate(
@@ -4129,7 +4129,7 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3 < mapFlags`
+///         + `0xfffffffc & mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -4340,7 +4340,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < flags`
+///         + `0xfffffffe & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -35,7 +35,7 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffe0 & device_flags`
+///         + `::UR_DEVICE_INIT_FLAGS_MASK & device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -902,7 +902,7 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///         + `::UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -954,7 +954,7 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -1056,7 +1056,7 @@ ur_result_t UR_APICALL urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pRegion`
@@ -1676,7 +1676,7 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ///         + `NULL == pPoolDesc`
 ///         + `NULL == ppPool`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffe & pPoolDesc->flags`
+///         + `::UR_USM_POOL_FLAGS_MASK & pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urUSMPoolCreate(
@@ -4129,7 +4129,7 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffc & mapFlags`
+///         + `::UR_MAP_FLAGS_MASK & mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -4340,7 +4340,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffe & flags`
+///         + `::UR_USM_MIGRATION_FLAGS_MASK & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -4389,7 +4389,7 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1ff < advice`
+///         + `::UR_USM_ADVICE_FLAGS_MASK & advice`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -32,7 +32,7 @@
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffe0 & device_flags`
+///         + `::UR_DEVICE_INIT_FLAGS_MASK & device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -783,7 +783,7 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///         + `::UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -830,7 +830,7 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -920,7 +920,7 @@ ur_result_t UR_APICALL urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xffffffc0 & flags`
+///         + `::UR_MEM_FLAGS_MASK & flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pRegion`
@@ -1467,7 +1467,7 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ///         + `NULL == pPoolDesc`
 ///         + `NULL == ppPool`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffe & pPoolDesc->flags`
+///         + `::UR_USM_POOL_FLAGS_MASK & pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urUSMPoolCreate(
@@ -3629,7 +3629,7 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffc & mapFlags`
+///         + `::UR_MAP_FLAGS_MASK & mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -3819,7 +3819,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0xfffffffe & flags`
+///         + `::UR_USM_MIGRATION_FLAGS_MASK & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -3863,7 +3863,7 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1ff < advice`
+///         + `::UR_USM_ADVICE_FLAGS_MASK & advice`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -32,7 +32,7 @@
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1f < device_flags`
+///         + `0xffffffe0 & device_flags`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -783,7 +783,7 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///         + `::UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -830,7 +830,7 @@ ur_result_t UR_APICALL urMemImageCreate(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -920,7 +920,7 @@ ur_result_t UR_APICALL urMemRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3f < flags`
+///         + `0xffffffc0 & flags`
 ///         + `::UR_BUFFER_CREATE_TYPE_REGION < bufferCreateType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pRegion`
@@ -1467,7 +1467,7 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 ///         + `NULL == pPoolDesc`
 ///         + `NULL == ppPool`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < pPoolDesc->flags`
+///         + `0xfffffffe & pPoolDesc->flags`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urUSMPoolCreate(
@@ -3629,7 +3629,7 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///         + `NULL == hQueue`
 ///         + `NULL == hBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x3 < mapFlags`
+///         + `0xfffffffc & mapFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppRetMap`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
@@ -3819,7 +3819,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `0x1 < flags`
+///         + `0xfffffffe & flags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE


### PR DESCRIPTION
The API generator has the ability to check that flags and enums are within range, however this does not apply to `[optional]` parameters. This then means that adapters will have to check if the value is within range. It would be great if we report this range as part of the API specification and avoid having the plugins compute what this value is - which could become outdated as additional enumerations are added/removed and is easily missed.

The adapter can then do the following:
```cpp
if(flags & UR_<ENUM>_MASK){
   return UR_RESULT_ERROR_INVALID_ENUMERATION;
}
```