### PR TITLE
[UR] Add sphinx-autobuild target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,13 @@ if(UR_FORMAT_CPP_STYLE)
         COMMAND git diff --exit-code
         DEPENDS generate
     )
+    
+    add_custom_target(sphinx-autobuild 
+        COMMAND sphinx-autobuild -b html 
+        ${PROJECT_SOURCE_DIR}/docs/source ${PROJECT_SOURCE_DIR}/docs
+        DEPENDS generate
+        USES_TERMINAL COMMENT "Build/Serve Sphinx Documentation (Live Preview)"
+    )
 else()
     message(WARNING "UR_FORMAT_CPP_STYLE not set. Targets: 'generate' and 'check-generated' and not available")
 endif()

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -34,6 +34,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4
 sphinx-book-theme==0.3.3
+sphinx-autobuild==2021.3.14
 urllib3==1.25.7
 pytest>=7.0
 clang-format==15.0.7


### PR DESCRIPTION
When developing the documentation I have found it useful to have a local live-preview of the docs to check that they are rendering correctly. This PR adds a `sphinx-autobuild` target so that you can deploy and run the docs locally.

How to:
 * Install `requiremnts.txt` and reconfigure the project
 * from build directory run `ninja sphinx-autobuild` 