### PR TITLE
[ur] Add missing USM advise flags

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1061,10 +1061,16 @@ class ur_usm_advice_flags_v(IntEnum):
     CLEAR_READ_MOSTLY = UR_BIT(2)                   ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_READ_MOSTLY
     SET_PREFERRED_LOCATION = UR_BIT(3)              ## Hint that the preferred memory location is the specified device
     CLEAR_PREFERRED_LOCATION = UR_BIT(4)            ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION
-    SET_NON_ATOMIC_MOSTLY = UR_BIT(5)               ## Hints that memory will mostly be accessed non-atomically
+    SET_NON_ATOMIC_MOSTLY = UR_BIT(5)               ## Hint that memory will mostly be accessed non-atomically
     CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6)             ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY
-    BIAS_CACHED = UR_BIT(7)                         ## Hints that memory should be cached
-    BIAS_UNCACHED = UR_BIT(8)                       ## Hints that memory should be not be cached
+    BIAS_CACHED = UR_BIT(7)                         ## Hint that memory should be cached
+    BIAS_UNCACHED = UR_BIT(8)                       ## Hint that memory should be not be cached
+    SET_ACCESSED_BY_DEVICE = UR_BIT(9)              ## Hint that memory will be mostly accessed by the specified device
+    CLEAR_ACCESSED_BY_DEVICE = UR_BIT(10)           ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE
+    SET_ACCESSED_BY_HOST = UR_BIT(11)               ## Hint that memory will be mostly accessed by the host
+    CLEAR_ACCESSED_BY_HOST = UR_BIT(12)             ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST
+    SET_PREFERRED_LOCATION_HOST = UR_BIT(13)        ## Hint that the preferred memory location is the host
+    CLEAR_PREFERRED_LOCATION_HOST = UR_BIT(14)      ## Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST
 
 class ur_usm_advice_flags_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2334,22 +2334,28 @@ typedef enum ur_usm_alloc_info_t {
 /// @brief USM memory advice
 typedef uint32_t ur_usm_advice_flags_t;
 typedef enum ur_usm_advice_flag_t {
-    UR_USM_ADVICE_FLAG_DEFAULT = UR_BIT(0),                  ///< The USM memory advice is default
-    UR_USM_ADVICE_FLAG_SET_READ_MOSTLY = UR_BIT(1),          ///< Hint that memory will be read from frequently and written to rarely
-    UR_USM_ADVICE_FLAG_CLEAR_READ_MOSTLY = UR_BIT(2),        ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_READ_MOSTLY
-    UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION = UR_BIT(3),   ///< Hint that the preferred memory location is the specified device
-    UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION = UR_BIT(4), ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION
-    UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY = UR_BIT(5),    ///< Hints that memory will mostly be accessed non-atomically
-    UR_USM_ADVICE_FLAG_CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6),  ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY
-    UR_USM_ADVICE_FLAG_BIAS_CACHED = UR_BIT(7),              ///< Hints that memory should be cached
-    UR_USM_ADVICE_FLAG_BIAS_UNCACHED = UR_BIT(8),            ///< Hints that memory should be not be cached
+    UR_USM_ADVICE_FLAG_DEFAULT = UR_BIT(0),                        ///< The USM memory advice is default
+    UR_USM_ADVICE_FLAG_SET_READ_MOSTLY = UR_BIT(1),                ///< Hint that memory will be read from frequently and written to rarely
+    UR_USM_ADVICE_FLAG_CLEAR_READ_MOSTLY = UR_BIT(2),              ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_READ_MOSTLY
+    UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION = UR_BIT(3),         ///< Hint that the preferred memory location is the specified device
+    UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION = UR_BIT(4),       ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION
+    UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY = UR_BIT(5),          ///< Hint that memory will mostly be accessed non-atomically
+    UR_USM_ADVICE_FLAG_CLEAR_NON_ATOMIC_MOSTLY = UR_BIT(6),        ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY
+    UR_USM_ADVICE_FLAG_BIAS_CACHED = UR_BIT(7),                    ///< Hint that memory should be cached
+    UR_USM_ADVICE_FLAG_BIAS_UNCACHED = UR_BIT(8),                  ///< Hint that memory should be not be cached
+    UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE = UR_BIT(9),         ///< Hint that memory will be mostly accessed by the specified device
+    UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE = UR_BIT(10),      ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE
+    UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST = UR_BIT(11),          ///< Hint that memory will be mostly accessed by the host
+    UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST = UR_BIT(12),        ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST
+    UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST = UR_BIT(13),   ///< Hint that the preferred memory location is the host
+    UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST = UR_BIT(14), ///< Removes the affect of ::UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST
     /// @cond
     UR_USM_ADVICE_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
 } ur_usm_advice_flag_t;
 /// @brief Bit Mask for validating ur_usm_advice_flags_t
-#define UR_USM_ADVICE_FLAGS_MASK 0xfffffe00
+#define UR_USM_ADVICE_FLAGS_MASK 0xffff8000
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of USM pool

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -108,16 +108,34 @@ etors:
       desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION"
     - name: SET_NON_ATOMIC_MOSTLY
       value: "$X_BIT(5)"
-      desc: "Hints that memory will mostly be accessed non-atomically"
+      desc: "Hint that memory will mostly be accessed non-atomically"
     - name: CLEAR_NON_ATOMIC_MOSTLY
       value: "$X_BIT(6)"
       desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_NON_ATOMIC_MOSTLY"
     - name: BIAS_CACHED
       value: "$X_BIT(7)"
-      desc: "Hints that memory should be cached"
+      desc: "Hint that memory should be cached"
     - name: BIAS_UNCACHED
       value: "$X_BIT(8)"
-      desc: "Hints that memory should be not be cached"
+      desc: "Hint that memory should be not be cached"
+    - name: SET_ACCESSED_BY_DEVICE
+      value: "$X_BIT(9)"
+      desc: "Hint that memory will be mostly accessed by the specified device"
+    - name: CLEAR_ACCESSED_BY_DEVICE
+      value: "$X_BIT(10)"
+      desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE"
+    - name: SET_ACCESSED_BY_HOST
+      value: "$X_BIT(11)"
+      desc: "Hint that memory will be mostly accessed by the host"
+    - name: CLEAR_ACCESSED_BY_HOST
+      value: "$X_BIT(12)"
+      desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST"
+    - name: SET_PREFERRED_LOCATION_HOST
+      value: "$X_BIT(13)"
+      desc: "Hint that the preferred memory location is the host"
+    - name: CLEAR_PREFERRED_LOCATION_HOST
+      value: "$X_BIT(14)"
+      desc: "Removes the affect of $X_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST"
 --- #--------------------------------------------------------------------------
 type: handle
 desc: "Handle of USM pool"
@@ -137,7 +155,7 @@ members:
       name: hints
       desc: "[in] Memory advice hints"
     - type: uint32_t
-      name: align      
+      name: align
       desc: |
             [in] alignment of the USM memory object
             Must be zero or a power of 2.

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -5052,6 +5052,30 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_USM_ADVICE_FLAG_BIAS_UNCACHED:
         os << "UR_USM_ADVICE_FLAG_BIAS_UNCACHED";
         break;
+
+    case UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE:
+        os << "UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE";
+        break;
+
+    case UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE:
+        os << "UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE";
+        break;
+
+    case UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST:
+        os << "UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST";
+        break;
+
+    case UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST:
+        os << "UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST";
+        break;
+
+    case UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST:
+        os << "UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST";
+        break;
+
+    case UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST:
+        os << "UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -5161,6 +5185,72 @@ inline void serializeFlag_ur_usm_advice_flags_t(std::ostream &os,
             first = false;
         }
         os << UR_USM_ADVICE_FLAG_BIAS_UNCACHED;
+    }
+
+    if ((val & UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE) ==
+        (uint32_t)UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE) {
+        val ^= (uint32_t)UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE;
+    }
+
+    if ((val & UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE) ==
+        (uint32_t)UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE) {
+        val ^= (uint32_t)UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE;
+    }
+
+    if ((val & UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST) ==
+        (uint32_t)UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST) {
+        val ^= (uint32_t)UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_HOST;
+    }
+
+    if ((val & UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST) ==
+        (uint32_t)UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST) {
+        val ^= (uint32_t)UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_HOST;
+    }
+
+    if ((val & UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST) ==
+        (uint32_t)UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST) {
+        val ^= (uint32_t)UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION_HOST;
+    }
+
+    if ((val & UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST) ==
+        (uint32_t)UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST) {
+        val ^= (uint32_t)UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION_HOST;
     }
     if (val != 0) {
         std::bitset<32> bits(val);


### PR DESCRIPTION
Fixes #423 by introducing the 6 missing `pi_mem_advice` to the `ur_usm_advice_flags_t`.