### PR TITLE
[urtrace] add json output support

### DIFF
--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -19,6 +19,15 @@
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#include <windows.h>
+inline int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
+#else
+
+#include <unistd.h>
+inline int ur_getpid(void) { return static_cast<int>(getpid()); }
+#endif
+
 /* for compatibility with non-clang compilers */
 #if defined(__has_feature)
 #define CLANG_HAS_FEATURE(x) __has_feature(x)

--- a/test/tools/urtrace/CMakeLists.txt
+++ b/test/tools/urtrace/CMakeLists.txt
@@ -22,3 +22,4 @@ add_trace_test(null_hello_no_args "--libpath $<TARGET_FILE_DIR:ur_adapter_null> 
 add_trace_test(null_hello_filter_device "--libpath $<TARGET_FILE_DIR:ur_adapter_null> --null --filter \".*Device.*\"")
 add_trace_test(null_hello_profiling "--libpath $<TARGET_FILE_DIR:ur_adapter_null> --null --profiling --time-unit ns")
 add_trace_test(null_hello_begin "--libpath $<TARGET_FILE_DIR:ur_adapter_null> --null --print-begin")
+add_trace_test(null_hello_json "--libpath $<TARGET_FILE_DIR:ur_adapter_null> --null --json")

--- a/test/tools/urtrace/null_hello_json.match
+++ b/test/tools/urtrace/null_hello_json.match
@@ -1,0 +1,17 @@
+{
+ "traceEvents": [
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urInit",            "args": "(.device_flags = 0)"        },
+Platform initialized.
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGet",            "args": "(.NumEntries = 1, .phPlatforms = [], .pNumPlatforms = {{.*}} (1))"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGet",            "args": "(.NumEntries = 1, .phPlatforms = [{{.*}}], .pNumPlatforms = nullptr)"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGetApiVersion",            "args": "(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.6))"        },
+API version: 0.6
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGet",            "args": "(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = [], .pNumDevices = {{.*}} (1))"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGet",            "args": "(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = [{{.*}}], .pNumDevices = nullptr)"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGetInfo",            "args": "(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = 4, .pPropValue = {{.*}} (UR_DEVICE_TYPE_GPU), .pPropSizeRet = nullptr)"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGetInfo",            "args": "(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = 1023, .pPropValue = {{.*}} (Null Device), .pPropSizeRet = nullptr)"        },
+Found a Null Device gpu.
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urTearDown",            "args": "(.pParams = nullptr)"        },
+{"name": "", "cat": "", "ph": "", "pid": "", "tid": "", "ts": ""}
+]
+}

--- a/tools/urtrace/README.md
+++ b/tools/urtrace/README.md
@@ -1,6 +1,6 @@
 # Unified Runtime tracing tool
 
-urtrace is a command-line tool for tracing and profiling Unified Runtime library
+`urtrace` is a command-line tool for tracing and profiling Unified Runtime library
 calls in a process. It can be used to inspect the function arguments of each call,
 and provides options for filtering, output formatting, and profiling.
 
@@ -10,10 +10,15 @@ is responsible for handling the performance-sensitive aspects of the tool,
 such as profiling and function tracing. The necessary arguments from the
 Python CLI to the C++ collector are passed through an environment variable.
 
-The urtrace tool requires unified runtime loader to be built with XPTI support
+The `urtrace` tool requires unified runtime loader to be built with XPTI support
 and that the xptifw is present in the system in a location where urtrace can find
 it. The locations where the tool looks for dynamic libraries, such as xptifw, can
 be specified with the option `--libpath`.
+
+It's also possible to configure `urtrace` to output JSON traces in the
+[Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#).
+These traces can be used with tools like [speedscope](https://www.speedscope.app/) to create
+visual representation of the profiling data.
 
 See [XPTI framework github repository](https://github.com/intel/llvm/tree/sycl/xptifw) for more information.
 
@@ -23,13 +28,16 @@ See `urtrace --help` to get detailed information on its usage.
 Here are a few examples:
 
 ### Trace all UR calls made by `./myapp --my-arg`
-urtrace ./myapp --my-arg
+`$ urtrace ./myapp --my-arg`
 
-### Trace and profile only UR functions that match the regex ".*(Device|Platform).*"
-urtrace --profiling --filter ".*(Device|Platform).*" ./hello_world
+### Trace and profile only UR functions that match the regex `".*(Device|Platform).*"`
+`$ urtrace --profiling --filter ".*(Device|Platform).*" ./hello_world`
 
 ### Use a custom adapter and also trace function begins
-urtrace --adapter libur_adapter_cuda.so --begin ./sycl_app
+`$ urtrace --adapter libur_adapter_cuda.so --begin ./sycl_app`
 
 ### Force load the null adapter and look for it in a custom path
-urtrace --null --libpath /opt/custom/ ./foo
+`$ urtrace --null --libpath /opt/custom/ ./foo`
+
+### Trace UR calls made by `./myapp --my-arg` and write JSON traces to a file
+`$ urtrace --json --file myapp.perf ./myapp --my-arg`

--- a/tools/urtrace/urtrace
+++ b/tools/urtrace/urtrace
@@ -46,6 +46,7 @@ parser.add_argument("--profiling", help="Measure function execution time.", acti
 parser.add_argument("--filter", help="Only trace functions that match the provided regex filter.")
 parser.add_argument("--null", help="Force the use of the null adapter.", action="store_true")
 parser.add_argument("--adapter", help="Force the use of the provided adapter.", action="append", default=[])
+parser.add_argument("--json", help="Write output in a JSON Trace Event Format.", action="store_true")
 group = parser.add_mutually_exclusive_group()
 group.add_argument("--file", help="Write trace output to a file with the given name instead of stderr.")
 group.add_argument("--stdout", help="Write trace output to stdout instead of stderr.", action="store_true")
@@ -73,6 +74,8 @@ if args.filter:
     collector_args += "filter:" + args.filter + ";"
 if args.no_args:
     collector_args += "no_args;"
+if args.json:
+    collector_args += "json;"
 env['UR_COLLECTOR_ARGS'] = collector_args
 
 log_collector = ""


### PR DESCRIPTION
This is to match a similar functionality in `sycl-prof` that's based on PI.

![left-heavy](https://github.com/oneapi-src/unified-runtime/assets/8775610/1638a5ed-0ce0-4704-b1f6-66fb7cb75552)
![urtrace-sandwich](https://github.com/oneapi-src/unified-runtime/assets/8775610/5ef9bb9f-9802-4905-8398-cac936af74aa)
