### PR TITLE
[uma] Add purge_[lazy|force] functions

### DIFF
--- a/source/common/uma_helpers.hpp
+++ b/source/common/uma_helpers.hpp
@@ -64,6 +64,11 @@ auto memoryProviderMakeUnique(Args &&...args) {
             noexcept(reinterpret_cast<T *>(obj)->get_last_result(args...)));
         return reinterpret_cast<T *>(obj)->get_last_result(args...);
     };
+    ops.get_recommended_page_size = [](void *obj, auto... args) {
+        static_assert(noexcept(
+            reinterpret_cast<T *>(obj)->get_recommended_page_size(args...)));
+        return reinterpret_cast<T *>(obj)->get_recommended_page_size(args...);
+    };
     ops.get_min_page_size = [](void *obj, auto... args) {
         static_assert(
             noexcept(reinterpret_cast<T *>(obj)->get_min_page_size(args...)));

--- a/source/common/uma_helpers.hpp
+++ b/source/common/uma_helpers.hpp
@@ -64,6 +64,21 @@ auto memoryProviderMakeUnique(Args &&...args) {
             noexcept(reinterpret_cast<T *>(obj)->get_last_result(args...)));
         return reinterpret_cast<T *>(obj)->get_last_result(args...);
     };
+    ops.get_min_page_size = [](void *obj, auto... args) {
+        static_assert(
+            noexcept(reinterpret_cast<T *>(obj)->get_min_page_size(args...)));
+        return reinterpret_cast<T *>(obj)->get_min_page_size(args...);
+    };
+    ops.purge_lazy = [](void *obj, auto... args) {
+        static_assert(
+            noexcept(reinterpret_cast<T *>(obj)->purge_lazy(args...)));
+        return reinterpret_cast<T *>(obj)->purge_lazy(args...);
+    };
+    ops.purge_force = [](void *obj, auto... args) {
+        static_assert(
+            noexcept(reinterpret_cast<T *>(obj)->purge_force(args...)));
+        return reinterpret_cast<T *>(obj)->purge_force(args...);
+    };
 
     uma_memory_provider_handle_t hProvider = nullptr;
     auto ret = umaMemoryProviderCreate(&ops, &argsTuple, &hProvider);

--- a/source/common/unified_memory_allocation/include/uma/base.h
+++ b/source/common/unified_memory_allocation/include/uma/base.h
@@ -42,6 +42,8 @@ enum uma_result_t {
            ///< Retrieved via the umaMemoryProviderGetLastResult entry point.
     UMA_RESULT_ERROR_INVALID_ARGUMENT =
         4, ///< Generic error code for invalid arguments
+    UMA_RESULT_ERROR_INVALID_ALIGNMENT = 5, /// Invalid alignment of an argument
+    UMA_RESULT_ERROR_NOT_SUPPORTED = 6,     /// Operation not supported
 
     UMA_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
 };

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -83,6 +83,16 @@ umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
                                const char **ppMessage);
 
 ///
+/// \brief Retrieve recommended page size for a given allocation size.
+/// \param hProvider handle to the memory provider
+/// \param size allocation size
+/// \param pageSize [out] will be updated with recommended page size.
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
+enum uma_result_t
+umaMemoryProviderGetRecommendedPageSize(uma_memory_provider_handle_t hProvider,
+                                        size_t size, size_t *pageSize);
+
+///
 /// \brief Retrieve minumum possible page size used by memory region referenced by given ptr
 /// \param hProvider handle to the memory provider
 /// \param ptr pointer to memory allocated by this memory provider

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -82,6 +82,42 @@ enum uma_result_t
 umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
                                const char **ppMessage);
 
+///
+/// \brief Retrieve minumum possible page size used by memory region referenced by given ptr
+/// \param hProvider handle to the memory provider
+/// \param ptr pointer to memory allocated by this memory provider
+/// \param pageSize [out] will be updated with page size value.
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
+enum uma_result_t
+umaMemoryProviderGetMinPageSize(uma_memory_provider_handle_t hProvider,
+                                void *ptr, size_t *pageSize);
+
+///
+/// \brief Discard physical pages within the virtual memory mapping associated at given addr and size.
+///        This call is asynchronous and may delay puring the pages indefinitely.
+/// \param hProvider handle to the memory provider
+/// \param ptr beginning of the virtual memory range
+/// \param size size of the virtual memory range
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMA_RESULT_ERROR_INVALID_ALIGNMENT if ptr or size is not page-aligned.
+///         UMA_RESULT_ERROR_NOT_SUPPORTED if operation is not supported by this provider.
+enum uma_result_t
+umaMemoryProviderPurgeLazy(uma_memory_provider_handle_t hProvider, void *ptr,
+                           size_t size);
+
+///
+/// \brief Discard physical pages within the virtual memory mapping associated at given addr and size.
+///        This call is synchronous and if it suceeds, pages are guaranteed to be zero-filled on the next access.
+/// \param hProvider handle to the memory provider
+/// \param ptr beginning of the virtual memory range
+/// \param size size of the virtual memory range
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
+///         UMA_RESULT_ERROR_INVALID_ALIGNMENT if ptr or size is not page-aligned.
+///         UMA_RESULT_ERROR_NOT_SUPPORTED if operation is not supported by this provider.
+enum uma_result_t
+umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
+                            size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -42,6 +42,10 @@ struct uma_memory_provider_ops_t {
     enum uma_result_t (*free)(void *provider, void *ptr, size_t size);
     enum uma_result_t (*get_last_result)(void *provider,
                                          const char **ppMessage);
+    enum uma_result_t (*get_min_page_size)(void *provider, void *ptr,
+                                           size_t *pageSize);
+    enum uma_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);
+    enum uma_result_t (*purge_force)(void *provider, void *ptr, size_t size);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -42,6 +42,8 @@ struct uma_memory_provider_ops_t {
     enum uma_result_t (*free)(void *provider, void *ptr, size_t size);
     enum uma_result_t (*get_last_result)(void *provider,
                                          const char **ppMessage);
+    enum uma_result_t (*get_recommended_page_size)(void *provider, size_t size,
+                                                   size_t *pageSize);
     enum uma_result_t (*get_min_page_size)(void *provider, void *ptr,
                                            size_t *pageSize);
     enum uma_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -71,6 +71,13 @@ void *umaMemoryProviderGetPriv(uma_memory_provider_handle_t hProvider) {
 }
 
 enum uma_result_t
+umaMemoryProviderGetRecommendedPageSize(uma_memory_provider_handle_t hProvider,
+                                        size_t size, size_t *pageSize) {
+    return hProvider->ops.get_recommended_page_size(hProvider->provider_priv,
+                                                    size, pageSize);
+}
+
+enum uma_result_t
 umaMemoryProviderGetMinPageSize(uma_memory_provider_handle_t hProvider,
                                 void *ptr, size_t *pageSize) {
     return hProvider->ops.get_min_page_size(hProvider->provider_priv, ptr,

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -69,3 +69,22 @@ umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
 void *umaMemoryProviderGetPriv(uma_memory_provider_handle_t hProvider) {
     return hProvider->provider_priv;
 }
+
+enum uma_result_t
+umaMemoryProviderGetMinPageSize(uma_memory_provider_handle_t hProvider,
+                                void *ptr, size_t *pageSize) {
+    return hProvider->ops.get_min_page_size(hProvider->provider_priv, ptr,
+                                            pageSize);
+}
+
+enum uma_result_t
+umaMemoryProviderPurgeLazy(uma_memory_provider_handle_t hProvider, void *ptr,
+                           size_t size) {
+    return hProvider->ops.purge_lazy(hProvider->provider_priv, ptr, size);
+}
+
+enum uma_result_t
+umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
+                            size_t size) {
+    return hProvider->ops.purge_force(hProvider->provider_priv, ptr, size);
+}

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -168,6 +168,27 @@ static enum uma_result_t trackingGetLastResult(void *provider,
     return umaMemoryProviderGetLastResult(p->hUpstream, msg);
 }
 
+static enum uma_result_t trackingGetMinPageSize(void *provider, void *ptr,
+                                                size_t *pageSize) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderGetMinPageSize(p->hUpstream, ptr, pageSize);
+}
+
+static enum uma_result_t trackingPurgeLazy(void *provider, void *ptr,
+                                           size_t size) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderPurgeLazy(p->hUpstream, ptr, size);
+}
+
+static enum uma_result_t trackingPurgeForce(void *provider, void *ptr,
+                                            size_t size) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderPurgeForce(p->hUpstream, ptr, size);
+}
+
 enum uma_result_t umaTrackingMemoryProviderCreate(
     uma_memory_provider_handle_t hUpstream, uma_memory_pool_handle_t hPool,
     uma_memory_provider_handle_t *hTrackingProvider) {
@@ -183,6 +204,9 @@ enum uma_result_t umaTrackingMemoryProviderCreate(
     trackingMemoryProviderOps.alloc = trackingAlloc;
     trackingMemoryProviderOps.free = trackingFree;
     trackingMemoryProviderOps.get_last_result = trackingGetLastResult;
+    trackingMemoryProviderOps.get_min_page_size = trackingGetMinPageSize;
+    trackingMemoryProviderOps.purge_force = trackingPurgeForce;
+    trackingMemoryProviderOps.purge_lazy = trackingPurgeLazy;
 
     return umaMemoryProviderCreate(&trackingMemoryProviderOps, &params,
                                    hTrackingProvider);

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -168,6 +168,14 @@ static enum uma_result_t trackingGetLastResult(void *provider,
     return umaMemoryProviderGetLastResult(p->hUpstream, msg);
 }
 
+static enum uma_result_t
+trackingGetRecommendedPageSize(void *provider, size_t size, size_t *pageSize) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderGetRecommendedPageSize(p->hUpstream, size,
+                                                   pageSize);
+}
+
 static enum uma_result_t trackingGetMinPageSize(void *provider, void *ptr,
                                                 size_t *pageSize) {
     uma_tracking_memory_provider_t *p =
@@ -205,6 +213,8 @@ enum uma_result_t umaTrackingMemoryProviderCreate(
     trackingMemoryProviderOps.free = trackingFree;
     trackingMemoryProviderOps.get_last_result = trackingGetLastResult;
     trackingMemoryProviderOps.get_min_page_size = trackingGetMinPageSize;
+    trackingMemoryProviderOps.get_recommended_page_size =
+        trackingGetRecommendedPageSize;
     trackingMemoryProviderOps.purge_force = trackingPurgeForce;
     trackingMemoryProviderOps.purge_lazy = trackingPurgeLazy;
 

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -38,6 +38,14 @@ static enum uma_result_t nullGetLastResult(void *provider, const char **ppMsg) {
     return UMA_RESULT_SUCCESS;
 }
 
+static enum uma_result_t nullGetRecommendedPageSize(void *provider, size_t size,
+                                                    size_t *pageSize) {
+    (void)provider;
+    (void)size;
+    (void)pageSize;
+    return UMA_RESULT_SUCCESS;
+}
+
 static enum uma_result_t nullGetPageSize(void *provider, void *ptr,
 
                                          size_t *pageSize) {
@@ -70,6 +78,7 @@ uma_memory_provider_handle_t nullProviderCreate(void) {
         .alloc = nullAlloc,
         .free = nullFree,
         .get_last_result = nullGetLastResult,
+        .get_recommended_page_size = nullGetRecommendedPageSize,
         .get_min_page_size = nullGetPageSize,
         .purge_lazy = nullPurgeLazy,
         .purge_force = nullPurgeForce};
@@ -123,6 +132,15 @@ static enum uma_result_t traceGetLastResult(void *provider,
                                           ppMsg);
 }
 
+static enum uma_result_t
+traceGetRecommendedPageSize(void *provider, size_t size, size_t *pageSize) {
+    struct traceParams *traceProvider = (struct traceParams *)provider;
+
+    traceProvider->trace("get_recommended_page_size");
+    return umaMemoryProviderGetRecommendedPageSize(
+        traceProvider->hUpstreamProvider, size, pageSize);
+}
+
 static enum uma_result_t traceGetPageSize(void *provider, void *ptr,
 
                                           size_t *pageSize) {
@@ -161,6 +179,7 @@ traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
         .alloc = traceAlloc,
         .free = traceFree,
         .get_last_result = traceGetLastResult,
+        .get_recommended_page_size = traceGetRecommendedPageSize,
         .get_min_page_size = traceGetPageSize,
         .purge_lazy = tracePurgeLazy,
         .purge_force = tracePurgeForce};

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -34,6 +34,10 @@ struct provider_base {
     enum uma_result_t get_last_result(const char **) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }
+    enum uma_result_t get_recommended_page_size(size_t size,
+                                                size_t *pageSize) noexcept {
+        return UMA_RESULT_ERROR_UNKNOWN;
+    }
     enum uma_result_t get_min_page_size(void *ptr, size_t *pageSize) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -34,6 +34,15 @@ struct provider_base {
     enum uma_result_t get_last_result(const char **) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }
+    enum uma_result_t get_min_page_size(void *ptr, size_t *pageSize) noexcept {
+        return UMA_RESULT_ERROR_UNKNOWN;
+    }
+    enum uma_result_t purge_lazy(void *ptr, size_t size) noexcept {
+        return UMA_RESULT_ERROR_UNKNOWN;
+    }
+    enum uma_result_t purge_force(void *ptr, size_t size) noexcept {
+        return UMA_RESULT_ERROR_UNKNOWN;
+    }
 };
 
 struct provider_malloc : public provider_base {

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -35,6 +35,22 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
     ASSERT_EQ(calls["get_last_result"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
+
+    ret = umaMemoryProviderGetMinPageSize(tracingProvider.get(), nullptr,
+                                          nullptr);
+    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
+    ASSERT_EQ(calls["get_min_page_size"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
+
+    ret = umaMemoryProviderPurgeLazy(tracingProvider.get(), nullptr, 0);
+    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
+    ASSERT_EQ(calls["purge_lazy"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
+
+    ret = umaMemoryProviderPurgeForce(tracingProvider.get(), nullptr, 0);
+    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
+    ASSERT_EQ(calls["purge_force"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
 }
 
 //////////////////////////// Negative test cases

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -36,6 +36,12 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(calls["get_last_result"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
 
+    ret = umaMemoryProviderGetRecommendedPageSize(tracingProvider.get(), 0,
+                                                  nullptr);
+    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
+    ASSERT_EQ(calls["get_recommended_page_size"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
+
     ret = umaMemoryProviderGetMinPageSize(tracingProvider.get(), nullptr,
                                           nullptr);
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);


### PR DESCRIPTION
for memory provider. They are similar to jemalloc 'purge' hooks. OS memory provider can implement those functions using madvise and MADV_FREE / MADV_DONTNEED.

I've also added a way to query (possible) page sizes for a given pointer so that we can require `ptr` and `size` parameters to `purge` to be page-aligned. I think it's better not to adjust those transparently within the provider. 

I'm not entirely sure how to handle this for transparent huge pages though. Right now the API allows returning an array of supported page sizes (sorted by size) from that function instead of a single value. This way an implementation can either just return an array of all possible page sizes for any given pointer or return a specific page size if it knows what it is. With this approach we can just return {4K, 2M, 1G} or If we'd have separate memory providers for huge pages and for regular pages, we can just return {4K} for the regular-one or {2M, 1G} for huge-pages provider.

@pbalcer also suggested adding a way to query for `recommended` page size so that we can avoid splitting huge pages whenever we call madvise on non-2MB-aligned address (e.g. in purge). Perhaps a better approach would be to just have a `provider::get_minimum_page_size(void *ptr)` (4k for OS memory), and a `provider::get_recommended_page_size(size_t size)`?

This would be quite similar approach to L0: https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=page#zevirtualmemquerypagesize