### PR TITLE
[UR] Fix codegen to adapters directory

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -204,7 +204,7 @@ def _mako_loader_cpp(path, namespace, tags, version, specs, meta):
 """
     generates c/c++ files from the specification documents
 """
-def _mako_null_driver_cpp(path, namespace, tags, version, specs, meta):
+def _mako_null_adapter_cpp(path, namespace, tags, version, specs, meta):
     dstpath = os.path.join(path, "null")
     os.makedirs(dstpath, exist_ok=True)
 
@@ -320,14 +320,14 @@ def generate_loader(path, section, namespace, tags, version, specs, meta):
 
 """
 Entry-point:
-    generates drivers for unified_runtime driver
+    generates adapter for unified_runtime
 """
-def generate_drivers(path, section, namespace, tags, version, specs, meta):
-    dstpath = os.path.join(path, "drivers")
+def generate_adapters(path, section, namespace, tags, version, specs, meta):
+    dstpath = os.path.join(path, "adapters")
     os.makedirs(dstpath, exist_ok=True)
 
     loc = 0
-    loc += _mako_null_driver_cpp(dstpath, namespace, tags, version, specs, meta)
+    loc += _mako_null_adapter_cpp(dstpath, namespace, tags, version, specs, meta)
     print("Generated %s lines of code.\n"%loc)
 
 """

--- a/scripts/json2src.py
+++ b/scripts/json2src.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     add_argument(parser, "lib", "generation of lib files.", True)
     add_argument(parser, "loader", "generation of loader files.", True)
     add_argument(parser, "layers", "generation of layer files.", True)
-    add_argument(parser, "drivers", "generation of null driver files.", True)
+    add_argument(parser, "adapters", "generation of null adapter files.", True)
     add_argument(parser, "common", "generation of common files.", True)
     parser.add_argument("--debug", action='store_true', help="dump intermediate data to disk.")
     parser.add_argument("--sections", type=list, default=None, help="Optional list of sections for which to generate source, default is all")
@@ -50,8 +50,8 @@ if __name__ == '__main__':
                 generate_code.generate_loader(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
             if args.layers:
                 generate_code.generate_layers(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
-            if args.drivers:
-                generate_code.generate_drivers(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
+            if args.adapters:
+                generate_code.generate_adapters(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
             if args.common:
                 generate_code.generate_common(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
 


### PR DESCRIPTION
Currently the generator for adapters is broken as the autogenerate driver is still placed in `source/drivers` instead of `source/adapters`. This PR fixes the path as well as renames functions from `driver` -> `adapter`.