### PR TITLE
[UMA] Improve the doxygen comments

### DIFF
--- a/source/common/unified_memory_allocation/include/uma/memory_pool.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool.h
@@ -21,12 +21,14 @@ typedef struct uma_memory_pool_t *uma_memory_pool_handle_t;
 struct uma_memory_pool_ops_t;
 
 ///
-/// \brief Creates new memory pool
+/// \brief Creates new memory pool.
 /// \param ops instance of uma_memory_pool_ops_t
-/// \param providers array of memory providers that will be used for coarse-grain allocations. Should contain at least one memory provider.
+/// \param providers array of memory providers that will be used for coarse-grain allocations.
+///        Should contain at least one memory provider.
 /// \param numProvider number of elements in the providers array
 /// \param params pointer to pool-specific parameters
-/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
+/// \param hPool [out] handle to the newly created memory pool
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 ///
 enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops,
                                 uma_memory_provider_handle_t *providers,
@@ -34,26 +36,26 @@ enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops,
                                 uma_memory_pool_handle_t *hPool);
 
 ///
-/// \brief Destroys memory pool
+/// \brief Destroys memory pool.
 /// \param hPool handle to the pool
 ///
 void umaPoolDestroy(uma_memory_pool_handle_t hPool);
 
 ///
-/// \brief Allocates size bytes of uninitialized storage of the specified hPool
+/// \brief Allocates size bytes of uninitialized storage of the specified hPool.
 /// \param hPool specified memory hPool
 /// \param size number of bytes to allocate
-/// \return Pointer to the allocated memory
+/// \return Pointer to the allocated memory.
 ///
 void *umaPoolMalloc(uma_memory_pool_handle_t hPool, size_t size);
 
 ///
-/// \brief Allocates size bytes of uninitialized storage of the specified hPool
+/// \brief Allocates size bytes of uninitialized storage of the specified hPool.
 /// with specified alignment
 /// \param hPool specified memory hPool
 /// \param size number of bytes to allocate
 /// \param alignment alignment of the allocation
-/// \return Pointer to the allocated memory
+/// \return Pointer to the allocated memory.
 ///
 void *umaPoolAlignedMalloc(uma_memory_pool_handle_t hPool, size_t size,
                            size_t alignment);
@@ -61,40 +63,40 @@ void *umaPoolAlignedMalloc(uma_memory_pool_handle_t hPool, size_t size,
 ///
 /// \brief Allocates memory of the specified hPool for an array of num elements
 ///        of size bytes each and initializes all bytes in the allocated storage
-///        to zero
+///        to zero.
 /// \param hPool specified memory hPool
 /// \param num number of objects
 /// \param size specified size of each element
-/// \return Pointer to the allocated memory
+/// \return Pointer to the allocated memory.
 ///
 void *umaPoolCalloc(uma_memory_pool_handle_t hPool, size_t num, size_t size);
 
 ///
-/// \brief Reallocates memory of the specified hPool
+/// \brief Reallocates memory of the specified hPool.
 /// \param hPool specified memory hPool
 /// \param ptr pointer to the memory block to be reallocated
 /// \param size new size for the memory block in bytes
-/// \return Pointer to the allocated memory
+/// \return Pointer to the allocated memory.
 ///
 void *umaPoolRealloc(uma_memory_pool_handle_t hPool, void *ptr, size_t size);
 
 ///
-/// \brief Obtains size of block of memory allocated from the pool
+/// \brief Obtains size of block of memory allocated from the pool.
 /// \param hPool specified memory hPool
 /// \param ptr pointer to the allocated memory
-/// \return Number of bytes
+/// \return Number of bytes.
 ///
 size_t umaPoolMallocUsableSize(uma_memory_pool_handle_t hPool, void *ptr);
 
 ///
-/// \brief Frees the memory space of the specified hPool pointed by ptr
+/// \brief Frees the memory space of the specified hPool pointed by ptr.
 /// \param hPool specified memory hPool
 /// \param ptr pointer to the allocated memory
 ///
 void umaPoolFree(uma_memory_pool_handle_t hPool, void *ptr);
 
 ///
-/// \brief Frees the memory space pointed by ptr if it belongs to UMA pool, does nothing otherwise
+/// \brief Frees the memory space pointed by ptr if it belongs to UMA pool, does nothing otherwise.
 /// \param ptr pointer to the allocated memory
 ///
 void umaFree(void *ptr);
@@ -126,7 +128,7 @@ enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
 ///
 /// \brief Retrieve memory pool associated with a given ptr.
 /// \param ptr pointer to memory belonging to a memory pool
-/// \return handle to a memory pool that contains ptr or NULL if pointer does not belong to any UMA pool
+/// \return Handle to a memory pool that contains ptr or NULL if pointer does not belong to any UMA pool.
 uma_memory_pool_handle_t umaPoolByPtr(const void *ptr);
 
 ///
@@ -135,7 +137,8 @@ uma_memory_pool_handle_t umaPoolByPtr(const void *ptr);
 /// \param hProviders [out] pointer to an array of memory providers. If numProviders is not equal to or
 ///        greater than the real number of providers, UMA_RESULT_ERROR_INVALID_ARGUMENT is returned.
 /// \param numProviders [in] number of memory providers to return
-/// \param numProvidersRet pointer to the actual number of memory providers.
+/// \param numProvidersRet pointer to the actual number of memory providers
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 enum uma_result_t
 umaPoolGetMemoryProviders(uma_memory_pool_handle_t hPool, size_t numProviders,
                           uma_memory_provider_handle_t *hProviders,

--- a/source/common/unified_memory_allocation/include/uma/memory_pool_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool_ops.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-/// \brief This structure comprises function pointers used by corresponding  umaPool*
+/// \brief This structure comprises function pointers used by corresponding umaPool*
 /// calls. Each memory pool implementation should initialize all function
 /// pointers.
 struct uma_memory_pool_ops_t {
@@ -24,13 +24,13 @@ struct uma_memory_pool_ops_t {
     uint32_t version;
 
     ///
-    /// \brief Intializes memory pool
-    /// \param providers array of memory providers that will be used for coarse-grain allocations. Should contain at least one memory provider.
+    /// \brief Intializes memory pool.
+    /// \param providers array of memory providers that will be used for coarse-grain allocations.
+    ///        Should contain at least one memory provider.
     /// \param numProvider number of elements in the providers array
     /// \param params pool-specific params
-    /// \param pool returns pointer to the pool
-    /// \return UMA_RESULT_SUCCESS on success or appropriate error code on
-    /// failure
+    /// \param pool [out] returns pointer to the pool
+    /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
     enum uma_result_t (*initialize)(uma_memory_provider_handle_t *providers,
                                     size_t numProviders, void *params,
                                     void **pool);

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -19,40 +19,41 @@ extern "C" {
 typedef struct uma_memory_provider_t *uma_memory_provider_handle_t;
 
 ///
-/// \brief Creates new memory provider
+/// \brief Creates new memory provider.
 /// \param ops instance of uma_memory_provider_ops_t
 /// \param params pointer to provider-specific parameters
-/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
+/// \param hProvider [out] pointer to the newly created memory provider
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 ///
 enum uma_result_t
 umaMemoryProviderCreate(struct uma_memory_provider_ops_t *ops, void *params,
                         uma_memory_provider_handle_t *hProvider);
 
 ///
-/// \brief Destroys memory provider
+/// \brief Destroys memory provider.
 /// \param hPool handle to the memory provider
 ///
 void umaMemoryProviderDestroy(uma_memory_provider_handle_t hProvider);
 
 ///
 /// \brief Allocates size bytes of uninitialized storage from memory provider
-/// with
-///        specified alignment
+///        with specified alignment.
 /// \param hProvider handle to the memory provider
 /// \param size number of bytes to allocate
 /// \param alignment alignment of the allocation
-/// \param ptr will be updated with pointer to the allocated memory
-/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure
+/// \param ptr [out] pointer to the allocated memory
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 ///
 enum uma_result_t umaMemoryProviderAlloc(uma_memory_provider_handle_t hProvider,
                                          size_t size, size_t alignment,
                                          void **ptr);
 
 ///
-/// \brief Frees the memory space pointed by ptr from the memory provider
+/// \brief Frees the memory space pointed by ptr from the memory provider.
 /// \param hProvider handle to the memory provider
 /// \param ptr pointer to the allocated memory
 /// \param size size of the allocation
+/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 ///
 enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
                                         void *ptr, size_t size);
@@ -74,7 +75,7 @@ enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
 ///
 /// \param hProvider handle to the memory provider
 /// \param ppMessage [out] pointer to a string containing provider specific
-///        result in string representation.
+///        result in string representation
 /// \return UMA_RESULT_SUCCESS if the result being reported is to be considered
 ///         a warning. Any other result code returned indicates that the
 ///         adapter specific result is an error.
@@ -86,14 +87,14 @@ umaMemoryProviderGetLastResult(uma_memory_provider_handle_t hProvider,
 /// \brief Retrieve recommended page size for a given allocation size.
 /// \param hProvider handle to the memory provider
 /// \param size allocation size
-/// \param pageSize [out] will be updated with recommended page size.
+/// \param pageSize [out] will be updated with recommended page size
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 enum uma_result_t
 umaMemoryProviderGetRecommendedPageSize(uma_memory_provider_handle_t hProvider,
                                         size_t size, size_t *pageSize);
 
 ///
-/// \brief Retrieve minumum possible page size used by memory region referenced by given ptr
+/// \brief Retrieve minumum possible page size used by memory region referenced by given ptr.
 /// \param hProvider handle to the memory provider
 /// \param ptr pointer to memory allocated by this memory provider
 /// \param pageSize [out] will be updated with page size value.

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -24,15 +24,14 @@ struct uma_memory_provider_ops_t {
     uint32_t version;
 
     ///
-    /// \brief Intializes memory pool
+    /// \brief Intializes memory pool.
     /// \param params pool-specific params
     /// \param pool returns pointer to the pool
-    /// \return UMA_RESULT_SUCCESS on success or appropriate error code on
-    /// failure
+    /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
     enum uma_result_t (*initialize)(void *params, void **pool);
 
     ///
-    /// \brief Finalizes memory pool
+    /// \brief Finalizes memory pool.
     /// \param pool pool to finalize
     void (*finalize)(void *pool);
 


### PR DESCRIPTION
Improve Unified Memory Allocator doxygen comments:
* sentences that start with a capital letter should end with a dot.
* add missing [out] parameters
* add missing return descriptions