### PR TITLE
[ur] remove ur_usm_flags_t

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1024,17 +1024,6 @@ class ur_sampler_desc_t(Structure):
     ]
 
 ###############################################################################
-## @brief USM memory property flags
-class ur_usm_flags_v(IntEnum):
-    BIAS_CACHED = UR_BIT(0)                         ## Allocation should be cached
-    BIAS_UNCACHED = UR_BIT(1)                       ## Allocation should not be cached
-
-class ur_usm_flags_t(c_int):
-    def __str__(self):
-        return hex(self.value)
-
-
-###############################################################################
 ## @brief USM host memory property flags
 class ur_usm_host_mem_flags_v(IntEnum):
     INITIAL_PLACEMENT = UR_BIT(0)                   ## Optimize shared allocation for first access on the host
@@ -1130,7 +1119,6 @@ class ur_usm_desc_t(Structure):
     _fields_ = [
         ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
-        ("flags", ur_usm_flags_t),                                      ## [in] memory allocation flags.
         ("hints", ur_usm_advice_flags_t),                               ## [in] Memory advice hints
         ("align", c_ulong)                                              ## [in] alignment of the USM memory object
                                                                         ## Must be zero or a power of 2.

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2322,20 +2322,6 @@ urSamplerCreateWithNativeHandle(
 #pragma region usm
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief USM memory property flags
-typedef uint32_t ur_usm_flags_t;
-typedef enum ur_usm_flag_t {
-    UR_USM_FLAG_BIAS_CACHED = UR_BIT(0),   ///< Allocation should be cached
-    UR_USM_FLAG_BIAS_UNCACHED = UR_BIT(1), ///< Allocation should not be cached
-    /// @cond
-    UR_USM_FLAG_FORCE_UINT32 = 0x7fffffff
-    /// @endcond
-
-} ur_usm_flag_t;
-/// @brief Bit Mask for validating ur_usm_flags_t
-#define UR_USM_FLAGS_MASK 0xfffffffc
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief USM host memory property flags
 typedef uint32_t ur_usm_host_mem_flags_t;
 typedef enum ur_usm_host_mem_flag_t {
@@ -2441,7 +2427,6 @@ typedef struct ur_usm_pool_handle_t_ *ur_usm_pool_handle_t;
 typedef struct ur_usm_desc_t {
     ur_structure_type_t stype;   ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_DESC
     const void *pNext;           ///< [in][optional] pointer to extension-specific structure
-    ur_usm_flags_t flags;        ///< [in] memory allocation flags.
     ur_usm_advice_flags_t hints; ///< [in] Memory advice hints
     uint32_t align;              ///< [in] alignment of the USM memory object
                                  ///< Must be zero or a power of 2.

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -11,18 +11,6 @@ desc: "Intel $OneApi Unified Runtime APIs"
 ordinal: "4"
 --- #--------------------------------------------------------------------------
 type: enum
-desc: "USM memory property flags"
-class: $xUSM
-name: $x_usm_flags_t
-etors:
-    - name: BIAS_CACHED
-      value: "$X_BIT(0)"
-      desc: "Allocation should be cached"
-    - name: BIAS_UNCACHED
-      value: "$X_BIT(1)"
-      desc: "Allocation should not be cached"  
---- #--------------------------------------------------------------------------
-type: enum
 desc: "USM host memory property flags"
 class: $xUSM
 name: $x_usm_host_mem_flags_t
@@ -148,9 +136,6 @@ class: $xUSM
 name: $x_usm_desc_t
 base: $x_base_desc_t
 members:
-    - type: $x_usm_flags_t
-      name: flags
-      desc: "[in] memory allocation flags."
     - type: $x_usm_advice_flags_t
       name: hints
       desc: "[in] Memory advice hints"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -59,7 +59,6 @@ inline void serializeTaggedTyped_ur_sampler_info_t(std::ostream &os,
                                                    const void *ptr,
                                                    enum ur_sampler_info_t value,
                                                    size_t size);
-inline void serializeFlag_ur_usm_flags_t(std::ostream &os, ur_usm_flags_t flag);
 inline void serializeFlag_ur_usm_host_mem_flags_t(std::ostream &os,
                                                   ur_usm_host_mem_flags_t flag);
 inline void
@@ -196,7 +195,6 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os, enum ur_sampler_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_sampler_desc_t params);
-inline std::ostream &operator<<(std::ostream &os, enum ur_usm_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_host_mem_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -4941,59 +4939,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
     return os;
 }
-inline std::ostream &operator<<(std::ostream &os, enum ur_usm_flag_t value) {
-    switch (value) {
-
-    case UR_USM_FLAG_BIAS_CACHED:
-        os << "UR_USM_FLAG_BIAS_CACHED";
-        break;
-
-    case UR_USM_FLAG_BIAS_UNCACHED:
-        os << "UR_USM_FLAG_BIAS_UNCACHED";
-        break;
-    default:
-        os << "unknown enumerator";
-        break;
-    }
-    return os;
-}
-namespace ur_params {
-inline void serializeFlag_ur_usm_flags_t(std::ostream &os,
-                                         ur_usm_flags_t flag) {
-    uint32_t val = flag;
-    bool first = true;
-
-    if ((val & UR_USM_FLAG_BIAS_CACHED) == (uint32_t)UR_USM_FLAG_BIAS_CACHED) {
-        val ^= (uint32_t)UR_USM_FLAG_BIAS_CACHED;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_USM_FLAG_BIAS_CACHED;
-    }
-
-    if ((val & UR_USM_FLAG_BIAS_UNCACHED) ==
-        (uint32_t)UR_USM_FLAG_BIAS_UNCACHED) {
-        val ^= (uint32_t)UR_USM_FLAG_BIAS_UNCACHED;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_USM_FLAG_BIAS_UNCACHED;
-    }
-    if (val != 0) {
-        std::bitset<32> bits(val);
-        if (!first) {
-            os << " | ";
-        }
-        os << "unknown bit flags " << bits;
-    } else if (first) {
-        os << "0";
-    }
-}
-} // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_host_mem_flag_t value) {
     switch (value) {
@@ -5548,11 +5493,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
-
-    os << ", ";
-    os << ".flags = ";
-
-    ur_params::serializeFlag_ur_usm_flags_t(os, (params.flags));
 
     os << ", ";
     os << ".hints = ";

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -124,7 +124,6 @@ struct UrUsmHostAllocParamsUsmDesc : UrUsmHostAllocParams {
     ur_usm_desc_t usm_desc;
     UrUsmHostAllocParamsUsmDesc() : UrUsmHostAllocParams() {
         usm_desc.align = 64;
-        usm_desc.flags = UR_USM_FLAG_BIAS_CACHED;
         usm_desc.hints = UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION;
         usm_desc.pNext = nullptr;
         usm_desc.stype = UR_STRUCTURE_TYPE_USM_DESC;
@@ -134,7 +133,7 @@ struct UrUsmHostAllocParamsUsmDesc : UrUsmHostAllocParams {
         return ".*\\.pUSMDesc = .+ \\(\\(struct "
                "ur_usm_desc_t\\)\\{\\.stype = UR_STRUCTURE_TYPE_USM_DESC, "
                "\\.pNext = "
-               "nullptr, \\.flags = UR_USM_FLAG_BIAS_CACHED, \\.hints = "
+               "nullptr, \\.hints = "
                "UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION, \\.align = "
                "64\\}\\).*";
     };


### PR DESCRIPTION
They were initially introduced for L0 compatibility but currently they are not used in SYCL/OpenMP.