### PR TITLE
[UR] Have urDeviceParition use desc for partitioning

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -591,7 +591,6 @@ class ur_device_partition_property_t(c_intptr_t):
 class ur_device_partition_v(IntEnum):
     EQUALLY = 0x1086                                ## Partition Equally
     BY_COUNTS = 0x1087                              ## Partition by counts
-    BY_COUNTS_LIST_END = 0x0                        ## End of by counts list
     BY_AFFINITY_DOMAIN = 0x1088                     ## Partition by affinity domain
     BY_CSLICE = 0x1089                              ## Partition by c-slice
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -223,26 +223,31 @@ typedef enum ur_result_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
 typedef enum ur_structure_type_t {
-    UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES = 0,               ///< ::ur_context_properties_t
-    UR_STRUCTURE_TYPE_IMAGE_DESC = 1,                       ///< ::ur_image_desc_t
-    UR_STRUCTURE_TYPE_BUFFER_PROPERTIES = 2,                ///< ::ur_buffer_properties_t
-    UR_STRUCTURE_TYPE_BUFFER_REGION = 3,                    ///< ::ur_buffer_region_t
-    UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES = 4,        ///< ::ur_buffer_channel_properties_t
-    UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES = 5, ///< ::ur_buffer_alloc_location_properties_t
-    UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES = 6,               ///< ::ur_program_properties_t
-    UR_STRUCTURE_TYPE_USM_DESC = 7,                         ///< ::ur_usm_desc_t
-    UR_STRUCTURE_TYPE_USM_HOST_DESC = 8,                    ///< ::ur_usm_host_desc_t
-    UR_STRUCTURE_TYPE_USM_DEVICE_DESC = 9,                  ///< ::ur_usm_device_desc_t
-    UR_STRUCTURE_TYPE_USM_POOL_DESC = 10,                   ///< ::ur_usm_pool_desc_t
-    UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 11,            ///< ::ur_usm_pool_limits_desc_t
-    UR_STRUCTURE_TYPE_DEVICE_BINARY = 12,                   ///< ::ur_device_binary_t
-    UR_STRUCTURE_TYPE_SAMPLER_DESC = 13,                    ///< ::ur_sampler_desc_t
-    UR_STRUCTURE_TYPE_QUEUE_PROPERTIES = 14,                ///< ::ur_queue_properties_t
-    UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES = 15,          ///< ::ur_queue_properties_t
-    UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES = 16,       ///< ::ur_context_native_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES = 17,        ///< ::ur_kernel_native_properties_t
-    UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES = 18,         ///< ::ur_queue_native_properties_t
-    UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES = 19,           ///< ::ur_mem_native_properties_t
+    UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES = 0,                        ///< ::ur_context_properties_t
+    UR_STRUCTURE_TYPE_IMAGE_DESC = 1,                                ///< ::ur_image_desc_t
+    UR_STRUCTURE_TYPE_BUFFER_PROPERTIES = 2,                         ///< ::ur_buffer_properties_t
+    UR_STRUCTURE_TYPE_BUFFER_REGION = 3,                             ///< ::ur_buffer_region_t
+    UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES = 4,                 ///< ::ur_buffer_channel_properties_t
+    UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES = 5,          ///< ::ur_buffer_alloc_location_properties_t
+    UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES = 6,                        ///< ::ur_program_properties_t
+    UR_STRUCTURE_TYPE_USM_DESC = 7,                                  ///< ::ur_usm_desc_t
+    UR_STRUCTURE_TYPE_USM_HOST_DESC = 8,                             ///< ::ur_usm_host_desc_t
+    UR_STRUCTURE_TYPE_USM_DEVICE_DESC = 9,                           ///< ::ur_usm_device_desc_t
+    UR_STRUCTURE_TYPE_USM_POOL_DESC = 10,                            ///< ::ur_usm_pool_desc_t
+    UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 11,                     ///< ::ur_usm_pool_limits_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_BINARY = 12,                            ///< ::ur_device_binary_t
+    UR_STRUCTURE_TYPE_SAMPLER_DESC = 13,                             ///< ::ur_sampler_desc_t
+    UR_STRUCTURE_TYPE_QUEUE_PROPERTIES = 14,                         ///< ::ur_queue_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES = 15,                   ///< ::ur_queue_properties_t
+    UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES = 16,                ///< ::ur_context_native_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES = 17,                 ///< ::ur_kernel_native_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES = 18,                  ///< ::ur_queue_native_properties_t
+    UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES = 19,                    ///< ::ur_mem_native_properties_t
+    UR_STRUCTURE_TYPE_DEVICE_PARTITION_DESC = 20,                    ///< ::ur_device_partition_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_PARTITION_EQUALLY_DESC = 21,            ///< ::ur_device_partition_equally_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_COUNTS_DESC = 22,          ///< ::ur_device_partition_by_counts_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_DESC = 23, ///< ::ur_device_partition_by_affinity_domain_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_CSLICE_DESC = 24,          ///< ::ur_device_partition_by_cslice_desc_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -701,6 +706,38 @@ typedef enum ur_device_type_t {
 } ur_device_type_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Device affinity domain
+typedef uint32_t ur_device_affinity_domain_flags_t;
+typedef enum ur_device_affinity_domain_flag_t {
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),               ///< Split the device into sub devices comprised of compute units that
+                                                                   ///< share a NUMA node.
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE = UR_BIT(1),           ///< Split the device into sub devices comprised of compute units that
+                                                                   ///< share a level 4 data cache.
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE = UR_BIT(2),           ///< Split the device into sub devices comprised of compute units that
+                                                                   ///< share a level 3 data cache.
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE = UR_BIT(3),           ///< Split the device into sub devices comprised of compute units that
+                                                                   ///< share a level 2 data cache.
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE = UR_BIT(4),           ///< Split the device into sub devices comprised of compute units that
+                                                                   ///< share a level 1 data cache.
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(5), ///< Split the device along the next partitionable affinity domain.
+                                                                   ///< The implementation shall find the first level along which the device
+                                                                   ///< or sub device may be further subdivided in the order:
+                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
+                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE,
+                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE,
+                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE,
+                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE,
+                                                                   ///< and partition the device into sub devices comprised of compute units
+                                                                   ///< that share memory subsystems at this level.
+    /// @cond
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_device_affinity_domain_flag_t;
+/// @brief Bit Mask for validating ur_device_affinity_domain_flags_t
+#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK 0xffffffc0
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves devices within a platform
 ///
 /// @details
@@ -832,16 +869,16 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,            ///< [::ur_bool_t] prefer user synchronization when sharing object with
                                                                 ///< other API
     UR_DEVICE_INFO_PARENT_DEVICE = 75,                          ///< [::ur_device_handle_t] return parent device handle
-    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< [::ur_device_partition_property_t[]] Returns an array of partition
-                                                                ///< types supported by the device
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< [::ur_device_partition_t[]] Returns an array of partition types
+                                                                ///< supported by the device
     UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,              ///< [uint32_t] maximum number of sub-devices when the device is
                                                                 ///< partitioned
     UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,              ///< [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
                                                                 ///< supported affinity domains for partitioning.
                                                                 ///< If the device does not support any affinity domains, then 0 will be returned.
-    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< [::ur_device_partition_property_t[]] return an array of
-                                                                ///< ::ur_device_partition_property_t for properties specified in
-                                                                ///< ::urDevicePartition
+    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< [::ur_device_partition_desc_t*] return a pointer to the
+                                                                ///< ::ur_device_partition_desc_t* for properties specified in
+                                                                ///< ::urDevicePartition.
     UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                     ///< [uint32_t] max number of sub groups
     UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81, ///< [::ur_bool_t] support sub group independent forward progress
     UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< [uint32_t[]] return an array of sub group sizes supported on Intel
@@ -997,6 +1034,55 @@ typedef enum ur_device_partition_t {
 } ur_device_partition_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Device partition properties descriptor.
+typedef struct ur_device_partition_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_DEVICE_PARTITION_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+
+} ur_device_partition_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device partition equally descriptor.
+typedef struct ur_device_partition_equally_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_DEVICE_PARTITION_EQUALLY_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    uint32_t counts;           ///< [in] n compute units per sub-device.
+
+} ur_device_partition_equally_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device partition by counts descriptor
+typedef struct ur_device_partition_by_counts_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_COUNTS_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    const uint32_t *counts;    ///< [in] Array of counts of compute units per sub-device
+    size_t size;               ///< [in] Length of counts array.
+
+} ur_device_partition_by_counts_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device partition by affinity domain descriptor.
+typedef struct ur_device_partition_by_affinity_domain_desc_t {
+    ur_structure_type_t stype;               ///< [in] type of this structure, must be
+                                             ///< ::UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_DESC
+    const void *pNext;                       ///< [in][optional] pointer to extension-specific structure
+    ur_device_affinity_domain_flags_t flags; ///< [in] Affinity domain flags
+
+} ur_device_partition_by_affinity_domain_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device partition by compute slice
+typedef struct ur_device_partition_by_cslice_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_CSLICE_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+
+} ur_device_partition_by_cslice_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Partition the device into sub-devices
 ///
 /// @details
@@ -1024,14 +1110,14 @@ typedef enum ur_device_partition_t {
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 UR_APIEXPORT ur_result_t UR_APICALL
 urDevicePartition(
-    ur_device_handle_t hDevice,                        ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
-    uint32_t NumDevices,                               ///< [in] the number of sub-devices.
-    ur_device_handle_t *phSubDevices,                  ///< [out][optional][range(0, NumDevices)] array of handle of devices.
-                                                       ///< If NumDevices is less than the number of sub-devices available, then
-                                                       ///< the function shall only retrieve that number of sub-devices.
-    uint32_t *pNumDevicesRet                           ///< [out][optional] pointer to the number of sub-devices the device can be
-                                                       ///< partitioned into according to the partitioning property.
+    ur_device_handle_t hDevice,                    ///< [in] handle of the device to partition.
+    const ur_device_partition_desc_t *pProperties, ///< [in] device partitioning descriptor structure chain.
+    uint32_t NumDevices,                           ///< [in] the number of sub-devices.
+    ur_device_handle_t *phSubDevices,              ///< [out][optional][range(0, NumDevices)] array of handle of devices.
+                                                   ///< If NumDevices is less than the number of sub-devices available, then
+                                                   ///< the function shall only retrieve that number of sub-devices.
+    uint32_t *pNumDevicesRet                       ///< [out][optional] pointer to the number of sub-devices the device can be
+                                                   ///< partitioned into according to the partitioning property.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1127,38 +1213,6 @@ typedef enum ur_device_exec_capability_flag_t {
 } ur_device_exec_capability_flag_t;
 /// @brief Bit Mask for validating ur_device_exec_capability_flags_t
 #define UR_DEVICE_EXEC_CAPABILITY_FLAGS_MASK 0xfffffffc
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Device affinity domain
-typedef uint32_t ur_device_affinity_domain_flags_t;
-typedef enum ur_device_affinity_domain_flag_t {
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),               ///< Split the device into sub devices comprised of compute units that
-                                                                   ///< share a NUMA node.
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE = UR_BIT(1),           ///< Split the device into sub devices comprised of compute units that
-                                                                   ///< share a level 4 data cache.
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE = UR_BIT(2),           ///< Split the device into sub devices comprised of compute units that
-                                                                   ///< share a level 3 data cache.
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE = UR_BIT(3),           ///< Split the device into sub devices comprised of compute units that
-                                                                   ///< share a level 2 data cache.
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE = UR_BIT(4),           ///< Split the device into sub devices comprised of compute units that
-                                                                   ///< share a level 1 data cache.
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(5), ///< Split the device along the next partitionable affinity domain.
-                                                                   ///< The implementation shall find the first level along which the device
-                                                                   ///< or sub device may be further subdivided in the order:
-                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
-                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE,
-                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE,
-                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE,
-                                                                   ///< ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE,
-                                                                   ///< and partition the device into sub devices comprised of compute units
-                                                                   ///< that share memory subsystems at this level.
-    /// @cond
-    UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
-    /// @endcond
-
-} ur_device_affinity_domain_flag_t;
-/// @brief Bit Mask for validating ur_device_affinity_domain_flags_t
-#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK 0xffffffc0
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native device handle.
@@ -6879,7 +6933,7 @@ typedef struct ur_device_release_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_device_partition_params_t {
     ur_device_handle_t *phDevice;
-    const ur_device_partition_property_t **ppProperties;
+    const ur_device_partition_desc_t **ppProperties;
     uint32_t *pNumDevices;
     ur_device_handle_t **pphSubDevices;
     uint32_t **ppNumDevicesRet;

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1024,7 +1024,6 @@ typedef intptr_t ur_device_partition_property_t;
 typedef enum ur_device_partition_t {
     UR_DEVICE_PARTITION_EQUALLY = 0x1086,            ///< Partition Equally
     UR_DEVICE_PARTITION_BY_COUNTS = 0x1087,          ///< Partition by counts
-    UR_DEVICE_PARTITION_BY_COUNTS_LIST_END = 0x0,    ///< End of by counts list
     UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN = 0x1088, ///< Partition by affinity domain
     UR_DEVICE_PARTITION_BY_CSLICE = 0x1089,          ///< Partition by c-slice
     /// @cond

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1346,7 +1346,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnDeviceRelease_t)(
 /// @brief Function-pointer for urDevicePartition
 typedef ur_result_t(UR_APICALL *ur_pfnDevicePartition_t)(
     ur_device_handle_t,
-    const ur_device_partition_property_t *,
+    const ur_device_partition_desc_t *,
     uint32_t,
     ur_device_handle_t *,
     uint32_t *);

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -302,6 +302,16 @@ etors:
       desc: $x_queue_native_properties_t
     - name: MEM_NATIVE_PROPERTIES
       desc: $x_mem_native_properties_t
+    - name: DEVICE_PARTITION_DESC
+      desc: $x_device_partition_desc_t
+    - name: DEVICE_PARTITION_EQUALLY_DESC
+      desc: $x_device_partition_equally_desc_t
+    - name: DEVICE_PARTITION_BY_COUNTS_DESC
+      desc: $x_device_partition_by_counts_desc_t
+    - name: DEVICE_PARTITION_BY_AFFINITY_DOMAIN_DESC
+      desc: $x_device_partition_by_affinity_domain_desc_t
+    - name: DEVICE_PARTITION_BY_CSLICE_DESC
+      desc: $x_device_partition_by_cslice_desc_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -493,9 +493,6 @@ etors:
     - name: BY_COUNTS
       desc: "Partition by counts"
       value: "0x1087"
-    - name: BY_COUNTS_LIST_END
-      desc: "End of by counts list"
-      value: "0x0"
     - name: BY_AFFINITY_DOMAIN
       desc: "Partition by affinity domain"
       value: "0x1088"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -99,6 +99,35 @@ etors:
     - name: VPU
       desc: "Vision Processing Unit"
 --- #--------------------------------------------------------------------------
+type: enum
+desc: "Device affinity domain"
+class: $xDevice
+name: $x_device_affinity_domain_flags_t
+etors:
+    - name: NUMA
+      desc: "Split the device into sub devices comprised of compute units that share a NUMA node."
+      value: "$X_BIT(0)"
+    - name: L4_CACHE
+      desc: "Split the device into sub devices comprised of compute units that share a level 4 data cache."
+      value: "$X_BIT(1)"
+    - name: L3_CACHE
+      desc: "Split the device into sub devices comprised of compute units that share a level 3 data cache."
+      value: "$X_BIT(2)"
+    - name: L2_CACHE
+      desc: "Split the device into sub devices comprised of compute units that share a level 2 data cache."
+      value: "$X_BIT(3)"
+    - name: L1_CACHE
+      desc: "Split the device into sub devices comprised of compute units that share a level 1 data cache."
+      value: "$X_BIT(4)"
+    - name: NEXT_PARTITIONABLE
+      desc: |
+            Split the device along the next partitionable affinity domain. 
+            The implementation shall find the first level along which the device
+            or sub device may be further subdivided in the order: 
+            $X_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE, 
+            and partition the device into sub devices comprised of compute units that share memory subsystems at this level. 
+      value: "$X_BIT(5)"
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves devices within a platform"
 class: $xDevice
@@ -301,7 +330,7 @@ etors:
     - name: PARENT_DEVICE
       desc: "[$x_device_handle_t] return parent device handle"
     - name: PARTITION_PROPERTIES
-      desc: "[$x_device_partition_property_t[]] Returns an array of partition types supported by the device"
+      desc: "[$x_device_partition_t[]] Returns an array of partition types supported by the device"
     - name: PARTITION_MAX_SUB_DEVICES
       desc: "[uint32_t] maximum number of sub-devices when the device is partitioned"
     - name: PARTITION_AFFINITY_DOMAIN
@@ -309,7 +338,7 @@ etors:
             [$x_device_affinity_domain_flags_t] Returns a bit-field of the supported affinity domains for partitioning. 
             If the device does not support any affinity domains, then 0 will be returned.
     - name: PARTITION_TYPE
-      desc: "[$x_device_partition_property_t[]] return an array of $x_device_partition_property_t for properties specified in $xDevicePartition"
+      desc: "[$x_device_partition_desc_t*] return a pointer to the $x_device_partition_desc_t* for properties specified in $xDevicePartition."
     - name: MAX_NUM_SUB_GROUPS
       desc: "[uint32_t] max number of sub groups"
     - name: SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS
@@ -474,6 +503,53 @@ etors:
       desc: "Partition by c-slice"
       value: "0x1089"
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Device partition properties descriptor."
+name: $x_device_partition_desc_t
+class: $xDevice
+base: $x_base_desc_t
+members: []
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Device partition equally descriptor."
+name: $x_device_partition_equally_desc_t
+class: $xDevice
+base: $x_base_desc_t
+members:
+  - type: uint32_t
+    name: counts
+    desc: "[in] n compute units per sub-device."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Device partition by counts descriptor"
+name: $x_device_partition_by_counts_desc_t
+class: $xDevice
+base: $x_base_desc_t
+members:
+  - type: const uint32_t*
+    name: counts
+    desc: "[in] Array of counts of compute units per sub-device"
+  - type: size_t
+    name: size
+    desc: "[in] Length of counts array."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Device partition by affinity domain descriptor."
+name: $x_device_partition_by_affinity_domain_desc_t
+class: $xDevice
+base: $x_base_desc_t
+members:
+  - type: $x_device_affinity_domain_flags_t
+    name: flags
+    desc: "[in] Affinity domain flags"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Device partition by compute slice"
+name: $x_device_partition_by_cslice_desc_t
+class: $xDevice
+base: $x_base_desc_t
+members: []
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Partition the device into sub-devices"
 class: $xDevice
@@ -492,10 +568,9 @@ params:
       name: hDevice
       desc: |
             [in] handle of the device to partition.
-    - type: const $x_device_partition_property_t*
+    - type: const $x_device_partition_desc_t*
       name: pProperties
-      desc: |
-            [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+      desc: "[in] device partitioning descriptor structure chain."
     - type: "uint32_t"
       name: NumDevices
       desc: |
@@ -613,35 +688,6 @@ etors:
     - name: NATIVE_KERNEL      
       desc: "Support native kernel execution"
       value: "$X_BIT(1)"
---- #--------------------------------------------------------------------------
-type: enum
-desc: "Device affinity domain"
-class: $xDevice
-name: $x_device_affinity_domain_flags_t
-etors:
-    - name: NUMA
-      desc: "Split the device into sub devices comprised of compute units that share a NUMA node."
-      value: "$X_BIT(0)"
-    - name: L4_CACHE
-      desc: "Split the device into sub devices comprised of compute units that share a level 4 data cache."
-      value: "$X_BIT(1)"
-    - name: L3_CACHE
-      desc: "Split the device into sub devices comprised of compute units that share a level 3 data cache."
-      value: "$X_BIT(2)"
-    - name: L2_CACHE
-      desc: "Split the device into sub devices comprised of compute units that share a level 2 data cache."
-      value: "$X_BIT(3)"
-    - name: L1_CACHE
-      desc: "Split the device into sub devices comprised of compute units that share a level 1 data cache."
-      value: "$X_BIT(4)"
-    - name: NEXT_PARTITIONABLE
-      desc: |
-            Split the device along the next partitionable affinity domain. 
-            The implementation shall find the first level along which the device
-            or sub device may be further subdivided in the order: 
-            $X_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE, 
-            and partition the device into sub devices comprised of compute units that share memory subsystems at this level. 
-      value: "$X_BIT(5)"
 --- #--------------------------------------------------------------------------
 type: class
 desc: "C++ wrapper for a device"

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -324,8 +324,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    const ur_device_partition_desc_t
+        *pProperties, ///< [in] device partitioning descriptor structure chain.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
     ur_device_handle_t *
         phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -3280,10 +3280,6 @@ inline std::ostream &operator<<(std::ostream &os,
         os << "UR_DEVICE_PARTITION_BY_COUNTS";
         break;
 
-    case UR_DEVICE_PARTITION_BY_COUNTS_LIST_END:
-        os << "UR_DEVICE_PARTITION_BY_COUNTS_LIST_END";
-        break;
-
     case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
         os << "UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN";
         break;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -24,6 +24,8 @@ inline void
 serializeTaggedTyped_ur_platform_info_t(std::ostream &os, const void *ptr,
                                         enum ur_platform_info_t value,
                                         size_t size);
+inline void serializeFlag_ur_device_affinity_domain_flags_t(
+    std::ostream &os, ur_device_affinity_domain_flags_t flag);
 inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
                                                   const void *ptr,
                                                   enum ur_device_info_t value,
@@ -32,8 +34,6 @@ inline void serializeFlag_ur_device_fp_capability_flags_t(
     std::ostream &os, ur_device_fp_capability_flags_t flag);
 inline void serializeFlag_ur_device_exec_capability_flags_t(
     std::ostream &os, ur_device_exec_capability_flags_t flag);
-inline void serializeFlag_ur_device_affinity_domain_flags_t(
-    std::ostream &os, ur_device_affinity_domain_flags_t flag);
 inline void serializeFlag_ur_memory_order_capability_flags_t(
     std::ostream &os, ur_memory_order_capability_flags_t flag);
 inline void serializeFlag_ur_memory_scope_capability_flags_t(
@@ -136,9 +136,25 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_device_binary_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_device_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_affinity_domain_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_partition_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_device_partition_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_equally_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_by_counts_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_by_affinity_domain_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_by_cslice_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_fp_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -147,8 +163,6 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_local_mem_type_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_exec_capability_flag_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                enum ur_device_affinity_domain_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_memory_order_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -632,6 +646,26 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_DESC:
+        os << "UR_STRUCTURE_TYPE_DEVICE_PARTITION_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_EQUALLY_DESC:
+        os << "UR_STRUCTURE_TYPE_DEVICE_PARTITION_EQUALLY_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_COUNTS_DESC:
+        os << "UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_COUNTS_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_DESC:
+        os << "UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_CSLICE_DESC:
+        os << "UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_CSLICE_DESC";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -757,6 +791,36 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES: {
         const ur_mem_native_properties_t *pstruct =
             (const ur_mem_native_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_DESC: {
+        const ur_device_partition_desc_t *pstruct =
+            (const ur_device_partition_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_EQUALLY_DESC: {
+        const ur_device_partition_equally_desc_t *pstruct =
+            (const ur_device_partition_equally_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_COUNTS_DESC: {
+        const ur_device_partition_by_counts_desc_t *pstruct =
+            (const ur_device_partition_by_counts_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_DESC: {
+        const ur_device_partition_by_affinity_domain_desc_t *pstruct =
+            (const ur_device_partition_by_affinity_domain_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_BY_CSLICE_DESC: {
+        const ur_device_partition_by_cslice_desc_t *pstruct =
+            (const ur_device_partition_by_cslice_desc_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -1119,6 +1183,121 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_type_t value) {
     }
     return os;
 }
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_affinity_domain_flag_t value) {
+    switch (value) {
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+namespace ur_params {
+inline void serializeFlag_ur_device_affinity_domain_flags_t(
+    std::ostream &os, ur_device_affinity_domain_flags_t flag) {
+    uint32_t val = flag;
+    bool first = true;
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE;
+    }
+    if (val != 0) {
+        std::bitset<32> bits(val);
+        if (!first) {
+            os << " | ";
+        }
+        os << "unknown bit flags " << bits;
+    } else if (first) {
+        os << "0";
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
     switch (value) {
 
@@ -2588,10 +2767,9 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
 
     case UR_DEVICE_INFO_PARTITION_PROPERTIES: {
 
-        const ur_device_partition_property_t *tptr =
-            (const ur_device_partition_property_t *)ptr;
+        const ur_device_partition_t *tptr = (const ur_device_partition_t *)ptr;
         os << "[";
-        size_t nelems = size / sizeof(ur_device_partition_property_t);
+        size_t nelems = size / sizeof(ur_device_partition_t);
         for (size_t i = 0; i < nelems; ++i) {
             if (i != 0) {
                 os << ", ";
@@ -2633,19 +2811,19 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_PARTITION_TYPE: {
-
-        const ur_device_partition_property_t *tptr =
-            (const ur_device_partition_property_t *)ptr;
-        os << "[";
-        size_t nelems = size / sizeof(ur_device_partition_property_t);
-        for (size_t i = 0; i < nelems; ++i) {
-            if (i != 0) {
-                os << ", ";
-            }
-
-            os << tptr[i];
+        const ur_device_partition_desc_t **tptr =
+            (const ur_device_partition_desc_t **)ptr;
+        if (sizeof(ur_device_partition_desc_t *) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_partition_desc_t *)
+               << ")";
+            return;
         }
-        os << "]";
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
     } break;
 
     case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS: {
@@ -3119,6 +3297,111 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_device_partition_desc_t params) {
+    os << "(struct ur_device_partition_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_equally_desc_t params) {
+    os << "(struct ur_device_partition_equally_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".counts = ";
+
+    os << (params.counts);
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_by_counts_desc_t params) {
+    os << "(struct ur_device_partition_by_counts_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".counts = ";
+
+    ur_params::serializePtr(os, (params.counts));
+
+    os << ", ";
+    os << ".size = ";
+
+    os << (params.size);
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_by_affinity_domain_desc_t params) {
+    os << "(struct ur_device_partition_by_affinity_domain_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".flags = ";
+
+    ur_params::serializeFlag_ur_device_affinity_domain_flags_t(os,
+                                                               (params.flags));
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_partition_by_cslice_desc_t params) {
+    os << "(struct ur_device_partition_by_cslice_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << "}";
+    return os;
+}
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_fp_capability_flag_t value) {
     switch (value) {
@@ -3350,121 +3633,6 @@ inline void serializeFlag_ur_device_exec_capability_flags_t(
             first = false;
         }
         os << UR_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL;
-    }
-    if (val != 0) {
-        std::bitset<32> bits(val);
-        if (!first) {
-            os << " | ";
-        }
-        os << "unknown bit flags " << bits;
-    } else if (first) {
-        os << "0";
-    }
-}
-} // namespace ur_params
-inline std::ostream &operator<<(std::ostream &os,
-                                enum ur_device_affinity_domain_flag_t value) {
-    switch (value) {
-
-    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA:
-        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA";
-        break;
-
-    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE:
-        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE";
-        break;
-
-    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE:
-        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE";
-        break;
-
-    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE:
-        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE";
-        break;
-
-    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE:
-        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE";
-        break;
-
-    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE:
-        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE";
-        break;
-    default:
-        os << "unknown enumerator";
-        break;
-    }
-    return os;
-}
-namespace ur_params {
-inline void serializeFlag_ur_device_affinity_domain_flags_t(
-    std::ostream &os, ur_device_affinity_domain_flags_t flag) {
-    uint32_t val = flag;
-    bool first = true;
-
-    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA) ==
-        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA) {
-        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA;
-    }
-
-    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) ==
-        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) {
-        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
-    }
-
-    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE) ==
-        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE) {
-        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE;
-    }
-
-    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE) ==
-        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE) {
-        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE;
-    }
-
-    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE) ==
-        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE) {
-        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE;
-    }
-
-    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE) ==
-        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE) {
-        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE;
     }
     if (val != 0) {
         std::bitset<32> bits(val);

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -392,8 +392,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    const ur_device_partition_desc_t
+        *pProperties, ///< [in] device partitioning descriptor structure chain.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
     ur_device_handle_t *
         phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -412,8 +412,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    const ur_device_partition_desc_t
+        *pProperties, ///< [in] device partitioning descriptor structure chain.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
     ur_device_handle_t *
         phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -465,8 +465,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 /// @brief Intercept function for urDevicePartition
 __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    const ur_device_partition_desc_t
+        *pProperties, ///< [in] device partitioning descriptor structure chain.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
     ur_device_handle_t *
         phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -515,8 +515,8 @@ ur_result_t UR_APICALL urDeviceRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    const ur_device_partition_desc_t
+        *pProperties, ///< [in] device partitioning descriptor structure chain.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
     ur_device_handle_t *
         phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -447,8 +447,8 @@ ur_result_t UR_APICALL urDeviceRelease(
 ///     - ::UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT
 ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
-    const ur_device_partition_property_t *
-        pProperties, ///< [in] null-terminated array of <$_device_partition_t enum, value> pairs.
+    const ur_device_partition_desc_t
+        *pProperties, ///< [in] device partitioning descriptor structure chain.
     uint32_t NumDevices, ///< [in] the number of sub-devices.
     ur_device_handle_t *
         phSubDevices, ///< [out][optional][range(0, NumDevices)] array of handle of devices.

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -239,9 +239,9 @@ struct UrDeviceGetInfoParamsInvalidSize : UrDeviceGetInfoParams {
 };
 
 struct UrDeviceGetInfoParamsPartitionArray : UrDeviceGetInfoParams {
-    ur_device_partition_property_t props[3] = {
-        UR_DEVICE_PARTITION_BY_COUNTS, UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
-        UR_DEVICE_PARTITION_BY_CSLICE};
+    ur_device_partition_t props[4] = {
+        UR_DEVICE_PARTITION_EQUALLY, UR_DEVICE_PARTITION_BY_COUNTS,
+        UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, UR_DEVICE_PARTITION_BY_CSLICE};
     UrDeviceGetInfoParamsPartitionArray() : UrDeviceGetInfoParams() {
         propName = UR_DEVICE_INFO_PARTITION_PROPERTIES;
         pPropValue = &props;
@@ -251,8 +251,11 @@ struct UrDeviceGetInfoParamsPartitionArray : UrDeviceGetInfoParams {
     const char *get_expected() {
         return ".hDevice = nullptr, .propName = "
                "UR_DEVICE_INFO_PARTITION_PROPERTIES, .propSize "
-               "= 24, .pPropValue = \\[4231, 4232, 4233\\], .pPropSizeRet = .+ "
-               "\\(24\\)";
+               "= 16, .pPropValue = \\[UR_DEVICE_PARTITION_EQUALLY, "
+               "UR_DEVICE_PARTITION_BY_COUNTS, "
+               "UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN, "
+               "UR_DEVICE_PARTITION_BY_CSLICE\\], .pPropSizeRet = .+ "
+               "\\(16\\)";
         // TODO: should resolve type values for ur_device_partition_property_t...
     };
 };


### PR DESCRIPTION
Specify device partitioning scheme using a `desc_t` instead of OpenCL style raw array. 

One thing I'm not quite sure of is I've chosen to create a `ur_partition_desc_t` which has no additional fields and will then point to a specific partitioning description. The alternative would be to type the parameter simply as `ur_base_desc_t` and then cast it based on `stype` i.e.:

```cpp
ur_result_t urDevicePartition(ur_device_handle_t hDevice, const ur_base_desc_t *pDesc, ... ){
  switch(pDesc->stype){
    case UR_STRUCTURE_TYPE_DEVICE_PARTITION_EQUALLY_DESC:
      const auto *eqlDesc = static_cast<ur_device_partition_equally_desc_t *>(pDesc);
    case ...:
    default:
      return UR_RESULT_ERROR_INVALID_ENUMERATION;
  };
}
```
This way it would avoid the indirection - but the typename isn't really indicative as to what you should pass in I suppose. We could also just do something like `typedef ur_device_partition_desc_t ur_base_desc_t`?

------
Another thing to consider is how do we handle the query `UR_DEVICE_INFO_PARTITION_TYPE`: previously this would just return the `ur_device_partition_property_t[]` of properties passed into `urDevicePartition`, but what should be returned if a descriptor is used? The descriptors are allocated on the caller size and a pointer to the structure chain is passed. Do we copy the structure chain somewhere into the UR adapter and the query will just return a pointer to the start of the chain?

```cpp
ur_device_partition_desc_t *desc = nullptr;
urDeviceGetInfo(device, UR_DEVICE_INFO_PARTITION_TYPE, sizeof(desc), &desc, nullptr);
// Use the pointer...
```