### PR TITLE
[UR][CTS] Disable CTS test to check max mem alloc size

### DIFF
--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -57,7 +57,10 @@ TEST_P(urMemBufferCreateTest, InvalidBufferSizeZero) {
                                        nullptr, &buffer));
 }
 
-TEST_P(urMemBufferCreateTest, InvalidBufferSizeMax) {
+// This test is problematic and not generally applicable across all adapters
+// For example: the CUDA adapter cannot query the maximum alloc size reliably
+// ahead of time.
+TEST_P(urMemBufferCreateTest, DISABLED_InvalidBufferSizeMax) {
     ur_mem_handle_t buffer = nullptr;
     uint64_t max_size = 0;
     ASSERT_SUCCESS(uur::GetDeviceMaxMemAllocSize(device, max_size));

--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -56,16 +56,3 @@ TEST_P(urMemBufferCreateTest, InvalidBufferSizeZero) {
                      urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 0,
                                        nullptr, &buffer));
 }
-
-// This test is problematic and not generally applicable across all adapters
-// For example: the CUDA adapter cannot query the maximum alloc size reliably
-// ahead of time.
-TEST_P(urMemBufferCreateTest, DISABLED_InvalidBufferSizeMax) {
-    ur_mem_handle_t buffer = nullptr;
-    uint64_t max_size = 0;
-    ASSERT_SUCCESS(uur::GetDeviceMaxMemAllocSize(device, max_size));
-    ASSERT_NE(max_size, 0);
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
-                     urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                       max_size + 1, nullptr, &buffer));
-}


### PR DESCRIPTION
We've chosen to disable a CTS test that attempts to allocate beyond the maximum allocation size since it's not generally applicable across adapters. The CUDA adapter cannot ahead of time determine it's maximum allowed allocation.