### PR TITLE
[ur] Use <experimental/filesystem> on older libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 project(unified-runtime VERSION 0.6.0)
 
 include(GNUInstallDirs)
+include(CheckIncludeFileCXX)
 include(CMakePackageConfigHelpers)
 include(CTest)
 
@@ -51,6 +52,13 @@ if(NOT MSVC)
         $<$<CXX_COMPILER_ID:Clang>:-fcolor-diagnostics>)
     if(UR_DEVELOPER_MODE)
         add_compile_options(-Werror -fno-omit-frame-pointer)
+    endif()
+    # If <filesystem> is not found, e.g. with the libstdc++ from GCC 7.5,
+    # <experimental/filesystem> will be used instead which requires linking
+    # libstdc++fs.a to resolve the filesystem symbols.
+    check_include_file_cxx("filesystem" HAS_INCLUDE_FILESYSTEM)
+    if(NOT HAS_INCLUDE_FILESYSTEM)
+        link_libraries(stdc++fs)
     endif()
 elseif(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -4,9 +4,18 @@
 #ifndef UR_SINKS_HPP
 #define UR_SINKS_HPP 1
 
-#include <filesystem>
 #include <fstream>
 #include <iostream>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace filesystem = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace filesystem = std::experimental::filesystem;
+#endif
+
+#include "ur_level.hpp"
 
 namespace logger {
 
@@ -123,7 +132,7 @@ class StderrSink : public Sink {
 
 class FileSink : public Sink {
   public:
-    FileSink(std::string logger_name, std::filesystem::path file_path)
+    FileSink(std::string logger_name, filesystem::path file_path)
         : Sink(logger_name) {
         ofstream = std::ofstream(file_path, std::ofstream::out);
         if (!ofstream.good()) {
@@ -135,7 +144,7 @@ class FileSink : public Sink {
         this->ostream = &ofstream;
     }
 
-    FileSink(std::string logger_name, std::filesystem::path file_path,
+    FileSink(std::string logger_name, filesystem::path file_path,
              Level flush_lvl)
         : FileSink(logger_name, file_path) {
         this->flush_level = flush_lvl;

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -2,8 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 #include <cstring>
-#include <filesystem>
 #include <fstream>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace filesystem = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace filesystem = std::experimental::filesystem;
+#endif
 
 #include <uur/environment.h>
 #include <uur/utils.h>
@@ -264,7 +271,7 @@ KernelsEnvironment::getKernelSourcePath(const std::string &kernel_name,
     }
 
     std::string binary_name;
-    for (const auto &entry : std::filesystem::directory_iterator(path.str())) {
+    for (const auto &entry : filesystem::directory_iterator(path.str())) {
         auto file_name = entry.path().filename().string();
         if (file_name.find(il_postfix) != std::string::npos) {
             binary_name = file_name;


### PR DESCRIPTION
Fixes #439 by detecting if the `<filesystem>` header is available, if
not including `<experimental/filesystem>` instead making use of the
`__has_include` macro if available.
