### PR TITLE
[ur] fix docs references to usm advice flags

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -991,11 +991,11 @@ class ur_usm_alloc_info_t(c_int):
 class ur_usm_advice_flags_v(IntEnum):
     DEFAULT = UR_BIT(0)                             ## The USM memory advice is default
     SET_READ_MOSTLY = UR_BIT(1)                     ## Hint that memory will be read from frequently and written to rarely
-    CLEAR_READ_MOSTLY = UR_BIT(2)                   ## Removes the affect of ::::UR_USM_ADVICE_SET_READ_MOSTLY
+    CLEAR_READ_MOSTLY = UR_BIT(2)                   ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_READ_MOSTLY
     SET_PREFERRED_LOCATION = UR_BIT(3)              ## Hint that the preferred memory location is the specified device
-    CLEAR_PREFERRED_LOCATION = UR_BIT(4)            ## Removes the affect of ::::UR_USM_ADVICE_SET_PREFERRED_LOCATION
+    CLEAR_PREFERRED_LOCATION = UR_BIT(4)            ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION
     SET_NON_ATOMIC_MOSTLY = UR_BIT(5)               ## Hints that memory will mostly be accessed non-atomically
-    CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6)             ## Removes the affect of ::::UR_USM_ADVICE_SET_NON_ATOMIC_MOSTLY
+    CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6)             ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY
     BIAS_CACHED = UR_BIT(7)                         ## Hints that memory should be cached
     BIAS_UNCACHED = UR_BIT(8)                       ## Hints that memory should be not be cached
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2203,11 +2203,11 @@ typedef uint32_t ur_usm_advice_flags_t;
 typedef enum ur_usm_advice_flag_t {
     UR_USM_ADVICE_FLAG_DEFAULT = UR_BIT(0),                  ///< The USM memory advice is default
     UR_USM_ADVICE_FLAG_SET_READ_MOSTLY = UR_BIT(1),          ///< Hint that memory will be read from frequently and written to rarely
-    UR_USM_ADVICE_FLAG_CLEAR_READ_MOSTLY = UR_BIT(2),        ///< Removes the affect of ::::UR_USM_ADVICE_SET_READ_MOSTLY
+    UR_USM_ADVICE_FLAG_CLEAR_READ_MOSTLY = UR_BIT(2),        ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_READ_MOSTLY
     UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION = UR_BIT(3),   ///< Hint that the preferred memory location is the specified device
-    UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION = UR_BIT(4), ///< Removes the affect of ::::UR_USM_ADVICE_SET_PREFERRED_LOCATION
+    UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION = UR_BIT(4), ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION
     UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY = UR_BIT(5),    ///< Hints that memory will mostly be accessed non-atomically
-    UR_USM_ADVICE_FLAG_CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6),  ///< Removes the affect of ::::UR_USM_ADVICE_SET_NON_ATOMIC_MOSTLY
+    UR_USM_ADVICE_FLAG_CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6),  ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY
     UR_USM_ADVICE_FLAG_BIAS_CACHED = UR_BIT(7),              ///< Hints that memory should be cached
     UR_USM_ADVICE_FLAG_BIAS_UNCACHED = UR_BIT(8),            ///< Hints that memory should be not be cached
     /// @cond

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -98,19 +98,19 @@ etors:
       desc: "Hint that memory will be read from frequently and written to rarely"
     - name: CLEAR_READ_MOSTLY
       value: "$X_BIT(2)"
-      desc: "Removes the affect of ::$X_USM_ADVICE_SET_READ_MOSTLY"
+      desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_READ_MOSTLY"
     - name: SET_PREFERRED_LOCATION
       value: "$X_BIT(3)"
       desc: "Hint that the preferred memory location is the specified device"
     - name: CLEAR_PREFERRED_LOCATION
       value: "$X_BIT(4)"
-      desc: "Removes the affect of ::$X_USM_ADVICE_SET_PREFERRED_LOCATION"
+      desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION"
     - name: SET_NON_ATOMIC_MOSTLY
       value: "$X_BIT(5)"
       desc: "Hints that memory will mostly be accessed non-atomically"
     - name: CLEAR_NON_ATOMIC_MOSTLY
       value: "$X_BIT(6)"
-      desc: "Removes the affect of ::$X_USM_ADVICE_SET_NON_ATOMIC_MOSTLY"
+      desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY"
     - name: BIAS_CACHED
       value: "$X_BIT(7)"
       desc: "Hints that memory should be cached"


### PR DESCRIPTION
Fixes `warning: explicit link request to '...' could not be resolved`.