### PR TITLE
[ur] Replace hDriver param name with hPlatform

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -470,13 +470,13 @@ typedef enum ur_api_version_t {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hDriver`
+///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5751,7 +5751,7 @@ typedef struct ur_platform_create_with_native_handle_params_t {
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_platform_get_api_version_params_t {
-    ur_platform_handle_t *phDriver;
+    ur_platform_handle_t *phPlatform;
     ur_api_version_t **ppVersion;
 } ur_platform_get_api_version_params_t;
 

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -121,7 +121,7 @@ details:
     - "The implementation of this function should be lock-free."
 params:
     - type: $x_platform_handle_t
-      name: hDriver
+      name: hPlatform
       desc: "[in] handle of the platform"
     - type: "$x_api_version_t*"
       name: pVersion

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -119,15 +119,15 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
 __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetApiVersion = d_context.urDdiTable.Platform.pfnGetApiVersion;
     if (nullptr != pfnGetApiVersion) {
-        result = pfnGetApiVersion(hDriver, pVersion);
+        result = pfnGetApiVersion(hPlatform, pVersion);
     } else {
         // generic implementation
     }

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -10395,9 +10395,9 @@ inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_platform_get_api_version_params_t *params) {
 
-    os << ".hDriver = ";
+    os << ".hPlatform = ";
 
-    ur_params::serializePtr(os, *(params->phDriver));
+    ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
     os << ".pVersion = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -131,8 +131,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
 __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
 ) {
     auto pfnGetApiVersion = context.urDdiTable.Platform.pfnGetApiVersion;
 
@@ -140,12 +140,12 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_get_api_version_params_t params = {&hDriver, &pVersion};
+    ur_platform_get_api_version_params_t params = {&hPlatform, &pVersion};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_PLATFORM_GET_API_VERSION,
                              "urPlatformGetApiVersion", &params);
 
-    ur_result_t result = pfnGetApiVersion(hDriver, pVersion);
+    ur_result_t result = pfnGetApiVersion(hPlatform, pVersion);
 
     context.notify_end(UR_FUNCTION_PLATFORM_GET_API_VERSION,
                        "urPlatformGetApiVersion", &params, &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -131,8 +131,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
 __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
 ) {
     auto pfnGetApiVersion = context.urDdiTable.Platform.pfnGetApiVersion;
 
@@ -141,7 +141,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     }
 
     if (context.enableParameterValidation) {
-        if (NULL == hDriver) {
+        if (NULL == hPlatform) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
@@ -150,7 +150,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
         }
     }
 
-    ur_result_t result = pfnGetApiVersion(hDriver, pVersion);
+    ur_result_t result = pfnGetApiVersion(hPlatform, pVersion);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -174,23 +174,24 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
 __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_platform_object_t *>(hDriver)->dditable;
+    auto dditable =
+        reinterpret_cast<ur_platform_object_t *>(hPlatform)->dditable;
     auto pfnGetApiVersion = dditable->ur.Platform.pfnGetApiVersion;
     if (nullptr == pfnGetApiVersion) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hDriver = reinterpret_cast<ur_platform_object_t *>(hDriver)->handle;
+    hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
 
     // forward to device-platform
-    result = pfnGetApiVersion(hDriver, pVersion);
+    result = pfnGetApiVersion(hPlatform, pVersion);
 
     return result;
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -178,12 +178,12 @@ ur_result_t UR_APICALL urPlatformGetInfo(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hDriver`
+///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
 ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
     ) try {
     auto pfnGetApiVersion =
         ur_lib::context->urDdiTable.Platform.pfnGetApiVersion;
@@ -191,7 +191,7 @@ ur_result_t UR_APICALL urPlatformGetApiVersion(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetApiVersion(hDriver, pVersion);
+    return pfnGetApiVersion(hPlatform, pVersion);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -142,12 +142,12 @@ ur_result_t UR_APICALL urPlatformGetInfo(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hDriver`
+///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pVersion`
 ur_result_t UR_APICALL urPlatformGetApiVersion(
-    ur_platform_handle_t hDriver, ///< [in] handle of the platform
-    ur_api_version_t *pVersion    ///< [out] api version
+    ur_platform_handle_t hPlatform, ///< [in] handle of the platform
+    ur_api_version_t *pVersion      ///< [out] api version
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/tools/urtrace/null_hello.match
+++ b/test/tools/urtrace/null_hello.match
@@ -2,7 +2,7 @@ urInit(.device_flags = 0) -> UR_RESULT_SUCCESS;
 Platform initialized.
 urPlatformGet(.NumEntries = 1, .phPlatforms = [], .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS;
 urPlatformGet(.NumEntries = 1, .phPlatforms = [{{.*}}], .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS;
-urPlatformGetApiVersion(.hDriver = {{.*}}, .pVersion = {{.*}} ({{.*}})) -> UR_RESULT_SUCCESS;
+urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} ({{.*}})) -> UR_RESULT_SUCCESS;
 API version: {{.*}}
 urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = [], .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS;
 urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = [{{.*}}], .pNumDevices = nullptr) -> UR_RESULT_SUCCESS;

--- a/test/tools/urtrace/null_hello_begin.match
+++ b/test/tools/urtrace/null_hello_begin.match
@@ -5,8 +5,8 @@ begin(2) - urPlatformGet(.NumEntries = 1, .phPlatforms = [], .pNumPlatforms = {{
 end(2) - urPlatformGet(.NumEntries = 1, .phPlatforms = [], .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS;
 begin(3) - urPlatformGet(.NumEntries = 1, .phPlatforms = [nullptr], .pNumPlatforms = nullptr);
 end(3) - urPlatformGet(.NumEntries = 1, .phPlatforms = [{{.*}}], .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS;
-begin(4) - urPlatformGetApiVersion(.hDriver = {{.*}}, .pVersion = {{.*}} (0.0));
-end(4) - urPlatformGetApiVersion(.hDriver = {{.*}}, .pVersion = {{.*}} (0.6)) -> UR_RESULT_SUCCESS;
+begin(4) - urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.0));
+end(4) - urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.6)) -> UR_RESULT_SUCCESS;
 API version: {{.*}}
 begin(5) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = [], .pNumDevices = {{.*}} (0));
 end(5) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = [], .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS;

--- a/test/tools/urtrace/null_hello_profiling.match
+++ b/test/tools/urtrace/null_hello_profiling.match
@@ -2,7 +2,7 @@ urInit(.device_flags = 0) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 Platform initialized.
 urPlatformGet(.NumEntries = 1, .phPlatforms = [], .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 urPlatformGet(.NumEntries = 1, .phPlatforms = [{{.*}}], .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
-urPlatformGetApiVersion(.hDriver = {{.*}}, .pVersion = {{.*}} ({{.*}})) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
+urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} ({{.*}})) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 API version: {{.*}}
 urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = [], .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = [{{.*}}], .pNumDevices = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)


### PR DESCRIPTION
Fixup an `hDriver` parameter name in the `urPlatformGetApiVersion` entry
point which should be `hPlatform` since UR does not include the concept
of a driver object.
