### PR TITLE
Change bool to ur_bool_t in some places

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -453,13 +453,13 @@ class ur_device_info_v(IntEnum):
     MAX_CONSTANT_ARGS = 49                          ## [uint32_t] max number of __const declared arguments in a kernel
     LOCAL_MEM_TYPE = 50                             ## [::ur_device_local_mem_type_t] local memory type
     LOCAL_MEM_SIZE = 51                             ## [uint64_t] local memory size in bytes
-    ERROR_CORRECTION_SUPPORT = 52                   ## [bool] support error correction to global and local memory
-    HOST_UNIFIED_MEMORY = 53                        ## [bool] unified host device memory
+    ERROR_CORRECTION_SUPPORT = 52                   ## [::ur_bool_t] support error correction to global and local memory
+    HOST_UNIFIED_MEMORY = 53                        ## [::ur_bool_t] unified host device memory
     PROFILING_TIMER_RESOLUTION = 54                 ## [size_t] profiling timer resolution in nanoseconds
-    ENDIAN_LITTLE = 55                              ## [bool] little endian byte order
-    AVAILABLE = 56                                  ## [bool] device is available
-    COMPILER_AVAILABLE = 57                         ## [bool] device compiler is available
-    LINKER_AVAILABLE = 58                           ## [bool] device linker is available
+    ENDIAN_LITTLE = 55                              ## [::ur_bool_t] little endian byte order
+    AVAILABLE = 56                                  ## [::ur_bool_t] device is available
+    COMPILER_AVAILABLE = 57                         ## [::ur_bool_t] device compiler is available
+    LINKER_AVAILABLE = 58                           ## [::ur_bool_t] device linker is available
     EXECUTION_CAPABILITIES = 59                     ## [::ur_device_exec_capability_flags_t] device kernel execution
                                                     ## capability bit-field
     QUEUE_ON_DEVICE_PROPERTIES = 60                 ## [::ur_queue_flags_t] device command queue property bit-field

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -801,13 +801,13 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,                      ///< [uint32_t] max number of __const declared arguments in a kernel
     UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,                         ///< [::ur_device_local_mem_type_t] local memory type
     UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,                         ///< [uint64_t] local memory size in bytes
-    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,               ///< [bool] support error correction to global and local memory
-    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                    ///< [bool] unified host device memory
+    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,               ///< [::ur_bool_t] support error correction to global and local memory
+    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                    ///< [::ur_bool_t] unified host device memory
     UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54,             ///< [size_t] profiling timer resolution in nanoseconds
-    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                          ///< [bool] little endian byte order
-    UR_DEVICE_INFO_AVAILABLE = 56,                              ///< [bool] device is available
-    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                     ///< [bool] device compiler is available
-    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                       ///< [bool] device linker is available
+    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                          ///< [::ur_bool_t] little endian byte order
+    UR_DEVICE_INFO_AVAILABLE = 56,                              ///< [::ur_bool_t] device is available
+    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                     ///< [::ur_bool_t] device compiler is available
+    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                       ///< [::ur_bool_t] device linker is available
     UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,                 ///< [::ur_device_exec_capability_flags_t] device kernel execution
                                                                 ///< capability bit-field
     UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,             ///< [::ur_queue_flags_t] device command queue property bit-field

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -250,19 +250,19 @@ etors:
     - name: LOCAL_MEM_SIZE
       desc: "[uint64_t] local memory size in bytes"
     - name: ERROR_CORRECTION_SUPPORT
-      desc: "[bool] support error correction to global and local memory"
+      desc: "[$x_bool_t] support error correction to global and local memory"
     - name: HOST_UNIFIED_MEMORY
-      desc: "[bool] unified host device memory"
+      desc: "[$x_bool_t] unified host device memory"
     - name: PROFILING_TIMER_RESOLUTION
       desc: "[size_t] profiling timer resolution in nanoseconds"
     - name: ENDIAN_LITTLE
-      desc: "[bool] little endian byte order"
+      desc: "[$x_bool_t] little endian byte order"
     - name: AVAILABLE
-      desc: "[bool] device is available"
+      desc: "[$x_bool_t] device is available"
     - name: COMPILER_AVAILABLE
-      desc: "[bool] device compiler is available"
+      desc: "[$x_bool_t] device compiler is available"
     - name: LINKER_AVAILABLE
-      desc: "[bool] device linker is available"
+      desc: "[$x_bool_t] device linker is available"
     - name: EXECUTION_CAPABILITIES
       desc: "[$x_device_exec_capability_flags_t] device kernel execution capability bit-field"
     - name: QUEUE_ON_DEVICE_PROPERTIES

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -2267,10 +2267,10 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
-        const bool *tptr = (const bool *)ptr;
-        if (sizeof(bool) > size) {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(bool) << ")";
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -2281,10 +2281,10 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY: {
-        const bool *tptr = (const bool *)ptr;
-        if (sizeof(bool) > size) {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(bool) << ")";
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -2309,10 +2309,10 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_ENDIAN_LITTLE: {
-        const bool *tptr = (const bool *)ptr;
-        if (sizeof(bool) > size) {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(bool) << ")";
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -2323,10 +2323,10 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_AVAILABLE: {
-        const bool *tptr = (const bool *)ptr;
-        if (sizeof(bool) > size) {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(bool) << ")";
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -2337,10 +2337,10 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_COMPILER_AVAILABLE: {
-        const bool *tptr = (const bool *)ptr;
-        if (sizeof(bool) > size) {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(bool) << ")";
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -2351,10 +2351,10 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_LINKER_AVAILABLE: {
-        const bool *tptr = (const bool *)ptr;
-        if (sizeof(bool) > size) {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(bool) << ")";
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";


### PR DESCRIPTION
Only use ur_bool_t in ur_device_info_t for consistency

Signed-off-by: Brandon Yates <brandon.yates@intel.com>