### PR TITLE
[ur][cts] Fix Windows signed/unsigned mismatch warning

### DIFF
--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -47,7 +47,7 @@ TEST_P(urEventGetInfoTest, Success) {
         ASSERT_EQ(sizeof(uint32_t), size);
         auto returned_reference_count =
             reinterpret_cast<uint32_t *>(data.data());
-        ASSERT_GT(*returned_reference_count, 0);
+        ASSERT_GT(*returned_reference_count, 0U);
         break;
     }
     default:


### PR DESCRIPTION
This warning is raised to an error when develop mode is on, fix the mistmatch by making the integer literal unsigned.