### PR TITLE
[ur] Make queue creation extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -213,6 +213,8 @@ class ur_structure_type_v(IntEnum):
     USM_POOL_LIMITS_DESC = 11                       ## ::ur_usm_pool_limits_desc_t
     DEVICE_BINARY = 12                              ## ::ur_device_binary_t
     SAMPLER_DESC = 13                               ## ::ur_sampler_desc_t
+    QUEUE_PROPERTIES = 14                           ## ::ur_queue_properties_t
+    QUEUE_INDEX_PROPERTIES = 15                     ## ::ur_queue_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -1269,8 +1271,8 @@ class ur_queue_info_v(IntEnum):
     DEVICE = 1                                      ## ::ur_device_handle_t: device associated with this queue.
     DEVICE_DEFAULT = 2                              ## ::ur_queue_handle_t: the current default queue of the underlying
                                                     ## device.
-    PROPERTIES = 3                                  ## ::ur_queue_flags_t: the properties associated with
-                                                    ## ::UR_QUEUE_PROPERTIES_FLAGS.
+    FLAGS = 3                                       ## ::ur_queue_flags_t: the properties associated with
+                                                    ## ::ur_queue_properties_t::flags.
     REFERENCE_COUNT = 4                             ## [uint32_t] Reference count of the queue object.
                                                     ## The reference count returned should be considered immediately stale. 
                                                     ## It is unsuitable for general use in applications. This feature is
@@ -1299,20 +1301,29 @@ class ur_queue_flags_t(c_int):
 
 
 ###############################################################################
-## @brief Queue property type
-class ur_queue_property_t(c_intptr_t):
-    pass
+## @brief Queue creation properties
+class ur_queue_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_QUEUE_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("flags", ur_queue_flags_t)                                     ## [in] Bitfield of queue creation flags
+    ]
 
 ###############################################################################
-## @brief Queue Properties
-class ur_queue_properties_v(IntEnum):
-    FLAGS = -1                                      ## [::ur_queue_flags_t]: the bitfield of queue flags
-    COMPUTE_INDEX = -2                              ## [uint32_t]: the queue index
-
-class ur_queue_properties_t(c_int):
-    def __str__(self):
-        return str(ur_queue_properties_v(self.value))
-
+## @brief Queue index creation properties
+## 
+## @details
+##     - Specify these properties in ::urQueueCreate via
+##       ::ur_queue_properties_t as part of a `pNext` chain.
+class ur_queue_index_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("computeIndex", c_ulong)                                       ## [in] Specifies the compute index as described in the
+                                                                        ## sycl_ext_intel_queue_index extension.
+    ]
 
 ###############################################################################
 ## @brief Command type
@@ -2346,9 +2357,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urQueueCreate
 if __use_win_types:
-    _urQueueCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_property_t), POINTER(ur_queue_handle_t) )
+    _urQueueCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_properties_t), POINTER(ur_queue_handle_t) )
 else:
-    _urQueueCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_property_t), POINTER(ur_queue_handle_t) )
+    _urQueueCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_queue_properties_t), POINTER(ur_queue_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urQueueRetain

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -237,6 +237,8 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 11,            ///< ::ur_usm_pool_limits_desc_t
     UR_STRUCTURE_TYPE_DEVICE_BINARY = 12,                   ///< ::ur_device_binary_t
     UR_STRUCTURE_TYPE_SAMPLER_DESC = 13,                    ///< ::ur_sampler_desc_t
+    UR_STRUCTURE_TYPE_QUEUE_PROPERTIES = 14,                ///< ::ur_queue_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES = 15,          ///< ::ur_queue_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3538,8 +3540,8 @@ typedef enum ur_queue_info_t {
     UR_QUEUE_INFO_DEVICE = 1,          ///< ::ur_device_handle_t: device associated with this queue.
     UR_QUEUE_INFO_DEVICE_DEFAULT = 2,  ///< ::ur_queue_handle_t: the current default queue of the underlying
                                        ///< device.
-    UR_QUEUE_INFO_PROPERTIES = 3,      ///< ::ur_queue_flags_t: the properties associated with
-                                       ///< ::UR_QUEUE_PROPERTIES_FLAGS.
+    UR_QUEUE_INFO_FLAGS = 3,           ///< ::ur_queue_flags_t: the properties associated with
+                                       ///< ::ur_queue_properties_t::flags.
     UR_QUEUE_INFO_REFERENCE_COUNT = 4, ///< [uint32_t] Reference count of the queue object.
                                        ///< The reference count returned should be considered immediately stale.
                                        ///< It is unsuitable for general use in applications. This feature is
@@ -3571,21 +3573,6 @@ typedef enum ur_queue_flag_t {
 #define UR_QUEUE_FLAGS_MASK 0xffffff80
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Queue property type
-typedef intptr_t ur_queue_property_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Queue Properties
-typedef enum ur_queue_properties_t {
-    UR_QUEUE_PROPERTIES_FLAGS = -1,         ///< [::ur_queue_flags_t]: the bitfield of queue flags
-    UR_QUEUE_PROPERTIES_COMPUTE_INDEX = -2, ///< [uint32_t]: the queue index
-    /// @cond
-    UR_QUEUE_PROPERTIES_FORCE_UINT32 = 0x7fffffff
-    /// @endcond
-
-} ur_queue_properties_t;
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a command queue
 ///
 /// @remarks
@@ -3614,7 +3601,35 @@ urQueueGetInfo(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Queue creation properties
+typedef struct ur_queue_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_QUEUE_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    ur_queue_flags_t flags;    ///< [in] Bitfield of queue creation flags
+
+} ur_queue_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Queue index creation properties
+///
+/// @details
+///     - Specify these properties in ::urQueueCreate via
+///       ::ur_queue_properties_t as part of a `pNext` chain.
+typedef struct ur_queue_index_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    uint32_t computeIndex;     ///< [in] Specifies the compute index as described in the
+                               ///< sycl_ext_intel_queue_index extension.
+
+} ur_queue_index_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a command queue for a device in a context
+///
+/// @details
+///     - See also ::ur_queue_index_properties_t.
 ///
 /// @remarks
 ///   _Analogues_
@@ -3637,15 +3652,10 @@ urQueueGetInfo(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueCreate(
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_device_handle_t hDevice,        ///< [in] handle of the device object
-    const ur_queue_property_t *pProps, ///< [in][optional] specifies a list of queue properties and their
-                                       ///< corresponding values.
-                                       ///< Each property name is immediately followed by the corresponding
-                                       ///< desired value.
-                                       ///< The list is terminated with a 0.
-                                       ///< If a property value is not specified, then its default value will be used.
-    ur_queue_handle_t *phQueue         ///< [out] pointer to handle of queue object created
+    ur_context_handle_t hContext,             ///< [in] handle of the context object
+    ur_device_handle_t hDevice,               ///< [in] handle of the device object
+    const ur_queue_properties_t *pProperties, ///< [in][optional] pointer to queue creation properties.
+    ur_queue_handle_t *phQueue                ///< [out] pointer to handle of queue object created
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7642,7 +7652,7 @@ typedef void(UR_APICALL *ur_pfnQueueGetInfoCb_t)(
 typedef struct ur_queue_create_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    const ur_queue_property_t **ppProps;
+    const ur_queue_properties_t **ppProperties;
     ur_queue_handle_t **pphQueue;
 } ur_queue_create_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1126,7 +1126,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnQueueGetInfo_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnQueueCreate_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    const ur_queue_property_t *,
+    const ur_queue_properties_t *,
     ur_queue_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -290,6 +290,10 @@ etors:
       desc: $x_device_binary_t
     - name: SAMPLER_DESC
       desc: $x_sampler_desc_t
+    - name: QUEUE_PROPERTIES
+      desc: $x_queue_properties_t
+    - name: QUEUE_INDEX_PROPERTIES
+      desc: $x_queue_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -21,8 +21,8 @@ etors:
       desc: "$x_device_handle_t: device associated with this queue."
     - name: DEVICE_DEFAULT
       desc: "$x_queue_handle_t: the current default queue of the underlying device."
-    - name: PROPERTIES
-      desc: "$x_queue_flags_t: the properties associated with $X_QUEUE_PROPERTIES_FLAGS."
+    - name: FLAGS
+      desc: "$x_queue_flags_t: the properties associated with $x_queue_properties_t::flags."
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the queue object.
@@ -58,23 +58,6 @@ etors:
       value: "$X_BIT(6)"
       desc: "High priority queue"
 --- #--------------------------------------------------------------------------
-type: typedef
-desc: "Queue property type"
-name: $x_queue_property_t
-value: intptr_t
---- #--------------------------------------------------------------------------
-type: enum
-desc: "Queue Properties"
-class: $xQueue
-name: $x_queue_properties_t
-etors:
-    - name: FLAGS
-      value: "-1"
-      desc: "[$x_queue_flags_t]: the bitfield of queue flags"
-    - name: COMPUTE_INDEX
-      value: "-2"
-      desc: "[uint32_t]: the queue index"
---- #--------------------------------------------------------------------------
 type: function
 desc: "Query information about a command queue"
 class: $xQueue
@@ -104,11 +87,38 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
+
+type: struct
+desc: "Queue creation properties"
+class: $xQueue
+name: $x_queue_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_queue_flags_t
+      name: flags
+      desc: "[in] Bitfield of queue creation flags"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Queue index creation properties"
+details:
+    - Specify these properties in $xQueueCreate via $x_queue_properties_t as
+      part of a `pNext` chain.
+class: $xQueue
+name: $x_queue_index_properties_t
+base: $x_base_properties_t
+members:
+    - type: uint32_t
+      name: computeIndex
+      desc: >
+            [in] Specifies the compute index as described in the
+            sycl_ext_intel_queue_index extension.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create a command queue for a device in a context"
 class: $xQueue
 name: Create
-decl: static
+details:
+    - See also $x_queue_index_properties_t.
 ordinal: "0"
 analogue:
     - "**clCreateCommandQueueWithProperties**"
@@ -119,13 +129,9 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: const $x_queue_property_t*
-      name: pProps
-      desc: |
-            [in][optional] specifies a list of queue properties and their corresponding values.
-            Each property name is immediately followed by the corresponding desired value.
-            The list is terminated with a 0. 
-            If a property value is not specified, then its default value will be used.
+    - type: const $x_queue_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to queue creation properties."
     - type: $x_queue_handle_t*
       name: phQueue
       desc: "[out] pointer to handle of queue object created"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -361,6 +361,14 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_SAMPLER_DESC:
         os << "UR_STRUCTURE_TYPE_SAMPLER_DESC";
         break;
+
+    case UR_STRUCTURE_TYPE_QUEUE_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_QUEUE_PROPERTIES";
+        break;
+
+    case UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -449,6 +457,18 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
 
     case UR_STRUCTURE_TYPE_SAMPLER_DESC: {
         const ur_sampler_desc_t *pstruct = (const ur_sampler_desc_t *)ptr;
+        serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_QUEUE_PROPERTIES: {
+        const ur_queue_properties_t *pstruct =
+            (const ur_queue_properties_t *)ptr;
+        serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES: {
+        const ur_queue_properties_t *pstruct =
+            (const ur_queue_properties_t *)ptr;
         serializePtr(os, pstruct);
     } break;
     default:
@@ -3285,8 +3305,8 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_queue_info_t value) {
         os << "UR_QUEUE_INFO_DEVICE_DEFAULT";
         break;
 
-    case UR_QUEUE_INFO_PROPERTIES:
-        os << "UR_QUEUE_INFO_PROPERTIES";
+    case UR_QUEUE_INFO_FLAGS:
+        os << "UR_QUEUE_INFO_FLAGS";
         break;
 
     case UR_QUEUE_INFO_REFERENCE_COUNT:
@@ -3429,20 +3449,45 @@ inline void serializeFlag_ur_queue_flags_t(std::ostream &os,
     }
 }
 inline std::ostream &operator<<(std::ostream &os,
-                                enum ur_queue_properties_t value) {
-    switch (value) {
+                                const struct ur_queue_properties_t params) {
+    os << "(struct ur_queue_properties_t){";
 
-    case UR_QUEUE_PROPERTIES_FLAGS:
-        os << "UR_QUEUE_PROPERTIES_FLAGS";
-        break;
+    os << ".stype = ";
 
-    case UR_QUEUE_PROPERTIES_COMPUTE_INDEX:
-        os << "UR_QUEUE_PROPERTIES_COMPUTE_INDEX";
-        break;
-    default:
-        os << "unknown enumerator";
-        break;
-    }
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".flags = ";
+
+    serializeFlag_ur_queue_flags_t(os, (params.flags));
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_queue_index_properties_t params) {
+    os << "(struct ur_queue_index_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".computeIndex = ";
+
+    os << (params.computeIndex);
+
+    os << "}";
     return os;
 }
 inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value) {
@@ -6922,9 +6967,9 @@ inline std::ostream &operator<<(std::ostream &os,
     serializePtr(os, *(params->phDevice));
 
     os << ", ";
-    os << ".pProps = ";
+    os << ".pProperties = ";
 
-    serializePtr(os, *(params->ppProps));
+    serializePtr(os, *(params->ppProperties));
 
     os << ", ";
     os << ".phQueue = ";

--- a/source/drivers/null/ur_nullddi.cpp
+++ b/source/drivers/null/ur_nullddi.cpp
@@ -1778,13 +1778,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in][optional] specifies a list of queue properties and their
-                ///< corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
+    const ur_queue_properties_t
+        *pProperties, ///< [in][optional] pointer to queue creation properties.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -1793,7 +1788,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnCreate = d_context.urDdiTable.Queue.pfnCreate;
     if (nullptr != pfnCreate) {
-        result = pfnCreate(hContext, hDevice, pProps, phQueue);
+        result = pfnCreate(hContext, hDevice, pProperties, phQueue);
     } else {
         // generic implementation
         *phQueue = reinterpret_cast<ur_queue_handle_t>(d_context.get());

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -2210,13 +2210,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in][optional] specifies a list of queue properties and their
-                ///< corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
+    const ur_queue_properties_t
+        *pProperties, ///< [in][optional] pointer to queue creation properties.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2226,11 +2221,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_queue_create_params_t params = {&hContext, &hDevice, &pProps, &phQueue};
+    ur_queue_create_params_t params = {&hContext, &hDevice, &pProperties,
+                                       &phQueue};
     uint64_t instance = context.notify_begin(UR_FUNCTION_QUEUE_CREATE,
                                              "urQueueCreate", &params);
 
-    ur_result_t result = pfnCreate(hContext, hDevice, pProps, phQueue);
+    ur_result_t result = pfnCreate(hContext, hDevice, pProperties, phQueue);
 
     context.notify_end(UR_FUNCTION_QUEUE_CREATE, "urQueueCreate", &params,
                        &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2604,13 +2604,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in][optional] specifies a list of queue properties and their
-                ///< corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
+    const ur_queue_properties_t
+        *pProperties, ///< [in][optional] pointer to queue creation properties.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2634,7 +2629,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
         }
     }
 
-    ur_result_t result = pfnCreate(hContext, hDevice, pProps, phQueue);
+    ur_result_t result = pfnCreate(hContext, hDevice, pProperties, phQueue);
 
     if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
         refCountContext.createRefCount(*phQueue);

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2560,13 +2560,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in][optional] specifies a list of queue properties and their
-                ///< corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
+    const ur_queue_properties_t
+        *pProperties, ///< [in][optional] pointer to queue creation properties.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2586,7 +2581,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnCreate(hContext, hDevice, pProps, phQueue);
+    result = pfnCreate(hContext, hDevice, pProperties, phQueue);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2772,6 +2772,9 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a command queue for a device in a context
 ///
+/// @details
+///     - See also ::ur_queue_index_properties_t.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateCommandQueueWithProperties**
@@ -2794,13 +2797,8 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in][optional] specifies a list of queue properties and their
-                ///< corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
+    const ur_queue_properties_t
+        *pProperties, ///< [in][optional] pointer to queue creation properties.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {
@@ -2809,7 +2807,7 @@ ur_result_t UR_APICALL urQueueCreate(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreate(hContext, hDevice, pProps, phQueue);
+    return pfnCreate(hContext, hDevice, pProperties, phQueue);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2424,6 +2424,9 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Create a command queue for a device in a context
 ///
+/// @details
+///     - See also ::ur_queue_index_properties_t.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clCreateCommandQueueWithProperties**
@@ -2446,13 +2449,8 @@ ur_result_t UR_APICALL urQueueGetInfo(
 ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_queue_property_t *
-        pProps, ///< [in][optional] specifies a list of queue properties and their
-                ///< corresponding values.
-    ///< Each property name is immediately followed by the corresponding
-    ///< desired value.
-    ///< The list is terminated with a 0.
-    ///< If a property value is not specified, then its default value will be used.
+    const ur_queue_properties_t
+        *pProperties, ///< [in][optional] pointer to queue creation properties.
     ur_queue_handle_t
         *phQueue ///< [out] pointer to handle of queue object created
 ) {

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -7,7 +7,7 @@ std::unordered_map<ur_queue_info_t, size_t> queue_info_size_map = {
     {UR_QUEUE_INFO_CONTEXT, sizeof(ur_context_handle_t)},
     {UR_QUEUE_INFO_DEVICE, sizeof(ur_device_handle_t)},
     {UR_QUEUE_INFO_DEVICE_DEFAULT, sizeof(ur_queue_handle_t)},
-    {UR_QUEUE_INFO_PROPERTIES, sizeof(ur_queue_flags_t)},
+    {UR_QUEUE_INFO_FLAGS, sizeof(ur_queue_flags_t)},
     {UR_QUEUE_INFO_REFERENCE_COUNT, sizeof(uint32_t)},
     {UR_QUEUE_INFO_SIZE, sizeof(uint32_t)},
 };
@@ -18,7 +18,7 @@ using urQueueGetInfoTestWithInfoParam =
 UUR_TEST_SUITE_P(urQueueGetInfoTestWithInfoParam,
                  ::testing::Values(UR_QUEUE_INFO_CONTEXT, UR_QUEUE_INFO_DEVICE,
                                    UR_QUEUE_INFO_DEVICE_DEFAULT,
-                                   UR_QUEUE_INFO_PROPERTIES,
+                                   UR_QUEUE_INFO_FLAGS,
                                    UR_QUEUE_INFO_REFERENCE_COUNT,
                                    UR_QUEUE_INFO_SIZE),
                  uur::deviceTestWithParamPrinter<ur_queue_info_t>);

--- a/test/conformance/testing/include/uur/checks.h
+++ b/test/conformance/testing/include/uur/checks.h
@@ -297,7 +297,7 @@ inline std::ostream &operator<<(std::ostream &out,
         CASE(UR_QUEUE_INFO_CONTEXT)
         CASE(UR_QUEUE_INFO_DEVICE)
         CASE(UR_QUEUE_INFO_DEVICE_DEFAULT)
-        CASE(UR_QUEUE_INFO_PROPERTIES)
+        CASE(UR_QUEUE_INFO_FLAGS)
         CASE(UR_QUEUE_INFO_REFERENCE_COUNT)
         CASE(UR_QUEUE_INFO_SIZE)
 

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -212,10 +212,13 @@ template <class T> struct urQueueTestWithParam : urContextTestWithParam<T> {
 struct urProfilingQueueTest : urContextTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
-        ur_queue_property_t props[] = {UR_QUEUE_PROPERTIES_FLAGS,
-                                       UR_QUEUE_FLAG_PROFILING_ENABLE, 0};
+        ur_queue_properties_t props = {
+            /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
+            /*.pNext =*/nullptr,
+            /*.flags =*/UR_QUEUE_FLAG_PROFILING_ENABLE,
+        };
         ASSERT_SUCCESS(
-            urQueueCreate(this->context, this->device, props, &queue));
+            urQueueCreate(this->context, this->device, &props, &queue));
     }
 
     void TearDown() override {
@@ -232,10 +235,13 @@ template <class T>
 struct urProfilingQueueTestWithParam : urContextTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
-        ur_queue_property_t props[] = {UR_QUEUE_PROPERTIES_FLAGS,
-                                       UR_QUEUE_FLAG_PROFILING_ENABLE, 0};
+        ur_queue_properties_t props = {
+            /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
+            /*.pNext =*/nullptr,
+            /*.flags =*/UR_QUEUE_FLAG_PROFILING_ENABLE,
+        };
         ASSERT_SUCCESS(
-            urQueueCreate(this->context, this->device, props, &queue));
+            urQueueCreate(this->context, this->device, &props, &queue));
     }
 
     void TearDown() override {


### PR DESCRIPTION
Move the optional queue creation properties into the
`ur_queue_properties_t` struct which enables extensibility via `pNext`
chains. Also make use of `pNext` chaining by moving the
`UR_QUEUE_PROPERTY_COMPUTE_INDEX` property, since it is used to enable
the sycl_ext_intel_queue_index extension, into the
`ur_queue_index_properties_t` struct.
