### PR TITLE
fix use of undeclared identifier 'malloc'/'free'

### DIFF
--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <mutex>
 #include <shared_mutex>
+#include <stdlib.h>
 
 // TODO: reimplement in C and optimize...
 struct uma_memory_tracker_t {


### PR DESCRIPTION
glibc 2.37, gcc (GCC) 13.1.1 20230429