### PR TITLE
[ur] Make urPlatformCreateWithNativeHandle extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -220,6 +220,7 @@ class ur_structure_type_v(IntEnum):
     QUEUE_NATIVE_PROPERTIES = 18                    ## ::ur_queue_native_properties_t
     MEM_NATIVE_PROPERTIES = 19                      ## ::ur_mem_native_properties_t
     EVENT_NATIVE_PROPERTIES = 20                    ## ::ur_event_native_properties_t
+    PLATFORM_NATIVE_PROPERTIES = 21                 ## ::ur_platform_native_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -309,6 +310,18 @@ class ur_api_version_t(c_int):
     def __str__(self):
         return str(ur_api_version_v(self.value))
 
+
+###############################################################################
+## @brief Native platform creation properties
+class ur_platform_native_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("isNativeHandleOwned", c_bool)                                 ## [in] Indicates UR owns the native handle or if it came from an
+                                                                        ## interoperability operation in the application that asked to not
+                                                                        ## transfer the ownership to the unified-runtime.
+    ]
 
 ###############################################################################
 ## @brief Identifies native backend adapters
@@ -1755,9 +1768,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urPlatformCreateWithNativeHandle
 if __use_win_types:
-    _urPlatformCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, POINTER(ur_platform_handle_t) )
+    _urPlatformCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, POINTER(ur_platform_native_properties_t), POINTER(ur_platform_handle_t) )
 else:
-    _urPlatformCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, POINTER(ur_platform_handle_t) )
+    _urPlatformCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, POINTER(ur_platform_native_properties_t), POINTER(ur_platform_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urPlatformGetApiVersion

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -244,6 +244,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES = 18,         ///< ::ur_queue_native_properties_t
     UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES = 19,           ///< ::ur_mem_native_properties_t
     UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES = 20,         ///< ::ur_event_native_properties_t
+    UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES = 21,      ///< ::ur_platform_native_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -506,6 +507,18 @@ urPlatformGetNativeHandle(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Native platform creation properties
+typedef struct ur_platform_native_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
+                               ///< interoperability operation in the application that asked to not
+                               ///< transfer the ownership to the unified-runtime.
+
+} ur_platform_native_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime platform object from native platform handle.
 ///
 /// @details
@@ -524,8 +537,9 @@ urPlatformGetNativeHandle(
 ///         + `NULL == phPlatform`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, ///< [in] the native handle of the platform.
-    ur_platform_handle_t *phPlatform    ///< [out] pointer to the handle of the platform object created.
+    ur_native_handle_t hNativePlatform,                 ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *pProperties, ///< [in][optional] pointer to native platform properties struct.
+    ur_platform_handle_t *phPlatform                    ///< [out] pointer to the handle of the platform object created.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5745,6 +5759,7 @@ typedef struct ur_platform_get_native_handle_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_platform_create_with_native_handle_params_t {
     ur_native_handle_t *phNativePlatform;
+    const ur_platform_native_properties_t **ppProperties;
     ur_platform_handle_t **pphPlatform;
 } ur_platform_create_with_native_handle_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -45,6 +45,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetNativeHandle_t)(
 /// @brief Function-pointer for urPlatformCreateWithNativeHandle
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
     ur_native_handle_t,
+    const ur_platform_native_properties_t *,
     ur_platform_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -304,6 +304,8 @@ etors:
       desc: $x_mem_native_properties_t
     - name: EVENT_NATIVE_PROPERTIES
       desc: $x_event_native_properties_t
+    - name: PLATFORM_NATIVE_PROPERTIES
+      desc: $x_platform_native_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -148,6 +148,19 @@ params:
       desc: |
             [out] a pointer to the native handle of the platform.
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Native platform creation properties"
+class: $xPlatform
+name: $x_platform_native_properties_t
+base: $x_base_properties_t
+members:
+    - type: bool
+      name: isNativeHandleOwned
+      desc: >
+          [in] Indicates UR owns the native handle or if it came from an
+          interoperability operation in the application that asked to not
+          transfer the ownership to the unified-runtime.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create runtime platform object from native platform handle."
 class: $xPlatform
@@ -161,12 +174,13 @@ details:
 params:
     - type: $x_native_handle_t
       name: hNativePlatform
-      desc: |
-            [in] the native handle of the platform.
+      desc: "[in] the native handle of the platform."
+    - type: const $x_platform_native_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to native platform properties struct."
     - type: "$x_platform_handle_t*"
       name: phPlatform
-      desc: |
-            [out] pointer to the handle of the platform object created.
+      desc: "[out] pointer to the handle of the platform object created."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get the platform specific compiler backend option from a generic frontend option."

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -166,6 +166,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
         phPlatform ///< [out] pointer to the handle of the platform object created.
     ) try {
@@ -175,7 +177,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
-        result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
+        result =
+            pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
     } else {
         // generic implementation
         *phPlatform = reinterpret_cast<ur_platform_handle_t>(d_context.get());

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -131,6 +131,9 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_platform_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_platform_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_platform_backend_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -638,6 +641,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -769,6 +776,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES: {
         const ur_event_native_properties_t *pstruct =
             (const ur_event_native_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES: {
+        const ur_platform_native_properties_t *pstruct =
+            (const ur_platform_native_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -1043,6 +1056,28 @@ serializeTaggedTyped_ur_platform_info_t(std::ostream &os, const void *ptr,
 } // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value) {
     os << UR_MAJOR_VERSION(value) << "." << UR_MINOR_VERSION(value);
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_platform_native_properties_t params) {
+    os << "(struct ur_platform_native_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".isNativeHandleOwned = ";
+
+    os << (params.isNativeHandleOwned);
+
+    os << "}";
     return os;
 }
 inline std::ostream &operator<<(std::ostream &os,
@@ -10400,6 +10435,11 @@ inline std::ostream &operator<<(
     os << ".hNativePlatform = ";
 
     ur_params::serializePtr(os, *(params->phNativePlatform));
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
     os << ".phPlatform = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -185,6 +185,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
         phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
@@ -195,13 +197,14 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_create_with_native_handle_params_t params = {&hNativePlatform,
-                                                             &phPlatform};
+    ur_platform_create_with_native_handle_params_t params = {
+        &hNativePlatform, &pProperties, &phPlatform};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE,
                              "urPlatformCreateWithNativeHandle", &params);
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
 
     context.notify_end(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE,
                        "urPlatformCreateWithNativeHandle", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -188,6 +188,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
         phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
@@ -208,7 +210,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
         }
     }
 
-    ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
+    ur_result_t result =
+        pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -239,6 +239,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
         phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {
@@ -258,7 +260,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
         reinterpret_cast<ur_native_object_t *>(hNativePlatform)->handle;
 
     // forward to device-platform
-    result = pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
+    result =
+        pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -252,6 +252,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
         phPlatform ///< [out] pointer to the handle of the platform object created.
     ) try {
@@ -261,7 +263,7 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithNativeHandle(hNativePlatform, phPlatform);
+    return pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -202,6 +202,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in] the native handle of the platform.
+    const ur_platform_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
         phPlatform ///< [out] pointer to the handle of the platform object created.
 ) {


### PR DESCRIPTION
Introduces the `ur_platform_native_properties_t` struct which may be
passed into `urPlatformCreateWithNativeHandle`. This enables
extensibility of platform creation from native handles.

Relates to #392.
