### PR TITLE
[ur] Fix linking against libstdc++fs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 project(unified-runtime VERSION 0.6.0)
 
 include(GNUInstallDirs)
-include(CheckIncludeFileCXX)
+include(CheckCXXSourceCompiles)
 include(CMakePackageConfigHelpers)
 include(CTest)
 
@@ -54,11 +54,19 @@ if(NOT MSVC)
     if(UR_DEVELOPER_MODE)
         add_compile_options(-Werror -fno-omit-frame-pointer)
     endif()
-    # If <filesystem> is not found, e.g. with the libstdc++ from GCC 7.5,
-    # <experimental/filesystem> will be used instead which requires linking
-    # libstdc++fs.a to resolve the filesystem symbols.
-    check_include_file_cxx("filesystem" HAS_INCLUDE_FILESYSTEM)
-    if(NOT HAS_INCLUDE_FILESYSTEM)
+    # Determine if libstdc++ is being used.
+    check_cxx_source_compiles("
+        #include <array>
+        #ifndef __GLIBCXX__
+        #error not using libstdc++
+        #endif
+        int main() {}"
+        USING_LIBSTDCXX)
+    if(USING_LIBSTDCXX)
+        # Support older versions of GCC where the <filesystem> header is not
+        # available and <experimental/filesystem> must be used instead. This
+        # requires linking against libstdc++fs.a, on systems where <filesystem>
+        # is available we still need to link this library.
         link_libraries(stdc++fs)
     endif()
 elseif(MSVC)


### PR DESCRIPTION
This patch replaces changes the logic used to specify linking against `libstdc++fs.a` required to use early iterations of `std::filesystem`. Previously CMake checked for the existence of the `<filesystem>` header to enable linking the static library, however in GCC 8 this header exists while still requiring manual linking against the static library. Now we check if we are compiling with `libstdc++` and always manually link against the static library. Fixes #451.