### PR TITLE
Reorder values in `ur_sampler_addressing_mode_t` enum

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -926,11 +926,11 @@ class ur_sampler_filter_mode_t(c_int):
 ###############################################################################
 ## @brief Sampler addressing mode
 class ur_sampler_addressing_mode_v(IntEnum):
-    MIRRORED_REPEAT = 0                             ## Mirrored Repeat
-    REPEAT = 1                                      ## Repeat
+    NONE = 0                                        ## None
+    CLAMP_TO_EDGE = 1                               ## Clamp to edge
     CLAMP = 2                                       ## Clamp
-    CLAMP_TO_EDGE = 3                               ## Clamp to edge
-    NONE = 4                                        ## None
+    REPEAT = 3                                      ## Repeat
+    MIRRORED_REPEAT = 4                             ## Mirrored Repeat
 
 class ur_sampler_addressing_mode_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2011,11 +2011,11 @@ typedef enum ur_sampler_filter_mode_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler addressing mode
 typedef enum ur_sampler_addressing_mode_t {
-    UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT = 0, ///< Mirrored Repeat
-    UR_SAMPLER_ADDRESSING_MODE_REPEAT = 1,          ///< Repeat
+    UR_SAMPLER_ADDRESSING_MODE_NONE = 0,            ///< None
+    UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE = 1,   ///< Clamp to edge
     UR_SAMPLER_ADDRESSING_MODE_CLAMP = 2,           ///< Clamp
-    UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE = 3,   ///< Clamp to edge
-    UR_SAMPLER_ADDRESSING_MODE_NONE = 4,            ///< None
+    UR_SAMPLER_ADDRESSING_MODE_REPEAT = 3,          ///< Repeat
+    UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT = 4, ///< Mirrored Repeat
     /// @cond
     UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2073,7 +2073,7 @@ typedef struct ur_sampler_desc_t {
 ///         + `NULL == pDesc`
 ///         + `NULL == phSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode`
+///         + `::UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT < pDesc->addressingMode`
 ///         + `::UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -25,16 +25,21 @@ desc: "Sampler addressing mode"
 class: $xSampler
 name: $x_sampler_addressing_mode_t
 etors:
-    - name: MIRRORED_REPEAT
-      desc: "Mirrored Repeat"
-    - name: REPEAT
-      desc: "Repeat"
-    - name: CLAMP
-      desc: "Clamp"
-    - name: CLAMP_TO_EDGE
-      desc: "Clamp to edge"
     - name: NONE
+      value: "0"
       desc: "None"
+    - name: CLAMP_TO_EDGE
+      value: "1"
+      desc: "Clamp to edge"
+    - name: CLAMP
+      value: "2"
+      desc: "Clamp"
+    - name: REPEAT
+      value: "3"
+      desc: "Repeat"
+    - name: MIRRORED_REPEAT
+      value: "4"
+      desc: "Mirrored Repeat"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Get sample object information"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -2426,24 +2426,24 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_sampler_addressing_mode_t value) {
     switch (value) {
 
-    case UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT:
-        os << "UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT";
-        break;
-
-    case UR_SAMPLER_ADDRESSING_MODE_REPEAT:
-        os << "UR_SAMPLER_ADDRESSING_MODE_REPEAT";
-        break;
-
-    case UR_SAMPLER_ADDRESSING_MODE_CLAMP:
-        os << "UR_SAMPLER_ADDRESSING_MODE_CLAMP";
+    case UR_SAMPLER_ADDRESSING_MODE_NONE:
+        os << "UR_SAMPLER_ADDRESSING_MODE_NONE";
         break;
 
     case UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE:
         os << "UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE";
         break;
 
-    case UR_SAMPLER_ADDRESSING_MODE_NONE:
-        os << "UR_SAMPLER_ADDRESSING_MODE_NONE";
+    case UR_SAMPLER_ADDRESSING_MODE_CLAMP:
+        os << "UR_SAMPLER_ADDRESSING_MODE_CLAMP";
+        break;
+
+    case UR_SAMPLER_ADDRESSING_MODE_REPEAT:
+        os << "UR_SAMPLER_ADDRESSING_MODE_REPEAT";
+        break;
+
+    case UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT:
+        os << "UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT";
         break;
     default:
         os << "unknown enumerator";

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1182,7 +1182,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode) {
+        if (UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT <
+            pDesc->addressingMode) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1296,7 +1296,7 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///         + `NULL == pDesc`
 ///         + `NULL == phSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode`
+///         + `::UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT < pDesc->addressingMode`
 ///         + `::UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1131,7 +1131,7 @@ ur_result_t UR_APICALL urMemImageGetInfo(
 ///         + `NULL == pDesc`
 ///         + `NULL == phSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_SAMPLER_ADDRESSING_MODE_NONE < pDesc->addressingMode`
+///         + `::UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT < pDesc->addressingMode`
 ///         + `::UR_SAMPLER_FILTER_MODE_LINEAR < pDesc->filterMode`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE


### PR DESCRIPTION
Reorder the values of the `ur_sampler_addressing_mode_t` enum to match the values used in libclc. For the cuda adapter (and maybe others) this means we can use the enum values directly in the sampler properties field without having to remap them.