### PR TITLE
[UR] Fix registry id allocation

### DIFF
--- a/scripts/generate_ids.py
+++ b/scripts/generate_ids.py
@@ -30,7 +30,7 @@ def generate_registry(path, specs):
     try:
         existing_registry = list(util.yamlRead(path))[1]['etors']
         for etor in existing_registry:
-            valid_ids.discard(etor['value'])
+            valid_ids.discard(int(etor['value']))
             etors[etor['name']] = etor['value']
     except (TypeError, IndexError, KeyError) as e:
         print('invalid existing registry, ignoring... ' + str(e))


### PR DESCRIPTION
When trying to add a new entry-point the registry was allocating duplicate id's causing it to fail to compile. The reason is that when the existing values are read from the `registry.yml` file as strings and the `valid_ids` list contains `ints`. Therefore, no id's were being removed during this step.

* The fix converts strings to ints, which then correctly removes id's from the `valid_ids` list.