### PR TITLE
[ur] only add 'generate' and 'check-generated' targets

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       run: pip install -r third_party/requirements.txt
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DUR_ENABLE_TRACING=ON -DUR_DEVELOPER_MODE=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUR_BUILD_TESTS=ON
+      run: cmake -B ${{github.workspace}}/build -DUR_ENABLE_TRACING=ON -DUR_DEVELOPER_MODE=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUR_BUILD_TESTS=ON -DUR_FORMAT_CPP_STYLE=ON
 
     - name: Generate source from spec, check for uncommitted diff
       run: cmake --build ${{github.workspace}}/build --target check-generated
@@ -49,7 +49,7 @@ jobs:
       run: python3 -m pip install -r third_party/requirements.txt
 
     - name: Configure CMake
-      run: cmake -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DUR_ENABLE_TRACING=ON -DUR_DEVELOPER_MODE=ON -DUR_BUILD_TESTS=ON -B ${{github.workspace}}/build
+      run: cmake -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DUR_ENABLE_TRACING=ON -DUR_DEVELOPER_MODE=ON -DUR_BUILD_TESTS=ON -B ${{github.workspace}}/build -DUR_FORMAT_CPP_STYLE=ON
 
     - name: Generate source from spec, check for uncommitted diff
       run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,15 +209,19 @@ add_custom_target(generate-code USES_TERMINAL
     COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
 )
 
-# Generate and format source from the specification
-add_custom_target(generate USES_TERMINAL
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target generate-code
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target cppformat
-)
+if(UR_FORMAT_CPP_STYLE)
+    # Generate and format source from the specification
+    add_custom_target(generate USES_TERMINAL
+        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target generate-code
+        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target cppformat
+    )
 
-# Generate source and check for uncommitted diffs
-add_custom_target(check-generated
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    COMMAND git diff --exit-code
-    DEPENDS generate
-)
+    # Generate source and check for uncommitted diffs
+    add_custom_target(check-generated
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMAND git diff --exit-code
+        DEPENDS generate
+    )
+else()
+    message(WARNING "UR_FORMAT_CPP_STYLE not set. Targets: 'generate' and 'check-generated' and not available")
+endif()

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Tools can be acquired via instructions in [third_party](/third_party/README.md).
 Requirements:
 - C++ compiler with C++17 support
 - cmake >= 3.14.0
-- clang-format-15.0 (can be installed with `python -m pip install clang-format`)
+- clang-format-15.0 (can be installed with `python -m pip install clang-format==15.0.7`)
 
 Project is defined using [CMake](https://cmake.org/).
 
@@ -101,17 +101,22 @@ List of options provided by CMake:
 
 **General**:
 
-If you've made modifications to the specification, you can also run a custom `generate` target prior to building.
-~~~~
-$ make generate
-~~~~
-
-This call will automatically generate the source code.
-
 To run automated code formatting build with option `UR_FORMAT_CPP_STYLE` and then run a custom `cppformat` target:
 ~~~~
 $ make cppformat
 ~~~~
+
+If you've made modifications to the specification, you can also run a custom `generate-code` or `generate` target prior to building.
+This call will generate the source code:
+~~~~
+$ make generate-code
+~~~~
+
+This call will generate the source code and run automated code formatting:
+~~~~
+$ make generate
+~~~~
+Note: `generate` target requires `UR_FORMAT_CPP_STYLE` to bet set.
 
 ### Adapter naming convention
 


### PR DESCRIPTION
when UR_FORMAT_CPP_STYLE is set. To make sure that CLANG_FORMAT_REQUIRED version is respected.