### PR TITLE
[UR] Add missing affinity_domain parition enums

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -583,6 +583,10 @@ class ur_device_exec_capability_flags_t(c_int):
 class ur_device_affinity_domain_flags_v(IntEnum):
     NUMA = UR_BIT(0)                                ## By NUMA
     NEXT_PARTITIONABLE = UR_BIT(1)                  ## BY next partitionable
+    L4_CACHE = UR_BIT(2)                            ## Sub-device will have compute units which share a level 4 cache
+    L3_CACHE = UR_BIT(2)                            ## Sub-device will have compute units which share a level 3 cache
+    L4_CACHE = UR_BIT(2)                            ## Sub-device will have compute units which share a level 2 cache
+    L1_CACHE = UR_BIT(2)                            ## Sub-device will have compute units which share a level 1 cache
 
 class ur_device_affinity_domain_flags_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1060,13 +1060,17 @@ typedef uint32_t ur_device_affinity_domain_flags_t;
 typedef enum ur_device_affinity_domain_flag_t {
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA = UR_BIT(0),               ///< By NUMA
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE = UR_BIT(1), ///< BY next partitionable
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE = UR_BIT(2),           ///< Sub-device will have compute units which share a level 4 cache
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE = UR_BIT(2),           ///< Sub-device will have compute units which share a level 3 cache
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE = UR_BIT(2),           ///< Sub-device will have compute units which share a level 2 cache
+    UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE = UR_BIT(2),           ///< Sub-device will have compute units which share a level 1 cache
     /// @cond
     UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
 } ur_device_affinity_domain_flag_t;
 /// @brief Bit Mask for validating ur_device_affinity_domain_flags_t
-#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK 0xfffffffc
+#define UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Return platform native device handle.

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -606,6 +606,18 @@ etors:
     - name: NEXT_PARTITIONABLE
       desc: "BY next partitionable"
       value: "$X_BIT(1)"
+    - name: L4_CACHE
+      desc: "Sub-device will have compute units which share a level 4 cache"
+      value: "$X_BIT(2)"
+    - name: L3_CACHE
+      desc: "Sub-device will have compute units which share a level 3 cache"
+      value: "$X_BIT(2)"
+    - name: L4_CACHE
+      desc: "Sub-device will have compute units which share a level 2 cache"
+      value: "$X_BIT(2)"
+    - name: L1_CACHE
+      desc: "Sub-device will have compute units which share a level 1 cache"
+      value: "$X_BIT(2)"
 --- #--------------------------------------------------------------------------
 type: class
 desc: "C++ wrapper for a device"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -1417,6 +1417,22 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE:
         os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE";
         break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE";
+        break;
+
+    case UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE:
+        os << "UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -1448,6 +1464,50 @@ inline void serializeFlag_ur_device_affinity_domain_flags_t(
             first = false;
         }
         os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE;
+    }
+
+    if ((val & UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE) ==
+        (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE) {
+        val ^= (uint32_t)UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE;
     }
     if (val != 0) {
         std::bitset<32> bits(val);


### PR DESCRIPTION
Adds remaining enumerations to support device partitioning by affinity domain with cache levels.


Closes #115 