### PR TITLE
[ur][common] pretty printing for props

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -282,7 +282,7 @@ class ur_platform_info_v(IntEnum):
                                                     ## size of the info needs to be dynamically queried.
     PROFILE = 5                                     ## [char*] The string denoting profile of the platform. The size of the
                                                     ## info needs to be dynamically queried.
-    BACKEND = 6                                     ## ::ur_platform_backend_t: The backend of the platform. Identifies the
+    BACKEND = 6                                     ## [::ur_platform_backend_t] The backend of the platform. Identifies the
                                                     ## native backend adapter implementing this platform.
 
 class ur_platform_info_t(c_int):
@@ -393,133 +393,135 @@ class ur_device_type_t(c_int):
 ###############################################################################
 ## @brief Supported device info
 class ur_device_info_v(IntEnum):
-    TYPE = 0                                        ## ::ur_device_type_t: type of the device
-    VENDOR_ID = 1                                   ## uint32_t: vendor Id of the device
-    DEVICE_ID = 2                                   ## uint32_t: Id of the device
-    MAX_COMPUTE_UNITS = 3                           ## uint32_t: the number of compute units
-    MAX_WORK_ITEM_DIMENSIONS = 4                    ## uint32_t: max work item dimensions
-    MAX_WORK_ITEM_SIZES = 5                         ## size_t[]: return an array of max work item sizes
-    MAX_WORK_GROUP_SIZE = 6                         ## size_t: max work group size
-    SINGLE_FP_CONFIG = 7                            ## Return a bit field of ::ur_device_fp_capability_flags_t: single
-                                                    ## precision floating point capability
-    HALF_FP_CONFIG = 8                              ## Return a bit field of ::ur_device_fp_capability_flags_t: half
-                                                    ## precision floating point capability
-    DOUBLE_FP_CONFIG = 9                            ## Return a bit field of ::ur_device_fp_capability_flags_t: double
-                                                    ## precision floating point capability
-    QUEUE_PROPERTIES = 10                           ## Return a bit field of ::ur_queue_flags_t: command queue properties
-                                                    ## supported by the device
-    PREFERRED_VECTOR_WIDTH_CHAR = 11                ## uint32_t: preferred vector width for char
-    PREFERRED_VECTOR_WIDTH_SHORT = 12               ## uint32_t: preferred vector width for short
-    PREFERRED_VECTOR_WIDTH_INT = 13                 ## uint32_t: preferred vector width for int
-    PREFERRED_VECTOR_WIDTH_LONG = 14                ## uint32_t: preferred vector width for long
-    PREFERRED_VECTOR_WIDTH_FLOAT = 15               ## uint32_t: preferred vector width for float
-    PREFERRED_VECTOR_WIDTH_DOUBLE = 16              ## uint32_t: preferred vector width for double
-    PREFERRED_VECTOR_WIDTH_HALF = 17                ## uint32_t: preferred vector width for half float
-    NATIVE_VECTOR_WIDTH_CHAR = 18                   ## uint32_t: native vector width for char
-    NATIVE_VECTOR_WIDTH_SHORT = 19                  ## uint32_t: native vector width for short
-    NATIVE_VECTOR_WIDTH_INT = 20                    ## uint32_t: native vector width for int
-    NATIVE_VECTOR_WIDTH_LONG = 21                   ## uint32_t: native vector width for long
-    NATIVE_VECTOR_WIDTH_FLOAT = 22                  ## uint32_t: native vector width for float
-    NATIVE_VECTOR_WIDTH_DOUBLE = 23                 ## uint32_t: native vector width for double
-    NATIVE_VECTOR_WIDTH_HALF = 24                   ## uint32_t: native vector width for half float
-    MAX_CLOCK_FREQUENCY = 25                        ## uint32_t: max clock frequency in MHz
-    MEMORY_CLOCK_RATE = 26                          ## uint32_t: memory clock frequency in MHz
-    ADDRESS_BITS = 27                               ## uint32_t: address bits
-    MAX_MEM_ALLOC_SIZE = 28                         ## uint64_t: max memory allocation size
-    IMAGE_SUPPORTED = 29                            ## bool: images are supported
-    MAX_READ_IMAGE_ARGS = 30                        ## uint32_t: max number of image objects arguments of a kernel declared
+    TYPE = 0                                        ## [::ur_device_type_t] type of the device
+    VENDOR_ID = 1                                   ## [uint32_t] vendor Id of the device
+    DEVICE_ID = 2                                   ## [uint32_t] Id of the device
+    MAX_COMPUTE_UNITS = 3                           ## [uint32_t] the number of compute units
+    MAX_WORK_ITEM_DIMENSIONS = 4                    ## [uint32_t] max work item dimensions
+    MAX_WORK_ITEM_SIZES = 5                         ## [size_t*] return an array of max work item sizes
+    MAX_WORK_GROUP_SIZE = 6                         ## [size_t] max work group size
+    SINGLE_FP_CONFIG = 7                            ## [::ur_device_fp_capability_flags_t] single precision floating point
+                                                    ## capability
+    HALF_FP_CONFIG = 8                              ## [::ur_device_fp_capability_flags_t] half precision floating point
+                                                    ## capability
+    DOUBLE_FP_CONFIG = 9                            ## [::ur_device_fp_capability_flags_t] double precision floating point
+                                                    ## capability
+    QUEUE_PROPERTIES = 10                           ## [::ur_queue_flags_t] command queue properties supported by the device
+    PREFERRED_VECTOR_WIDTH_CHAR = 11                ## [uint32_t] preferred vector width for char
+    PREFERRED_VECTOR_WIDTH_SHORT = 12               ## [uint32_t] preferred vector width for short
+    PREFERRED_VECTOR_WIDTH_INT = 13                 ## [uint32_t] preferred vector width for int
+    PREFERRED_VECTOR_WIDTH_LONG = 14                ## [uint32_t] preferred vector width for long
+    PREFERRED_VECTOR_WIDTH_FLOAT = 15               ## [uint32_t] preferred vector width for float
+    PREFERRED_VECTOR_WIDTH_DOUBLE = 16              ## [uint32_t] preferred vector width for double
+    PREFERRED_VECTOR_WIDTH_HALF = 17                ## [uint32_t] preferred vector width for half float
+    NATIVE_VECTOR_WIDTH_CHAR = 18                   ## [uint32_t] native vector width for char
+    NATIVE_VECTOR_WIDTH_SHORT = 19                  ## [uint32_t] native vector width for short
+    NATIVE_VECTOR_WIDTH_INT = 20                    ## [uint32_t] native vector width for int
+    NATIVE_VECTOR_WIDTH_LONG = 21                   ## [uint32_t] native vector width for long
+    NATIVE_VECTOR_WIDTH_FLOAT = 22                  ## [uint32_t] native vector width for float
+    NATIVE_VECTOR_WIDTH_DOUBLE = 23                 ## [uint32_t] native vector width for double
+    NATIVE_VECTOR_WIDTH_HALF = 24                   ## [uint32_t] native vector width for half float
+    MAX_CLOCK_FREQUENCY = 25                        ## [uint32_t] max clock frequency in MHz
+    MEMORY_CLOCK_RATE = 26                          ## [uint32_t] memory clock frequency in MHz
+    ADDRESS_BITS = 27                               ## [uint32_t] address bits
+    MAX_MEM_ALLOC_SIZE = 28                         ## [uint64_t] max memory allocation size
+    IMAGE_SUPPORTED = 29                            ## [::ur_bool_t] images are supported
+    MAX_READ_IMAGE_ARGS = 30                        ## [uint32_t] max number of image objects arguments of a kernel declared
                                                     ## with the read_only qualifier
-    MAX_WRITE_IMAGE_ARGS = 31                       ## uint32_t: max number of image objects arguments of a kernel declared
+    MAX_WRITE_IMAGE_ARGS = 31                       ## [uint32_t] max number of image objects arguments of a kernel declared
                                                     ## with the write_only qualifier
-    MAX_READ_WRITE_IMAGE_ARGS = 32                  ## uint32_t: max number of image objects arguments of a kernel declared
+    MAX_READ_WRITE_IMAGE_ARGS = 32                  ## [uint32_t] max number of image objects arguments of a kernel declared
                                                     ## with the read_write qualifier
-    IMAGE2D_MAX_WIDTH = 33                          ## size_t: max width of Image2D object
-    IMAGE2D_MAX_HEIGHT = 34                         ## size_t: max heigh of Image2D object
-    IMAGE3D_MAX_WIDTH = 35                          ## size_t: max width of Image3D object
-    IMAGE3D_MAX_HEIGHT = 36                         ## size_t: max height of Image3D object
-    IMAGE3D_MAX_DEPTH = 37                          ## size_t: max depth of Image3D object
-    IMAGE_MAX_BUFFER_SIZE = 38                      ## size_t: max image buffer size
-    IMAGE_MAX_ARRAY_SIZE = 39                       ## size_t: max image array size
-    MAX_SAMPLERS = 40                               ## uint32_t: max number of samplers that can be used in a kernel
-    MAX_PARAMETER_SIZE = 41                         ## size_t: max size in bytes of all arguments passed to a kernel
-    MEM_BASE_ADDR_ALIGN = 42                        ## uint32_t: memory base address alignment
-    GLOBAL_MEM_CACHE_TYPE = 43                      ## ::ur_device_mem_cache_type_t: global memory cache type
-    GLOBAL_MEM_CACHELINE_SIZE = 44                  ## uint32_t: global memory cache line size in bytes
-    GLOBAL_MEM_CACHE_SIZE = 45                      ## uint64_t: size of global memory cache in bytes
-    GLOBAL_MEM_SIZE = 46                            ## uint64_t: size of global memory in bytes
-    GLOBAL_MEM_FREE = 47                            ## uint64_t: size of global memory which is free in bytes
-    MAX_CONSTANT_BUFFER_SIZE = 48                   ## uint64_t: max constant buffer size in bytes
-    MAX_CONSTANT_ARGS = 49                          ## uint32_t: max number of __const declared arguments in a kernel
-    LOCAL_MEM_TYPE = 50                             ## ::ur_device_local_mem_type_t: local memory type
-    LOCAL_MEM_SIZE = 51                             ## uint64_t: local memory size in bytes
-    ERROR_CORRECTION_SUPPORT = 52                   ## bool: support error correction to global and local memory
-    HOST_UNIFIED_MEMORY = 53                        ## bool: unified host device memory
-    PROFILING_TIMER_RESOLUTION = 54                 ## size_t: profiling timer resolution in nanoseconds
-    ENDIAN_LITTLE = 55                              ## bool: little endian byte order
-    AVAILABLE = 56                                  ## bool: device is available
-    COMPILER_AVAILABLE = 57                         ## bool: device compiler is available
-    LINKER_AVAILABLE = 58                           ## bool: device linker is available
-    EXECUTION_CAPABILITIES = 59                     ## ::ur_device_exec_capability_flags_t: device kernel execution
+    IMAGE2D_MAX_WIDTH = 33                          ## [size_t] max width of Image2D object
+    IMAGE2D_MAX_HEIGHT = 34                         ## [size_t] max heigh of Image2D object
+    IMAGE3D_MAX_WIDTH = 35                          ## [size_t] max width of Image3D object
+    IMAGE3D_MAX_HEIGHT = 36                         ## [size_t] max height of Image3D object
+    IMAGE3D_MAX_DEPTH = 37                          ## [size_t] max depth of Image3D object
+    IMAGE_MAX_BUFFER_SIZE = 38                      ## [size_t] max image buffer size
+    IMAGE_MAX_ARRAY_SIZE = 39                       ## [size_t] max image array size
+    MAX_SAMPLERS = 40                               ## [uint32_t] max number of samplers that can be used in a kernel
+    MAX_PARAMETER_SIZE = 41                         ## [size_t] max size in bytes of all arguments passed to a kernel
+    MEM_BASE_ADDR_ALIGN = 42                        ## [uint32_t] memory base address alignment
+    GLOBAL_MEM_CACHE_TYPE = 43                      ## [::ur_device_mem_cache_type_t] global memory cache type
+    GLOBAL_MEM_CACHELINE_SIZE = 44                  ## [uint32_t] global memory cache line size in bytes
+    GLOBAL_MEM_CACHE_SIZE = 45                      ## [uint64_t] size of global memory cache in bytes
+    GLOBAL_MEM_SIZE = 46                            ## [uint64_t] size of global memory in bytes
+    GLOBAL_MEM_FREE = 47                            ## [uint64_t] size of global memory which is free in bytes
+    MAX_CONSTANT_BUFFER_SIZE = 48                   ## [uint64_t] max constant buffer size in bytes
+    MAX_CONSTANT_ARGS = 49                          ## [uint32_t] max number of __const declared arguments in a kernel
+    LOCAL_MEM_TYPE = 50                             ## [::ur_device_local_mem_type_t] local memory type
+    LOCAL_MEM_SIZE = 51                             ## [uint64_t] local memory size in bytes
+    ERROR_CORRECTION_SUPPORT = 52                   ## [bool] support error correction to global and local memory
+    HOST_UNIFIED_MEMORY = 53                        ## [bool] unified host device memory
+    PROFILING_TIMER_RESOLUTION = 54                 ## [size_t] profiling timer resolution in nanoseconds
+    ENDIAN_LITTLE = 55                              ## [bool] little endian byte order
+    AVAILABLE = 56                                  ## [bool] device is available
+    COMPILER_AVAILABLE = 57                         ## [bool] device compiler is available
+    LINKER_AVAILABLE = 58                           ## [bool] device linker is available
+    EXECUTION_CAPABILITIES = 59                     ## [::ur_device_exec_capability_flags_t] device kernel execution
                                                     ## capability bit-field
-    QUEUE_ON_DEVICE_PROPERTIES = 60                 ## ::ur_queue_flags_t: device command queue property bit-field
-    QUEUE_ON_HOST_PROPERTIES = 61                   ## ::ur_queue_flags_t: host queue property bit-field
-    BUILT_IN_KERNELS = 62                           ## char[]: a semi-colon separated list of built-in kernels
-    PLATFORM = 63                                   ## ::ur_platform_handle_t: the platform associated with the device
+    QUEUE_ON_DEVICE_PROPERTIES = 60                 ## [::ur_queue_flags_t] device command queue property bit-field
+    QUEUE_ON_HOST_PROPERTIES = 61                   ## [::ur_queue_flags_t] host queue property bit-field
+    BUILT_IN_KERNELS = 62                           ## [char*] a semi-colon separated list of built-in kernels
+    PLATFORM = 63                                   ## [::ur_platform_handle_t] the platform associated with the device
     REFERENCE_COUNT = 64                            ## [uint32_t] Reference count of the device object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    IL_VERSION = 65                                 ## char[]: IL version
-    NAME = 66                                       ## char[]: Device name
-    VENDOR = 67                                     ## char[]: Device vendor
-    DRIVER_VERSION = 68                             ## char[]: Driver version
-    PROFILE = 69                                    ## char[]: Device profile
-    VERSION = 70                                    ## char[]: Device version
-    BACKEND_RUNTIME_VERSION = 71                    ## char[]: Version of backend runtime
-    EXTENSIONS = 72                                 ## char[]: Return a space separated list of extension names
-    PRINTF_BUFFER_SIZE = 73                         ## size_t: Maximum size in bytes of internal printf buffer
-    PREFERRED_INTEROP_USER_SYNC = 74                ## bool: prefer user synchronization when sharing object with other API
-    PARENT_DEVICE = 75                              ## ::ur_device_handle_t: return parent device handle
-    PARTITION_PROPERTIES = 76                       ## ::ur_device_partition_property_t[]: Returns the list of partition
+    IL_VERSION = 65                                 ## [char*] IL version
+    NAME = 66                                       ## [char*] Device name
+    VENDOR = 67                                     ## [char*] Device vendor
+    DRIVER_VERSION = 68                             ## [char*] Driver version
+    PROFILE = 69                                    ## [char*] Device profile
+    VERSION = 70                                    ## [char*] Device version
+    BACKEND_RUNTIME_VERSION = 71                    ## [char*] Version of backend runtime
+    EXTENSIONS = 72                                 ## [char*] Return a space separated list of extension names
+    PRINTF_BUFFER_SIZE = 73                         ## [size_t] Maximum size in bytes of internal printf buffer
+    PREFERRED_INTEROP_USER_SYNC = 74                ## [::ur_bool_t] prefer user synchronization when sharing object with
+                                                    ## other API
+    PARENT_DEVICE = 75                              ## [::ur_device_handle_t] return parent device handle
+    PARTITION_PROPERTIES = 76                       ## [::ur_device_partition_property_t*] Returns the list of partition
                                                     ## types supported by the device
-    PARTITION_MAX_SUB_DEVICES = 77                  ## uint32_t: maximum number of sub-devices when the device is partitioned
-    PARTITION_AFFINITY_DOMAIN = 78                  ## [::ur_device_affinity_domain_flags_t]: Returns a bit-field of the
+    PARTITION_MAX_SUB_DEVICES = 77                  ## [uint32_t] maximum number of sub-devices when the device is
+                                                    ## partitioned
+    PARTITION_AFFINITY_DOMAIN = 78                  ## [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
                                                     ## supported affinity domains for partitioning. 
                                                     ## If the device does not support any affinity domains, then 0 will be returned.
-    PARTITION_TYPE = 79                             ## ::ur_device_partition_property_t[]: return a list of
+    PARTITION_TYPE = 79                             ## [::ur_device_partition_property_t*] return a list of
                                                     ## ::ur_device_partition_property_t for properties specified in
                                                     ## ::urDevicePartition
-    MAX_NUM_SUB_GROUPS = 80                         ## uint32_t: max number of sub groups
-    SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81     ## bool: support sub group independent forward progress
-    SUB_GROUP_SIZES_INTEL = 82                      ## uint32_t[]: return an array of sub group sizes supported on Intel
+    MAX_NUM_SUB_GROUPS = 80                         ## [uint32_t] max number of sub groups
+    SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81     ## [::ur_bool_t] support sub group independent forward progress
+    SUB_GROUP_SIZES_INTEL = 82                      ## [uint32_t*] return an array of sub group sizes supported on Intel
                                                     ## device
-    USM_HOST_SUPPORT = 83                           ## bool: support USM host memory access
-    USM_DEVICE_SUPPORT = 84                         ## bool: support USM device memory access
-    USM_SINGLE_SHARED_SUPPORT = 85                  ## bool: support USM single device shared memory access
-    USM_CROSS_SHARED_SUPPORT = 86                   ## bool: support USM cross device shared memory access
-    USM_SYSTEM_SHARED_SUPPORT = 87                  ## bool: support USM system wide shared memory access
-    UUID = 88                                       ## char[]: return device UUID
-    PCI_ADDRESS = 89                                ## char[]: return device PCI address
-    GPU_EU_COUNT = 90                               ## uint32_t: return Intel GPU EU count
-    GPU_EU_SIMD_WIDTH = 91                          ## uint32_t: return Intel GPU EU SIMD width
-    GPU_EU_SLICES = 92                              ## uint32_t: return Intel GPU number of slices
-    GPU_SUBSLICES_PER_SLICE = 93                    ## uint32_t: return Intel GPU number of subslices per slice
-    MAX_MEMORY_BANDWIDTH = 94                       ## uint32_t: return max memory bandwidth in Mb/s
-    IMAGE_SRGB = 95                                 ## bool: image is SRGB
-    ATOMIC_64 = 96                                  ## bool: support 64 bit atomics
-    ATOMIC_MEMORY_ORDER_CAPABILITIES = 97           ## ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+    USM_HOST_SUPPORT = 83                           ## [::ur_bool_t] support USM host memory access
+    USM_DEVICE_SUPPORT = 84                         ## [::ur_bool_t] support USM device memory access
+    USM_SINGLE_SHARED_SUPPORT = 85                  ## [::ur_bool_t] support USM single device shared memory access
+    USM_CROSS_SHARED_SUPPORT = 86                   ## [::ur_bool_t] support USM cross device shared memory access
+    USM_SYSTEM_SHARED_SUPPORT = 87                  ## [::ur_bool_t] support USM system wide shared memory access
+    UUID = 88                                       ## [char*] return device UUID
+    PCI_ADDRESS = 89                                ## [char*] return device PCI address
+    GPU_EU_COUNT = 90                               ## [uint32_t] return Intel GPU EU count
+    GPU_EU_SIMD_WIDTH = 91                          ## [uint32_t] return Intel GPU EU SIMD width
+    GPU_EU_SLICES = 92                              ## [uint32_t] return Intel GPU number of slices
+    GPU_SUBSLICES_PER_SLICE = 93                    ## [uint32_t] return Intel GPU number of subslices per slice
+    MAX_MEMORY_BANDWIDTH = 94                       ## [uint32_t] return max memory bandwidth in Mb/s
+    IMAGE_SRGB = 95                                 ## [::ur_bool_t] image is SRGB
+    ATOMIC_64 = 96                                  ## [::ur_bool_t] support 64 bit atomics
+    ATOMIC_MEMORY_ORDER_CAPABILITIES = 97           ## [::ur_memory_order_capability_flags_t] return a bit-field of atomic
                                                     ## memory order capabilities
-    ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98           ## ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+    ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98           ## [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
                                                     ## memory scope capabilities
-    ATOMIC_FENCE_ORDER_CAPABILITIES = 99            ## ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+    ATOMIC_FENCE_ORDER_CAPABILITIES = 99            ## [::ur_memory_order_capability_flags_t] return a bit-field of atomic
                                                     ## memory fence order capabilities
-    ATOMIC_FENCE_SCOPE_CAPABILITIES = 100           ## ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+    ATOMIC_FENCE_SCOPE_CAPABILITIES = 100           ## [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
                                                     ## memory fence scope capabilities
-    BFLOAT16 = 101                                  ## bool: support for bfloat16
-    MAX_COMPUTE_QUEUE_INDICES = 102                 ## uint32_t: Returns 1 if the device doesn't have a notion of a 
+    BFLOAT16 = 101                                  ## [::ur_bool_t] support for bfloat16
+    MAX_COMPUTE_QUEUE_INDICES = 102                 ## [uint32_t] Returns 1 if the device doesn't have a notion of a 
                                                     ## queue index. Otherwise, returns the number of queue indices that are
                                                     ## available for this device.
-    KERNEL_SET_SPECIALIZATION_CONSTANTS = 103       ## `bool`: support the ::urKernelSetSpecializationConstants entry point
+    KERNEL_SET_SPECIALIZATION_CONSTANTS = 103       ## [::ur_bool_t] support the ::urKernelSetSpecializationConstants entry
+                                                    ## point
 
 class ur_device_info_t(c_int):
     def __str__(self):
@@ -678,15 +680,14 @@ class ur_context_properties_t(Structure):
 ## @brief Supported context info
 class ur_context_info_v(IntEnum):
     NUM_DEVICES = 0                                 ## [uint32_t] The number of the devices in the context
-    DEVICES = 1                                     ## [::ur_device_handle_t ...] The array of the device handles in the
-                                                    ## context
+    DEVICES = 1                                     ## [::ur_device_handle_t*] The array of the device handles in the context
     REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the context object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    USM_MEMCPY2D_SUPPORT = 3                        ## [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
+    USM_MEMCPY2D_SUPPORT = 3                        ## [::ur_bool_t] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
                                                     ## supported.
-    USM_FILL2D_SUPPORT = 4                          ## [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is
+    USM_FILL2D_SUPPORT = 4                          ## [::ur_bool_t] to indicate if the ::urEnqueueUSMFill2D entrypoint is
                                                     ## supported.
     ATOMIC_MEMORY_ORDER_CAPABILITIES = 5            ## [::ur_memory_order_capability_flags_t] return a bit-field of atomic
                                                     ## memory order capabilities.
@@ -748,8 +749,8 @@ class ur_mem_type_t(c_int):
 ###############################################################################
 ## @brief Memory Information type
 class ur_mem_info_v(IntEnum):
-    SIZE = 0                                        ## size_t: actual size of of memory object in bytes
-    CONTEXT = 1                                     ## ::ur_context_handle_t: context in which the memory object was created
+    SIZE = 0                                        ## [size_t] actual size of of memory object in bytes
+    CONTEXT = 1                                     ## [::ur_context_handle_t] context in which the memory object was created
 
 class ur_mem_info_t(c_int):
     def __str__(self):
@@ -807,13 +808,13 @@ class ur_image_channel_type_t(c_int):
 ###############################################################################
 ## @brief Image information types
 class ur_image_info_v(IntEnum):
-    FORMAT = 0                                      ## ::ur_image_format_t: image format
-    ELEMENT_SIZE = 1                                ## size_t: element size
-    ROW_PITCH = 2                                   ## size_t: row pitch
-    SLICE_PITCH = 3                                 ## size_t: slice pitch
-    WIDTH = 4                                       ## size_t: image width
-    HEIGHT = 5                                      ## size_t: image height
-    DEPTH = 6                                       ## size_t: image depth
+    FORMAT = 0                                      ## [::ur_image_format_t] image format
+    ELEMENT_SIZE = 1                                ## [size_t] element size
+    ROW_PITCH = 2                                   ## [size_t] row pitch
+    SLICE_PITCH = 3                                 ## [size_t] slice pitch
+    WIDTH = 4                                       ## [size_t] image width
+    HEIGHT = 5                                      ## [size_t] image height
+    DEPTH = 6                                       ## [size_t] image depth
 
 class ur_image_info_t(c_int):
     def __str__(self):
@@ -1170,16 +1171,16 @@ class ur_program_info_v(IntEnum):
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    CONTEXT = 1                                     ## Program context info.
-    NUM_DEVICES = 2                                 ## Return number of devices associated with Program.
-    DEVICES = 3                                     ## Return list of devices associated with Program, return type uint32_t*.
-    SOURCE = 4                                      ## Return program source associated with Program, return type char*.
-    BINARY_SIZES = 5                                ## Return program binary sizes for each device, return type size_t*.
-    BINARIES = 6                                    ## Return program binaries for all devices for this Program, return type
-                                                    ## uchar*.
-    NUM_KERNELS = 7                                 ## Number of kernels in Program, return type size_t.
-    KERNEL_NAMES = 8                                ## Return a null-terminated, semi-colon separated list of kernel names in
-                                                    ## Program, return type char*.
+    CONTEXT = 1                                     ## [::ur_context_handle_t] Program context info.
+    NUM_DEVICES = 2                                 ## [uint32_t] Return number of devices associated with Program.
+    DEVICES = 3                                     ## [x_device_handle_t*] Return list of devices associated with Program.
+    SOURCE = 4                                      ## [char*] Return program source associated with Program.
+    BINARY_SIZES = 5                                ## [size_t*] Return program binary sizes for each device.
+    BINARIES = 6                                    ## [unsigned char*] Return program binaries for all devices for this
+                                                    ## Program.
+    NUM_KERNELS = 7                                 ## [size_t] Number of kernels in Program, return type size_t.
+    KERNEL_NAMES = 8                                ## [char*] Return a null-terminated, semi-colon separated list of kernel
+                                                    ## names in Program.
 
 class ur_program_info_t(c_int):
     def __str__(self):
@@ -1215,11 +1216,11 @@ class ur_program_binary_type_t(c_int):
 ###############################################################################
 ## @brief Get Program object build information
 class ur_program_build_info_v(IntEnum):
-    STATUS = 0                                      ## Program build status, return type ::ur_program_build_status_t.
-    OPTIONS = 1                                     ## Null-terminated options string specified by last build, compile or
-                                                    ## link operation performed on the program. Return type char*.
-    LOG = 2                                         ## Null-terminated program build log, return type char*.
-    BINARY_TYPE = 3                                 ## Program binary type, return type ::ur_program_binary_type_t.
+    STATUS = 0                                      ## [::ur_program_build_status_t] Program build status.
+    OPTIONS = 1                                     ## [char*] Null-terminated options string specified by last build,
+                                                    ## compile or link operation performed on the program.
+    LOG = 2                                         ## [char*] Null-terminated program build log.
+    BINARY_TYPE = 3                                 ## [::ur_program_binary_type_t] Program binary type.
 
 class ur_program_build_info_t(c_int):
     def __str__(self):
@@ -1238,15 +1239,15 @@ class ur_specialization_constant_info_t(Structure):
 ###############################################################################
 ## @brief Get Kernel object information
 class ur_kernel_info_v(IntEnum):
-    FUNCTION_NAME = 0                               ## Return null-terminated kernel function name, return type char*.
-    NUM_ARGS = 1                                    ## Return Kernel number of arguments.
+    FUNCTION_NAME = 0                               ## [char*] Return null-terminated kernel function name.
+    NUM_ARGS = 1                                    ## [size_t] Return Kernel number of arguments.
     REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the kernel object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    CONTEXT = 3                                     ## Return Context object associated with Kernel.
-    PROGRAM = 4                                     ## Return Program object associated with Kernel.
-    ATTRIBUTES = 5                                  ## Return null-terminated kernel attributes string, return type char*.
+    CONTEXT = 3                                     ## [::ur_context_handle_t] Return Context object associated with Kernel.
+    PROGRAM = 4                                     ## [::ur_program_handle_t] Return Program object associated with Kernel.
+    ATTRIBUTES = 5                                  ## [char*] Return null-terminated kernel attributes string.
     NUM_REGS = 6                                    ## [uint32_t] Return the number of registers used by the compiled kernel
                                                     ## (device specific).
 
@@ -1258,15 +1259,16 @@ class ur_kernel_info_t(c_int):
 ###############################################################################
 ## @brief Get Kernel Work Group information
 class ur_kernel_group_info_v(IntEnum):
-    GLOBAL_WORK_SIZE = 0                            ## Return Work Group maximum global size, return type size_t[3]
-    WORK_GROUP_SIZE = 1                             ## Return maximum Work Group size, return type size_t
-    COMPILE_WORK_GROUP_SIZE = 2                     ## Return Work Group size required by the source code, such as
-                                                    ## __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]
-    LOCAL_MEM_SIZE = 3                              ## Return local memory required by the Kernel, return type size_t
-    PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4          ## Return preferred multiple of Work Group size for launch, return type
-                                                    ## size_t
-    PRIVATE_MEM_SIZE = 5                            ## Return minimum amount of private memory in bytes used by each work
-                                                    ## item in the Kernel, return type size_t
+    GLOBAL_WORK_SIZE = 0                            ## [size_t*] Return Work Group maximum global size, always returns a
+                                                    ## three element array
+    WORK_GROUP_SIZE = 1                             ## [size_t] Return maximum Work Group size
+    COMPILE_WORK_GROUP_SIZE = 2                     ## [size_t*] Return Work Group size required by the source code, such as
+                                                    ## __attribute__((required_work_group_size(X,Y,Z)), always returns a
+                                                    ## three element array
+    LOCAL_MEM_SIZE = 3                              ## [size_t] Return local memory required by the Kernel
+    PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4          ## [size_t] Return preferred multiple of Work Group size for launch
+    PRIVATE_MEM_SIZE = 5                            ## [size_t] Return minimum amount of private memory in bytes used by each
+                                                    ## work item in the Kernel
 
 class ur_kernel_group_info_t(c_int):
     def __str__(self):
@@ -1276,11 +1278,10 @@ class ur_kernel_group_info_t(c_int):
 ###############################################################################
 ## @brief Get Kernel SubGroup information
 class ur_kernel_sub_group_info_v(IntEnum):
-    MAX_SUB_GROUP_SIZE = 0                          ## Return maximum SubGroup size, return type uint32_t
-    MAX_NUM_SUB_GROUPS = 1                          ## Return maximum number of SubGroup, return type uint32_t
-    COMPILE_NUM_SUB_GROUPS = 2                      ## Return number of SubGroup required by the source code, return type
-                                                    ## uint32_t
-    SUB_GROUP_SIZE_INTEL = 3                        ## Return SubGroup size required by Intel, return type uint32_t
+    MAX_SUB_GROUP_SIZE = 0                          ## [uint32_t] Return maximum SubGroup size
+    MAX_NUM_SUB_GROUPS = 1                          ## [uint32_t] Return maximum number of SubGroup
+    COMPILE_NUM_SUB_GROUPS = 2                      ## [uint32_t] Return number of SubGroup required by the source code
+    SUB_GROUP_SIZE_INTEL = 3                        ## [uint32_t] Return SubGroup size required by Intel
 
 class ur_kernel_sub_group_info_t(c_int):
     def __str__(self):
@@ -1302,11 +1303,10 @@ class ur_kernel_cache_config_t(c_int):
 ###############################################################################
 ## @brief Set additional Kernel execution information
 class ur_kernel_exec_info_v(IntEnum):
-    USM_INDIRECT_ACCESS = 0                         ## Kernel might access data through USM pointer, type bool_t*
-    USM_PTRS = 1                                    ## Provide an explicit list of USM pointers that the kernel will access,
-                                                    ## type void*[].
-    CACHE_CONFIG = 2                                ## Provide the preferred cache configuration, type
-                                                    ## ::ur_kernel_cache_config_t
+    USM_INDIRECT_ACCESS = 0                         ## [::ur_bool_t] Kernel might access data through USM pointer.
+    USM_PTRS = 1                                    ## [void **] Provide an explicit list of USM pointers that the kernel
+                                                    ## will access.
+    CACHE_CONFIG = 2                                ## [::ur_kernel_cache_config_t] Provide the preferred cache configuration
 
 class ur_kernel_exec_info_t(c_int):
     def __str__(self):
@@ -1316,17 +1316,17 @@ class ur_kernel_exec_info_t(c_int):
 ###############################################################################
 ## @brief Query queue info
 class ur_queue_info_v(IntEnum):
-    CONTEXT = 0                                     ## ::ur_queue_handle_t: context associated with this queue.
-    DEVICE = 1                                      ## ::ur_device_handle_t: device associated with this queue.
-    DEVICE_DEFAULT = 2                              ## ::ur_queue_handle_t: the current default queue of the underlying
+    CONTEXT = 0                                     ## [::ur_queue_handle_t] context associated with this queue.
+    DEVICE = 1                                      ## [::ur_device_handle_t] device associated with this queue.
+    DEVICE_DEFAULT = 2                              ## [::ur_queue_handle_t] the current default queue of the underlying
                                                     ## device.
-    FLAGS = 3                                       ## ::ur_queue_flags_t: the properties associated with
+    FLAGS = 3                                       ## [::ur_queue_flags_t] the properties associated with
                                                     ## ::ur_queue_properties_t::flags.
     REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of the queue object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    SIZE = 5                                        ## uint32_t: The size of the queue
+    SIZE = 5                                        ## [uint32_t] The size of the queue
 
 class ur_queue_info_t(c_int):
     def __str__(self):
@@ -1439,14 +1439,14 @@ class ur_event_info_t(c_int):
 ###############################################################################
 ## @brief Profiling query information type
 class ur_profiling_info_v(IntEnum):
-    COMMAND_QUEUED = 0                              ## A 64-bit value of current device counter in nanoseconds when the event
-                                                    ## is enqueued
-    COMMAND_SUBMIT = 1                              ## A 64-bit value of current device counter in nanoseconds when the event
-                                                    ## is submitted
-    COMMAND_START = 2                               ## A 64-bit value of current device counter in nanoseconds when the event
-                                                    ## starts execution
-    COMMAND_END = 3                                 ## A 64-bit value of current device counter in nanoseconds when the event
-                                                    ## has finished execution
+    COMMAND_QUEUED = 0                              ## [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                                    ## when the event is enqueued
+    COMMAND_SUBMIT = 1                              ## [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                                    ## when the event is submitted
+    COMMAND_START = 2                               ## [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                                    ## when the event starts execution
+    COMMAND_END = 3                                 ## [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                                    ## when the event has finished execution
 
 class ur_profiling_info_t(c_int):
     def __str__(self):

--- a/include/ur.py
+++ b/include/ur.py
@@ -272,15 +272,15 @@ class ur_device_init_flags_t(c_int):
 ###############################################################################
 ## @brief Supported platform info
 class ur_platform_info_v(IntEnum):
-    NAME = 1                                        ## [char*] The string denoting name of the platform. The size of the info
-                                                    ## needs to be dynamically queried.
-    VENDOR_NAME = 2                                 ## [char*] The string denoting name of the vendor of the platform. The
+    NAME = 1                                        ## [char[]] The string denoting name of the platform. The size of the
+                                                    ## info needs to be dynamically queried.
+    VENDOR_NAME = 2                                 ## [char[]] The string denoting name of the vendor of the platform. The
                                                     ## size of the info needs to be dynamically queried.
-    VERSION = 3                                     ## [char*] The string denoting the version of the platform. The size of
+    VERSION = 3                                     ## [char[]] The string denoting the version of the platform. The size of
                                                     ## the info needs to be dynamically queried.
-    EXTENSIONS = 4                                  ## [char*] The string denoting extensions supported by the platform. The
+    EXTENSIONS = 4                                  ## [char[]] The string denoting extensions supported by the platform. The
                                                     ## size of the info needs to be dynamically queried.
-    PROFILE = 5                                     ## [char*] The string denoting profile of the platform. The size of the
+    PROFILE = 5                                     ## [char[]] The string denoting profile of the platform. The size of the
                                                     ## info needs to be dynamically queried.
     BACKEND = 6                                     ## [::ur_platform_backend_t] The backend of the platform. Identifies the
                                                     ## native backend adapter implementing this platform.
@@ -398,7 +398,7 @@ class ur_device_info_v(IntEnum):
     DEVICE_ID = 2                                   ## [uint32_t] Id of the device
     MAX_COMPUTE_UNITS = 3                           ## [uint32_t] the number of compute units
     MAX_WORK_ITEM_DIMENSIONS = 4                    ## [uint32_t] max work item dimensions
-    MAX_WORK_ITEM_SIZES = 5                         ## [size_t*] return an array of max work item sizes
+    MAX_WORK_ITEM_SIZES = 5                         ## [size_t[]] return an array of max work item sizes
     MAX_WORK_GROUP_SIZE = 6                         ## [size_t] max work group size
     SINGLE_FP_CONFIG = 7                            ## [::ur_device_fp_capability_flags_t] single precision floating point
                                                     ## capability
@@ -462,45 +462,45 @@ class ur_device_info_v(IntEnum):
                                                     ## capability bit-field
     QUEUE_ON_DEVICE_PROPERTIES = 60                 ## [::ur_queue_flags_t] device command queue property bit-field
     QUEUE_ON_HOST_PROPERTIES = 61                   ## [::ur_queue_flags_t] host queue property bit-field
-    BUILT_IN_KERNELS = 62                           ## [char*] a semi-colon separated list of built-in kernels
+    BUILT_IN_KERNELS = 62                           ## [char[]] a semi-colon separated list of built-in kernels
     PLATFORM = 63                                   ## [::ur_platform_handle_t] the platform associated with the device
     REFERENCE_COUNT = 64                            ## [uint32_t] Reference count of the device object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
-    IL_VERSION = 65                                 ## [char*] IL version
-    NAME = 66                                       ## [char*] Device name
-    VENDOR = 67                                     ## [char*] Device vendor
-    DRIVER_VERSION = 68                             ## [char*] Driver version
-    PROFILE = 69                                    ## [char*] Device profile
-    VERSION = 70                                    ## [char*] Device version
-    BACKEND_RUNTIME_VERSION = 71                    ## [char*] Version of backend runtime
-    EXTENSIONS = 72                                 ## [char*] Return a space separated list of extension names
+    IL_VERSION = 65                                 ## [char[]] IL version
+    NAME = 66                                       ## [char[]] Device name
+    VENDOR = 67                                     ## [char[]] Device vendor
+    DRIVER_VERSION = 68                             ## [char[]] Driver version
+    PROFILE = 69                                    ## [char[]] Device profile
+    VERSION = 70                                    ## [char[]] Device version
+    BACKEND_RUNTIME_VERSION = 71                    ## [char[]] Version of backend runtime
+    EXTENSIONS = 72                                 ## [char[]] Return a space separated list of extension names
     PRINTF_BUFFER_SIZE = 73                         ## [size_t] Maximum size in bytes of internal printf buffer
     PREFERRED_INTEROP_USER_SYNC = 74                ## [::ur_bool_t] prefer user synchronization when sharing object with
                                                     ## other API
     PARENT_DEVICE = 75                              ## [::ur_device_handle_t] return parent device handle
-    PARTITION_PROPERTIES = 76                       ## [::ur_device_partition_property_t*] Returns the list of partition
+    PARTITION_PROPERTIES = 76                       ## [::ur_device_partition_property_t[]] Returns an array of partition
                                                     ## types supported by the device
     PARTITION_MAX_SUB_DEVICES = 77                  ## [uint32_t] maximum number of sub-devices when the device is
                                                     ## partitioned
     PARTITION_AFFINITY_DOMAIN = 78                  ## [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
                                                     ## supported affinity domains for partitioning. 
                                                     ## If the device does not support any affinity domains, then 0 will be returned.
-    PARTITION_TYPE = 79                             ## [::ur_device_partition_property_t*] return a list of
+    PARTITION_TYPE = 79                             ## [::ur_device_partition_property_t[]] return an array of
                                                     ## ::ur_device_partition_property_t for properties specified in
                                                     ## ::urDevicePartition
     MAX_NUM_SUB_GROUPS = 80                         ## [uint32_t] max number of sub groups
     SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81     ## [::ur_bool_t] support sub group independent forward progress
-    SUB_GROUP_SIZES_INTEL = 82                      ## [uint32_t*] return an array of sub group sizes supported on Intel
+    SUB_GROUP_SIZES_INTEL = 82                      ## [uint32_t[]] return an array of sub group sizes supported on Intel
                                                     ## device
     USM_HOST_SUPPORT = 83                           ## [::ur_bool_t] support USM host memory access
     USM_DEVICE_SUPPORT = 84                         ## [::ur_bool_t] support USM device memory access
     USM_SINGLE_SHARED_SUPPORT = 85                  ## [::ur_bool_t] support USM single device shared memory access
     USM_CROSS_SHARED_SUPPORT = 86                   ## [::ur_bool_t] support USM cross device shared memory access
     USM_SYSTEM_SHARED_SUPPORT = 87                  ## [::ur_bool_t] support USM system wide shared memory access
-    UUID = 88                                       ## [char*] return device UUID
-    PCI_ADDRESS = 89                                ## [char*] return device PCI address
+    UUID = 88                                       ## [char[]] return device UUID
+    PCI_ADDRESS = 89                                ## [char[]] return device PCI address
     GPU_EU_COUNT = 90                               ## [uint32_t] return Intel GPU EU count
     GPU_EU_SIMD_WIDTH = 91                          ## [uint32_t] return Intel GPU EU SIMD width
     GPU_EU_SLICES = 92                              ## [uint32_t] return Intel GPU number of slices
@@ -680,7 +680,8 @@ class ur_context_properties_t(Structure):
 ## @brief Supported context info
 class ur_context_info_v(IntEnum):
     NUM_DEVICES = 0                                 ## [uint32_t] The number of the devices in the context
-    DEVICES = 1                                     ## [::ur_device_handle_t*] The array of the device handles in the context
+    DEVICES = 1                                     ## [::ur_device_handle_t[]] The array of the device handles in the
+                                                    ## context
     REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the context object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
@@ -946,7 +947,7 @@ class ur_sampler_info_v(IntEnum):
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
     CONTEXT = 1                                     ## [::ur_context_handle_t] Sampler context info
-    NORMALIZED_COORDS = 2                           ## [bool] Sampler normalized coordinate setting
+    NORMALIZED_COORDS = 2                           ## [::ur_bool_t] Sampler normalized coordinate setting
     ADDRESSING_MODE = 3                             ## [::ur_sampler_addressing_mode_t] Sampler addressing mode setting
     FILTER_MODE = 4                                 ## [::ur_sampler_filter_mode_t] Sampler filter mode setting
 
@@ -1173,13 +1174,14 @@ class ur_program_info_v(IntEnum):
                                                     ## provided for identifying memory leaks.
     CONTEXT = 1                                     ## [::ur_context_handle_t] Program context info.
     NUM_DEVICES = 2                                 ## [uint32_t] Return number of devices associated with Program.
-    DEVICES = 3                                     ## [x_device_handle_t*] Return list of devices associated with Program.
-    SOURCE = 4                                      ## [char*] Return program source associated with Program.
-    BINARY_SIZES = 5                                ## [size_t*] Return program binary sizes for each device.
-    BINARIES = 6                                    ## [unsigned char*] Return program binaries for all devices for this
+    DEVICES = 3                                     ## [::ur_device_handle_t[]] Return list of devices associated with
+                                                    ## Program.
+    SOURCE = 4                                      ## [char[]] Return program source associated with Program.
+    BINARY_SIZES = 5                                ## [size_t[]] Return program binary sizes for each device.
+    BINARIES = 6                                    ## [unsigned char[]] Return program binaries for all devices for this
                                                     ## Program.
     NUM_KERNELS = 7                                 ## [size_t] Number of kernels in Program, return type size_t.
-    KERNEL_NAMES = 8                                ## [char*] Return a null-terminated, semi-colon separated list of kernel
+    KERNEL_NAMES = 8                                ## [char[]] Return a null-terminated, semi-colon separated list of kernel
                                                     ## names in Program.
 
 class ur_program_info_t(c_int):
@@ -1217,9 +1219,9 @@ class ur_program_binary_type_t(c_int):
 ## @brief Get Program object build information
 class ur_program_build_info_v(IntEnum):
     STATUS = 0                                      ## [::ur_program_build_status_t] Program build status.
-    OPTIONS = 1                                     ## [char*] Null-terminated options string specified by last build,
+    OPTIONS = 1                                     ## [char[]] Null-terminated options string specified by last build,
                                                     ## compile or link operation performed on the program.
-    LOG = 2                                         ## [char*] Null-terminated program build log.
+    LOG = 2                                         ## [char[]] Null-terminated program build log.
     BINARY_TYPE = 3                                 ## [::ur_program_binary_type_t] Program binary type.
 
 class ur_program_build_info_t(c_int):
@@ -1239,7 +1241,7 @@ class ur_specialization_constant_info_t(Structure):
 ###############################################################################
 ## @brief Get Kernel object information
 class ur_kernel_info_v(IntEnum):
-    FUNCTION_NAME = 0                               ## [char*] Return null-terminated kernel function name.
+    FUNCTION_NAME = 0                               ## [char[]] Return null-terminated kernel function name.
     NUM_ARGS = 1                                    ## [size_t] Return Kernel number of arguments.
     REFERENCE_COUNT = 2                             ## [uint32_t] Reference count of the kernel object.
                                                     ## The reference count returned should be considered immediately stale. 
@@ -1247,7 +1249,7 @@ class ur_kernel_info_v(IntEnum):
                                                     ## provided for identifying memory leaks.
     CONTEXT = 3                                     ## [::ur_context_handle_t] Return Context object associated with Kernel.
     PROGRAM = 4                                     ## [::ur_program_handle_t] Return Program object associated with Kernel.
-    ATTRIBUTES = 5                                  ## [char*] Return null-terminated kernel attributes string.
+    ATTRIBUTES = 5                                  ## [char[]] Return null-terminated kernel attributes string.
     NUM_REGS = 6                                    ## [uint32_t] Return the number of registers used by the compiled kernel
                                                     ## (device specific).
 
@@ -1259,12 +1261,10 @@ class ur_kernel_info_t(c_int):
 ###############################################################################
 ## @brief Get Kernel Work Group information
 class ur_kernel_group_info_v(IntEnum):
-    GLOBAL_WORK_SIZE = 0                            ## [size_t*] Return Work Group maximum global size, always returns a
-                                                    ## three element array
+    GLOBAL_WORK_SIZE = 0                            ## [size_t[3]] Return Work Group maximum global size
     WORK_GROUP_SIZE = 1                             ## [size_t] Return maximum Work Group size
-    COMPILE_WORK_GROUP_SIZE = 2                     ## [size_t*] Return Work Group size required by the source code, such as
-                                                    ## __attribute__((required_work_group_size(X,Y,Z)), always returns a
-                                                    ## three element array
+    COMPILE_WORK_GROUP_SIZE = 2                     ## [size_t[3]] Return Work Group size required by the source code, such
+                                                    ## as __attribute__((required_work_group_size(X,Y,Z))
     LOCAL_MEM_SIZE = 3                              ## [size_t] Return local memory required by the Kernel
     PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4          ## [size_t] Return preferred multiple of Work Group size for launch
     PRIVATE_MEM_SIZE = 5                            ## [size_t] Return minimum amount of private memory in bytes used by each
@@ -1304,7 +1304,7 @@ class ur_kernel_cache_config_t(c_int):
 ## @brief Set additional Kernel execution information
 class ur_kernel_exec_info_v(IntEnum):
     USM_INDIRECT_ACCESS = 0                         ## [::ur_bool_t] Kernel might access data through USM pointer.
-    USM_PTRS = 1                                    ## [void **] Provide an explicit list of USM pointers that the kernel
+    USM_PTRS = 1                                    ## [void *[]] Provide an explicit array of USM pointers that the kernel
                                                     ## will access.
     CACHE_CONFIG = 2                                ## [::ur_kernel_cache_config_t] Provide the preferred cache configuration
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -398,7 +398,7 @@ typedef enum ur_platform_info_t {
                                       ///< size of the info needs to be dynamically queried.
     UR_PLATFORM_INFO_PROFILE = 5,     ///< [char*] The string denoting profile of the platform. The size of the
                                       ///< info needs to be dynamically queried.
-    UR_PLATFORM_INFO_BACKEND = 6,     ///< ::ur_platform_backend_t: The backend of the platform. Identifies the
+    UR_PLATFORM_INFO_BACKEND = 6,     ///< [::ur_platform_backend_t] The backend of the platform. Identifies the
                                       ///< native backend adapter implementing this platform.
     /// @cond
     UR_PLATFORM_INFO_FORCE_UINT32 = 0x7fffffff
@@ -424,17 +424,17 @@ typedef enum ur_platform_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_PLATFORM_INFO_BACKEND < PlatformInfoType`
+///         + `::UR_PLATFORM_INFO_BACKEND < propName`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size,                         ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo,                 ///< [out][optional] array of bytes holding the info.
-                                         ///< If Size is not equal to or greater to the real number of bytes needed
-                                         ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                                         ///< returned and pPlatformInfo is not used.
-    size_t *pSizeRet                     ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize,                ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *pPropValue,               ///< [out][optional][typename(propName)] array of bytes holding the info.
+                                    ///< If Size is not equal to or greater to the real number of bytes needed
+                                    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+                                    ///< returned and pPlatformInfo is not used.
+    size_t *pSizeRet                ///< [out][optional] pointer to the actual number of bytes being queried by pPlatformInfo.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -708,133 +708,135 @@ urDeviceGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device info
 typedef enum ur_device_info_t {
-    UR_DEVICE_INFO_TYPE = 0,                                    ///< ::ur_device_type_t: type of the device
-    UR_DEVICE_INFO_VENDOR_ID = 1,                               ///< uint32_t: vendor Id of the device
-    UR_DEVICE_INFO_DEVICE_ID = 2,                               ///< uint32_t: Id of the device
-    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,                       ///< uint32_t: the number of compute units
-    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                ///< uint32_t: max work item dimensions
-    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< size_t[]: return an array of max work item sizes
-    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                     ///< size_t: max work group size
-    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< Return a bit field of ::ur_device_fp_capability_flags_t: single
-                                                                ///< precision floating point capability
-    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                          ///< Return a bit field of ::ur_device_fp_capability_flags_t: half
-                                                                ///< precision floating point capability
-    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                        ///< Return a bit field of ::ur_device_fp_capability_flags_t: double
-                                                                ///< precision floating point capability
-    UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,                       ///< Return a bit field of ::ur_queue_flags_t: command queue properties
-                                                                ///< supported by the device
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,            ///< uint32_t: preferred vector width for char
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 12,           ///< uint32_t: preferred vector width for short
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 13,             ///< uint32_t: preferred vector width for int
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 14,            ///< uint32_t: preferred vector width for long
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 15,           ///< uint32_t: preferred vector width for float
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 16,          ///< uint32_t: preferred vector width for double
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 17,            ///< uint32_t: preferred vector width for half float
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 18,               ///< uint32_t: native vector width for char
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 19,              ///< uint32_t: native vector width for short
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 20,                ///< uint32_t: native vector width for int
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 21,               ///< uint32_t: native vector width for long
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 22,              ///< uint32_t: native vector width for float
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 23,             ///< uint32_t: native vector width for double
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 24,               ///< uint32_t: native vector width for half float
-    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 25,                    ///< uint32_t: max clock frequency in MHz
-    UR_DEVICE_INFO_MEMORY_CLOCK_RATE = 26,                      ///< uint32_t: memory clock frequency in MHz
-    UR_DEVICE_INFO_ADDRESS_BITS = 27,                           ///< uint32_t: address bits
-    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 28,                     ///< uint64_t: max memory allocation size
-    UR_DEVICE_INFO_IMAGE_SUPPORTED = 29,                        ///< bool: images are supported
-    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 30,                    ///< uint32_t: max number of image objects arguments of a kernel declared
+    UR_DEVICE_INFO_TYPE = 0,                                    ///< [::ur_device_type_t] type of the device
+    UR_DEVICE_INFO_VENDOR_ID = 1,                               ///< [uint32_t] vendor Id of the device
+    UR_DEVICE_INFO_DEVICE_ID = 2,                               ///< [uint32_t] Id of the device
+    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,                       ///< [uint32_t] the number of compute units
+    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                ///< [uint32_t] max work item dimensions
+    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< [size_t*] return an array of max work item sizes
+    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                     ///< [size_t] max work group size
+    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< [::ur_device_fp_capability_flags_t] single precision floating point
+                                                                ///< capability
+    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                          ///< [::ur_device_fp_capability_flags_t] half precision floating point
+                                                                ///< capability
+    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                        ///< [::ur_device_fp_capability_flags_t] double precision floating point
+                                                                ///< capability
+    UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,                       ///< [::ur_queue_flags_t] command queue properties supported by the device
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,            ///< [uint32_t] preferred vector width for char
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 12,           ///< [uint32_t] preferred vector width for short
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 13,             ///< [uint32_t] preferred vector width for int
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 14,            ///< [uint32_t] preferred vector width for long
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 15,           ///< [uint32_t] preferred vector width for float
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 16,          ///< [uint32_t] preferred vector width for double
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 17,            ///< [uint32_t] preferred vector width for half float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 18,               ///< [uint32_t] native vector width for char
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 19,              ///< [uint32_t] native vector width for short
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 20,                ///< [uint32_t] native vector width for int
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 21,               ///< [uint32_t] native vector width for long
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 22,              ///< [uint32_t] native vector width for float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 23,             ///< [uint32_t] native vector width for double
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 24,               ///< [uint32_t] native vector width for half float
+    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 25,                    ///< [uint32_t] max clock frequency in MHz
+    UR_DEVICE_INFO_MEMORY_CLOCK_RATE = 26,                      ///< [uint32_t] memory clock frequency in MHz
+    UR_DEVICE_INFO_ADDRESS_BITS = 27,                           ///< [uint32_t] address bits
+    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 28,                     ///< [uint64_t] max memory allocation size
+    UR_DEVICE_INFO_IMAGE_SUPPORTED = 29,                        ///< [::ur_bool_t] images are supported
+    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 30,                    ///< [uint32_t] max number of image objects arguments of a kernel declared
                                                                 ///< with the read_only qualifier
-    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 31,                   ///< uint32_t: max number of image objects arguments of a kernel declared
+    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 31,                   ///< [uint32_t] max number of image objects arguments of a kernel declared
                                                                 ///< with the write_only qualifier
-    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 32,              ///< uint32_t: max number of image objects arguments of a kernel declared
+    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 32,              ///< [uint32_t] max number of image objects arguments of a kernel declared
                                                                 ///< with the read_write qualifier
-    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 33,                      ///< size_t: max width of Image2D object
-    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 34,                     ///< size_t: max heigh of Image2D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 35,                      ///< size_t: max width of Image3D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 36,                     ///< size_t: max height of Image3D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 37,                      ///< size_t: max depth of Image3D object
-    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 38,                  ///< size_t: max image buffer size
-    UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE = 39,                   ///< size_t: max image array size
-    UR_DEVICE_INFO_MAX_SAMPLERS = 40,                           ///< uint32_t: max number of samplers that can be used in a kernel
-    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 41,                     ///< size_t: max size in bytes of all arguments passed to a kernel
-    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 42,                    ///< uint32_t: memory base address alignment
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 43,                  ///< ::ur_device_mem_cache_type_t: global memory cache type
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 44,              ///< uint32_t: global memory cache line size in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 45,                  ///< uint64_t: size of global memory cache in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 46,                        ///< uint64_t: size of global memory in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_FREE = 47,                        ///< uint64_t: size of global memory which is free in bytes
-    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 48,               ///< uint64_t: max constant buffer size in bytes
-    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,                      ///< uint32_t: max number of __const declared arguments in a kernel
-    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,                         ///< ::ur_device_local_mem_type_t: local memory type
-    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,                         ///< uint64_t: local memory size in bytes
-    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,               ///< bool: support error correction to global and local memory
-    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                    ///< bool: unified host device memory
-    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54,             ///< size_t: profiling timer resolution in nanoseconds
-    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                          ///< bool: little endian byte order
-    UR_DEVICE_INFO_AVAILABLE = 56,                              ///< bool: device is available
-    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                     ///< bool: device compiler is available
-    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                       ///< bool: device linker is available
-    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,                 ///< ::ur_device_exec_capability_flags_t: device kernel execution
+    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 33,                      ///< [size_t] max width of Image2D object
+    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 34,                     ///< [size_t] max heigh of Image2D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 35,                      ///< [size_t] max width of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 36,                     ///< [size_t] max height of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 37,                      ///< [size_t] max depth of Image3D object
+    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 38,                  ///< [size_t] max image buffer size
+    UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE = 39,                   ///< [size_t] max image array size
+    UR_DEVICE_INFO_MAX_SAMPLERS = 40,                           ///< [uint32_t] max number of samplers that can be used in a kernel
+    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 41,                     ///< [size_t] max size in bytes of all arguments passed to a kernel
+    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 42,                    ///< [uint32_t] memory base address alignment
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 43,                  ///< [::ur_device_mem_cache_type_t] global memory cache type
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 44,              ///< [uint32_t] global memory cache line size in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 45,                  ///< [uint64_t] size of global memory cache in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 46,                        ///< [uint64_t] size of global memory in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_FREE = 47,                        ///< [uint64_t] size of global memory which is free in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 48,               ///< [uint64_t] max constant buffer size in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,                      ///< [uint32_t] max number of __const declared arguments in a kernel
+    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,                         ///< [::ur_device_local_mem_type_t] local memory type
+    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,                         ///< [uint64_t] local memory size in bytes
+    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,               ///< [bool] support error correction to global and local memory
+    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                    ///< [bool] unified host device memory
+    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54,             ///< [size_t] profiling timer resolution in nanoseconds
+    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                          ///< [bool] little endian byte order
+    UR_DEVICE_INFO_AVAILABLE = 56,                              ///< [bool] device is available
+    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                     ///< [bool] device compiler is available
+    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                       ///< [bool] device linker is available
+    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,                 ///< [::ur_device_exec_capability_flags_t] device kernel execution
                                                                 ///< capability bit-field
-    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,             ///< ::ur_queue_flags_t: device command queue property bit-field
-    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,               ///< ::ur_queue_flags_t: host queue property bit-field
-    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< char[]: a semi-colon separated list of built-in kernels
-    UR_DEVICE_INFO_PLATFORM = 63,                               ///< ::ur_platform_handle_t: the platform associated with the device
+    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,             ///< [::ur_queue_flags_t] device command queue property bit-field
+    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,               ///< [::ur_queue_flags_t] host queue property bit-field
+    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< [char*] a semi-colon separated list of built-in kernels
+    UR_DEVICE_INFO_PLATFORM = 63,                               ///< [::ur_platform_handle_t] the platform associated with the device
     UR_DEVICE_INFO_REFERENCE_COUNT = 64,                        ///< [uint32_t] Reference count of the device object.
                                                                 ///< The reference count returned should be considered immediately stale.
                                                                 ///< It is unsuitable for general use in applications. This feature is
                                                                 ///< provided for identifying memory leaks.
-    UR_DEVICE_INFO_IL_VERSION = 65,                             ///< char[]: IL version
-    UR_DEVICE_INFO_NAME = 66,                                   ///< char[]: Device name
-    UR_DEVICE_INFO_VENDOR = 67,                                 ///< char[]: Device vendor
-    UR_DEVICE_INFO_DRIVER_VERSION = 68,                         ///< char[]: Driver version
-    UR_DEVICE_INFO_PROFILE = 69,                                ///< char[]: Device profile
-    UR_DEVICE_INFO_VERSION = 70,                                ///< char[]: Device version
-    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                ///< char[]: Version of backend runtime
-    UR_DEVICE_INFO_EXTENSIONS = 72,                             ///< char[]: Return a space separated list of extension names
-    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,                     ///< size_t: Maximum size in bytes of internal printf buffer
-    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,            ///< bool: prefer user synchronization when sharing object with other API
-    UR_DEVICE_INFO_PARENT_DEVICE = 75,                          ///< ::ur_device_handle_t: return parent device handle
-    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< ::ur_device_partition_property_t[]: Returns the list of partition
+    UR_DEVICE_INFO_IL_VERSION = 65,                             ///< [char*] IL version
+    UR_DEVICE_INFO_NAME = 66,                                   ///< [char*] Device name
+    UR_DEVICE_INFO_VENDOR = 67,                                 ///< [char*] Device vendor
+    UR_DEVICE_INFO_DRIVER_VERSION = 68,                         ///< [char*] Driver version
+    UR_DEVICE_INFO_PROFILE = 69,                                ///< [char*] Device profile
+    UR_DEVICE_INFO_VERSION = 70,                                ///< [char*] Device version
+    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                ///< [char*] Version of backend runtime
+    UR_DEVICE_INFO_EXTENSIONS = 72,                             ///< [char*] Return a space separated list of extension names
+    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,                     ///< [size_t] Maximum size in bytes of internal printf buffer
+    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,            ///< [::ur_bool_t] prefer user synchronization when sharing object with
+                                                                ///< other API
+    UR_DEVICE_INFO_PARENT_DEVICE = 75,                          ///< [::ur_device_handle_t] return parent device handle
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< [::ur_device_partition_property_t*] Returns the list of partition
                                                                 ///< types supported by the device
-    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,              ///< uint32_t: maximum number of sub-devices when the device is partitioned
-    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,              ///< [::ur_device_affinity_domain_flags_t]: Returns a bit-field of the
+    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,              ///< [uint32_t] maximum number of sub-devices when the device is
+                                                                ///< partitioned
+    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,              ///< [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
                                                                 ///< supported affinity domains for partitioning.
                                                                 ///< If the device does not support any affinity domains, then 0 will be returned.
-    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< ::ur_device_partition_property_t[]: return a list of
+    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< [::ur_device_partition_property_t*] return a list of
                                                                 ///< ::ur_device_partition_property_t for properties specified in
                                                                 ///< ::urDevicePartition
-    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                     ///< uint32_t: max number of sub groups
-    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81, ///< bool: support sub group independent forward progress
-    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< uint32_t[]: return an array of sub group sizes supported on Intel
+    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                     ///< [uint32_t] max number of sub groups
+    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81, ///< [::ur_bool_t] support sub group independent forward progress
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< [uint32_t*] return an array of sub group sizes supported on Intel
                                                                 ///< device
-    UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                       ///< bool: support USM host memory access
-    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                     ///< bool: support USM device memory access
-    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,              ///< bool: support USM single device shared memory access
-    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,               ///< bool: support USM cross device shared memory access
-    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,              ///< bool: support USM system wide shared memory access
-    UR_DEVICE_INFO_UUID = 88,                                   ///< char[]: return device UUID
-    UR_DEVICE_INFO_PCI_ADDRESS = 89,                            ///< char[]: return device PCI address
-    UR_DEVICE_INFO_GPU_EU_COUNT = 90,                           ///< uint32_t: return Intel GPU EU count
-    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                      ///< uint32_t: return Intel GPU EU SIMD width
-    UR_DEVICE_INFO_GPU_EU_SLICES = 92,                          ///< uint32_t: return Intel GPU number of slices
-    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 93,                ///< uint32_t: return Intel GPU number of subslices per slice
-    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 94,                   ///< uint32_t: return max memory bandwidth in Mb/s
-    UR_DEVICE_INFO_IMAGE_SRGB = 95,                             ///< bool: image is SRGB
-    UR_DEVICE_INFO_ATOMIC_64 = 96,                              ///< bool: support 64 bit atomics
-    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 97,       ///< ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+    UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                       ///< [::ur_bool_t] support USM host memory access
+    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                     ///< [::ur_bool_t] support USM device memory access
+    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,              ///< [::ur_bool_t] support USM single device shared memory access
+    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,               ///< [::ur_bool_t] support USM cross device shared memory access
+    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,              ///< [::ur_bool_t] support USM system wide shared memory access
+    UR_DEVICE_INFO_UUID = 88,                                   ///< [char*] return device UUID
+    UR_DEVICE_INFO_PCI_ADDRESS = 89,                            ///< [char*] return device PCI address
+    UR_DEVICE_INFO_GPU_EU_COUNT = 90,                           ///< [uint32_t] return Intel GPU EU count
+    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                      ///< [uint32_t] return Intel GPU EU SIMD width
+    UR_DEVICE_INFO_GPU_EU_SLICES = 92,                          ///< [uint32_t] return Intel GPU number of slices
+    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 93,                ///< [uint32_t] return Intel GPU number of subslices per slice
+    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 94,                   ///< [uint32_t] return max memory bandwidth in Mb/s
+    UR_DEVICE_INFO_IMAGE_SRGB = 95,                             ///< [::ur_bool_t] image is SRGB
+    UR_DEVICE_INFO_ATOMIC_64 = 96,                              ///< [::ur_bool_t] support 64 bit atomics
+    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 97,       ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
                                                                 ///< memory order capabilities
-    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98,       ///< ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 98,       ///< [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
                                                                 ///< memory scope capabilities
-    UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES = 99,        ///< ::ur_memory_order_capability_flags_t: return a bit-field of atomic
+    UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES = 99,        ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
                                                                 ///< memory fence order capabilities
-    UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES = 100,       ///< ::ur_memory_scope_capability_flags_t: return a bit-field of atomic
+    UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES = 100,       ///< [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
                                                                 ///< memory fence scope capabilities
-    UR_DEVICE_INFO_BFLOAT16 = 101,                              ///< bool: support for bfloat16
-    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 102,             ///< uint32_t: Returns 1 if the device doesn't have a notion of a
+    UR_DEVICE_INFO_BFLOAT16 = 101,                              ///< [::ur_bool_t] support for bfloat16
+    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 102,             ///< [uint32_t] Returns 1 if the device doesn't have a notion of a
                                                                 ///< queue index. Otherwise, returns the number of queue indices that are
                                                                 ///< available for this device.
-    UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS = 103,   ///< `bool`: support the ::urKernelSetSpecializationConstants entry point
+    UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS = 103,   ///< [::ur_bool_t] support the ::urKernelSetSpecializationConstants entry
+                                                                ///< point
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -866,7 +868,7 @@ urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize,            ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue,           ///< [out][optional] array of bytes holding the info.
+    void *pPropValue,           ///< [out][optional][typename(propName)] array of bytes holding the info.
                                 ///< If propSize is not equal to or greater than the real number of bytes
                                 ///< needed to return the info
                                 ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -1312,15 +1314,14 @@ urContextRetain(
 /// @brief Supported context info
 typedef enum ur_context_info_t {
     UR_CONTEXT_INFO_NUM_DEVICES = 0,                      ///< [uint32_t] The number of the devices in the context
-    UR_CONTEXT_INFO_DEVICES = 1,                          ///< [::ur_device_handle_t ...] The array of the device handles in the
-                                                          ///< context
+    UR_CONTEXT_INFO_DEVICES = 1,                          ///< [::ur_device_handle_t*] The array of the device handles in the context
     UR_CONTEXT_INFO_REFERENCE_COUNT = 2,                  ///< [uint32_t] Reference count of the context object.
                                                           ///< The reference count returned should be considered immediately stale.
                                                           ///< It is unsuitable for general use in applications. This feature is
                                                           ///< provided for identifying memory leaks.
-    UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT = 3,             ///< [bool] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
+    UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT = 3,             ///< [::ur_bool_t] to indicate if the ::urEnqueueUSMMemcpy2D entrypoint is
                                                           ///< supported.
-    UR_CONTEXT_INFO_USM_FILL2D_SUPPORT = 4,               ///< [bool] to indicate if the ::urEnqueueUSMFill2D entrypoint is
+    UR_CONTEXT_INFO_USM_FILL2D_SUPPORT = 4,               ///< [::ur_bool_t] to indicate if the ::urEnqueueUSMFill2D entrypoint is
                                                           ///< supported.
     UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 5, ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
                                                           ///< memory order capabilities.
@@ -1385,7 +1386,7 @@ urContextGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t propSize,              ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue,             ///< [out][optional] array of bytes holding the info.
+    void *pPropValue,             ///< [out][optional][typename(propName)] array of bytes holding the info.
                                   ///< if propSize is not equal to or greater than the real number of bytes
                                   ///< needed to return
                                   ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1522,8 +1523,8 @@ typedef enum ur_mem_type_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory Information type
 typedef enum ur_mem_info_t {
-    UR_MEM_INFO_SIZE = 0,    ///< size_t: actual size of of memory object in bytes
-    UR_MEM_INFO_CONTEXT = 1, ///< ::ur_context_handle_t: context in which the memory object was created
+    UR_MEM_INFO_SIZE = 0,    ///< [size_t] actual size of of memory object in bytes
+    UR_MEM_INFO_CONTEXT = 1, ///< [::ur_context_handle_t] context in which the memory object was created
     /// @cond
     UR_MEM_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1581,13 +1582,13 @@ typedef enum ur_image_channel_type_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image information types
 typedef enum ur_image_info_t {
-    UR_IMAGE_INFO_FORMAT = 0,       ///< ::ur_image_format_t: image format
-    UR_IMAGE_INFO_ELEMENT_SIZE = 1, ///< size_t: element size
-    UR_IMAGE_INFO_ROW_PITCH = 2,    ///< size_t: row pitch
-    UR_IMAGE_INFO_SLICE_PITCH = 3,  ///< size_t: slice pitch
-    UR_IMAGE_INFO_WIDTH = 4,        ///< size_t: image width
-    UR_IMAGE_INFO_HEIGHT = 5,       ///< size_t: image height
-    UR_IMAGE_INFO_DEPTH = 6,        ///< size_t: image depth
+    UR_IMAGE_INFO_FORMAT = 0,       ///< [::ur_image_format_t] image format
+    UR_IMAGE_INFO_ELEMENT_SIZE = 1, ///< [size_t] element size
+    UR_IMAGE_INFO_ROW_PITCH = 2,    ///< [size_t] row pitch
+    UR_IMAGE_INFO_SLICE_PITCH = 3,  ///< [size_t] slice pitch
+    UR_IMAGE_INFO_WIDTH = 4,        ///< [size_t] image width
+    UR_IMAGE_INFO_HEIGHT = 5,       ///< [size_t] image height
+    UR_IMAGE_INFO_DEPTH = 6,        ///< [size_t] image depth
     /// @cond
     UR_IMAGE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1921,7 +1922,7 @@ urMemGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName,  ///< [in] type of the info to retrieve.
     size_t propSize,         ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue,        ///< [out][optional] array of bytes holding the info.
+    void *pPropValue,        ///< [out][optional][typename(propName)] array of bytes holding the info.
                              ///< If propSize is less than the real number of bytes needed to return
                              ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
                              ///< pPropValue is not used.
@@ -1951,7 +1952,7 @@ urMemImageGetInfo(
     ur_mem_handle_t hMemory,  ///< [in] handle to the image object being queried.
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t propSize,          ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue,         ///< [out][optional] array of bytes holding the info.
+    void *pPropValue,         ///< [out][optional][typename(propName)] array of bytes holding the info.
                               ///< If propSize is less than the real number of bytes needed to return
                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
                               ///< pPropValue is not used.
@@ -2125,8 +2126,8 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
-    size_t propValueSize,         ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out] value of the sampler property
+    size_t propSize,              ///< [in] size in bytes of the sampler property value provided
+    void *pPropValue,             ///< [out][typename(propName)] value of the sampler property
     size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 );
 
@@ -2518,9 +2519,10 @@ urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
-    size_t propValueSize,         ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional] value of the USM allocation property
-    size_t *pPropValueSizeRet     ///< [out][optional] bytes returned in USM allocation property
+    size_t propSize,              ///< [in] size in bytes of the USM allocation property value
+    void *pPropValue,             ///< [out][optional][typename(propName)] value of the USM allocation
+                                  ///< property
+    size_t *pPropSizeRet          ///< [out][optional] bytes returned in USM allocation property
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2892,16 +2894,16 @@ typedef enum ur_program_info_t {
                                          ///< The reference count returned should be considered immediately stale.
                                          ///< It is unsuitable for general use in applications. This feature is
                                          ///< provided for identifying memory leaks.
-    UR_PROGRAM_INFO_CONTEXT = 1,         ///< Program context info.
-    UR_PROGRAM_INFO_NUM_DEVICES = 2,     ///< Return number of devices associated with Program.
-    UR_PROGRAM_INFO_DEVICES = 3,         ///< Return list of devices associated with Program, return type uint32_t*.
-    UR_PROGRAM_INFO_SOURCE = 4,          ///< Return program source associated with Program, return type char*.
-    UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< Return program binary sizes for each device, return type size_t*.
-    UR_PROGRAM_INFO_BINARIES = 6,        ///< Return program binaries for all devices for this Program, return type
-                                         ///< uchar*.
-    UR_PROGRAM_INFO_NUM_KERNELS = 7,     ///< Number of kernels in Program, return type size_t.
-    UR_PROGRAM_INFO_KERNEL_NAMES = 8,    ///< Return a null-terminated, semi-colon separated list of kernel names in
-                                         ///< Program, return type char*.
+    UR_PROGRAM_INFO_CONTEXT = 1,         ///< [::ur_context_handle_t] Program context info.
+    UR_PROGRAM_INFO_NUM_DEVICES = 2,     ///< [uint32_t] Return number of devices associated with Program.
+    UR_PROGRAM_INFO_DEVICES = 3,         ///< [x_device_handle_t*] Return list of devices associated with Program.
+    UR_PROGRAM_INFO_SOURCE = 4,          ///< [char*] Return program source associated with Program.
+    UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< [size_t*] Return program binary sizes for each device.
+    UR_PROGRAM_INFO_BINARIES = 6,        ///< [unsigned char*] Return program binaries for all devices for this
+                                         ///< Program.
+    UR_PROGRAM_INFO_NUM_KERNELS = 7,     ///< [size_t] Number of kernels in Program, return type size_t.
+    UR_PROGRAM_INFO_KERNEL_NAMES = 8,    ///< [char*] Return a null-terminated, semi-colon separated list of kernel
+                                         ///< names in Program.
     /// @cond
     UR_PROGRAM_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2928,7 +2930,8 @@ urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName,   ///< [in] name of the Program property to query
     size_t propSize,              ///< [in] the size of the Program property.
-    void *pPropValue,             ///< [in,out][optional] array of bytes of holding the program info property.
+    void *pPropValue,             ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                                  ///< program info property.
                                   ///< If propSize is not equal to or greater than the real number of bytes
                                   ///< needed to return
                                   ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2965,11 +2968,11 @@ typedef enum ur_program_binary_type_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Program object build information
 typedef enum ur_program_build_info_t {
-    UR_PROGRAM_BUILD_INFO_STATUS = 0,      ///< Program build status, return type ::ur_program_build_status_t.
-    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,     ///< Null-terminated options string specified by last build, compile or
-                                           ///< link operation performed on the program. Return type char*.
-    UR_PROGRAM_BUILD_INFO_LOG = 2,         ///< Null-terminated program build log, return type char*.
-    UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3, ///< Program binary type, return type ::ur_program_binary_type_t.
+    UR_PROGRAM_BUILD_INFO_STATUS = 0,      ///< [::ur_program_build_status_t] Program build status.
+    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,     ///< [char*] Null-terminated options string specified by last build,
+                                           ///< compile or link operation performed on the program.
+    UR_PROGRAM_BUILD_INFO_LOG = 2,         ///< [char*] Null-terminated program build log.
+    UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3, ///< [::ur_program_binary_type_t] Program binary type.
     /// @cond
     UR_PROGRAM_BUILD_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2998,7 +3001,7 @@ urProgramGetBuildInfo(
     ur_device_handle_t hDevice,       ///< [in] handle of the Device object
     ur_program_build_info_t propName, ///< [in] name of the Program build info to query
     size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional] value of the Program build property.
+    void *pPropValue,                 ///< [in,out][optional][typename(propName)] value of the Program build property.
                                       ///< If propSize is not equal to or greater than the real number of bytes
                                       ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
                                       ///< error is returned and pPropValue is not used.
@@ -3180,15 +3183,15 @@ urKernelSetArgLocal(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel object information
 typedef enum ur_kernel_info_t {
-    UR_KERNEL_INFO_FUNCTION_NAME = 0,   ///< Return null-terminated kernel function name, return type char*.
-    UR_KERNEL_INFO_NUM_ARGS = 1,        ///< Return Kernel number of arguments.
+    UR_KERNEL_INFO_FUNCTION_NAME = 0,   ///< [char*] Return null-terminated kernel function name.
+    UR_KERNEL_INFO_NUM_ARGS = 1,        ///< [size_t] Return Kernel number of arguments.
     UR_KERNEL_INFO_REFERENCE_COUNT = 2, ///< [uint32_t] Reference count of the kernel object.
                                         ///< The reference count returned should be considered immediately stale.
                                         ///< It is unsuitable for general use in applications. This feature is
                                         ///< provided for identifying memory leaks.
-    UR_KERNEL_INFO_CONTEXT = 3,         ///< Return Context object associated with Kernel.
-    UR_KERNEL_INFO_PROGRAM = 4,         ///< Return Program object associated with Kernel.
-    UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< Return null-terminated kernel attributes string, return type char*.
+    UR_KERNEL_INFO_CONTEXT = 3,         ///< [::ur_context_handle_t] Return Context object associated with Kernel.
+    UR_KERNEL_INFO_PROGRAM = 4,         ///< [::ur_program_handle_t] Return Program object associated with Kernel.
+    UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< [char*] Return null-terminated kernel attributes string.
     UR_KERNEL_INFO_NUM_REGS = 6,        ///< [uint32_t] Return the number of registers used by the compiled kernel
                                         ///< (device specific).
     /// @cond
@@ -3200,15 +3203,16 @@ typedef enum ur_kernel_info_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel Work Group information
 typedef enum ur_kernel_group_info_t {
-    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,                   ///< Return Work Group maximum global size, return type size_t[3]
-    UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,                    ///< Return maximum Work Group size, return type size_t
-    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,            ///< Return Work Group size required by the source code, such as
-                                                                 ///< __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]
-    UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,                     ///< Return local memory required by the Kernel, return type size_t
-    UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4, ///< Return preferred multiple of Work Group size for launch, return type
-                                                                 ///< size_t
-    UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,                   ///< Return minimum amount of private memory in bytes used by each work
-                                                                 ///< item in the Kernel, return type size_t
+    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,                   ///< [size_t*] Return Work Group maximum global size, always returns a
+                                                                 ///< three element array
+    UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,                    ///< [size_t] Return maximum Work Group size
+    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,            ///< [size_t*] Return Work Group size required by the source code, such as
+                                                                 ///< __attribute__((required_work_group_size(X,Y,Z)), always returns a
+                                                                 ///< three element array
+    UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,                     ///< [size_t] Return local memory required by the Kernel
+    UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4, ///< [size_t] Return preferred multiple of Work Group size for launch
+    UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,                   ///< [size_t] Return minimum amount of private memory in bytes used by each
+                                                                 ///< work item in the Kernel
     /// @cond
     UR_KERNEL_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3218,11 +3222,10 @@ typedef enum ur_kernel_group_info_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel SubGroup information
 typedef enum ur_kernel_sub_group_info_t {
-    UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE = 0,     ///< Return maximum SubGroup size, return type uint32_t
-    UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS = 1,     ///< Return maximum number of SubGroup, return type uint32_t
-    UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2, ///< Return number of SubGroup required by the source code, return type
-                                                         ///< uint32_t
-    UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3,   ///< Return SubGroup size required by Intel, return type uint32_t
+    UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE = 0,     ///< [uint32_t] Return maximum SubGroup size
+    UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS = 1,     ///< [uint32_t] Return maximum number of SubGroup
+    UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS = 2, ///< [uint32_t] Return number of SubGroup required by the source code
+    UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL = 3,   ///< [uint32_t] Return SubGroup size required by Intel
     /// @cond
     UR_KERNEL_SUB_GROUP_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3244,11 +3247,10 @@ typedef enum ur_kernel_cache_config_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Set additional Kernel execution information
 typedef enum ur_kernel_exec_info_t {
-    UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0, ///< Kernel might access data through USM pointer, type bool_t*
-    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,            ///< Provide an explicit list of USM pointers that the kernel will access,
-                                                 ///< type void*[].
-    UR_KERNEL_EXEC_INFO_CACHE_CONFIG = 2,        ///< Provide the preferred cache configuration, type
-                                                 ///< ::ur_kernel_cache_config_t
+    UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0, ///< [::ur_bool_t] Kernel might access data through USM pointer.
+    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,            ///< [void **] Provide an explicit list of USM pointers that the kernel
+                                                 ///< will access.
+    UR_KERNEL_EXEC_INFO_CACHE_CONFIG = 2,        ///< [::ur_kernel_cache_config_t] Provide the preferred cache configuration
     /// @cond
     UR_KERNEL_EXEC_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3275,7 +3277,8 @@ urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pPropValue,           ///< [in,out][optional] array of bytes holding the kernel info property.
+    void *pPropValue,           ///< [in,out][optional][typename(propName)] array of bytes holding the
+                                ///< kernel info property.
                                 ///< If propSize is not equal to or greater than the real number of bytes
                                 ///< needed to return
                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -3306,7 +3309,7 @@ urKernelGetGroupInfo(
     ur_device_handle_t hDevice,      ///< [in] handle of the Device object
     ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
     size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+    void *pPropValue,                ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                                      ///< property.
     size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
                                      ///< queried by propName.
@@ -3330,7 +3333,7 @@ urKernelGetSubGroupInfo(
     ur_device_handle_t hDevice,          ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
     size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+    void *pPropValue,                    ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                                          ///< property.
     size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
                                          ///< queried by propName.
@@ -3439,7 +3442,7 @@ urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][range(0, propSize)] pointer to memory location holding the
+    const void *pPropValue          ///< [in][typename(propName)] pointer to memory location holding the
                                     ///< property value.
 );
 
@@ -3585,17 +3588,17 @@ urKernelCreateWithNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Query queue info
 typedef enum ur_queue_info_t {
-    UR_QUEUE_INFO_CONTEXT = 0,         ///< ::ur_queue_handle_t: context associated with this queue.
-    UR_QUEUE_INFO_DEVICE = 1,          ///< ::ur_device_handle_t: device associated with this queue.
-    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< ::ur_queue_handle_t: the current default queue of the underlying
+    UR_QUEUE_INFO_CONTEXT = 0,         ///< [::ur_queue_handle_t] context associated with this queue.
+    UR_QUEUE_INFO_DEVICE = 1,          ///< [::ur_device_handle_t] device associated with this queue.
+    UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< [::ur_queue_handle_t] the current default queue of the underlying
                                        ///< device.
-    UR_QUEUE_INFO_FLAGS = 3,           ///< ::ur_queue_flags_t: the properties associated with
+    UR_QUEUE_INFO_FLAGS = 3,           ///< [::ur_queue_flags_t] the properties associated with
                                        ///< ::ur_queue_properties_t::flags.
     UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< [uint32_t] Reference count of the queue object.
                                        ///< The reference count returned should be considered immediately stale.
                                        ///< It is unsuitable for general use in applications. This feature is
                                        ///< provided for identifying memory leaks.
-    UR_QUEUE_INFO_SIZE = 5,            ///< uint32_t: The size of the queue
+    UR_QUEUE_INFO_SIZE = 5,            ///< [uint32_t] The size of the queue
     /// @cond
     UR_QUEUE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3644,8 +3647,8 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
-    size_t propValueSize,     ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional] value of the queue property
+    size_t propSize,          ///< [in] size in bytes of the queue property value provided
+    void *pPropValue,         ///< [out][optional][typename(propName)] value of the queue property
     size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
 );
 
@@ -3939,14 +3942,14 @@ typedef enum ur_event_info_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Profiling query information type
 typedef enum ur_profiling_info_t {
-    UR_PROFILING_INFO_COMMAND_QUEUED = 0, ///< A 64-bit value of current device counter in nanoseconds when the event
-                                          ///< is enqueued
-    UR_PROFILING_INFO_COMMAND_SUBMIT = 1, ///< A 64-bit value of current device counter in nanoseconds when the event
-                                          ///< is submitted
-    UR_PROFILING_INFO_COMMAND_START = 2,  ///< A 64-bit value of current device counter in nanoseconds when the event
-                                          ///< starts execution
-    UR_PROFILING_INFO_COMMAND_END = 3,    ///< A 64-bit value of current device counter in nanoseconds when the event
-                                          ///< has finished execution
+    UR_PROFILING_INFO_COMMAND_QUEUED = 0, ///< [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                          ///< when the event is enqueued
+    UR_PROFILING_INFO_COMMAND_SUBMIT = 1, ///< [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                          ///< when the event is submitted
+    UR_PROFILING_INFO_COMMAND_START = 2,  ///< [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                          ///< when the event starts execution
+    UR_PROFILING_INFO_COMMAND_END = 3,    ///< [uint64_t] A 64-bit value of current device counter in nanoseconds
+                                          ///< when the event has finished execution
     /// @cond
     UR_PROFILING_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3969,7 +3972,7 @@ typedef enum ur_profiling_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EVENT_INFO_REFERENCE_COUNT < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///         + `pPropValue && propValueSize == 0`
+///         + `pPropValue && propSize == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -3977,9 +3980,9 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize,     ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional] value of the event property
-    size_t *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize,          ///< [in] size in bytes of the event property value
+    void *pPropValue,         ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet      ///< [out][optional] bytes returned in event property
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3999,7 +4002,7 @@ urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROFILING_INFO_COMMAND_END < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///         + `pPropValue && propValueSize == 0`
+///         + `pPropValue && propSize == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -4007,9 +4010,9 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urEventGetProfilingInfo(
     ur_event_handle_t hEvent,     ///< [in] handle of the event object
     ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
-    size_t propValueSize,         ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional] value of the profiling property
-    size_t *pPropValueSizeRet     ///< [out][optional] pointer to the actual size in bytes returned in
+    size_t propSize,              ///< [in] size in bytes of the profiling property value
+    void *pPropValue,             ///< [out][optional][typename(propName)] value of the profiling property
+    size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes returned in
                                   ///< propValue
 );
 
@@ -5459,9 +5462,9 @@ typedef void(UR_APICALL *ur_pfnPlatformGetCb_t)(
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_platform_get_info_params_t {
     ur_platform_handle_t *phPlatform;
-    ur_platform_info_t *pPlatformInfoType;
-    size_t *pSize;
-    void **ppPlatformInfo;
+    ur_platform_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
     size_t **ppSizeRet;
 } ur_platform_get_info_params_t;
 
@@ -5720,9 +5723,9 @@ typedef struct ur_context_callbacks_t {
 typedef struct ur_event_get_info_params_t {
     ur_event_handle_t *phEvent;
     ur_event_info_t *ppropName;
-    size_t *ppropValueSize;
+    size_t *ppropSize;
     void **ppPropValue;
-    size_t **ppPropValueSizeRet;
+    size_t **ppPropSizeRet;
 } ur_event_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5744,9 +5747,9 @@ typedef void(UR_APICALL *ur_pfnEventGetInfoCb_t)(
 typedef struct ur_event_get_profiling_info_params_t {
     ur_event_handle_t *phEvent;
     ur_profiling_info_t *ppropName;
-    size_t *ppropValueSize;
+    size_t *ppropSize;
     void **ppPropValue;
-    size_t **ppPropValueSizeRet;
+    size_t **ppPropSizeRet;
 } ur_event_get_profiling_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6637,7 +6640,7 @@ typedef void(UR_APICALL *ur_pfnSamplerReleaseCb_t)(
 typedef struct ur_sampler_get_info_params_t {
     ur_sampler_handle_t *phSampler;
     ur_sampler_info_t *ppropName;
-    size_t *ppropValueSize;
+    size_t *ppropSize;
     void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_sampler_get_info_params_t;
@@ -7677,7 +7680,7 @@ typedef struct ur_global_callbacks_t {
 typedef struct ur_queue_get_info_params_t {
     ur_queue_handle_t *phQueue;
     ur_queue_info_t *ppropName;
-    size_t *ppropValueSize;
+    size_t *ppropSize;
     void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_queue_get_info_params_t;
@@ -7956,9 +7959,9 @@ typedef struct ur_usm_get_mem_alloc_info_params_t {
     ur_context_handle_t *phContext;
     const void **ppMem;
     ur_usm_alloc_info_t *ppropName;
-    size_t *ppropValueSize;
+    size_t *ppropSize;
     void **ppPropValue;
-    size_t **ppPropValueSizeRet;
+    size_t **ppPropSizeRet;
 } ur_usm_get_mem_alloc_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -388,15 +388,15 @@ urPlatformGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported platform info
 typedef enum ur_platform_info_t {
-    UR_PLATFORM_INFO_NAME = 1,        ///< [char*] The string denoting name of the platform. The size of the info
-                                      ///< needs to be dynamically queried.
-    UR_PLATFORM_INFO_VENDOR_NAME = 2, ///< [char*] The string denoting name of the vendor of the platform. The
+    UR_PLATFORM_INFO_NAME = 1,        ///< [char[]] The string denoting name of the platform. The size of the
+                                      ///< info needs to be dynamically queried.
+    UR_PLATFORM_INFO_VENDOR_NAME = 2, ///< [char[]] The string denoting name of the vendor of the platform. The
                                       ///< size of the info needs to be dynamically queried.
-    UR_PLATFORM_INFO_VERSION = 3,     ///< [char*] The string denoting the version of the platform. The size of
+    UR_PLATFORM_INFO_VERSION = 3,     ///< [char[]] The string denoting the version of the platform. The size of
                                       ///< the info needs to be dynamically queried.
-    UR_PLATFORM_INFO_EXTENSIONS = 4,  ///< [char*] The string denoting extensions supported by the platform. The
+    UR_PLATFORM_INFO_EXTENSIONS = 4,  ///< [char[]] The string denoting extensions supported by the platform. The
                                       ///< size of the info needs to be dynamically queried.
-    UR_PLATFORM_INFO_PROFILE = 5,     ///< [char*] The string denoting profile of the platform. The size of the
+    UR_PLATFORM_INFO_PROFILE = 5,     ///< [char[]] The string denoting profile of the platform. The size of the
                                       ///< info needs to be dynamically queried.
     UR_PLATFORM_INFO_BACKEND = 6,     ///< [::ur_platform_backend_t] The backend of the platform. Identifies the
                                       ///< native backend adapter implementing this platform.
@@ -430,7 +430,8 @@ urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize,                ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPropValue,               ///< [out][optional][typename(propName)] array of bytes holding the info.
+    void *pPropValue,               ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                                    ///< the info.
                                     ///< If Size is not equal to or greater to the real number of bytes needed
                                     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
                                     ///< returned and pPlatformInfo is not used.
@@ -713,7 +714,7 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_DEVICE_ID = 2,                               ///< [uint32_t] Id of the device
     UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,                       ///< [uint32_t] the number of compute units
     UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                ///< [uint32_t] max work item dimensions
-    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< [size_t*] return an array of max work item sizes
+    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< [size_t[]] return an array of max work item sizes
     UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                     ///< [size_t] max work group size
     UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< [::ur_device_fp_capability_flags_t] single precision floating point
                                                                 ///< capability
@@ -777,45 +778,45 @@ typedef enum ur_device_info_t {
                                                                 ///< capability bit-field
     UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,             ///< [::ur_queue_flags_t] device command queue property bit-field
     UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,               ///< [::ur_queue_flags_t] host queue property bit-field
-    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< [char*] a semi-colon separated list of built-in kernels
+    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< [char[]] a semi-colon separated list of built-in kernels
     UR_DEVICE_INFO_PLATFORM = 63,                               ///< [::ur_platform_handle_t] the platform associated with the device
     UR_DEVICE_INFO_REFERENCE_COUNT = 64,                        ///< [uint32_t] Reference count of the device object.
                                                                 ///< The reference count returned should be considered immediately stale.
                                                                 ///< It is unsuitable for general use in applications. This feature is
                                                                 ///< provided for identifying memory leaks.
-    UR_DEVICE_INFO_IL_VERSION = 65,                             ///< [char*] IL version
-    UR_DEVICE_INFO_NAME = 66,                                   ///< [char*] Device name
-    UR_DEVICE_INFO_VENDOR = 67,                                 ///< [char*] Device vendor
-    UR_DEVICE_INFO_DRIVER_VERSION = 68,                         ///< [char*] Driver version
-    UR_DEVICE_INFO_PROFILE = 69,                                ///< [char*] Device profile
-    UR_DEVICE_INFO_VERSION = 70,                                ///< [char*] Device version
-    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                ///< [char*] Version of backend runtime
-    UR_DEVICE_INFO_EXTENSIONS = 72,                             ///< [char*] Return a space separated list of extension names
+    UR_DEVICE_INFO_IL_VERSION = 65,                             ///< [char[]] IL version
+    UR_DEVICE_INFO_NAME = 66,                                   ///< [char[]] Device name
+    UR_DEVICE_INFO_VENDOR = 67,                                 ///< [char[]] Device vendor
+    UR_DEVICE_INFO_DRIVER_VERSION = 68,                         ///< [char[]] Driver version
+    UR_DEVICE_INFO_PROFILE = 69,                                ///< [char[]] Device profile
+    UR_DEVICE_INFO_VERSION = 70,                                ///< [char[]] Device version
+    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                ///< [char[]] Version of backend runtime
+    UR_DEVICE_INFO_EXTENSIONS = 72,                             ///< [char[]] Return a space separated list of extension names
     UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,                     ///< [size_t] Maximum size in bytes of internal printf buffer
     UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,            ///< [::ur_bool_t] prefer user synchronization when sharing object with
                                                                 ///< other API
     UR_DEVICE_INFO_PARENT_DEVICE = 75,                          ///< [::ur_device_handle_t] return parent device handle
-    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< [::ur_device_partition_property_t*] Returns the list of partition
+    UR_DEVICE_INFO_PARTITION_PROPERTIES = 76,                   ///< [::ur_device_partition_property_t[]] Returns an array of partition
                                                                 ///< types supported by the device
     UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,              ///< [uint32_t] maximum number of sub-devices when the device is
                                                                 ///< partitioned
     UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,              ///< [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
                                                                 ///< supported affinity domains for partitioning.
                                                                 ///< If the device does not support any affinity domains, then 0 will be returned.
-    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< [::ur_device_partition_property_t*] return a list of
+    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< [::ur_device_partition_property_t[]] return an array of
                                                                 ///< ::ur_device_partition_property_t for properties specified in
                                                                 ///< ::urDevicePartition
     UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                     ///< [uint32_t] max number of sub groups
     UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81, ///< [::ur_bool_t] support sub group independent forward progress
-    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< [uint32_t*] return an array of sub group sizes supported on Intel
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< [uint32_t[]] return an array of sub group sizes supported on Intel
                                                                 ///< device
     UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                       ///< [::ur_bool_t] support USM host memory access
     UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                     ///< [::ur_bool_t] support USM device memory access
     UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,              ///< [::ur_bool_t] support USM single device shared memory access
     UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,               ///< [::ur_bool_t] support USM cross device shared memory access
     UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,              ///< [::ur_bool_t] support USM system wide shared memory access
-    UR_DEVICE_INFO_UUID = 88,                                   ///< [char*] return device UUID
-    UR_DEVICE_INFO_PCI_ADDRESS = 89,                            ///< [char*] return device PCI address
+    UR_DEVICE_INFO_UUID = 88,                                   ///< [char[]] return device UUID
+    UR_DEVICE_INFO_PCI_ADDRESS = 89,                            ///< [char[]] return device PCI address
     UR_DEVICE_INFO_GPU_EU_COUNT = 90,                           ///< [uint32_t] return Intel GPU EU count
     UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                      ///< [uint32_t] return Intel GPU EU SIMD width
     UR_DEVICE_INFO_GPU_EU_SLICES = 92,                          ///< [uint32_t] return Intel GPU number of slices
@@ -868,7 +869,8 @@ urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize,            ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue,           ///< [out][optional][typename(propName)] array of bytes holding the info.
+    void *pPropValue,           ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                                ///< the info.
                                 ///< If propSize is not equal to or greater than the real number of bytes
                                 ///< needed to return the info
                                 ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -1314,7 +1316,8 @@ urContextRetain(
 /// @brief Supported context info
 typedef enum ur_context_info_t {
     UR_CONTEXT_INFO_NUM_DEVICES = 0,                      ///< [uint32_t] The number of the devices in the context
-    UR_CONTEXT_INFO_DEVICES = 1,                          ///< [::ur_device_handle_t*] The array of the device handles in the context
+    UR_CONTEXT_INFO_DEVICES = 1,                          ///< [::ur_device_handle_t[]] The array of the device handles in the
+                                                          ///< context
     UR_CONTEXT_INFO_REFERENCE_COUNT = 2,                  ///< [uint32_t] Reference count of the context object.
                                                           ///< The reference count returned should be considered immediately stale.
                                                           ///< It is unsuitable for general use in applications. This feature is
@@ -1386,7 +1389,8 @@ urContextGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t propSize,              ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue,             ///< [out][optional][typename(propName)] array of bytes holding the info.
+    void *pPropValue,             ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                                  ///< the info.
                                   ///< if propSize is not equal to or greater than the real number of bytes
                                   ///< needed to return
                                   ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1922,7 +1926,8 @@ urMemGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName,  ///< [in] type of the info to retrieve.
     size_t propSize,         ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue,        ///< [out][optional][typename(propName)] array of bytes holding the info.
+    void *pPropValue,        ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                             ///< the info.
                              ///< If propSize is less than the real number of bytes needed to return
                              ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
                              ///< pPropValue is not used.
@@ -1952,7 +1957,8 @@ urMemImageGetInfo(
     ur_mem_handle_t hMemory,  ///< [in] handle to the image object being queried.
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t propSize,          ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue,         ///< [out][optional][typename(propName)] array of bytes holding the info.
+    void *pPropValue,         ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                              ///< the info.
                               ///< If propSize is less than the real number of bytes needed to return
                               ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
                               ///< pPropValue is not used.
@@ -1999,7 +2005,7 @@ typedef enum ur_sampler_info_t {
                                            ///< It is unsuitable for general use in applications. This feature is
                                            ///< provided for identifying memory leaks.
     UR_SAMPLER_INFO_CONTEXT = 1,           ///< [::ur_context_handle_t] Sampler context info
-    UR_SAMPLER_INFO_NORMALIZED_COORDS = 2, ///< [bool] Sampler normalized coordinate setting
+    UR_SAMPLER_INFO_NORMALIZED_COORDS = 2, ///< [::ur_bool_t] Sampler normalized coordinate setting
     UR_SAMPLER_INFO_ADDRESSING_MODE = 3,   ///< [::ur_sampler_addressing_mode_t] Sampler addressing mode setting
     UR_SAMPLER_INFO_FILTER_MODE = 4,       ///< [::ur_sampler_filter_mode_t] Sampler filter mode setting
     /// @cond
@@ -2127,7 +2133,7 @@ urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName,   ///< [in] name of the sampler property to query
     size_t propSize,              ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue,             ///< [out][typename(propName)] value of the sampler property
+    void *pPropValue,             ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *pPropSizeRet          ///< [out] size in bytes returned in sampler property value
 );
 
@@ -2520,8 +2526,8 @@ urUSMGetMemAllocInfo(
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t propName, ///< [in] the name of the USM allocation property to query
     size_t propSize,              ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue,             ///< [out][optional][typename(propName)] value of the USM allocation
-                                  ///< property
+    void *pPropValue,             ///< [out][optional][typename(propName, propSize)] value of the USM
+                                  ///< allocation property
     size_t *pPropSizeRet          ///< [out][optional] bytes returned in USM allocation property
 );
 
@@ -2896,13 +2902,14 @@ typedef enum ur_program_info_t {
                                          ///< provided for identifying memory leaks.
     UR_PROGRAM_INFO_CONTEXT = 1,         ///< [::ur_context_handle_t] Program context info.
     UR_PROGRAM_INFO_NUM_DEVICES = 2,     ///< [uint32_t] Return number of devices associated with Program.
-    UR_PROGRAM_INFO_DEVICES = 3,         ///< [x_device_handle_t*] Return list of devices associated with Program.
-    UR_PROGRAM_INFO_SOURCE = 4,          ///< [char*] Return program source associated with Program.
-    UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< [size_t*] Return program binary sizes for each device.
-    UR_PROGRAM_INFO_BINARIES = 6,        ///< [unsigned char*] Return program binaries for all devices for this
+    UR_PROGRAM_INFO_DEVICES = 3,         ///< [::ur_device_handle_t[]] Return list of devices associated with
+                                         ///< Program.
+    UR_PROGRAM_INFO_SOURCE = 4,          ///< [char[]] Return program source associated with Program.
+    UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< [size_t[]] Return program binary sizes for each device.
+    UR_PROGRAM_INFO_BINARIES = 6,        ///< [unsigned char[]] Return program binaries for all devices for this
                                          ///< Program.
     UR_PROGRAM_INFO_NUM_KERNELS = 7,     ///< [size_t] Number of kernels in Program, return type size_t.
-    UR_PROGRAM_INFO_KERNEL_NAMES = 8,    ///< [char*] Return a null-terminated, semi-colon separated list of kernel
+    UR_PROGRAM_INFO_KERNEL_NAMES = 8,    ///< [char[]] Return a null-terminated, semi-colon separated list of kernel
                                          ///< names in Program.
     /// @cond
     UR_PROGRAM_INFO_FORCE_UINT32 = 0x7fffffff
@@ -2930,8 +2937,8 @@ urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName,   ///< [in] name of the Program property to query
     size_t propSize,              ///< [in] the size of the Program property.
-    void *pPropValue,             ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                                  ///< program info property.
+    void *pPropValue,             ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                                  ///< holding the program info property.
                                   ///< If propSize is not equal to or greater than the real number of bytes
                                   ///< needed to return
                                   ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2969,9 +2976,9 @@ typedef enum ur_program_binary_type_t {
 /// @brief Get Program object build information
 typedef enum ur_program_build_info_t {
     UR_PROGRAM_BUILD_INFO_STATUS = 0,      ///< [::ur_program_build_status_t] Program build status.
-    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,     ///< [char*] Null-terminated options string specified by last build,
+    UR_PROGRAM_BUILD_INFO_OPTIONS = 1,     ///< [char[]] Null-terminated options string specified by last build,
                                            ///< compile or link operation performed on the program.
-    UR_PROGRAM_BUILD_INFO_LOG = 2,         ///< [char*] Null-terminated program build log.
+    UR_PROGRAM_BUILD_INFO_LOG = 2,         ///< [char[]] Null-terminated program build log.
     UR_PROGRAM_BUILD_INFO_BINARY_TYPE = 3, ///< [::ur_program_binary_type_t] Program binary type.
     /// @cond
     UR_PROGRAM_BUILD_INFO_FORCE_UINT32 = 0x7fffffff
@@ -3001,7 +3008,8 @@ urProgramGetBuildInfo(
     ur_device_handle_t hDevice,       ///< [in] handle of the Device object
     ur_program_build_info_t propName, ///< [in] name of the Program build info to query
     size_t propSize,                  ///< [in] size of the Program build info property.
-    void *pPropValue,                 ///< [in,out][optional][typename(propName)] value of the Program build property.
+    void *pPropValue,                 ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                                      ///< build property.
                                       ///< If propSize is not equal to or greater than the real number of bytes
                                       ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
                                       ///< error is returned and pPropValue is not used.
@@ -3183,7 +3191,7 @@ urKernelSetArgLocal(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel object information
 typedef enum ur_kernel_info_t {
-    UR_KERNEL_INFO_FUNCTION_NAME = 0,   ///< [char*] Return null-terminated kernel function name.
+    UR_KERNEL_INFO_FUNCTION_NAME = 0,   ///< [char[]] Return null-terminated kernel function name.
     UR_KERNEL_INFO_NUM_ARGS = 1,        ///< [size_t] Return Kernel number of arguments.
     UR_KERNEL_INFO_REFERENCE_COUNT = 2, ///< [uint32_t] Reference count of the kernel object.
                                         ///< The reference count returned should be considered immediately stale.
@@ -3191,7 +3199,7 @@ typedef enum ur_kernel_info_t {
                                         ///< provided for identifying memory leaks.
     UR_KERNEL_INFO_CONTEXT = 3,         ///< [::ur_context_handle_t] Return Context object associated with Kernel.
     UR_KERNEL_INFO_PROGRAM = 4,         ///< [::ur_program_handle_t] Return Program object associated with Kernel.
-    UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< [char*] Return null-terminated kernel attributes string.
+    UR_KERNEL_INFO_ATTRIBUTES = 5,      ///< [char[]] Return null-terminated kernel attributes string.
     UR_KERNEL_INFO_NUM_REGS = 6,        ///< [uint32_t] Return the number of registers used by the compiled kernel
                                         ///< (device specific).
     /// @cond
@@ -3203,12 +3211,10 @@ typedef enum ur_kernel_info_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Get Kernel Work Group information
 typedef enum ur_kernel_group_info_t {
-    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,                   ///< [size_t*] Return Work Group maximum global size, always returns a
-                                                                 ///< three element array
+    UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE = 0,                   ///< [size_t[3]] Return Work Group maximum global size
     UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE = 1,                    ///< [size_t] Return maximum Work Group size
-    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,            ///< [size_t*] Return Work Group size required by the source code, such as
-                                                                 ///< __attribute__((required_work_group_size(X,Y,Z)), always returns a
-                                                                 ///< three element array
+    UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE = 2,            ///< [size_t[3]] Return Work Group size required by the source code, such
+                                                                 ///< as __attribute__((required_work_group_size(X,Y,Z))
     UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE = 3,                     ///< [size_t] Return local memory required by the Kernel
     UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 4, ///< [size_t] Return preferred multiple of Work Group size for launch
     UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE = 5,                   ///< [size_t] Return minimum amount of private memory in bytes used by each
@@ -3248,7 +3254,7 @@ typedef enum ur_kernel_cache_config_t {
 /// @brief Set additional Kernel execution information
 typedef enum ur_kernel_exec_info_t {
     UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS = 0, ///< [::ur_bool_t] Kernel might access data through USM pointer.
-    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,            ///< [void **] Provide an explicit list of USM pointers that the kernel
+    UR_KERNEL_EXEC_INFO_USM_PTRS = 1,            ///< [void *[]] Provide an explicit array of USM pointers that the kernel
                                                  ///< will access.
     UR_KERNEL_EXEC_INFO_CACHE_CONFIG = 2,        ///< [::ur_kernel_cache_config_t] Provide the preferred cache configuration
     /// @cond
@@ -3277,8 +3283,8 @@ urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
-    void *pPropValue,           ///< [in,out][optional][typename(propName)] array of bytes holding the
-                                ///< kernel info property.
+    void *pPropValue,           ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                                ///< holding the kernel info property.
                                 ///< If propSize is not equal to or greater than the real number of bytes
                                 ///< needed to return
                                 ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -3309,8 +3315,8 @@ urKernelGetGroupInfo(
     ur_device_handle_t hDevice,      ///< [in] handle of the Device object
     ur_kernel_group_info_t propName, ///< [in] name of the work Group property to query
     size_t propSize,                 ///< [in] size of the Kernel Work Group property value
-    void *pPropValue,                ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                                     ///< property.
+    void *pPropValue,                ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                                     ///< Work Group property.
     size_t *pPropSizeRet             ///< [out][optional] pointer to the actual size in bytes of data being
                                      ///< queried by propName.
 );
@@ -3333,8 +3339,8 @@ urKernelGetSubGroupInfo(
     ur_device_handle_t hDevice,          ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t propName, ///< [in] name of the SubGroup property to query
     size_t propSize,                     ///< [in] size of the Kernel SubGroup property value
-    void *pPropValue,                    ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                                         ///< property.
+    void *pPropValue,                    ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                                         ///< SubGroup property.
     size_t *pPropSizeRet                 ///< [out][optional] pointer to the actual size in bytes of data being
                                          ///< queried by propName.
 );
@@ -3442,8 +3448,8 @@ urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
-    const void *pPropValue          ///< [in][typename(propName)] pointer to memory location holding the
-                                    ///< property value.
+    const void *pPropValue          ///< [in][typename(propName, propSize)] pointer to memory location holding
+                                    ///< the property value.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3648,7 +3654,8 @@ urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t propSize,          ///< [in] size in bytes of the queue property value provided
-    void *pPropValue,         ///< [out][optional][typename(propName)] value of the queue property
+    void *pPropValue,         ///< [out][optional][typename(propName, propSize)] value of the queue
+                              ///< property
     size_t *pPropSizeRet      ///< [out][optional] size in bytes returned in queue property value
 );
 
@@ -3981,7 +3988,8 @@ urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize,          ///< [in] size in bytes of the event property value
-    void *pPropValue,         ///< [out][optional][typename(propName)] value of the event property
+    void *pPropValue,         ///< [out][optional][typename(propName, propSize)] value of the event
+                              ///< property
     size_t *pPropSizeRet      ///< [out][optional] bytes returned in event property
 );
 
@@ -4011,7 +4019,8 @@ urEventGetProfilingInfo(
     ur_event_handle_t hEvent,     ///< [in] handle of the event object
     ur_profiling_info_t propName, ///< [in] the name of the profiling property to query
     size_t propSize,              ///< [in] size in bytes of the profiling property value
-    void *pPropValue,             ///< [out][optional][typename(propName)] value of the profiling property
+    void *pPropValue,             ///< [out][optional][typename(propName, propSize)] value of the profiling
+                                  ///< property
     size_t *pPropSizeRet          ///< [out][optional] pointer to the actual size in bytes returned in
                                   ///< propValue
 );

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -318,14 +318,16 @@ class ur_name_handle_t(c_void_p):
   - `desc` will be used as the enum's description comment
   - `name` must be a unique ISO-C standard identifier, start with `$` tag, be snake_case and end with `_t`
   - `name` that endswith `_flags_t` will be used to create bitfields
-* An enum may take the following optional scalar fields: {`class`, `condition`, `ordinal`, `version`}
+* An enum may take the following optional scalar fields: {`class`, `condition`, `ordinal`, `version`, `typed_etors`}
   - `class` will be used to scope the enum declaration within the specified C++ class
   - `condition` will be used as a C/C++ preprocessor `#if` conditional expression
   - `ordinal` will be used to override the default order (in which they appear) the enum appears within its section; `default="1000"`
   - `version` will be used to define the minimum API version in which the enum will appear; `default="1.0"` This will also affect the order in which the enum appears within its section and class.
+  - `typed_etors` boolean value that will be used to determine whether the enum's values have associated types.
 * An enum requires the following sequence of mappings: {`etors`}
   - An etor requires the following scalar fields: {`name`, `desc`}
     + `desc` will be used as the etors's description comment
+    + If the enum has `typed_etors`, `desc` must begin with type identifier: {`"[type]"`}
     + `name` must be a unique ISO-C standard identifier, and be all caps
   - An etor may take the following optional scalar field: {`value`, `version`}
     + `value` must be an ISO-C standard identifier
@@ -462,8 +464,9 @@ class ur_name_flags_v(IntEnum):
       - `in` is used for members that are read-only; if the member is a pointer, then the memory being pointed to is also read-only
       - `out` is used for members that are write-only; if the member is a pointer, then the memory being pointed to is also write-only
       - `in,out` is used for members that are both read and write; typically this is used for pointers to other data structures that contain both read and write members
-    + `desc` may include one the following annotations: {`"[optional]"`}
+    + `desc` may include one the following annotations: {`"[optional]"`, `"[typename(typeVarName)]"`}
       - `optional` is used for members that are pointers where it is legal for the value to be `nullptr`
+      - `typename` is used to denote the type enum for params that are opaque pointers to values of tagged data types.
     + `type` must be an ISO-C standard identifier; except it may **not** be a `handle_t`
     + `name` must be a unique ISO-C standard identifier
   - A member may take the following optional scalar field: {`init`, `version`}
@@ -600,12 +603,13 @@ class ur_name_t(Structure):
       - `in` is used for params that are read-only; if the param is a pointer, then the memory being pointed to is also read-only
       - `out` is used for params that are write-only; if the param is a pointer, then the memory being pointed to is also write-only
       - `in,out` is used for params that are both read and write; typically this is used for pointers to other data structures that contain both read and write params
-    + `desc` may include one the following annotations: {`"[optional]"`, `"[range(start,end)]"`, `"[release]"`}
+    + `desc` may include one the following annotations: {`"[optional]"`, `"[range(start,end)]"`, `"[release]"`, `"[typename(typeVarName)]"`}
       - `optional` is used for params that are handles or pointers where it is legal for the value to be `nullptr`
       - `range` is used for params that are array pointers to specify the valid range that the is valid to read
         + `start` and `end` must be an ISO-C standard identifier or literal
         + `start` is inclusive and `end` is exclusive
       - `release` is used for params that are handles or pointers to handles where the function will destroy any backing memory associated with the handle(s)
+      - `typename` is used to denote the type enum for params that are opaque pointers to values of tagged data types.
     + `type` must be an ISO-C standard identifier
     + `name` must be a unique ISO-C standard identifier
   - A param may take the following optional scalar field: {`init`, `version`}

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -464,7 +464,7 @@ class ur_name_flags_v(IntEnum):
       - `in` is used for members that are read-only; if the member is a pointer, then the memory being pointed to is also read-only
       - `out` is used for members that are write-only; if the member is a pointer, then the memory being pointed to is also write-only
       - `in,out` is used for members that are both read and write; typically this is used for pointers to other data structures that contain both read and write members
-    + `desc` may include one the following annotations: {`"[optional]"`, `"[typename(typeVarName)]"`}
+    + `desc` may include one the following annotations: {`"[optional]"`, `"[typename(typeVarName, sizeVarName)]"`}
       - `optional` is used for members that are pointers where it is legal for the value to be `nullptr`
       - `typename` is used to denote the type enum for params that are opaque pointers to values of tagged data types.
     + `type` must be an ISO-C standard identifier; except it may **not** be a `handle_t`

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -89,7 +89,7 @@ etors:
     - name: NUM_DEVICES
       desc: "[uint32_t] The number of the devices in the context"
     - name: DEVICES
-      desc: "[$x_device_handle_t*] The array of the device handles in the context"
+      desc: "[$x_device_handle_t[]] The array of the device handles in the context"
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the context object.
@@ -154,7 +154,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional][typename(propName)] array of bytes holding the info.
+            [out][optional][typename(propName, propSize)] array of bytes holding the info.
             if propSize is not equal to or greater than the real number of bytes needed to return 
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -84,20 +84,21 @@ type: enum
 desc: "Supported context info"
 class: $xContext
 name: $x_context_info_t
+typed_etors: True
 etors:
     - name: NUM_DEVICES
       desc: "[uint32_t] The number of the devices in the context"
     - name: DEVICES
-      desc: "[$x_device_handle_t ...] The array of the device handles in the context"
+      desc: "[$x_device_handle_t*] The array of the device handles in the context"
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the context object.
             The reference count returned should be considered immediately stale. 
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: USM_MEMCPY2D_SUPPORT
-      desc: "[bool] to indicate if the $xEnqueueUSMMemcpy2D entrypoint is supported."
+      desc: "[$x_bool_t] to indicate if the $xEnqueueUSMMemcpy2D entrypoint is supported."
     - name: USM_FILL2D_SUPPORT
-      desc: "[bool] to indicate if the $xEnqueueUSMFill2D entrypoint is supported."
+      desc: "[$x_bool_t] to indicate if the $xEnqueueUSMFill2D entrypoint is supported."
     - name: ATOMIC_MEMORY_ORDER_CAPABILITIES
       desc: "[$x_memory_order_capability_flags_t] return a bit-field of atomic memory order capabilities."
     - name: ATOMIC_MEMORY_SCOPE_CAPABILITIES
@@ -153,7 +154,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional] array of bytes holding the info.
+            [out][optional][typename(propName)] array of bytes holding the info.
             if propSize is not equal to or greater than the real number of bytes needed to return 
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -143,223 +143,224 @@ type: enum
 desc: "Supported device info"
 class: $xDevice
 name: $x_device_info_t
+typed_etors: True
 etors:
     - name: TYPE
-      desc: "$x_device_type_t: type of the device"
+      desc: "[$x_device_type_t] type of the device"
     - name: VENDOR_ID
-      desc: "uint32_t: vendor Id of the device"
+      desc: "[uint32_t] vendor Id of the device"
     - name: DEVICE_ID
-      desc: "uint32_t: Id of the device"
+      desc: "[uint32_t] Id of the device"
     - name: MAX_COMPUTE_UNITS
-      desc: "uint32_t: the number of compute units"
+      desc: "[uint32_t] the number of compute units"
     - name: MAX_WORK_ITEM_DIMENSIONS
-      desc: "uint32_t: max work item dimensions"
+      desc: "[uint32_t] max work item dimensions"
     - name: MAX_WORK_ITEM_SIZES
-      desc: "size_t[]: return an array of max work item sizes"
+      desc: "[size_t*] return an array of max work item sizes"
     - name: MAX_WORK_GROUP_SIZE
-      desc: "size_t: max work group size"
+      desc: "[size_t] max work group size"
     - name: SINGLE_FP_CONFIG
-      desc: "Return a bit field of $x_device_fp_capability_flags_t: single precision floating point capability"
+      desc: "[$x_device_fp_capability_flags_t] single precision floating point capability"
     - name: HALF_FP_CONFIG
-      desc: "Return a bit field of $x_device_fp_capability_flags_t: half precision floating point capability"
+      desc: "[$x_device_fp_capability_flags_t] half precision floating point capability"
     - name: DOUBLE_FP_CONFIG
-      desc: "Return a bit field of $x_device_fp_capability_flags_t: double precision floating point capability"
+      desc: "[$x_device_fp_capability_flags_t] double precision floating point capability"
     - name: QUEUE_PROPERTIES
-      desc: "Return a bit field of $x_queue_flags_t: command queue properties supported by the device"
+      desc: "[$x_queue_flags_t] command queue properties supported by the device"
     - name: PREFERRED_VECTOR_WIDTH_CHAR
-      desc: "uint32_t: preferred vector width for char"
+      desc: "[uint32_t] preferred vector width for char"
     - name: PREFERRED_VECTOR_WIDTH_SHORT
-      desc: "uint32_t: preferred vector width for short"
+      desc: "[uint32_t] preferred vector width for short"
     - name: PREFERRED_VECTOR_WIDTH_INT
-      desc: "uint32_t: preferred vector width for int"
+      desc: "[uint32_t] preferred vector width for int"
     - name: PREFERRED_VECTOR_WIDTH_LONG
-      desc: "uint32_t: preferred vector width for long"
+      desc: "[uint32_t] preferred vector width for long"
     - name: PREFERRED_VECTOR_WIDTH_FLOAT
-      desc: "uint32_t: preferred vector width for float"
+      desc: "[uint32_t] preferred vector width for float"
     - name: PREFERRED_VECTOR_WIDTH_DOUBLE
-      desc: "uint32_t: preferred vector width for double"
+      desc: "[uint32_t] preferred vector width for double"
     - name: PREFERRED_VECTOR_WIDTH_HALF
-      desc: "uint32_t: preferred vector width for half float"
+      desc: "[uint32_t] preferred vector width for half float"
     - name: NATIVE_VECTOR_WIDTH_CHAR
-      desc: "uint32_t: native vector width for char"
+      desc: "[uint32_t] native vector width for char"
     - name: NATIVE_VECTOR_WIDTH_SHORT
-      desc: "uint32_t: native vector width for short"
+      desc: "[uint32_t] native vector width for short"
     - name: NATIVE_VECTOR_WIDTH_INT
-      desc: "uint32_t: native vector width for int"
+      desc: "[uint32_t] native vector width for int"
     - name: NATIVE_VECTOR_WIDTH_LONG
-      desc: "uint32_t: native vector width for long"
+      desc: "[uint32_t] native vector width for long"
     - name: NATIVE_VECTOR_WIDTH_FLOAT
-      desc: "uint32_t: native vector width for float"
+      desc: "[uint32_t] native vector width for float"
     - name: NATIVE_VECTOR_WIDTH_DOUBLE
-      desc: "uint32_t: native vector width for double"
+      desc: "[uint32_t] native vector width for double"
     - name: NATIVE_VECTOR_WIDTH_HALF
-      desc: "uint32_t: native vector width for half float"
+      desc: "[uint32_t] native vector width for half float"
     - name: MAX_CLOCK_FREQUENCY
-      desc: "uint32_t: max clock frequency in MHz"
+      desc: "[uint32_t] max clock frequency in MHz"
     - name: MEMORY_CLOCK_RATE
-      desc: "uint32_t: memory clock frequency in MHz"
+      desc: "[uint32_t] memory clock frequency in MHz"
     - name: ADDRESS_BITS
-      desc: "uint32_t: address bits"
+      desc: "[uint32_t] address bits"
     - name: MAX_MEM_ALLOC_SIZE
-      desc: "uint64_t: max memory allocation size"
+      desc: "[uint64_t] max memory allocation size"
     - name: IMAGE_SUPPORTED
-      desc: "bool: images are supported"
+      desc: "[$x_bool_t] images are supported"
     - name: MAX_READ_IMAGE_ARGS
-      desc: "uint32_t: max number of image objects arguments of a kernel declared with the read_only qualifier"
+      desc: "[uint32_t] max number of image objects arguments of a kernel declared with the read_only qualifier"
     - name: MAX_WRITE_IMAGE_ARGS
-      desc: "uint32_t: max number of image objects arguments of a kernel declared with the write_only qualifier"
+      desc: "[uint32_t] max number of image objects arguments of a kernel declared with the write_only qualifier"
     - name: MAX_READ_WRITE_IMAGE_ARGS
-      desc: "uint32_t: max number of image objects arguments of a kernel declared with the read_write qualifier"
+      desc: "[uint32_t] max number of image objects arguments of a kernel declared with the read_write qualifier"
     - name: IMAGE2D_MAX_WIDTH
-      desc: "size_t: max width of Image2D object"
+      desc: "[size_t] max width of Image2D object"
     - name: IMAGE2D_MAX_HEIGHT
-      desc: "size_t: max heigh of Image2D object"
+      desc: "[size_t] max heigh of Image2D object"
     - name: IMAGE3D_MAX_WIDTH
-      desc: "size_t: max width of Image3D object"
+      desc: "[size_t] max width of Image3D object"
     - name: IMAGE3D_MAX_HEIGHT
-      desc: "size_t: max height of Image3D object"
+      desc: "[size_t] max height of Image3D object"
     - name: IMAGE3D_MAX_DEPTH
-      desc: "size_t: max depth of Image3D object"
+      desc: "[size_t] max depth of Image3D object"
     - name: IMAGE_MAX_BUFFER_SIZE
-      desc: "size_t: max image buffer size"
+      desc: "[size_t] max image buffer size"
     - name: IMAGE_MAX_ARRAY_SIZE
-      desc: "size_t: max image array size"
+      desc: "[size_t] max image array size"
     - name: MAX_SAMPLERS
-      desc: "uint32_t: max number of samplers that can be used in a kernel"
+      desc: "[uint32_t] max number of samplers that can be used in a kernel"
     - name: MAX_PARAMETER_SIZE
-      desc: "size_t: max size in bytes of all arguments passed to a kernel"
+      desc: "[size_t] max size in bytes of all arguments passed to a kernel"
     - name: MEM_BASE_ADDR_ALIGN
-      desc: "uint32_t: memory base address alignment"
+      desc: "[uint32_t] memory base address alignment"
     - name: GLOBAL_MEM_CACHE_TYPE
-      desc: "$x_device_mem_cache_type_t: global memory cache type"
+      desc: "[$x_device_mem_cache_type_t] global memory cache type"
     - name: GLOBAL_MEM_CACHELINE_SIZE
-      desc: "uint32_t: global memory cache line size in bytes"
+      desc: "[uint32_t] global memory cache line size in bytes"
     - name: GLOBAL_MEM_CACHE_SIZE
-      desc: "uint64_t: size of global memory cache in bytes"
+      desc: "[uint64_t] size of global memory cache in bytes"
     - name: GLOBAL_MEM_SIZE
-      desc: "uint64_t: size of global memory in bytes"
+      desc: "[uint64_t] size of global memory in bytes"
     - name: GLOBAL_MEM_FREE
-      desc: "uint64_t: size of global memory which is free in bytes"
+      desc: "[uint64_t] size of global memory which is free in bytes"
     - name: MAX_CONSTANT_BUFFER_SIZE
-      desc: "uint64_t: max constant buffer size in bytes"
+      desc: "[uint64_t] max constant buffer size in bytes"
     - name: MAX_CONSTANT_ARGS
-      desc: "uint32_t: max number of __const declared arguments in a kernel"
+      desc: "[uint32_t] max number of __const declared arguments in a kernel"
     - name: LOCAL_MEM_TYPE
-      desc: "$x_device_local_mem_type_t: local memory type"
+      desc: "[$x_device_local_mem_type_t] local memory type"
     - name: LOCAL_MEM_SIZE
-      desc: "uint64_t: local memory size in bytes"
+      desc: "[uint64_t] local memory size in bytes"
     - name: ERROR_CORRECTION_SUPPORT
-      desc: "bool: support error correction to global and local memory"
+      desc: "[bool] support error correction to global and local memory"
     - name: HOST_UNIFIED_MEMORY
-      desc: "bool: unified host device memory"
+      desc: "[bool] unified host device memory"
     - name: PROFILING_TIMER_RESOLUTION
-      desc: "size_t: profiling timer resolution in nanoseconds"
+      desc: "[size_t] profiling timer resolution in nanoseconds"
     - name: ENDIAN_LITTLE
-      desc: "bool: little endian byte order"
+      desc: "[bool] little endian byte order"
     - name: AVAILABLE
-      desc: "bool: device is available"
+      desc: "[bool] device is available"
     - name: COMPILER_AVAILABLE
-      desc: "bool: device compiler is available"
+      desc: "[bool] device compiler is available"
     - name: LINKER_AVAILABLE
-      desc: "bool: device linker is available"
+      desc: "[bool] device linker is available"
     - name: EXECUTION_CAPABILITIES
-      desc: "$x_device_exec_capability_flags_t: device kernel execution capability bit-field"
+      desc: "[$x_device_exec_capability_flags_t] device kernel execution capability bit-field"
     - name: QUEUE_ON_DEVICE_PROPERTIES
-      desc: "$x_queue_flags_t: device command queue property bit-field"
+      desc: "[$x_queue_flags_t] device command queue property bit-field"
     - name: QUEUE_ON_HOST_PROPERTIES
-      desc: "$x_queue_flags_t: host queue property bit-field"
+      desc: "[$x_queue_flags_t] host queue property bit-field"
     - name: BUILT_IN_KERNELS
-      desc: "char[]: a semi-colon separated list of built-in kernels"
+      desc: "[char*] a semi-colon separated list of built-in kernels"
     - name: PLATFORM
-      desc: "$x_platform_handle_t: the platform associated with the device"
+      desc: "[$x_platform_handle_t] the platform associated with the device"
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the device object.
             The reference count returned should be considered immediately stale. 
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: IL_VERSION
-      desc: "char[]: IL version"
+      desc: "[char*] IL version"
     - name: NAME
-      desc: "char[]: Device name"
+      desc: "[char*] Device name"
     - name: VENDOR
-      desc: "char[]: Device vendor"
+      desc: "[char*] Device vendor"
     - name: DRIVER_VERSION
-      desc: "char[]: Driver version"
+      desc: "[char*] Driver version"
     - name: PROFILE
-      desc: "char[]: Device profile"
+      desc: "[char*] Device profile"
     - name: VERSION
-      desc: "char[]: Device version"
+      desc: "[char*] Device version"
     - name: BACKEND_RUNTIME_VERSION
-      desc: "char[]: Version of backend runtime"
+      desc: "[char*] Version of backend runtime"
     - name: EXTENSIONS
-      desc: "char[]: Return a space separated list of extension names"
+      desc: "[char*] Return a space separated list of extension names"
     - name: PRINTF_BUFFER_SIZE
-      desc: "size_t: Maximum size in bytes of internal printf buffer"
+      desc: "[size_t] Maximum size in bytes of internal printf buffer"
     - name: PREFERRED_INTEROP_USER_SYNC
-      desc: "bool: prefer user synchronization when sharing object with other API"
+      desc: "[$x_bool_t] prefer user synchronization when sharing object with other API"
     - name: PARENT_DEVICE
-      desc: "$x_device_handle_t: return parent device handle"
+      desc: "[$x_device_handle_t] return parent device handle"
     - name: PARTITION_PROPERTIES
-      desc: "$x_device_partition_property_t[]: Returns the list of partition types supported by the device"
+      desc: "[$x_device_partition_property_t*] Returns the list of partition types supported by the device"
     - name: PARTITION_MAX_SUB_DEVICES
-      desc: "uint32_t: maximum number of sub-devices when the device is partitioned"
+      desc: "[uint32_t] maximum number of sub-devices when the device is partitioned"
     - name: PARTITION_AFFINITY_DOMAIN
-      desc: |  
-            [$x_device_affinity_domain_flags_t]: Returns a bit-field of the supported affinity domains for partitioning. 
+      desc: |
+            [$x_device_affinity_domain_flags_t] Returns a bit-field of the supported affinity domains for partitioning. 
             If the device does not support any affinity domains, then 0 will be returned.
     - name: PARTITION_TYPE
-      desc: "$x_device_partition_property_t[]: return a list of $x_device_partition_property_t for properties specified in $xDevicePartition"
+      desc: "[$x_device_partition_property_t*] return a list of $x_device_partition_property_t for properties specified in $xDevicePartition"
     - name: MAX_NUM_SUB_GROUPS
-      desc: "uint32_t: max number of sub groups"
+      desc: "[uint32_t] max number of sub groups"
     - name: SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS
-      desc: "bool: support sub group independent forward progress"
+      desc: "[$x_bool_t] support sub group independent forward progress"
     - name: SUB_GROUP_SIZES_INTEL
-      desc: "uint32_t[]: return an array of sub group sizes supported on Intel device"
+      desc: "[uint32_t*] return an array of sub group sizes supported on Intel device"
     - name: USM_HOST_SUPPORT
-      desc: "bool: support USM host memory access"
+      desc: "[$x_bool_t] support USM host memory access"
     - name: USM_DEVICE_SUPPORT
-      desc: "bool: support USM device memory access"
+      desc: "[$x_bool_t] support USM device memory access"
     - name: USM_SINGLE_SHARED_SUPPORT
-      desc: "bool: support USM single device shared memory access"
+      desc: "[$x_bool_t] support USM single device shared memory access"
     - name: USM_CROSS_SHARED_SUPPORT
-      desc: "bool: support USM cross device shared memory access"
+      desc: "[$x_bool_t] support USM cross device shared memory access"
     - name: USM_SYSTEM_SHARED_SUPPORT
-      desc: "bool: support USM system wide shared memory access"
+      desc: "[$x_bool_t] support USM system wide shared memory access"
     - name: UUID
-      desc: "char[]: return device UUID"
+      desc: "[char*] return device UUID"
     - name: PCI_ADDRESS
-      desc: "char[]: return device PCI address"
+      desc: "[char*] return device PCI address"
     - name: GPU_EU_COUNT
-      desc: "uint32_t: return Intel GPU EU count"
+      desc: "[uint32_t] return Intel GPU EU count"
     - name: GPU_EU_SIMD_WIDTH
-      desc: "uint32_t: return Intel GPU EU SIMD width"
+      desc: "[uint32_t] return Intel GPU EU SIMD width"
     - name: GPU_EU_SLICES
-      desc: "uint32_t: return Intel GPU number of slices"
+      desc: "[uint32_t] return Intel GPU number of slices"
     - name: GPU_SUBSLICES_PER_SLICE
-      desc: "uint32_t: return Intel GPU number of subslices per slice"
+      desc: "[uint32_t] return Intel GPU number of subslices per slice"
     - name: MAX_MEMORY_BANDWIDTH
-      desc: "uint32_t: return max memory bandwidth in Mb/s"
+      desc: "[uint32_t] return max memory bandwidth in Mb/s"
     - name: IMAGE_SRGB
-      desc: "bool: image is SRGB"
+      desc: "[$x_bool_t] image is SRGB"
     - name: ATOMIC_64
-      desc: "bool: support 64 bit atomics"
+      desc: "[$x_bool_t] support 64 bit atomics"
     - name: ATOMIC_MEMORY_ORDER_CAPABILITIES
-      desc: "$x_memory_order_capability_flags_t: return a bit-field of atomic memory order capabilities"
+      desc: "[$x_memory_order_capability_flags_t] return a bit-field of atomic memory order capabilities"
     - name: ATOMIC_MEMORY_SCOPE_CAPABILITIES
-      desc: "$x_memory_scope_capability_flags_t: return a bit-field of atomic memory scope capabilities"
+      desc: "[$x_memory_scope_capability_flags_t] return a bit-field of atomic memory scope capabilities"
     - name: ATOMIC_FENCE_ORDER_CAPABILITIES
-      desc: "$x_memory_order_capability_flags_t: return a bit-field of atomic memory fence order capabilities"
+      desc: "[$x_memory_order_capability_flags_t] return a bit-field of atomic memory fence order capabilities"
     - name: ATOMIC_FENCE_SCOPE_CAPABILITIES
-      desc: "$x_memory_scope_capability_flags_t: return a bit-field of atomic memory fence scope capabilities"
+      desc: "[$x_memory_scope_capability_flags_t] return a bit-field of atomic memory fence scope capabilities"
     - name: BFLOAT16
-      desc: "bool: support for bfloat16"
+      desc: "[$x_bool_t] support for bfloat16"
     - name: MAX_COMPUTE_QUEUE_INDICES
       desc: |
-            uint32_t: Returns 1 if the device doesn't have a notion of a 
+            [uint32_t] Returns 1 if the device doesn't have a notion of a 
             queue index. Otherwise, returns the number of queue indices that are
             available for this device.
     - name: KERNEL_SET_SPECIALIZATION_CONSTANTS
-      desc: "`bool`: support the $xKernelSetSpecializationConstants entry point"
+      desc: "[$x_bool_t] support the $xKernelSetSpecializationConstants entry point"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"
@@ -386,7 +387,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional] array of bytes holding the info.
+            [out][optional][typename(propName)] array of bytes holding the info.
             If propSize is not equal to or greater than the real number of bytes needed to return the info
             then the $X_RESULT_ERROR_INVALID_VALUE error is returned and pPropValue is not used.
     - type: "size_t*"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -156,7 +156,7 @@ etors:
     - name: MAX_WORK_ITEM_DIMENSIONS
       desc: "[uint32_t] max work item dimensions"
     - name: MAX_WORK_ITEM_SIZES
-      desc: "[size_t*] return an array of max work item sizes"
+      desc: "[size_t[]] return an array of max work item sizes"
     - name: MAX_WORK_GROUP_SIZE
       desc: "[size_t] max work group size"
     - name: SINGLE_FP_CONFIG
@@ -270,7 +270,7 @@ etors:
     - name: QUEUE_ON_HOST_PROPERTIES
       desc: "[$x_queue_flags_t] host queue property bit-field"
     - name: BUILT_IN_KERNELS
-      desc: "[char*] a semi-colon separated list of built-in kernels"
+      desc: "[char[]] a semi-colon separated list of built-in kernels"
     - name: PLATFORM
       desc: "[$x_platform_handle_t] the platform associated with the device"
     - name: REFERENCE_COUNT
@@ -279,21 +279,21 @@ etors:
             The reference count returned should be considered immediately stale. 
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: IL_VERSION
-      desc: "[char*] IL version"
+      desc: "[char[]] IL version"
     - name: NAME
-      desc: "[char*] Device name"
+      desc: "[char[]] Device name"
     - name: VENDOR
-      desc: "[char*] Device vendor"
+      desc: "[char[]] Device vendor"
     - name: DRIVER_VERSION
-      desc: "[char*] Driver version"
+      desc: "[char[]] Driver version"
     - name: PROFILE
-      desc: "[char*] Device profile"
+      desc: "[char[]] Device profile"
     - name: VERSION
-      desc: "[char*] Device version"
+      desc: "[char[]] Device version"
     - name: BACKEND_RUNTIME_VERSION
-      desc: "[char*] Version of backend runtime"
+      desc: "[char[]] Version of backend runtime"
     - name: EXTENSIONS
-      desc: "[char*] Return a space separated list of extension names"
+      desc: "[char[]] Return a space separated list of extension names"
     - name: PRINTF_BUFFER_SIZE
       desc: "[size_t] Maximum size in bytes of internal printf buffer"
     - name: PREFERRED_INTEROP_USER_SYNC
@@ -301,7 +301,7 @@ etors:
     - name: PARENT_DEVICE
       desc: "[$x_device_handle_t] return parent device handle"
     - name: PARTITION_PROPERTIES
-      desc: "[$x_device_partition_property_t*] Returns the list of partition types supported by the device"
+      desc: "[$x_device_partition_property_t[]] Returns an array of partition types supported by the device"
     - name: PARTITION_MAX_SUB_DEVICES
       desc: "[uint32_t] maximum number of sub-devices when the device is partitioned"
     - name: PARTITION_AFFINITY_DOMAIN
@@ -309,13 +309,13 @@ etors:
             [$x_device_affinity_domain_flags_t] Returns a bit-field of the supported affinity domains for partitioning. 
             If the device does not support any affinity domains, then 0 will be returned.
     - name: PARTITION_TYPE
-      desc: "[$x_device_partition_property_t*] return a list of $x_device_partition_property_t for properties specified in $xDevicePartition"
+      desc: "[$x_device_partition_property_t[]] return an array of $x_device_partition_property_t for properties specified in $xDevicePartition"
     - name: MAX_NUM_SUB_GROUPS
       desc: "[uint32_t] max number of sub groups"
     - name: SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS
       desc: "[$x_bool_t] support sub group independent forward progress"
     - name: SUB_GROUP_SIZES_INTEL
-      desc: "[uint32_t*] return an array of sub group sizes supported on Intel device"
+      desc: "[uint32_t[]] return an array of sub group sizes supported on Intel device"
     - name: USM_HOST_SUPPORT
       desc: "[$x_bool_t] support USM host memory access"
     - name: USM_DEVICE_SUPPORT
@@ -327,9 +327,9 @@ etors:
     - name: USM_SYSTEM_SHARED_SUPPORT
       desc: "[$x_bool_t] support USM system wide shared memory access"
     - name: UUID
-      desc: "[char*] return device UUID"
+      desc: "[char[]] return device UUID"
     - name: PCI_ADDRESS
-      desc: "[char*] return device PCI address"
+      desc: "[char[]] return device PCI address"
     - name: GPU_EU_COUNT
       desc: "[uint32_t] return Intel GPU EU count"
     - name: GPU_EU_SIMD_WIDTH
@@ -387,7 +387,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional][typename(propName)] array of bytes holding the info.
+            [out][optional][typename(propName, propSize)] array of bytes holding the info.
             If propSize is not equal to or greater than the real number of bytes needed to return the info
             then the $X_RESULT_ERROR_INVALID_VALUE error is returned and pPropValue is not used.
     - type: "size_t*"

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -136,7 +136,7 @@ params:
       desc: "[in] size in bytes of the event property value"
     - type: void*
       name: pPropValue
-      desc: "[out][optional][typename(propName)] value of the event property"
+      desc: "[out][optional][typename(propName, propSize)] value of the event property"
     - type: size_t*
       name: pPropSizeRet
       desc: "[out][optional] bytes returned in event property"
@@ -166,7 +166,7 @@ params:
       desc: "[in] size in bytes of the profiling property value"
     - type: void*
       name: pPropValue
-      desc: "[out][optional][typename(propName)] value of the profiling property"
+      desc: "[out][optional][typename(propName, propSize)] value of the profiling property"
     - type: size_t*
       name: pPropSizeRet
       desc: "[out][optional] pointer to the actual size in bytes returned in propValue"

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -86,6 +86,7 @@ type: enum
 desc: "Event query information type"
 class: $xEvent
 name: $x_event_info_t
+typed_etors: True
 etors:
     - name: COMMAND_QUEUE
       desc: "[$x_queue_handle_t] Command queue information of an event object"
@@ -105,15 +106,16 @@ type: enum
 desc: "Profiling query information type"
 class: $xEvent
 name: $x_profiling_info_t
+typed_etors: True
 etors:
     - name: COMMAND_QUEUED
-      desc: "A 64-bit value of current device counter in nanoseconds when the event is enqueued"
+      desc: "[uint64_t] A 64-bit value of current device counter in nanoseconds when the event is enqueued"
     - name: COMMAND_SUBMIT
-      desc: "A 64-bit value of current device counter in nanoseconds when the event is submitted"
+      desc: "[uint64_t] A 64-bit value of current device counter in nanoseconds when the event is submitted"
     - name: COMMAND_START
-      desc: "A 64-bit value of current device counter in nanoseconds when the event starts execution"
+      desc: "[uint64_t] A 64-bit value of current device counter in nanoseconds when the event starts execution"
     - name: COMMAND_END
-      desc: "A 64-bit value of current device counter in nanoseconds when the event has finished execution"
+      desc: "[uint64_t] A 64-bit value of current device counter in nanoseconds when the event has finished execution"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get event object information"
@@ -130,17 +132,17 @@ params:
       name: propName
       desc: "[in] the name of the event property to query"
     - type: size_t
-      name: propValueSize
+      name: propSize
       desc: "[in] size in bytes of the event property value"
     - type: void*
       name: pPropValue
-      desc: "[out][optional] value of the event property"
+      desc: "[out][optional][typename(propName)] value of the event property"
     - type: size_t*
-      name: pPropValueSizeRet
+      name: pPropSizeRet
       desc: "[out][optional] bytes returned in event property"
 returns:
     - $X_RESULT_ERROR_INVALID_VALUE:
-      - "`pPropValue && propValueSize == 0`"
+      - "`pPropValue && propSize == 0`"
     - $X_RESULT_ERROR_INVALID_EVENT
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -160,17 +162,17 @@ params:
       name: propName
       desc: "[in] the name of the profiling property to query"
     - type: size_t
-      name: propValueSize
+      name: propSize
       desc: "[in] size in bytes of the profiling property value"
     - type: void*
       name: pPropValue
-      desc: "[out][optional] value of the profiling property"
+      desc: "[out][optional][typename(propName)] value of the profiling property"
     - type: size_t*
-      name: pPropValueSizeRet
+      name: pPropSizeRet
       desc: "[out][optional] pointer to the actual size in bytes returned in propValue"
 returns:
     - $X_RESULT_ERROR_INVALID_VALUE:
-      - "`pPropValue && propValueSize == 0`"
+      - "`pPropValue && propSize == 0`"
     - $X_RESULT_ERROR_INVALID_EVENT
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -83,7 +83,7 @@ name: $x_kernel_info_t
 typed_etors: True
 etors:
     - name: FUNCTION_NAME
-      desc: "[char*] Return null-terminated kernel function name."
+      desc: "[char[]] Return null-terminated kernel function name."
     - name: NUM_ARGS
       desc: "[size_t] Return Kernel number of arguments."
     - name: REFERENCE_COUNT
@@ -96,7 +96,7 @@ etors:
     - name: PROGRAM
       desc: "[$x_program_handle_t] Return Program object associated with Kernel."
     - name: ATTRIBUTES
-      desc: "[char*] Return null-terminated kernel attributes string."
+      desc: "[char[]] Return null-terminated kernel attributes string."
     - name: NUM_REGS
       desc: "[uint32_t] Return the number of registers used by the compiled kernel (device specific)."
 --- #--------------------------------------------------------------------------
@@ -107,11 +107,11 @@ name: $x_kernel_group_info_t
 typed_etors: True
 etors:
     - name: GLOBAL_WORK_SIZE
-      desc: "[size_t*] Return Work Group maximum global size, always returns a three element array"
+      desc: "[size_t[3]] Return Work Group maximum global size"
     - name: WORK_GROUP_SIZE
       desc: "[size_t] Return maximum Work Group size"
     - name: COMPILE_WORK_GROUP_SIZE
-      desc: "[size_t*] Return Work Group size required by the source code, such as __attribute__((required_work_group_size(X,Y,Z)), always returns a three element array"
+      desc: "[size_t[3]] Return Work Group size required by the source code, such as __attribute__((required_work_group_size(X,Y,Z))"
     - name: LOCAL_MEM_SIZE
       desc: "[size_t] Return local memory required by the Kernel"
     - name: PREFERRED_WORK_GROUP_SIZE_MULTIPLE
@@ -155,7 +155,7 @@ etors:
     - name: USM_INDIRECT_ACCESS
       desc: "[$x_bool_t] Kernel might access data through USM pointer."
     - name: USM_PTRS
-      desc: "[void **] Provide an explicit list of USM pointers that the kernel will access."
+      desc: "[void *[]] Provide an explicit array of USM pointers that the kernel will access."
     - name: CACHE_CONFIG
       desc: "[$x_kernel_cache_config_t] Provide the preferred cache configuration"
 --- #--------------------------------------------------------------------------
@@ -180,7 +180,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [in,out][optional][typename(propName)] array of bytes holding the kernel info property.
+            [in,out][optional][typename(propName, propSize)] array of bytes holding the kernel info property.
             If propSize is not equal to or greater than the real number of bytes needed to return 
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
@@ -210,7 +210,7 @@ params:
       desc: "[in] size of the Kernel Work Group property value"
     - type: "void*"
       name: pPropValue
-      desc: "[in,out][optional][typename(propName)] value of the Kernel Work Group property."
+      desc: "[in,out][optional][typename(propName, propSize)] value of the Kernel Work Group property."
     - type: "size_t*"
       name: "pPropSizeRet"
       desc: "[out][optional] pointer to the actual size in bytes of data being queried by propName."
@@ -235,7 +235,7 @@ params:
       desc: "[in] size of the Kernel SubGroup property value"
     - type: "void*"
       name: pPropValue
-      desc: "[in,out][optional][typename(propName)] value of the Kernel SubGroup property."
+      desc: "[in,out][optional][typename(propName, propSize)] value of the Kernel SubGroup property."
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
@@ -319,7 +319,7 @@ params:
       desc: "[in] size in byte the attribute value"
     - type: "const void*"
       name: pPropValue
-      desc: "[in][typename(propName)] pointer to memory location holding the property value."
+      desc: "[in][typename(propName, propSize)] pointer to memory location holding the property value."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Set a Sampler object as the argument value of a Kernel."

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -80,22 +80,23 @@ type: enum
 desc: "Get Kernel object information"
 class: $xKernel
 name: $x_kernel_info_t
+typed_etors: True
 etors:
     - name: FUNCTION_NAME
-      desc: "Return null-terminated kernel function name, return type char*."
+      desc: "[char*] Return null-terminated kernel function name."
     - name: NUM_ARGS
-      desc: "Return Kernel number of arguments."
+      desc: "[size_t] Return Kernel number of arguments."
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the kernel object.
             The reference count returned should be considered immediately stale. 
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: CONTEXT
-      desc: "Return Context object associated with Kernel."
+      desc: "[$x_context_handle_t] Return Context object associated with Kernel."
     - name: PROGRAM
-      desc: "Return Program object associated with Kernel."
+      desc: "[$x_program_handle_t] Return Program object associated with Kernel."
     - name: ATTRIBUTES
-      desc: "Return null-terminated kernel attributes string, return type char*."
+      desc: "[char*] Return null-terminated kernel attributes string."
     - name: NUM_REGS
       desc: "[uint32_t] Return the number of registers used by the compiled kernel (device specific)."
 --- #--------------------------------------------------------------------------
@@ -103,33 +104,35 @@ type: enum
 desc: "Get Kernel Work Group information"
 class: $xKernel
 name: $x_kernel_group_info_t
+typed_etors: True
 etors:
     - name: GLOBAL_WORK_SIZE
-      desc: "Return Work Group maximum global size, return type size_t[3]"
+      desc: "[size_t*] Return Work Group maximum global size, always returns a three element array"
     - name: WORK_GROUP_SIZE
-      desc: "Return maximum Work Group size, return type size_t"
+      desc: "[size_t] Return maximum Work Group size"
     - name: COMPILE_WORK_GROUP_SIZE
-      desc: "Return Work Group size required by the source code, such as __attribute__((required_work_group_size(X,Y,Z)), return type size_t[3]"
+      desc: "[size_t*] Return Work Group size required by the source code, such as __attribute__((required_work_group_size(X,Y,Z)), always returns a three element array"
     - name: LOCAL_MEM_SIZE
-      desc: "Return local memory required by the Kernel, return type size_t"
+      desc: "[size_t] Return local memory required by the Kernel"
     - name: PREFERRED_WORK_GROUP_SIZE_MULTIPLE
-      desc: "Return preferred multiple of Work Group size for launch, return type size_t"
+      desc: "[size_t] Return preferred multiple of Work Group size for launch"
     - name: PRIVATE_MEM_SIZE
-      desc: "Return minimum amount of private memory in bytes used by each work item in the Kernel, return type size_t"
+      desc: "[size_t] Return minimum amount of private memory in bytes used by each work item in the Kernel"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Get Kernel SubGroup information"
 class: $xKernel
 name: $x_kernel_sub_group_info_t
+typed_etors: True
 etors:
     - name: MAX_SUB_GROUP_SIZE
-      desc: "Return maximum SubGroup size, return type uint32_t"
+      desc: "[uint32_t] Return maximum SubGroup size"
     - name: MAX_NUM_SUB_GROUPS
-      desc: "Return maximum number of SubGroup, return type uint32_t"
+      desc: "[uint32_t] Return maximum number of SubGroup"
     - name: COMPILE_NUM_SUB_GROUPS
-      desc: "Return number of SubGroup required by the source code, return type uint32_t"
+      desc: "[uint32_t] Return number of SubGroup required by the source code"
     - name: SUB_GROUP_SIZE_INTEL
-      desc: "Return SubGroup size required by Intel, return type uint32_t"
+      desc: "[uint32_t] Return SubGroup size required by Intel"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Kernel Cache Configuartion."
@@ -147,13 +150,14 @@ type: enum
 desc: "Set additional Kernel execution information"
 class: $xKernel
 name: $x_kernel_exec_info_t
+typed_etors: True
 etors:
     - name: USM_INDIRECT_ACCESS
-      desc: "Kernel might access data through USM pointer, type bool_t*"
+      desc: "[$x_bool_t] Kernel might access data through USM pointer."
     - name: USM_PTRS
-      desc: "Provide an explicit list of USM pointers that the kernel will access, type void*[]."
+      desc: "[void **] Provide an explicit list of USM pointers that the kernel will access."
     - name: CACHE_CONFIG
-      desc: "Provide the preferred cache configuration, type $x_kernel_cache_config_t"
+      desc: "[$x_kernel_cache_config_t] Provide the preferred cache configuration"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Query information about a Kernel object"
@@ -176,7 +180,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [in,out][optional] array of bytes holding the kernel info property.
+            [in,out][optional][typename(propName)] array of bytes holding the kernel info property.
             If propSize is not equal to or greater than the real number of bytes needed to return 
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
@@ -206,7 +210,7 @@ params:
       desc: "[in] size of the Kernel Work Group property value"
     - type: "void*"
       name: pPropValue
-      desc: "[in,out][optional][range(0, propSize)] value of the Kernel Work Group property."
+      desc: "[in,out][optional][typename(propName)] value of the Kernel Work Group property."
     - type: "size_t*"
       name: "pPropSizeRet"
       desc: "[out][optional] pointer to the actual size in bytes of data being queried by propName."
@@ -231,7 +235,7 @@ params:
       desc: "[in] size of the Kernel SubGroup property value"
     - type: "void*"
       name: pPropValue
-      desc: "[in,out][range(0, propSize)][optional] value of the Kernel SubGroup property."
+      desc: "[in,out][optional][typename(propName)] value of the Kernel SubGroup property."
     - type: "size_t*"
       name: pPropSizeRet
       desc: |
@@ -315,7 +319,7 @@ params:
       desc: "[in] size in byte the attribute value"
     - type: "const void*"
       name: pPropValue
-      desc: "[in][range(0, propSize)] pointer to memory location holding the property value."
+      desc: "[in][typename(propName)] pointer to memory location holding the property value."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Set a Sampler object as the argument value of a Kernel."

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -58,11 +58,12 @@ type: enum
 desc: "Memory Information type"
 class: $xMem
 name: $x_mem_info_t
+typed_etors: True
 etors:
     - name: SIZE
-      desc: "size_t: actual size of of memory object in bytes"
+      desc: "[size_t] actual size of of memory object in bytes"
     - name: CONTEXT
-      desc: "$x_context_handle_t: context in which the memory object was created"
+      desc: "[$x_context_handle_t] context in which the memory object was created"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Image channel order info: number of channels and the channel layout"
@@ -140,21 +141,22 @@ type: enum
 desc: "Image information types"
 class: $xMem
 name: $x_image_info_t
+typed_etors: True
 etors:
   - name: FORMAT
-    desc: "$x_image_format_t: image format"
+    desc: "[$x_image_format_t] image format"
   - name: ELEMENT_SIZE
-    desc: "size_t: element size"
+    desc: "[size_t] element size"
   - name: ROW_PITCH
-    desc: "size_t: row pitch"
+    desc: "[size_t] row pitch"
   - name: SLICE_PITCH
-    desc: "size_t: slice pitch"
+    desc: "[size_t] slice pitch"
   - name: WIDTH
-    desc: "size_t: image width"
+    desc: "[size_t] image width"
   - name: HEIGHT
-    desc: "size_t: image height"
+    desc: "[size_t] image height"
   - name: DEPTH
-    desc: "size_t: image depth"
+    desc: "[size_t] image depth"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Image format including channel layout and data type"
@@ -478,7 +480,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional] array of bytes holding the info.
+            [out][optional][typename(propName)] array of bytes holding the info.
             If propSize is less than the real number of bytes needed to return
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
@@ -509,7 +511,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional] array of bytes holding the info.
+            [out][optional][typename(propName)] array of bytes holding the info.
             If propSize is less than the real number of bytes needed to return
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -480,7 +480,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional][typename(propName)] array of bytes holding the info.
+            [out][optional][typename(propName, propSize)] array of bytes holding the info.
             If propSize is less than the real number of bytes needed to return
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
@@ -511,7 +511,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional][typename(propName)] array of bytes holding the info.
+            [out][optional][typename(propName, propSize)] array of bytes holding the info.
             If propSize is less than the real number of bytes needed to return
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -44,6 +44,7 @@ type: enum
 desc: "Supported platform info"
 class: $xPlatform
 name: $x_platform_info_t
+typed_etors: True
 etors:
     - name: NAME
       value: "1"
@@ -64,7 +65,7 @@ etors:
       todo: "currently always return FULL_PROFILE, deprecate?"
     - name: BACKEND
       value: "6"
-      desc: "$x_platform_backend_t: The backend of the platform. Identifies the native backend adapter implementing this platform."
+      desc: "[$x_platform_backend_t] The backend of the platform. Identifies the native backend adapter implementing this platform."
 
 --- #--------------------------------------------------------------------------
 type: function
@@ -83,16 +84,16 @@ params:
       name: hPlatform
       desc: "[in] handle of the platform"
     - type: $x_platform_info_t
-      name: PlatformInfoType
+      name: propName
       desc: "[in] type of the info to retrieve"
     - type: "size_t"
-      name: Size
+      name: propSize
       desc: |
             [in] the number of bytes pointed to by pPlatformInfo.
     - type: "void*"
-      name: pPlatformInfo
+      name: pPropValue
       desc: |
-            [out][optional] array of bytes holding the info.
+            [out][optional][typename(propName)] array of bytes holding the info.
             If Size is not equal to or greater to the real number of bytes needed to return the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPlatformInfo is not used.
     - type: "size_t*"
       name: pSizeRet

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -48,20 +48,20 @@ typed_etors: True
 etors:
     - name: NAME
       value: "1"
-      desc: "[char*] The string denoting name of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The string denoting name of the platform. The size of the info needs to be dynamically queried."
     - name: VENDOR_NAME
       value: "2"
-      desc: "[char*] The string denoting name of the vendor of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The string denoting name of the vendor of the platform. The size of the info needs to be dynamically queried."
     - name: VERSION
       value: "3"
-      desc: "[char*] The string denoting the version of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The string denoting the version of the platform. The size of the info needs to be dynamically queried."
     - name: EXTENSIONS
       value: "4"
-      desc: "[char*] The string denoting extensions supported by the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The string denoting extensions supported by the platform. The size of the info needs to be dynamically queried."
       todo: "document extensions names and their meaning"
     - name: PROFILE
       value: "5"
-      desc: "[char*] The string denoting profile of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The string denoting profile of the platform. The size of the info needs to be dynamically queried."
       todo: "currently always return FULL_PROFILE, deprecate?"
     - name: BACKEND
       value: "6"
@@ -93,7 +93,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [out][optional][typename(propName)] array of bytes holding the info.
+            [out][optional][typename(propName, propSize)] array of bytes holding the info.
             If Size is not equal to or greater to the real number of bytes needed to return the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPlatformInfo is not used.
     - type: "size_t*"
       name: pSizeRet

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -317,17 +317,17 @@ etors:
     - name: NUM_DEVICES
       desc: "[uint32_t] Return number of devices associated with Program."
     - name: DEVICES
-      desc: "[x_device_handle_t*] Return list of devices associated with Program."
+      desc: "[$x_device_handle_t[]] Return list of devices associated with Program."
     - name: SOURCE
-      desc: "[char*] Return program source associated with Program."
+      desc: "[char[]] Return program source associated with Program."
     - name: BINARY_SIZES
-      desc: "[size_t*] Return program binary sizes for each device."
+      desc: "[size_t[]] Return program binary sizes for each device."
     - name: BINARIES
-      desc: "[unsigned char*] Return program binaries for all devices for this Program."
+      desc: "[unsigned char[]] Return program binaries for all devices for this Program."
     - name: NUM_KERNELS
       desc: "[size_t] Number of kernels in Program, return type size_t."
     - name: KERNEL_NAMES
-      desc: "[char*] Return a null-terminated, semi-colon separated list of kernel names in Program."
+      desc: "[char[]] Return a null-terminated, semi-colon separated list of kernel names in Program."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Query information about a Program object"
@@ -350,7 +350,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [in,out][optional][typename(propName)] array of bytes of holding the program info property.
+            [in,out][optional][typename(propName, propSize)] array of bytes of holding the program info property.
             If propSize is not equal to or greater than the real number of bytes needed to return 
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
@@ -395,9 +395,9 @@ etors:
     - name: STATUS
       desc: "[$x_program_build_status_t] Program build status."
     - name: OPTIONS
-      desc: "[char*] Null-terminated options string specified by last build, compile or link operation performed on the program."
+      desc: "[char[]] Null-terminated options string specified by last build, compile or link operation performed on the program."
     - name: LOG
-      desc: "[char*] Null-terminated program build log."
+      desc: "[char[]] Null-terminated program build log."
     - name: BINARY_TYPE
       desc: "[$x_program_binary_type_t] Program binary type."
 --- #--------------------------------------------------------------------------
@@ -425,7 +425,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [in,out][optional][typename(propName)] value of the Program build property.
+            [in,out][optional][typename(propName, propSize)] value of the Program build property.
             If propSize is not equal to or greater than the real number of bytes
             needed to return the info then the $X_RESULT_ERROR_INVALID_SIZE
             error is returned and pPropValue is not used.

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -305,6 +305,7 @@ type: enum
 desc: "Get Program object information"
 class: $xProgram
 name: $x_program_info_t
+typed_etors: True
 etors:
     - name: REFERENCE_COUNT
       desc: |
@@ -312,21 +313,21 @@ etors:
             The reference count returned should be considered immediately stale. 
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: CONTEXT
-      desc: "Program context info."
+      desc: "[$x_context_handle_t] Program context info."
     - name: NUM_DEVICES
-      desc: "Return number of devices associated with Program."
+      desc: "[uint32_t] Return number of devices associated with Program."
     - name: DEVICES
-      desc: "Return list of devices associated with Program, return type uint32_t*."
+      desc: "[x_device_handle_t*] Return list of devices associated with Program."
     - name: SOURCE
-      desc: "Return program source associated with Program, return type char*."
+      desc: "[char*] Return program source associated with Program."
     - name: BINARY_SIZES
-      desc: "Return program binary sizes for each device, return type size_t*."
+      desc: "[size_t*] Return program binary sizes for each device."
     - name: BINARIES
-      desc: "Return program binaries for all devices for this Program, return type uchar*."
+      desc: "[unsigned char*] Return program binaries for all devices for this Program."
     - name: NUM_KERNELS
-      desc: "Number of kernels in Program, return type size_t."
+      desc: "[size_t] Number of kernels in Program, return type size_t."
     - name: KERNEL_NAMES
-      desc: "Return a null-terminated, semi-colon separated list of kernel names in Program, return type char*."
+      desc: "[char*] Return a null-terminated, semi-colon separated list of kernel names in Program."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Query information about a Program object"
@@ -349,7 +350,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [in,out][optional] array of bytes of holding the program info property.
+            [in,out][optional][typename(propName)] array of bytes of holding the program info property.
             If propSize is not equal to or greater than the real number of bytes needed to return 
             the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
     - type: "size_t*"
@@ -389,15 +390,16 @@ type: enum
 desc: "Get Program object build information"
 class: $xProgram
 name: $x_program_build_info_t
+typed_etors: True
 etors:
     - name: STATUS
-      desc: "Program build status, return type $x_program_build_status_t."
+      desc: "[$x_program_build_status_t] Program build status."
     - name: OPTIONS
-      desc: "Null-terminated options string specified by last build, compile or link operation performed on the program. Return type char*."
+      desc: "[char*] Null-terminated options string specified by last build, compile or link operation performed on the program."
     - name: LOG
-      desc: "Null-terminated program build log, return type char*."
+      desc: "[char*] Null-terminated program build log."
     - name: BINARY_TYPE
-      desc: "Program binary type, return type $x_program_binary_type_t."
+      desc: "[$x_program_binary_type_t] Program binary type."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Query build information about a Program object for a Device"
@@ -423,7 +425,7 @@ params:
     - type: "void*"
       name: pPropValue
       desc: |
-            [in,out][optional] value of the Program build property.
+            [in,out][optional][typename(propName)] value of the Program build property.
             If propSize is not equal to or greater than the real number of bytes
             needed to return the info then the $X_RESULT_ERROR_INVALID_SIZE
             error is returned and pPropValue is not used.

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -78,7 +78,7 @@ params:
       desc: "[in] size in bytes of the queue property value provided"
     - type: "void*"
       name: pPropValue
-      desc: "[out][optional][typename(propName)] value of the queue property"
+      desc: "[out][optional][typename(propName, propSize)] value of the queue property"
     - type: "size_t*"
       name: pPropSizeRet
       desc: "[out][optional] size in bytes returned in queue property value"

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -14,22 +14,23 @@ type: enum
 desc: "Query queue info"
 class: $xQueue
 name: $x_queue_info_t
+typed_etors: True
 etors:
     - name: CONTEXT
-      desc: "$x_queue_handle_t: context associated with this queue."
+      desc: "[$x_queue_handle_t] context associated with this queue."
     - name: DEVICE
-      desc: "$x_device_handle_t: device associated with this queue."
+      desc: "[$x_device_handle_t] device associated with this queue."
     - name: DEVICE_DEFAULT
-      desc: "$x_queue_handle_t: the current default queue of the underlying device."
+      desc: "[$x_queue_handle_t] the current default queue of the underlying device."
     - name: FLAGS
-      desc: "$x_queue_flags_t: the properties associated with $x_queue_properties_t::flags."
+      desc: "[$x_queue_flags_t] the properties associated with $x_queue_properties_t::flags."
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the queue object.
             The reference count returned should be considered immediately stale. 
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: SIZE
-      desc: "uint32_t: The size of the queue"
+      desc: "[uint32_t] The size of the queue"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Queue property flags"
@@ -73,11 +74,11 @@ params:
       name: propName
       desc: "[in] name of the queue property to query"
     - type: "size_t"
-      name: propValueSize
+      name: propSize
       desc: "[in] size in bytes of the queue property value provided"
     - type: "void*"
       name: pPropValue
-      desc: "[out][optional] value of the queue property"
+      desc: "[out][optional][typename(propName)] value of the queue property"
     - type: "size_t*"
       name: pPropSizeRet
       desc: "[out][optional] size in bytes returned in queue property value"

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -40,6 +40,7 @@ type: enum
 desc: "Get sample object information"
 class: $xSampler
 name: $x_sampler_info_t
+typed_etors: True
 etors:
     - name: REFERENCE_COUNT
       desc: |
@@ -49,7 +50,7 @@ etors:
     - name: CONTEXT
       desc: "[$x_context_handle_t] Sampler context info"
     - name: NORMALIZED_COORDS
-      desc: "[bool] Sampler normalized coordinate setting"
+      desc: "[$x_bool_t] Sampler normalized coordinate setting"
     - name: ADDRESSING_MODE
       desc: "[$x_sampler_addressing_mode_t] Sampler addressing mode setting"
     - name: FILTER_MODE
@@ -149,7 +150,7 @@ params:
       desc: "[in] size in bytes of the sampler property value provided"
     - type: "void*"
       name: pPropValue
-      desc: "[out][typename(propName)] value of the sampler property"
+      desc: "[out][typename(propName, propSize)] value of the sampler property"
     - type: "size_t*"
       name: pPropSizeRet
       desc: "[out] size in bytes returned in sampler property value"

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -145,11 +145,11 @@ params:
       name: propName
       desc: "[in] name of the sampler property to query"
     - type: "size_t"
-      name: propValueSize
+      name: propSize
       desc: "[in] size in bytes of the sampler property value provided"
     - type: "void*"
       name: pPropValue
-      desc: "[out] value of the sampler property"
+      desc: "[out][typename(propName)] value of the sampler property"
     - type: "size_t*"
       name: pPropSizeRet
       desc: "[out] size in bytes returned in sampler property value"

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -73,6 +73,7 @@ type: enum
 desc: "USM memory allocation information type"
 class: $xUSM
 name: $x_usm_alloc_info_t
+typed_etors: True
 etors:
     - name: TYPE
       desc: "[$x_usm_type_t] Memory allocation type info"
@@ -343,13 +344,13 @@ params:
       name: propName
       desc: "[in] the name of the USM allocation property to query"
     - type: size_t
-      name: propValueSize
+      name: propSize
       desc: "[in] size in bytes of the USM allocation property value"
     - type: void*
       name: pPropValue
-      desc: "[out][optional] value of the USM allocation property"
+      desc: "[out][optional][typename(propName)] value of the USM allocation property"
     - type: size_t*
-      name: pPropValueSizeRet
+      name: pPropSizeRet
       desc: "[out][optional] bytes returned in USM allocation property"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -348,7 +348,7 @@ params:
       desc: "[in] size in bytes of the USM allocation property value"
     - type: void*
       name: pPropValue
-      desc: "[out][optional][typename(propName)] value of the USM allocation property"
+      desc: "[out][optional][typename(propName, propSize)] value of the USM allocation property"
     - type: size_t*
       name: pPropSizeRet
       desc: "[out][optional] bytes returned in USM allocation property"

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -192,12 +192,21 @@ def _validate_doc(f, d, tags, line_num):
                     elif not isinstance(item, str):
                         raise Exception(prefix+"must be a string: '%s'"%type(item))
 
+    def extract_type(s):
+        match = re.match(r'^\[(.+)\]\s', s)
+        if match:
+            return match.group(1)
+        else:
+            return None
+
     def __validate_etors(d, tags):
         if 'etors' not in d:
             raise Exception("'enum' requires the following sequence of mappings: {`etors`}")
 
         if not isinstance(d['etors'], list):
             raise Exception("'etors' must be a sequence: '%s'"%type(d['etors']))
+
+        typed = d.get('typed_etors', False)
 
         value = -1
         d_ver = d.get('version', default_version)
@@ -209,6 +218,14 @@ def _validate_doc(f, d, tags, line_num):
 
             if ('desc' not in item) or ('name' not in item):
                 raise Exception(prefix+"requires the following scalar fields: {`desc`, `name`}")
+
+            if typed:
+                type = extract_type(item['desc'])
+                if type is None:
+                    raise Exception(prefix+"typed etor " + item['name'] + " must begin with a type identifier: [type]")
+                type_name = _subt(type, tags)
+                if not is_iso(type_name):
+                    raise Exception(prefix+"type " + str(type) + " in a typed etor " + item['name'] + " must be a valid ISO C identifer")
 
             __validate_name(item, 'name', tags, case='upper', prefix=prefix)
 

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -306,6 +306,7 @@ class param_traits:
     RE_OPTIONAL = r".*\[optional\].*"
     RE_RANGE    = r".*\[range\((.+),\s*(.+)\)\][\S\s]*"
     RE_RELEASE  = r".*\[release\].*"
+    RE_TYPENAME    = r".*\[typename\((.+)\)\].*"
 
     @classmethod
     def is_mbz(cls, item):
@@ -362,12 +363,20 @@ class param_traits:
             return re.sub(cls.RE_RANGE, r"\2", item['desc'])
         except:
             return None
+
     @classmethod
     def is_release(cls, item):
         try:
             return True if re.match(cls.RE_RELEASE, item['desc']) else False
         except:
             return False
+
+    @classmethod
+    def get_typename(cls, item):
+        try:
+            return re.sub(cls.RE_TYPENAME, r"\1", item['desc'])
+        except:
+            return None
 
 """
     Extracts traits from a function object

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -82,7 +82,7 @@ class type_traits:
     RE_HANDLE   = r"(.*)handle_t"
     RE_IPC      = r"(.*)ipc(.*)handle_t"
     RE_POINTER  = r"(.*\w+)\*+"
-    RE_PPOINTER  = r"(.*\w+)\*{2,}"
+    RE_PPOINTER = r"(.*\w+)\*{2,}"
     RE_DESC     = r"(.*)desc_t.*"
     RE_PROPS    = r"(.*)properties_t.*"
     RE_FLAGS    = r"(.*)flags_t"
@@ -306,7 +306,7 @@ class param_traits:
     RE_OPTIONAL = r".*\[optional\].*"
     RE_RANGE    = r".*\[range\((.+),\s*(.+)\)\][\S\s]*"
     RE_RELEASE  = r".*\[release\].*"
-    RE_TYPENAME    = r".*\[typename\((.+)\)\].*"
+    RE_TYPENAME = r".*\[typename\((.+),\s(.+)\)\].*"
 
     @classmethod
     def is_mbz(cls, item):
@@ -372,10 +372,19 @@ class param_traits:
             return False
 
     @classmethod
-    def get_typename(cls, item):
-        try:
-            return re.sub(cls.RE_TYPENAME, r"\1", item['desc'])
-        except:
+    def typename(cls, item):
+        match = re.match(cls.RE_TYPENAME, item['desc'])
+        if match:
+            return match.group(1)
+        else:
+            return None
+
+    @classmethod
+    def typename_size(cls, item):
+        match = re.match(cls.RE_TYPENAME, item['desc'])
+        if match:
+            return match.group(2)
+        else:
             return None
 
 """
@@ -590,6 +599,18 @@ def make_etor_name(namespace, tags, enum, etor, py=False, meta=None):
     else:
         name = subt(namespace, tags, etor)
     return name
+
+"""
+Private:
+    returns the associated type of an etor from a typed enum
+"""
+def etor_get_associated_type(namespace, tags, item):
+    match = re.match(r'^\[(.+)\]\s', item['desc'])
+    if match:
+        associated_type = match.group(1)
+        return subt(namespace, tags, associated_type)
+    else:
+        return None
 
 """
 Private:

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -16,7 +16,243 @@
 
 namespace ur_params {
 template <typename T> inline void serializePtr(std::ostream &os, T *ptr);
+
+inline void serializeStruct(std::ostream &os, const void *ptr);
+inline void serializeFlag_ur_device_init_flags_t(std::ostream &os,
+                                                 ur_device_init_flags_t flag);
+inline void
+serializeTaggedTyped_ur_platform_info_t(std::ostream &os, const void *ptr,
+                                        enum ur_platform_info_t value,
+                                        size_t size);
+inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
+                                                  const void *ptr,
+                                                  enum ur_device_info_t value,
+                                                  size_t size);
+inline void serializeFlag_ur_device_fp_capability_flags_t(
+    std::ostream &os, ur_device_fp_capability_flags_t flag);
+inline void serializeFlag_ur_device_exec_capability_flags_t(
+    std::ostream &os, ur_device_exec_capability_flags_t flag);
+inline void serializeFlag_ur_device_affinity_domain_flags_t(
+    std::ostream &os, ur_device_affinity_domain_flags_t flag);
+inline void serializeFlag_ur_memory_order_capability_flags_t(
+    std::ostream &os, ur_memory_order_capability_flags_t flag);
+inline void serializeFlag_ur_memory_scope_capability_flags_t(
+    std::ostream &os, ur_memory_scope_capability_flags_t flag);
+inline void serializeFlag_ur_context_flags_t(std::ostream &os,
+                                             ur_context_flags_t flag);
+inline void serializeTaggedTyped_ur_context_info_t(std::ostream &os,
+                                                   const void *ptr,
+                                                   enum ur_context_info_t value,
+                                                   size_t size);
+inline void serializeFlag_ur_mem_flags_t(std::ostream &os, ur_mem_flags_t flag);
+inline void serializeTaggedTyped_ur_mem_info_t(std::ostream &os,
+                                               const void *ptr,
+                                               enum ur_mem_info_t value,
+                                               size_t size);
+inline void serializeTaggedTyped_ur_image_info_t(std::ostream &os,
+                                                 const void *ptr,
+                                                 enum ur_image_info_t value,
+                                                 size_t size);
+inline void serializeTaggedTyped_ur_sampler_info_t(std::ostream &os,
+                                                   const void *ptr,
+                                                   enum ur_sampler_info_t value,
+                                                   size_t size);
+inline void serializeFlag_ur_usm_flags_t(std::ostream &os, ur_usm_flags_t flag);
+inline void serializeFlag_ur_usm_host_mem_flags_t(std::ostream &os,
+                                                  ur_usm_host_mem_flags_t flag);
+inline void
+serializeFlag_ur_usm_device_mem_flags_t(std::ostream &os,
+                                        ur_usm_device_mem_flags_t flag);
+inline void serializeFlag_ur_usm_pool_flags_t(std::ostream &os,
+                                              ur_usm_pool_flags_t flag);
+inline void
+serializeTaggedTyped_ur_usm_alloc_info_t(std::ostream &os, const void *ptr,
+                                         enum ur_usm_alloc_info_t value,
+                                         size_t size);
+inline void serializeFlag_ur_usm_advice_flags_t(std::ostream &os,
+                                                ur_usm_advice_flags_t flag);
+inline void serializeTaggedTyped_ur_program_info_t(std::ostream &os,
+                                                   const void *ptr,
+                                                   enum ur_program_info_t value,
+                                                   size_t size);
+inline void
+serializeTaggedTyped_ur_program_build_info_t(std::ostream &os, const void *ptr,
+                                             enum ur_program_build_info_t value,
+                                             size_t size);
+inline void serializeTaggedTyped_ur_kernel_info_t(std::ostream &os,
+                                                  const void *ptr,
+                                                  enum ur_kernel_info_t value,
+                                                  size_t size);
+inline void
+serializeTaggedTyped_ur_kernel_group_info_t(std::ostream &os, const void *ptr,
+                                            enum ur_kernel_group_info_t value,
+                                            size_t size);
+inline void serializeTaggedTyped_ur_kernel_sub_group_info_t(
+    std::ostream &os, const void *ptr, enum ur_kernel_sub_group_info_t value,
+    size_t size);
+inline void
+serializeTaggedTyped_ur_kernel_exec_info_t(std::ostream &os, const void *ptr,
+                                           enum ur_kernel_exec_info_t value,
+                                           size_t size);
+inline void serializeTaggedTyped_ur_queue_info_t(std::ostream &os,
+                                                 const void *ptr,
+                                                 enum ur_queue_info_t value,
+                                                 size_t size);
+inline void serializeFlag_ur_queue_flags_t(std::ostream &os,
+                                           ur_queue_flags_t flag);
+inline void serializeTaggedTyped_ur_event_info_t(std::ostream &os,
+                                                 const void *ptr,
+                                                 enum ur_event_info_t value,
+                                                 size_t size);
+inline void
+serializeTaggedTyped_ur_profiling_info_t(std::ostream &os, const void *ptr,
+                                         enum ur_profiling_info_t value,
+                                         size_t size);
+inline void serializeFlag_ur_map_flags_t(std::ostream &os, ur_map_flags_t flag);
+inline void
+serializeFlag_ur_usm_migration_flags_t(std::ostream &os,
+                                       ur_usm_migration_flags_t flag);
 } // namespace ur_params
+
+inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_structure_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_base_properties_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_base_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_rect_offset_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_rect_region_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_init_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_platform_info_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_platform_backend_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_device_binary_t params);
+inline std::ostream &operator<<(std::ostream &os, enum ur_device_type_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_partition_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_fp_capability_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_mem_cache_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_local_mem_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_exec_capability_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_device_affinity_domain_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_memory_order_capability_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_memory_scope_capability_flag_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_context_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_context_properties_t params);
+inline std::ostream &operator<<(std::ostream &os, enum ur_context_info_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_mem_flag_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_mem_type_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_mem_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_image_channel_order_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_image_channel_type_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_image_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_image_format_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_image_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_buffer_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_buffer_channel_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_buffer_alloc_location_properties_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_buffer_region_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_buffer_create_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_sampler_filter_mode_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_sampler_addressing_mode_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_sampler_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_sampler_desc_t params);
+inline std::ostream &operator<<(std::ostream &os, enum ur_usm_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_usm_host_mem_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_usm_device_mem_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_usm_pool_flag_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_usm_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_usm_alloc_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_usm_advice_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_host_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_device_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_pool_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_pool_limits_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_program_metadata_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const union ur_program_metadata_value_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_program_metadata_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_program_properties_t params);
+inline std::ostream &operator<<(std::ostream &os, enum ur_program_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_program_build_status_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_program_binary_type_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_program_build_info_t value);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_specialization_constant_info_t params);
+inline std::ostream &operator<<(std::ostream &os, enum ur_kernel_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_kernel_group_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_kernel_sub_group_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_kernel_cache_config_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_kernel_exec_info_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_queue_info_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_queue_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_queue_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_queue_index_properties_t params);
+inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_event_status_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_event_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_profiling_info_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_execution_info_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_map_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_usm_migration_flag_t value);
 
 inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
     switch (value) {
@@ -681,6 +917,67 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void
+serializeTaggedTyped_ur_platform_info_t(std::ostream &os, const void *ptr,
+                                        enum ur_platform_info_t value,
+                                        size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_PLATFORM_INFO_NAME: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PLATFORM_INFO_VENDOR_NAME: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PLATFORM_INFO_VERSION: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PLATFORM_INFO_EXTENSIONS: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PLATFORM_INFO_PROFILE: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PLATFORM_INFO_BACKEND: {
+        const ur_platform_backend_t *tptr = (const ur_platform_backend_t *)ptr;
+        if (sizeof(ur_platform_backend_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_platform_backend_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value) {
     os << UR_MAJOR_VERSION(value) << "." << UR_MINOR_VERSION(value);
     return os;
@@ -1195,6 +1492,1417 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
+                                                  const void *ptr,
+                                                  enum ur_device_info_t value,
+                                                  size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_DEVICE_INFO_TYPE: {
+        const ur_device_type_t *tptr = (const ur_device_type_t *)ptr;
+        if (sizeof(ur_device_type_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_type_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_VENDOR_ID: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_DEVICE_ID: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES: {
+
+        const size_t *tptr = (const size_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(size_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_SINGLE_FP_CONFIG: {
+        const ur_device_fp_capability_flags_t *tptr =
+            (const ur_device_fp_capability_flags_t *)ptr;
+        if (sizeof(ur_device_fp_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_fp_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_device_fp_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_HALF_FP_CONFIG: {
+        const ur_device_fp_capability_flags_t *tptr =
+            (const ur_device_fp_capability_flags_t *)ptr;
+        if (sizeof(ur_device_fp_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_fp_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_device_fp_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_DOUBLE_FP_CONFIG: {
+        const ur_device_fp_capability_flags_t *tptr =
+            (const ur_device_fp_capability_flags_t *)ptr;
+        if (sizeof(ur_device_fp_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_fp_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_device_fp_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_QUEUE_PROPERTIES: {
+        const ur_queue_flags_t *tptr = (const ur_queue_flags_t *)ptr;
+        if (sizeof(ur_queue_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_flags_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_queue_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ADDRESS_BITS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE_SUPPORTED: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_SAMPLERS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_PARAMETER_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE: {
+        const ur_device_mem_cache_type_t *tptr =
+            (const ur_device_mem_cache_type_t *)ptr;
+        if (sizeof(ur_device_mem_cache_type_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_mem_cache_type_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_CONSTANT_ARGS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_LOCAL_MEM_TYPE: {
+        const ur_device_local_mem_type_t *tptr =
+            (const ur_device_local_mem_type_t *)ptr;
+        if (sizeof(ur_device_local_mem_type_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_local_mem_type_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_LOCAL_MEM_SIZE: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
+        const bool *tptr = (const bool *)ptr;
+        if (sizeof(bool) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(bool) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY: {
+        const bool *tptr = (const bool *)ptr;
+        if (sizeof(bool) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(bool) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ENDIAN_LITTLE: {
+        const bool *tptr = (const bool *)ptr;
+        if (sizeof(bool) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(bool) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_AVAILABLE: {
+        const bool *tptr = (const bool *)ptr;
+        if (sizeof(bool) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(bool) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_COMPILER_AVAILABLE: {
+        const bool *tptr = (const bool *)ptr;
+        if (sizeof(bool) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(bool) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_LINKER_AVAILABLE: {
+        const bool *tptr = (const bool *)ptr;
+        if (sizeof(bool) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(bool) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_EXECUTION_CAPABILITIES: {
+        const ur_device_exec_capability_flags_t *tptr =
+            (const ur_device_exec_capability_flags_t *)ptr;
+        if (sizeof(ur_device_exec_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_exec_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_device_exec_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES: {
+        const ur_queue_flags_t *tptr = (const ur_queue_flags_t *)ptr;
+        if (sizeof(ur_queue_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_flags_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_queue_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES: {
+        const ur_queue_flags_t *tptr = (const ur_queue_flags_t *)ptr;
+        if (sizeof(ur_queue_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_flags_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_queue_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_BUILT_IN_KERNELS: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_PLATFORM: {
+        const ur_platform_handle_t *tptr = (const ur_platform_handle_t *)ptr;
+        if (sizeof(ur_platform_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_platform_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IL_VERSION: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_NAME: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_VENDOR: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_DRIVER_VERSION: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_PROFILE: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_VERSION: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_EXTENSIONS: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PARENT_DEVICE: {
+        const ur_device_handle_t *tptr = (const ur_device_handle_t *)ptr;
+        if (sizeof(ur_device_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PARTITION_PROPERTIES: {
+
+        const ur_device_partition_property_t *tptr =
+            (const ur_device_partition_property_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(ur_device_partition_property_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN: {
+        const ur_device_affinity_domain_flags_t *tptr =
+            (const ur_device_affinity_domain_flags_t *)ptr;
+        if (sizeof(ur_device_affinity_domain_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_affinity_domain_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_device_affinity_domain_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_PARTITION_TYPE: {
+
+        const ur_device_partition_property_t *tptr =
+            (const ur_device_partition_property_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(ur_device_partition_property_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
+
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(uint32_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_DEVICE_INFO_USM_HOST_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_USM_DEVICE_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_UUID: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_PCI_ADDRESS: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_DEVICE_INFO_GPU_EU_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GPU_EU_SLICES: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE_SRGB: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ATOMIC_64: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
+        const ur_memory_order_capability_flags_t *tptr =
+            (const ur_memory_order_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_order_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_order_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_order_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES: {
+        const ur_memory_scope_capability_flags_t *tptr =
+            (const ur_memory_scope_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_scope_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_scope_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_scope_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES: {
+        const ur_memory_order_capability_flags_t *tptr =
+            (const ur_memory_order_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_order_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_order_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_order_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES: {
+        const ur_memory_scope_capability_flags_t *tptr =
+            (const ur_memory_scope_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_scope_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_scope_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_scope_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_BFLOAT16: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_partition_t value) {
     switch (value) {
@@ -1887,6 +3595,158 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_context_info_t(std::ostream &os,
+                                                   const void *ptr,
+                                                   enum ur_context_info_t value,
+                                                   size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_CONTEXT_INFO_NUM_DEVICES: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_DEVICES: {
+
+        const ur_device_handle_t *tptr = (const ur_device_handle_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(ur_device_handle_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            ur_params::serializePtr(os, tptr[i]);
+        }
+        os << "]";
+    } break;
+
+    case UR_CONTEXT_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
+        const ur_memory_order_capability_flags_t *tptr =
+            (const ur_memory_order_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_order_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_order_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_order_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES: {
+        const ur_memory_scope_capability_flags_t *tptr =
+            (const ur_memory_scope_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_scope_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_scope_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_scope_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES: {
+        const ur_memory_order_capability_flags_t *tptr =
+            (const ur_memory_order_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_order_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_order_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_order_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES: {
+        const ur_memory_scope_capability_flags_t *tptr =
+            (const ur_memory_scope_capability_flags_t *)ptr;
+        if (sizeof(ur_memory_scope_capability_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_memory_scope_capability_flags_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_memory_scope_capability_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os, enum ur_mem_flag_t value) {
     switch (value) {
 
@@ -2050,6 +3910,51 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_mem_info_t value) {
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_mem_info_t(std::ostream &os,
+                                               const void *ptr,
+                                               enum ur_mem_info_t value,
+                                               size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_MEM_INFO_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_MEM_INFO_CONTEXT: {
+        const ur_context_handle_t *tptr = (const ur_context_handle_t *)ptr;
+        if (sizeof(ur_context_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_context_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_image_channel_order_t value) {
     switch (value) {
@@ -2224,6 +4129,121 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_image_info_t value) {
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_image_info_t(std::ostream &os,
+                                                 const void *ptr,
+                                                 enum ur_image_info_t value,
+                                                 size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_IMAGE_INFO_FORMAT: {
+        const ur_image_format_t *tptr = (const ur_image_format_t *)ptr;
+        if (sizeof(ur_image_format_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_image_format_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_IMAGE_INFO_ELEMENT_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_IMAGE_INFO_ROW_PITCH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_IMAGE_INFO_SLICE_PITCH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_IMAGE_INFO_WIDTH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_IMAGE_INFO_HEIGHT: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_IMAGE_INFO_DEPTH: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_image_format_t params) {
     os << "(struct ur_image_format_t){";
@@ -2480,6 +4500,96 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_sampler_info_t(std::ostream &os,
+                                                   const void *ptr,
+                                                   enum ur_sampler_info_t value,
+                                                   size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_SAMPLER_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_SAMPLER_INFO_CONTEXT: {
+        const ur_context_handle_t *tptr = (const ur_context_handle_t *)ptr;
+        if (sizeof(ur_context_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_context_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_SAMPLER_INFO_NORMALIZED_COORDS: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_SAMPLER_INFO_ADDRESSING_MODE: {
+        const ur_sampler_addressing_mode_t *tptr =
+            (const ur_sampler_addressing_mode_t *)ptr;
+        if (sizeof(ur_sampler_addressing_mode_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_sampler_addressing_mode_t)
+               << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_SAMPLER_INFO_FILTER_MODE: {
+        const ur_sampler_filter_mode_t *tptr =
+            (const ur_sampler_filter_mode_t *)ptr;
+        if (sizeof(ur_sampler_filter_mode_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_sampler_filter_mode_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_sampler_desc_t params) {
     os << "(struct ur_sampler_desc_t){";
@@ -2769,6 +4879,93 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void
+serializeTaggedTyped_ur_usm_alloc_info_t(std::ostream &os, const void *ptr,
+                                         enum ur_usm_alloc_info_t value,
+                                         size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_USM_ALLOC_INFO_TYPE: {
+        const ur_usm_type_t *tptr = (const ur_usm_type_t *)ptr;
+        if (sizeof(ur_usm_type_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_usm_type_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_USM_ALLOC_INFO_BASE_PTR: {
+        const void **tptr = (const void **)ptr;
+        if (sizeof(void *) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(void *) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_USM_ALLOC_INFO_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_USM_ALLOC_INFO_DEVICE: {
+        const ur_device_handle_t *tptr = (const ur_device_handle_t *)ptr;
+        if (sizeof(ur_device_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_USM_ALLOC_INFO_POOL: {
+        const ur_usm_pool_handle_t *tptr = (const ur_usm_pool_handle_t *)ptr;
+        if (sizeof(ur_usm_pool_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_usm_pool_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_advice_flag_t value) {
     switch (value) {
@@ -3203,6 +5400,127 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_program_info_t(std::ostream &os,
+                                                   const void *ptr,
+                                                   enum ur_program_info_t value,
+                                                   size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_PROGRAM_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROGRAM_INFO_CONTEXT: {
+        const ur_context_handle_t *tptr = (const ur_context_handle_t *)ptr;
+        if (sizeof(ur_context_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_context_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_PROGRAM_INFO_NUM_DEVICES: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROGRAM_INFO_DEVICES: {
+
+        const ur_device_handle_t *tptr = (const ur_device_handle_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(ur_device_handle_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            ur_params::serializePtr(os, tptr[i]);
+        }
+        os << "]";
+    } break;
+
+    case UR_PROGRAM_INFO_SOURCE: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PROGRAM_INFO_BINARY_SIZES: {
+
+        const size_t *tptr = (const size_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(size_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_PROGRAM_INFO_BINARIES: {
+
+        const unsigned char *tptr = (const unsigned char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PROGRAM_INFO_NUM_KERNELS: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROGRAM_INFO_KERNEL_NAMES: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_program_build_status_t value) {
     switch (value) {
@@ -3278,6 +5596,65 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void
+serializeTaggedTyped_ur_program_build_info_t(std::ostream &os, const void *ptr,
+                                             enum ur_program_build_info_t value,
+                                             size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_PROGRAM_BUILD_INFO_STATUS: {
+        const ur_program_build_status_t *tptr =
+            (const ur_program_build_status_t *)ptr;
+        if (sizeof(ur_program_build_status_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_program_build_status_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROGRAM_BUILD_INFO_OPTIONS: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PROGRAM_BUILD_INFO_LOG: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_PROGRAM_BUILD_INFO_BINARY_TYPE: {
+        const ur_program_binary_type_t *tptr =
+            (const ur_program_binary_type_t *)ptr;
+        if (sizeof(ur_program_binary_type_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_program_binary_type_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_specialization_constant_info_t params) {
@@ -3336,6 +5713,105 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_kernel_info_t value) {
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_kernel_info_t(std::ostream &os,
+                                                  const void *ptr,
+                                                  enum ur_kernel_info_t value,
+                                                  size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_KERNEL_INFO_FUNCTION_NAME: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_KERNEL_INFO_NUM_ARGS: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_INFO_CONTEXT: {
+        const ur_context_handle_t *tptr = (const ur_context_handle_t *)ptr;
+        if (sizeof(ur_context_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_context_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_INFO_PROGRAM: {
+        const ur_program_handle_t *tptr = (const ur_program_handle_t *)ptr;
+        if (sizeof(ur_program_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_program_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_INFO_ATTRIBUTES: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_KERNEL_INFO_NUM_REGS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_group_info_t value) {
     switch (value) {
@@ -3369,6 +5845,109 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void
+serializeTaggedTyped_ur_kernel_group_info_t(std::ostream &os, const void *ptr,
+                                            enum ur_kernel_group_info_t value,
+                                            size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE: {
+
+        const size_t *tptr = (const size_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(size_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE: {
+
+        const size_t *tptr = (const size_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(size_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_sub_group_info_t value) {
     switch (value) {
@@ -3394,6 +5973,78 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_kernel_sub_group_info_t(
+    std::ostream &os, const void *ptr, enum ur_kernel_sub_group_info_t value,
+    size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_cache_config_t value) {
     switch (value) {
@@ -3436,6 +6087,67 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void
+serializeTaggedTyped_ur_kernel_exec_info_t(std::ostream &os, const void *ptr,
+                                           enum ur_kernel_exec_info_t value,
+                                           size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_KERNEL_EXEC_INFO_USM_PTRS: {
+
+        const void **tptr = (const void **)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(void *);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "]";
+    } break;
+
+    case UR_KERNEL_EXEC_INFO_CACHE_CONFIG: {
+        const ur_kernel_cache_config_t *tptr =
+            (const ur_kernel_cache_config_t *)ptr;
+        if (sizeof(ur_kernel_cache_config_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_kernel_cache_config_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os, enum ur_queue_info_t value) {
     switch (value) {
 
@@ -3468,6 +6180,107 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_queue_info_t value) {
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_queue_info_t(std::ostream &os,
+                                                 const void *ptr,
+                                                 enum ur_queue_info_t value,
+                                                 size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_QUEUE_INFO_CONTEXT: {
+        const ur_queue_handle_t *tptr = (const ur_queue_handle_t *)ptr;
+        if (sizeof(ur_queue_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_QUEUE_INFO_DEVICE: {
+        const ur_device_handle_t *tptr = (const ur_device_handle_t *)ptr;
+        if (sizeof(ur_device_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_device_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_QUEUE_INFO_DEVICE_DEFAULT: {
+        const ur_queue_handle_t *tptr = (const ur_queue_handle_t *)ptr;
+        if (sizeof(ur_queue_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_QUEUE_INFO_FLAGS: {
+        const ur_queue_flags_t *tptr = (const ur_queue_flags_t *)ptr;
+        if (sizeof(ur_queue_flags_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_flags_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializeFlag_ur_queue_flags_t(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_QUEUE_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_QUEUE_INFO_SIZE: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os, enum ur_queue_flag_t value) {
     switch (value) {
 
@@ -3791,6 +6604,93 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_event_info_t value) {
     }
     return os;
 }
+namespace ur_params {
+inline void serializeTaggedTyped_ur_event_info_t(std::ostream &os,
+                                                 const void *ptr,
+                                                 enum ur_event_info_t value,
+                                                 size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_EVENT_INFO_COMMAND_QUEUE: {
+        const ur_queue_handle_t *tptr = (const ur_queue_handle_t *)ptr;
+        if (sizeof(ur_queue_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_queue_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_EVENT_INFO_CONTEXT: {
+        const ur_context_handle_t *tptr = (const ur_context_handle_t *)ptr;
+        if (sizeof(ur_context_handle_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_context_handle_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        ur_params::serializePtr(os, *tptr);
+
+        os << ")";
+    } break;
+
+    case UR_EVENT_INFO_COMMAND_TYPE: {
+        const ur_command_t *tptr = (const ur_command_t *)ptr;
+        if (sizeof(ur_command_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_command_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_EVENT_INFO_COMMAND_EXECUTION_STATUS: {
+        const ur_event_status_t *tptr = (const ur_event_status_t *)ptr;
+        if (sizeof(ur_event_status_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_event_status_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_EVENT_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_profiling_info_t value) {
     switch (value) {
@@ -3816,6 +6716,79 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
+namespace ur_params {
+inline void
+serializeTaggedTyped_ur_profiling_info_t(std::ostream &os, const void *ptr,
+                                         enum ur_profiling_info_t value,
+                                         size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_PROFILING_INFO_COMMAND_QUEUED: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROFILING_INFO_COMMAND_SUBMIT: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROFILING_INFO_COMMAND_START: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_PROFILING_INFO_COMMAND_END: {
+        const uint64_t *tptr = (const uint64_t *)ptr;
+        if (sizeof(uint64_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint64_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+}
+} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_execution_info_t value) {
     switch (value) {
@@ -4503,8 +7476,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_context_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -5950,8 +8923,8 @@ operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_event_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -5981,8 +8954,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_profiling_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -6136,8 +9109,8 @@ operator<<(std::ostream &os, const struct ur_kernel_get_info_params_t *params) {
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_kernel_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -6172,8 +9145,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_kernel_group_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -6208,8 +9181,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_kernel_sub_group_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -6364,8 +9337,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_kernel_exec_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     return os;
 }
@@ -6607,8 +9580,8 @@ inline std::ostream &operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_mem_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -6638,8 +9611,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_image_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -6696,8 +9669,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_platform_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pSizeRet = ";
@@ -6965,8 +9938,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_program_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -7001,8 +9974,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_program_build_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -7096,8 +10069,8 @@ operator<<(std::ostream &os, const struct ur_queue_get_info_params_t *params) {
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_queue_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -7269,8 +10242,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_sampler_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -7459,8 +10432,8 @@ operator<<(std::ostream &os,
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_usm_alloc_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -7562,8 +10535,8 @@ operator<<(std::ostream &os, const struct ur_device_get_info_params_t *params) {
 
     os << ", ";
     os << ".pPropValue = ";
-
-    ur_params::serializePtr(os, *(params->ppPropValue));
+    ur_params::serializeTaggedTyped_ur_device_info_t(
+        os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
 
     os << ", ";
     os << ".pPropSizeRet = ";
@@ -7730,6 +10703,10 @@ template <typename T> inline void serializePtr(std::ostream &os, T *ptr) {
         os << ")";
     } else if constexpr (std::is_void_v<T> || !is_type_complete_v<T>) {
         os << (void *)ptr;
+    } else if constexpr (std::is_same_v<std::remove_cv_t<T>, char>) {
+        os << (void *)(ptr) << " (";
+        os << ptr;
+        os << ")";
     } else {
         os << (void *)(ptr) << " (";
         os << *ptr;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -5944,9 +5944,9 @@ operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
     os << *(params->ppropName);
 
     os << ", ";
-    os << ".propValueSize = ";
+    os << ".propSize = ";
 
-    os << *(params->ppropValueSize);
+    os << *(params->ppropSize);
 
     os << ", ";
     os << ".pPropValue = ";
@@ -5954,9 +5954,9 @@ operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->ppPropValue));
 
     os << ", ";
-    os << ".pPropValueSizeRet = ";
+    os << ".pPropSizeRet = ";
 
-    ur_params::serializePtr(os, *(params->ppPropValueSizeRet));
+    ur_params::serializePtr(os, *(params->ppPropSizeRet));
 
     return os;
 }
@@ -5975,9 +5975,9 @@ operator<<(std::ostream &os,
     os << *(params->ppropName);
 
     os << ", ";
-    os << ".propValueSize = ";
+    os << ".propSize = ";
 
-    os << *(params->ppropValueSize);
+    os << *(params->ppropSize);
 
     os << ", ";
     os << ".pPropValue = ";
@@ -5985,9 +5985,9 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->ppPropValue));
 
     os << ", ";
-    os << ".pPropValueSizeRet = ";
+    os << ".pPropSizeRet = ";
 
-    ur_params::serializePtr(os, *(params->ppPropValueSizeRet));
+    ur_params::serializePtr(os, *(params->ppPropSizeRet));
 
     return os;
 }
@@ -6685,19 +6685,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-    os << ".PlatformInfoType = ";
+    os << ".propName = ";
 
-    os << *(params->pPlatformInfoType);
-
-    os << ", ";
-    os << ".Size = ";
-
-    os << *(params->pSize);
+    os << *(params->ppropName);
 
     os << ", ";
-    os << ".pPlatformInfo = ";
+    os << ".propSize = ";
 
-    ur_params::serializePtr(os, *(params->ppPlatformInfo));
+    os << *(params->ppropSize);
+
+    os << ", ";
+    os << ".pPropValue = ";
+
+    ur_params::serializePtr(os, *(params->ppPropValue));
 
     os << ", ";
     os << ".pSizeRet = ";
@@ -7090,9 +7090,9 @@ operator<<(std::ostream &os, const struct ur_queue_get_info_params_t *params) {
     os << *(params->ppropName);
 
     os << ", ";
-    os << ".propValueSize = ";
+    os << ".propSize = ";
 
-    os << *(params->ppropValueSize);
+    os << *(params->ppropSize);
 
     os << ", ";
     os << ".pPropValue = ";
@@ -7263,9 +7263,9 @@ operator<<(std::ostream &os,
     os << *(params->ppropName);
 
     os << ", ";
-    os << ".propValueSize = ";
+    os << ".propSize = ";
 
-    os << *(params->ppropValueSize);
+    os << *(params->ppropSize);
 
     os << ", ";
     os << ".pPropValue = ";
@@ -7453,9 +7453,9 @@ operator<<(std::ostream &os,
     os << *(params->ppropName);
 
     os << ", ";
-    os << ".propValueSize = ";
+    os << ".propSize = ";
 
-    os << *(params->ppropValueSize);
+    os << *(params->ppropSize);
 
     os << ", ";
     os << ".pPropValue = ";
@@ -7463,9 +7463,9 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->ppPropValue));
 
     os << ", ";
-    os << ".pPropValueSizeRet = ";
+    os << ".pPropSizeRet = ";
 
-    ur_params::serializePtr(os, *(params->ppPropValueSizeRet));
+    ur_params::serializePtr(os, *(params->ppPropSizeRet));
 
     return os;
 }

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -82,10 +82,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
 __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -97,8 +98,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Platform.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
-                            pSizeRet);
+        result =
+            pfnGetInfo(hPlatform, propName, propSize, pPropValue, pSizeRet);
     } else {
         // generic implementation
     }
@@ -231,8 +232,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
-    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -491,7 +493,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -747,7 +750,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -775,7 +779,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -862,8 +867,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
+        propSize, ///< [in] size in bytes of the sampler property value provided
+    void *
+        pPropValue, ///< [out][typename(propName)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -872,8 +878,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Sampler.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
-                            pPropSizeRet);
+        result =
+            pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1031,18 +1037,20 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
+        propSize, ///< [in] size in bytes of the USM allocation property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
+                    ///< property
     size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+        pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetMemAllocInfo = d_context.urDdiTable.USM.pfnGetMemAllocInfo;
     if (nullptr != pfnGetMemAllocInfo) {
-        result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                                    pPropValue, pPropValueSizeRet);
+        result = pfnGetMemAllocInfo(hContext, pMem, propName, propSize,
+                                    pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1286,7 +1294,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                    ///< program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1317,7 +1326,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -1480,7 +1489,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
+                    ///< kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1512,7 +1522,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -1541,7 +1551,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -1626,7 +1636,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
                    ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1754,8 +1764,9 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out][optional] value of the queue property
+        propSize, ///< [in] size in bytes of the queue property value provided
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -1764,8 +1775,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Queue.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
-                            pPropSizeRet);
+        result =
+            pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1918,18 +1929,18 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize, ///< [in] size in bytes of the event property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetInfo = d_context.urDdiTable.Event.pfnGetInfo;
     if (nullptr != pfnGetInfo) {
-        result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                            pPropValueSizeRet);
+        result =
+            pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -1942,21 +1953,21 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
+        propName,    ///< [in] the name of the profiling property to query
+    size_t propSize, ///< [in] size in bytes of the profiling property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
     size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                     ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetProfilingInfo = d_context.urDdiTable.Event.pfnGetProfilingInfo;
     if (nullptr != pfnGetProfilingInfo) {
-        result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
-                                     pPropValue, pPropValueSizeRet);
+        result = pfnGetProfilingInfo(hEvent, propName, propSize, pPropValue,
+                                     pPropSizeRet);
     } else {
         // generic implementation
     }

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -86,7 +86,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -234,7 +235,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -494,7 +496,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -751,7 +754,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -780,7 +784,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -869,7 +874,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the sampler property value provided
     void *
-        pPropValue, ///< [out][typename(propName)] value of the sampler property
+        pPropValue, ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1039,8 +1044,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     size_t
         propSize, ///< [in] size in bytes of the USM allocation property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
-                    ///< property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the USM
+                    ///< allocation property
     size_t *
         pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
@@ -1294,8 +1299,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                    ///< program info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                    ///< holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1326,7 +1331,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                    ///< build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -1489,8 +1495,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
-                    ///< kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                    ///< holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1522,8 +1528,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< Work Group property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1551,8 +1557,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< SubGroup property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1636,8 +1642,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
-                   ///< property value.
+        pPropValue ///< [in][typename(propName, propSize)] pointer to memory location holding
+                   ///< the property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1766,7 +1772,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the queue property value provided
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the queue
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -1931,7 +1938,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the event
+                    ///< property
     size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1956,7 +1964,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
         propName,    ///< [in] the name of the profiling property to query
     size_t propSize, ///< [in] size in bytes of the profiling property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the profiling
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
                      ///< propValue

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -100,7 +100,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -279,7 +280,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -600,7 +602,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -920,7 +923,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -955,7 +959,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1064,7 +1069,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the sampler property value provided
     void *
-        pPropValue, ///< [out][typename(propName)] value of the sampler property
+        pPropValue, ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1278,8 +1283,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     size_t
         propSize, ///< [in] size in bytes of the USM allocation property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
-                    ///< property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the USM
+                    ///< allocation property
     size_t *
         pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
@@ -1594,8 +1599,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                    ///< program info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                    ///< holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1632,7 +1637,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                    ///< build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -1838,8 +1844,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
-                    ///< kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                    ///< holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1877,8 +1883,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< Work Group property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -1912,8 +1918,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< SubGroup property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2020,8 +2026,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
-                   ///< property value.
+        pPropValue ///< [in][typename(propName, propSize)] pointer to memory location holding
+                   ///< the property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
 
@@ -2191,7 +2197,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the queue property value provided
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the queue
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2399,7 +2406,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the event
+                    ///< property
     size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
@@ -2430,7 +2438,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
         propName,    ///< [in] the name of the profiling property to query
     size_t propSize, ///< [in] size in bytes of the profiling property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the profiling
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
                      ///< propValue

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -96,10 +96,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
 __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -112,13 +113,13 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_get_info_params_t params = {&hPlatform, &PlatformInfoType,
-                                            &Size, &pPlatformInfo, &pSizeRet};
+    ur_platform_get_info_params_t params = {&hPlatform, &propName, &propSize,
+                                            &pPropValue, &pSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET_INFO,
                                              "urPlatformGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+        pfnGetInfo(hPlatform, propName, propSize, pPropValue, pSizeRet);
 
     context.notify_end(UR_FUNCTION_PLATFORM_GET_INFO, "urPlatformGetInfo",
                        &params, &result, instance);
@@ -276,8 +277,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
-    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -597,7 +599,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -916,7 +919,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -950,7 +954,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1057,8 +1062,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
+        propSize, ///< [in] size in bytes of the sampler property value provided
+    void *
+        pPropValue, ///< [out][typename(propName)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1068,13 +1074,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_sampler_get_info_params_t params = {&hSampler, &propName, &propValueSize,
+    ur_sampler_get_info_params_t params = {&hSampler, &propName, &propSize,
                                            &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_SAMPLER_GET_INFO,
                                              "urSamplerGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+        pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_SAMPLER_GET_INFO, "urSamplerGetInfo",
                        &params, &result, instance);
@@ -1270,10 +1276,12 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
+        propSize, ///< [in] size in bytes of the USM allocation property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
+                    ///< property
     size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+        pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo = context.urDdiTable.USM.pfnGetMemAllocInfo;
 
@@ -1282,13 +1290,12 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     }
 
     ur_usm_get_mem_alloc_info_params_t params = {
-        &hContext,      &pMem,       &propName,
-        &propValueSize, &pPropValue, &pPropValueSizeRet};
+        &hContext, &pMem, &propName, &propSize, &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO,
                                              "urUSMGetMemAllocInfo", &params);
 
-    ur_result_t result = pfnGetMemAllocInfo(
-        hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetMemAllocInfo(hContext, pMem, propName, propSize,
+                                            pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO,
                        "urUSMGetMemAllocInfo", &params, &result, instance);
@@ -1587,7 +1594,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                    ///< program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1624,7 +1632,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -1830,7 +1838,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
+                    ///< kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1868,7 +1877,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -1903,7 +1912,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2011,7 +2020,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
                    ///< property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
@@ -2180,8 +2189,9 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out][optional] value of the queue property
+        propSize, ///< [in] size in bytes of the queue property value provided
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2191,13 +2201,13 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_queue_get_info_params_t params = {&hQueue, &propName, &propValueSize,
+    ur_queue_get_info_params_t params = {&hQueue, &propName, &propSize,
                                          &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_GET_INFO,
                                              "urQueueGetInfo", &params);
 
     ur_result_t result =
-        pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+        pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_QUEUE_GET_INFO, "urQueueGetInfo", &params,
                        &result, instance);
@@ -2387,10 +2397,10 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize, ///< [in] size in bytes of the event property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
 
@@ -2398,13 +2408,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_event_get_info_params_t params = {&hEvent, &propName, &propValueSize,
-                                         &pPropValue, &pPropValueSizeRet};
+    ur_event_get_info_params_t params = {&hEvent, &propName, &propSize,
+                                         &pPropValue, &pPropSizeRet};
     uint64_t instance = context.notify_begin(UR_FUNCTION_EVENT_GET_INFO,
                                              "urEventGetInfo", &params);
 
-    ur_result_t result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                                    pPropValueSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_EVENT_GET_INFO, "urEventGetInfo", &params,
                        &result, instance);
@@ -2417,13 +2427,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
+        propName,    ///< [in] the name of the profiling property to query
+    size_t propSize, ///< [in] size in bytes of the profiling property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
     size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                     ///< propValue
 ) {
     auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
 
@@ -2432,13 +2442,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     }
 
     ur_event_get_profiling_info_params_t params = {
-        &hEvent, &propName, &propValueSize, &pPropValue, &pPropValueSizeRet};
+        &hEvent, &propName, &propSize, &pPropValue, &pPropSizeRet};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_EVENT_GET_PROFILING_INFO,
                              "urEventGetProfilingInfo", &params);
 
-    ur_result_t result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
-                                             pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetProfilingInfo(hEvent, propName, propSize,
+                                             pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_EVENT_GET_PROFILING_INFO,
                        "urEventGetProfilingInfo", &params, &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -94,10 +94,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
 __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -115,13 +116,13 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (UR_PLATFORM_INFO_BACKEND < PlatformInfoType) {
+        if (UR_PLATFORM_INFO_BACKEND < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
     }
 
     ur_result_t result =
-        pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+        pfnGetInfo(hPlatform, propName, propSize, pPropValue, pSizeRet);
 
     return result;
 }
@@ -284,8 +285,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
-    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -643,7 +645,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1054,7 +1057,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1090,7 +1094,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1224,8 +1229,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
+        propSize, ///< [in] size in bytes of the sampler property value provided
+    void *
+        pPropValue, ///< [out][typename(propName)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1254,7 +1260,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     }
 
     ur_result_t result =
-        pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+        pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1500,10 +1506,12 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
+        propSize, ///< [in] size in bytes of the USM allocation property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
+                    ///< property
     size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+        pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo = context.urDdiTable.USM.pfnGetMemAllocInfo;
 
@@ -1525,8 +1533,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
         }
     }
 
-    ur_result_t result = pfnGetMemAllocInfo(
-        hContext, pMem, propName, propValueSize, pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetMemAllocInfo(hContext, pMem, propName, propSize,
+                                            pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1909,7 +1917,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                    ///< program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1948,7 +1957,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2185,7 +2194,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
+                    ///< kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2225,7 +2235,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2266,7 +2276,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2383,7 +2393,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
                    ///< property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
@@ -2572,8 +2582,9 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out][optional] value of the queue property
+        propSize, ///< [in] size in bytes of the queue property value provided
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2594,7 +2605,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     }
 
     ur_result_t result =
-        pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+        pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -2806,10 +2817,10 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize, ///< [in] size in bytes of the event property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
 
@@ -2826,13 +2837,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
-        if (pPropValue && propValueSize == 0) {
+        if (pPropValue && propSize == 0) {
             return UR_RESULT_ERROR_INVALID_VALUE;
         }
     }
 
-    ur_result_t result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                                    pPropValueSizeRet);
+    ur_result_t result =
+        pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -2842,13 +2853,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
+        propName,    ///< [in] the name of the profiling property to query
+    size_t propSize, ///< [in] size in bytes of the profiling property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
     size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                     ///< propValue
 ) {
     auto pfnGetProfilingInfo = context.urDdiTable.Event.pfnGetProfilingInfo;
 
@@ -2865,13 +2876,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
-        if (pPropValue && propValueSize == 0) {
+        if (pPropValue && propSize == 0) {
             return UR_RESULT_ERROR_INVALID_VALUE;
         }
     }
 
-    ur_result_t result = pfnGetProfilingInfo(hEvent, propName, propValueSize,
-                                             pPropValue, pPropValueSizeRet);
+    ur_result_t result = pfnGetProfilingInfo(hEvent, propName, propSize,
+                                             pPropValue, pPropSizeRet);
 
     return result;
 }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -98,7 +98,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -287,7 +288,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -646,7 +648,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1058,7 +1061,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1095,7 +1099,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1231,7 +1236,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the sampler property value provided
     void *
-        pPropValue, ///< [out][typename(propName)] value of the sampler property
+        pPropValue, ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1508,8 +1513,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     size_t
         propSize, ///< [in] size in bytes of the USM allocation property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
-                    ///< property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the USM
+                    ///< allocation property
     size_t *
         pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
@@ -1917,8 +1922,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                    ///< program info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                    ///< holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1957,7 +1962,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                    ///< build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2194,8 +2200,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
-                    ///< kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                    ///< holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2235,8 +2241,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< Work Group property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2276,8 +2282,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< SubGroup property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2393,8 +2399,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
-                   ///< property value.
+        pPropValue ///< [in][typename(propName, propSize)] pointer to memory location holding
+                   ///< the property value.
 ) {
     auto pfnSetExecInfo = context.urDdiTable.Kernel.pfnSetExecInfo;
 
@@ -2584,7 +2590,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the queue property value provided
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the queue
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2819,7 +2826,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the event
+                    ///< property
     size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = context.urDdiTable.Event.pfnGetInfo;
@@ -2856,7 +2864,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
         propName,    ///< [in] the name of the profiling property to query
     size_t propSize, ///< [in] size in bytes of the profiling property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the profiling
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
                      ///< propValue

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -140,10 +140,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
 __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -164,8 +165,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo, pSizeRet);
+    result = pfnGetInfo(hPlatform, propName, propSize, pPropValue, pSizeRet);
 
     return result;
 }
@@ -355,8 +355,9 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
-    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -720,7 +721,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1110,7 +1112,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1142,7 +1145,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1260,8 +1264,9 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
+        propSize, ///< [in] size in bytes of the sampler property value provided
+    void *
+        pPropValue, ///< [out][typename(propName)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1278,8 +1283,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     hSampler = reinterpret_cast<ur_sampler_object_t *>(hSampler)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hSampler, propName, propValueSize, pPropValue, pPropSizeRet);
+    result = pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -1508,10 +1512,12 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
+        propSize, ///< [in] size in bytes of the USM allocation property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
+                    ///< property
     size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+        pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1526,8 +1532,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                                pPropValue, pPropValueSizeRet);
+    result = pfnGetMemAllocInfo(hContext, pMem, propName, propSize, pPropValue,
+                                pPropSizeRet);
 
     return result;
 }
@@ -1884,7 +1890,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                    ///< program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1919,7 +1926,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2157,7 +2164,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
+                    ///< kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2193,7 +2201,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2230,7 +2238,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2338,7 +2346,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
                    ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2531,8 +2539,9 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out][optional] value of the queue property
+        propSize, ///< [in] size in bytes of the queue property value provided
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2549,8 +2558,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
 
     // forward to device-platform
-    result =
-        pfnGetInfo(hQueue, propName, propValueSize, pPropValue, pPropSizeRet);
+    result = pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -2775,10 +2783,10 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize, ///< [in] size in bytes of the event property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2793,8 +2801,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;
 
     // forward to device-platform
-    result = pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                        pPropValueSizeRet);
+    result = pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -2804,13 +2811,13 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
+        propName,    ///< [in] the name of the profiling property to query
+    size_t propSize, ///< [in] size in bytes of the profiling property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
     size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                     ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2825,8 +2832,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;
 
     // forward to device-platform
-    result = pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
-                                 pPropValueSizeRet);
+    result = pfnGetProfilingInfo(hEvent, propName, propSize, pPropValue,
+                                 pPropSizeRet);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -144,7 +144,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -357,7 +358,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -722,7 +724,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1113,7 +1116,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1146,7 +1150,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1266,7 +1271,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the sampler property value provided
     void *
-        pPropValue, ///< [out][typename(propName)] value of the sampler property
+        pPropValue, ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1514,8 +1519,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     size_t
         propSize, ///< [in] size in bytes of the USM allocation property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
-                    ///< property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the USM
+                    ///< allocation property
     size_t *
         pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
@@ -1890,8 +1895,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                    ///< program info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                    ///< holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1926,7 +1931,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                    ///< build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2164,8 +2170,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
-                    ///< kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                    ///< holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2201,8 +2207,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< Work Group property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2238,8 +2244,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< SubGroup property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2346,8 +2352,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
-                   ///< property value.
+        pPropValue ///< [in][typename(propName, propSize)] pointer to memory location holding
+                   ///< the property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2541,7 +2547,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the queue property value provided
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the queue
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2785,7 +2792,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the event
+                    ///< property
     size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2814,7 +2822,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
         propName,    ///< [in] the name of the profiling property to query
     size_t propSize, ///< [in] size in bytes of the profiling property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the profiling
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
                      ///< propValue

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -136,12 +136,13 @@ ur_result_t UR_APICALL urPlatformGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_PLATFORM_INFO_BACKEND < PlatformInfoType`
+///         + `::UR_PLATFORM_INFO_BACKEND < propName`
 ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -153,8 +154,7 @@ ur_result_t UR_APICALL urPlatformGetInfo(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hPlatform, PlatformInfoType, Size, pPlatformInfo,
-                      pSizeRet);
+    return pfnGetInfo(hPlatform, propName, propSize, pPropValue, pSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -364,8 +364,9 @@ ur_result_t UR_APICALL urDeviceGet(
 ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
-    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -769,7 +770,8 @@ ur_result_t UR_APICALL urContextGetInfo(
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1178,7 +1180,8 @@ ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1216,7 +1219,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1360,8 +1364,9 @@ ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
+        propSize, ///< [in] size in bytes of the sampler property value provided
+    void *
+        pPropValue, ///< [out][typename(propName)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1370,8 +1375,7 @@ ur_result_t UR_APICALL urSamplerGetInfo(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hSampler, propName, propValueSize, pPropValue,
-                      pPropSizeRet);
+    return pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1644,10 +1648,12 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
+        propSize, ///< [in] size in bytes of the USM allocation property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
+                    ///< property
     size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+        pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     auto pfnGetMemAllocInfo =
         ur_lib::context->urDdiTable.USM.pfnGetMemAllocInfo;
@@ -1655,8 +1661,8 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetMemAllocInfo(hContext, pMem, propName, propValueSize,
-                              pPropValue, pPropValueSizeRet);
+    return pfnGetMemAllocInfo(hContext, pMem, propName, propSize, pPropValue,
+                              pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2064,7 +2070,8 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                    ///< program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2103,7 +2110,7 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2341,7 +2348,8 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
+                    ///< kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2381,7 +2389,7 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2415,7 +2423,7 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2553,7 +2561,7 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
                    ///< property value.
 ) {
     auto pfnSetExecInfo = ur_lib::context->urDdiTable.Kernel.pfnSetExecInfo;
@@ -2755,8 +2763,9 @@ ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out][optional] value of the queue property
+        propSize, ///< [in] size in bytes of the queue property value provided
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2765,8 +2774,7 @@ ur_result_t UR_APICALL urQueueGetInfo(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hQueue, propName, propValueSize, pPropValue,
-                      pPropSizeRet);
+    return pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3026,25 +3034,24 @@ ur_result_t UR_APICALL urQueueFlush(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EVENT_INFO_REFERENCE_COUNT < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///         + `pPropValue && propValueSize == 0`
+///         + `pPropValue && propSize == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize, ///< [in] size in bytes of the event property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Event.pfnGetInfo;
     if (nullptr == pfnGetInfo) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetInfo(hEvent, propName, propValueSize, pPropValue,
-                      pPropValueSizeRet);
+    return pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3064,20 +3071,20 @@ ur_result_t UR_APICALL urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROFILING_INFO_COMMAND_END < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///         + `pPropValue && propValueSize == 0`
+///         + `pPropValue && propSize == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
+        propName,    ///< [in] the name of the profiling property to query
+    size_t propSize, ///< [in] size in bytes of the profiling property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
     size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                     ///< propValue
 ) {
     auto pfnGetProfilingInfo =
         ur_lib::context->urDdiTable.Event.pfnGetProfilingInfo;
@@ -3085,8 +3092,8 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetProfilingInfo(hEvent, propName, propValueSize, pPropValue,
-                               pPropValueSizeRet);
+    return pfnGetProfilingInfo(hEvent, propName, propSize, pPropValue,
+                               pPropSizeRet);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -142,7 +142,8 @@ ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -366,7 +367,8 @@ ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -771,7 +773,8 @@ ur_result_t UR_APICALL urContextGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1181,7 +1184,8 @@ ur_result_t UR_APICALL urMemGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1220,7 +1224,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1366,7 +1371,7 @@ ur_result_t UR_APICALL urSamplerGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the sampler property value provided
     void *
-        pPropValue, ///< [out][typename(propName)] value of the sampler property
+        pPropValue, ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1650,8 +1655,8 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     size_t
         propSize, ///< [in] size in bytes of the USM allocation property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
-                    ///< property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the USM
+                    ///< allocation property
     size_t *
         pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
@@ -2070,8 +2075,8 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                    ///< program info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                    ///< holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2110,7 +2115,8 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                    ///< build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2348,8 +2354,8 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
-                    ///< kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                    ///< holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2389,8 +2395,8 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< Work Group property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2423,8 +2429,8 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< SubGroup property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2561,8 +2567,8 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
-                   ///< property value.
+        pPropValue ///< [in][typename(propName, propSize)] pointer to memory location holding
+                   ///< the property value.
 ) {
     auto pfnSetExecInfo = ur_lib::context->urDdiTable.Kernel.pfnSetExecInfo;
     if (nullptr == pfnSetExecInfo) {
@@ -2765,7 +2771,8 @@ ur_result_t UR_APICALL urQueueGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the queue property value provided
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the queue
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -3043,7 +3050,8 @@ ur_result_t UR_APICALL urEventGetInfo(
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the event
+                    ///< property
     size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     auto pfnGetInfo = ur_lib::context->urDdiTable.Event.pfnGetInfo;
@@ -3081,7 +3089,8 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
         propName,    ///< [in] the name of the profiling property to query
     size_t propSize, ///< [in] size in bytes of the profiling property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the profiling
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
                      ///< propValue

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -118,7 +118,8 @@ ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -315,7 +316,8 @@ ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -672,7 +674,8 @@ ur_result_t UR_APICALL urContextGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1031,7 +1034,8 @@ ur_result_t UR_APICALL urMemGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1066,7 +1070,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
     void *
-        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1195,7 +1200,7 @@ ur_result_t UR_APICALL urSamplerGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the sampler property value provided
     void *
-        pPropValue, ///< [out][typename(propName)] value of the sampler property
+        pPropValue, ///< [out][typename(propName, propSize)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1449,8 +1454,8 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     size_t
         propSize, ///< [in] size in bytes of the USM allocation property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
-                    ///< property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the USM
+                    ///< allocation property
     size_t *
         pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
@@ -1819,8 +1824,8 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
-                    ///< program info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes of
+                    ///< holding the program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1855,7 +1860,8 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Program
+                    ///< build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2061,8 +2067,8 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
-                    ///< kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] array of bytes
+                    ///< holding the kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2098,8 +2104,8 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< Work Group property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2127,8 +2133,8 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
-                    ///< property.
+        pPropValue, ///< [in,out][optional][typename(propName, propSize)] value of the Kernel
+                    ///< SubGroup property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
                      ///< queried by propName.
@@ -2247,8 +2253,8 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
-                   ///< property value.
+        pPropValue ///< [in][typename(propName, propSize)] pointer to memory location holding
+                   ///< the property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2424,7 +2430,8 @@ ur_result_t UR_APICALL urQueueGetInfo(
     size_t
         propSize, ///< [in] size in bytes of the queue property value provided
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the queue
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2668,7 +2675,8 @@ ur_result_t UR_APICALL urEventGetInfo(
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the event
+                    ///< property
     size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2702,7 +2710,8 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
         propName,    ///< [in] the name of the profiling property to query
     size_t propSize, ///< [in] size in bytes of the profiling property value
     void *
-        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
+        pPropValue, ///< [out][optional][typename(propName, propSize)] value of the profiling
+                    ///< property
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
                      ///< propValue

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -112,12 +112,13 @@ ur_result_t UR_APICALL urPlatformGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_PLATFORM_INFO_BACKEND < PlatformInfoType`
+///         + `::UR_PLATFORM_INFO_BACKEND < propName`
 ur_result_t UR_APICALL urPlatformGetInfo(
-    ur_platform_handle_t hPlatform,      ///< [in] handle of the platform
-    ur_platform_info_t PlatformInfoType, ///< [in] type of the info to retrieve
-    size_t Size, ///< [in] the number of bytes pointed to by pPlatformInfo.
-    void *pPlatformInfo, ///< [out][optional] array of bytes holding the info.
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_platform_info_t propName,    ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If Size is not equal to or greater to the real number of bytes needed
     ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
     ///< returned and pPlatformInfo is not used.
@@ -312,8 +313,9 @@ ur_result_t UR_APICALL urDeviceGet(
 ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
-    size_t propSize,  ///< [in] the number of bytes pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info
     ///< then the ::UR_RESULT_ERROR_INVALID_VALUE error is returned and
@@ -669,7 +671,8 @@ ur_result_t UR_APICALL urContextGetInfo(
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< if propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1027,7 +1030,8 @@ ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointed to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1061,7 +1065,8 @@ ur_result_t UR_APICALL urMemImageGetInfo(
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
         propSize, ///< [in] the number of bytes of memory pointer to by pPropValue.
-    void *pPropValue, ///< [out][optional] array of bytes holding the info.
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] array of bytes holding the info.
     ///< If propSize is less than the real number of bytes needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
     ///< pPropValue is not used.
@@ -1188,8 +1193,9 @@ ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the sampler property value provided
-    void *pPropValue, ///< [out] value of the sampler property
+        propSize, ///< [in] size in bytes of the sampler property value provided
+    void *
+        pPropValue, ///< [out][typename(propName)] value of the sampler property
     size_t *
         pPropSizeRet ///< [out] size in bytes returned in sampler property value
 ) {
@@ -1441,10 +1447,12 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_usm_alloc_info_t
         propName, ///< [in] the name of the USM allocation property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the USM allocation property value
-    void *pPropValue, ///< [out][optional] value of the USM allocation property
+        propSize, ///< [in] size in bytes of the USM allocation property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the USM allocation
+                    ///< property
     size_t *
-        pPropValueSizeRet ///< [out][optional] bytes returned in USM allocation property
+        pPropSizeRet ///< [out][optional] bytes returned in USM allocation property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -1811,7 +1819,8 @@ ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes of holding the program info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes of holding the
+                    ///< program info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -1846,7 +1855,7 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
         propName,    ///< [in] name of the Program build info to query
     size_t propSize, ///< [in] size of the Program build info property.
     void *
-        pPropValue, ///< [in,out][optional] value of the Program build property.
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Program build property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE
     ///< error is returned and pPropValue is not used.
@@ -2052,7 +2061,8 @@ ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
     void *
-        pPropValue, ///< [in,out][optional] array of bytes holding the kernel info property.
+        pPropValue, ///< [in,out][optional][typename(propName)] array of bytes holding the
+                    ///< kernel info property.
     ///< If propSize is not equal to or greater than the real number of bytes
     ///< needed to return
     ///< the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is returned and
@@ -2088,7 +2098,7 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
         propName,    ///< [in] name of the work Group property to query
     size_t propSize, ///< [in] size of the Kernel Work Group property value
     void *
-        pPropValue, ///< [in,out][optional][range(0, propSize)] value of the Kernel Work Group
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel Work Group
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2117,7 +2127,7 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
         propName,    ///< [in] name of the SubGroup property to query
     size_t propSize, ///< [in] size of the Kernel SubGroup property value
     void *
-        pPropValue, ///< [in,out][range(0, propSize)][optional] value of the Kernel SubGroup
+        pPropValue, ///< [in,out][optional][typename(propName)] value of the Kernel SubGroup
                     ///< property.
     size_t *
         pPropSizeRet ///< [out][optional] pointer to the actual size in bytes of data being
@@ -2237,7 +2247,7 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
     const void *
-        pPropValue ///< [in][range(0, propSize)] pointer to memory location holding the
+        pPropValue ///< [in][typename(propName)] pointer to memory location holding the
                    ///< property value.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2412,8 +2422,9 @@ ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
-        propValueSize, ///< [in] size in bytes of the queue property value provided
-    void *pPropValue, ///< [out][optional] value of the queue property
+        propSize, ///< [in] size in bytes of the queue property value provided
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the queue property
     size_t *
         pPropSizeRet ///< [out][optional] size in bytes returned in queue property value
 ) {
@@ -2648,17 +2659,17 @@ ur_result_t UR_APICALL urQueueFlush(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EVENT_INFO_REFERENCE_COUNT < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///         + `pPropValue && propValueSize == 0`
+///         + `pPropValue && propSize == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
-    size_t propValueSize, ///< [in] size in bytes of the event property value
-    void *pPropValue,     ///< [out][optional] value of the event property
-    size_t
-        *pPropValueSizeRet ///< [out][optional] bytes returned in event property
+    size_t propSize, ///< [in] size in bytes of the event property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the event property
+    size_t *pPropSizeRet ///< [out][optional] bytes returned in event property
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -2681,20 +2692,20 @@ ur_result_t UR_APICALL urEventGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_PROFILING_INFO_COMMAND_END < propName`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///         + `pPropValue && propValueSize == 0`
+///         + `pPropValue && propSize == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
-        propName, ///< [in] the name of the profiling property to query
-    size_t
-        propValueSize, ///< [in] size in bytes of the profiling property value
-    void *pPropValue,  ///< [out][optional] value of the profiling property
+        propName,    ///< [in] the name of the profiling property to query
+    size_t propSize, ///< [in] size in bytes of the profiling property value
+    void *
+        pPropValue, ///< [out][optional][typename(propName)] value of the profiling property
     size_t *
-        pPropValueSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
-                          ///< propValue
+        pPropSizeRet ///< [out][optional] pointer to the actual size in bytes returned in
+                     ///< propValue
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -92,7 +92,7 @@ TEST_P(urEventGetInfoNegativeTest, InvalidValue) {
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
 
-    /* Invalid propValueSize */
+    /* Invalid propSize */
     ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0,
                                     data.data(), nullptr),
                      UR_RESULT_ERROR_INVALID_VALUE);

--- a/test/conformance/event/urEventGetProfilingInfo.cpp
+++ b/test/conformance/event/urEventGetProfilingInfo.cpp
@@ -63,7 +63,7 @@ TEST_P(urEventGetProfilingInfoNegativeTest, InvalidValue) {
     ASSERT_NE(size, 0);
     std::vector<uint8_t> data(size);
 
-    /* Invalid propValueSize */
+    /* Invalid propSize */
     ASSERT_EQ_RESULT(
         urEventGetProfilingInfo(event, info_type, 0, data.data(), nullptr),
         UR_RESULT_ERROR_INVALID_VALUE);

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -67,7 +67,7 @@ TEST_P(urUSMGetMemAllocInfoTest, InvalidEnumeration) {
                              sizeof(ur_usm_type_t), &USMType, nullptr));
 }
 
-TEST_P(urUSMGetMemAllocInfoTest, InvalidValuePropValueSize) {
+TEST_P(urUSMGetMemAllocInfoTest, InvalidValuePropSize) {
     ur_usm_type_t USMType;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
                      urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_TYPE,


### PR DESCRIPTION
[ur] introduce enum associated types and use it for props
Many UR functions use enum tags alongside opaque (typically void *)
pointers to construct an algebraic data type. This is useful because
it allows for creating function arguments that can be one of
several types of values. However, this approach, at least in C,
is not very typesafe. It's fairly easy to make a mistake that
can't be easily caught at compile time (and even at runtime).

To help with that a little bit, at least on the spec side of things,
this patch introduces optional 'typed_etor' and 'typename' qualifiers.
An enum with typed etor requires that all its values have specify
a type in their 'desc' field. The typename can be used to tag
opaque pointers with a tag field name.

Typed_etors are checked by codegen scripts, whereas correctness
of typenames is indirectly enforced by the code itself (won't compile
if it's wrong).

[common] use associated type information to serialize info_t types

This patch uses the typed etors and typename information to pretty
print `*_info_t` prop names, which otherwise are opaque pointers.