### PR TITLE
[UR] UR_MEM_FLAG_ALLOC_HOST_POINTER does not require a host ptr

### DIFF
--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -34,7 +34,6 @@ using urMemBufferCreateWithHostPtrFlagsTest =
     urMemBufferCreateTestWithFlagsParam;
 UUR_TEST_SUITE_P(urMemBufferCreateWithHostPtrFlagsTest,
                  ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
-                                   UR_MEM_FLAG_ALLOC_HOST_POINTER,
                                    UR_MEM_FLAG_USE_HOST_POINTER),
                  uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 

--- a/test/conformance/memory/urMemImageCreate.cpp
+++ b/test/conformance/memory/urMemImageCreate.cpp
@@ -146,7 +146,6 @@ using urMemImageCreateWithHostPtrFlagsTest =
 
 UUR_TEST_SUITE_P(urMemImageCreateWithHostPtrFlagsTest,
                  ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
-                                   UR_MEM_FLAG_ALLOC_HOST_POINTER,
                                    UR_MEM_FLAG_USE_HOST_POINTER),
                  uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 


### PR DESCRIPTION
`UR_MEM_FLAG_ALLOC_HOST_POINTER` does not require a host ptr to be passed.