### PR TITLE
[UMA] Add umaMemoryProviderSetAttributes to set madvise-like attributes

### DIFF
--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -12,6 +12,10 @@
 #include <uma/base.h>
 #include <uma/memory_provider_ops.h>
 
+#define UMA_ATTR_DONTNEED 4    /* Don't need these pages.  */
+#define UMA_ATTR_HUGEPAGE 14   /* Worth backing with hugepages.  */
+#define UMA_ATTR_NOHUGEPAGE 15 /* Not worth backing with hugepages.  */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,6 +60,17 @@ enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,
 ///
 enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
                                         void *ptr, size_t size);
+
+///
+/// \brief Set attributes of the memory space pointed by ptr from the memory provider
+/// \param hProvider handle to the memory provider
+/// \param ptr pointer to the allocated memory
+/// \param size size of the allocation
+/// \param attrs attributes of the memory space to be set
+///
+enum uma_result_t
+umaMemoryProviderSetAttributes(uma_memory_provider_handle_t hProvider,
+                               void *ptr, size_t size, int attrs);
 
 ///
 /// \brief Retrieve string representation of the underlying provider specific

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -40,6 +40,8 @@ struct uma_memory_provider_ops_t {
     enum uma_result_t (*alloc)(void *provider, size_t size, size_t alignment,
                                void **ptr);
     enum uma_result_t (*free)(void *provider, void *ptr, size_t size);
+    enum uma_result_t (*set_attrs)(void *provider, void *ptr, size_t size,
+                                   int attrs);
     enum uma_result_t (*get_last_result)(void *provider,
                                          const char **ppMessage);
 };

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -60,6 +60,12 @@ enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
 }
 
 enum uma_result_t
+umaMemoryProviderSetAttributes(uma_memory_provider_handle_t hProvider,
+                               void *ptr, size_t size, int attrs) {
+    return hProvider->ops.set_attrs(hProvider->provider_priv, ptr, size, attrs);
+}
+
+enum uma_result_t
 umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
                                const char **ppMessage) {
     return hProvider->ops.get_last_result(hProvider->provider_priv, ppMessage);

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -32,6 +32,15 @@ static enum uma_result_t nullFree(void *provider, void *ptr, size_t size) {
     return UMA_RESULT_SUCCESS;
 }
 
+static enum uma_result_t nullSetAttributes(void *provider, void *ptr,
+                                           size_t size, int attrs) {
+    (void)provider;
+    (void)ptr;
+    (void)size;
+    (void)attrs;
+    return UMA_RESULT_SUCCESS;
+}
+
 static enum uma_result_t nullGetLastResult(void *provider, const char **ppMsg) {
     (void)provider;
     (void)ppMsg;
@@ -44,6 +53,7 @@ uma_memory_provider_handle_t nullProviderCreate(void) {
                                             .finalize = nullFinalize,
                                             .alloc = nullAlloc,
                                             .free = nullFree,
+                                            .set_attrs = nullSetAttributes,
                                             .get_last_result =
                                                 nullGetLastResult};
 
@@ -87,6 +97,15 @@ static enum uma_result_t traceFree(void *provider, void *ptr, size_t size) {
     return umaMemoryProviderFree(traceProvider->hUpstreamProvider, ptr, size);
 }
 
+static enum uma_result_t traceSetAttributes(void *provider, void *ptr,
+                                            size_t size, int attrs) {
+    struct traceParams *traceProvider = (struct traceParams *)provider;
+
+    traceProvider->trace("set_attrs");
+    return umaMemoryProviderSetAttributes(traceProvider->hUpstreamProvider, ptr,
+                                          size, attrs);
+}
+
 static enum uma_result_t traceGetLastResult(void *provider,
                                             const char **ppMsg) {
     struct traceParams *traceProvider = (struct traceParams *)provider;
@@ -104,6 +123,7 @@ traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
                                             .finalize = traceFinalize,
                                             .alloc = traceAlloc,
                                             .free = traceFree,
+                                            .set_attrs = traceSetAttributes,
                                             .get_last_result =
                                                 traceGetLastResult};
 

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -31,6 +31,11 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(calls["free"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
 
+    ret = umaMemoryProviderSetAttributes(tracingProvider.get(), nullptr, 0, 0);
+    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
+    ASSERT_EQ(calls["set_attrs"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
+
     ret = umaMemoryProviderGetLastResult(tracingProvider.get(), nullptr);
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
     ASSERT_EQ(calls["get_last_result"], 1);


### PR DESCRIPTION
Add umaMemoryProviderSetAttributes to set madvise-like attributes of the memory space pointed by ptr from the memory provider.