### PR TITLE
Match USM entry-points error-codes with spec

### DIFF
--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -43,7 +43,7 @@ TEST_P(urUSMDeviceAllocTest, InvalidNullHandleContext) {
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullHandleDevice) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_DEVICE,
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urUSMDeviceAlloc(context, nullptr, nullptr, nullptr,
                                       sizeof(int), &ptr));
 }
@@ -58,14 +58,14 @@ TEST_P(urUSMDeviceAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_USM_SIZE,
-        urUSMDeviceAlloc(context, device, nullptr, nullptr, 13, &ptr));
+        urUSMDeviceAlloc(context, device, nullptr, nullptr, -1, &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidValueAlignPowerOfTwo) {
     void *ptr = nullptr;
     ur_usm_desc_t desc = {};
     desc.stype = UR_STRUCTURE_TYPE_USM_DESC;
-    desc.align = 1;
+    desc.align = 5;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_VALUE,
         urUSMDeviceAlloc(context, device, &desc, nullptr, sizeof(int), &ptr));

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -71,14 +71,14 @@ TEST_P(urUSMHostAllocTest, InvalidNullPtrMem) {
 TEST_P(urUSMHostAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_USM_SIZE,
-                     urUSMHostAlloc(context, nullptr, nullptr, 13, &ptr));
+                     urUSMHostAlloc(context, nullptr, nullptr, -1, &ptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidValueAlignPowerOfTwo) {
     void *ptr = nullptr;
     ur_usm_desc_t desc = {};
     desc.stype = UR_STRUCTURE_TYPE_USM_DESC;
-    desc.align = 1;
+    desc.align = 5;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_VALUE,
         urUSMHostAlloc(context, &desc, nullptr, sizeof(int), &ptr));

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -101,7 +101,7 @@ TEST_P(urUSMSharedAllocTest, InvalidNullHandleDevice) {
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidNullPtrMem) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                      urUSMSharedAlloc(context, device, nullptr, nullptr,
                                       sizeof(int), nullptr));
 }
@@ -110,14 +110,14 @@ TEST_P(urUSMSharedAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_USM_SIZE,
-        urUSMSharedAlloc(context, device, nullptr, nullptr, 13, &ptr));
+        urUSMSharedAlloc(context, device, nullptr, nullptr, -1, &ptr));
 }
 
 TEST_P(urUSMSharedAllocTest, InvalidValueAlignPowerOfTwo) {
     void *ptr = nullptr;
     ur_usm_desc_t desc = {};
     desc.stype = UR_STRUCTURE_TYPE_USM_DESC;
-    desc.align = 1;
+    desc.align = 5;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_VALUE,
         urUSMSharedAlloc(context, device, &desc, nullptr, sizeof(int), &ptr));


### PR DESCRIPTION
* Change USM entry-points error codes to match the spec.
* Change the tested alignment for some usm mem allocation tests from 1 to 5 as 1 should be a valid alignment.
* Change the tested size for some usm mem allocation tests from 13 to -1 as 13 should be a valid size.