### PR TITLE
[ur] Make urDeviceCreateWithNativeHandle extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -221,6 +221,7 @@ class ur_structure_type_v(IntEnum):
     MEM_NATIVE_PROPERTIES = 19                      ## ::ur_mem_native_properties_t
     EVENT_NATIVE_PROPERTIES = 20                    ## ::ur_event_native_properties_t
     PLATFORM_NATIVE_PROPERTIES = 21                 ## ::ur_platform_native_properties_t
+    DEVICE_NATIVE_PROPERTIES = 22                   ## ::ur_device_native_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -662,6 +663,18 @@ class ur_device_affinity_domain_flags_t(c_int):
     def __str__(self):
         return hex(self.value)
 
+
+###############################################################################
+## @brief Native device creation properties
+class ur_device_native_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("isNativeHandleOwned", c_bool)                                 ## [in] Indicates UR owns the native handle or if it came from an
+                                                                        ## interoperability operation in the application that asked to not
+                                                                        ## transfer the ownership to the unified-runtime.
+    ]
 
 ###############################################################################
 ## @brief Memory order capabilities
@@ -2737,9 +2750,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urDeviceCreateWithNativeHandle
 if __use_win_types:
-    _urDeviceCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, ur_platform_handle_t, POINTER(ur_device_handle_t) )
+    _urDeviceCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, ur_platform_handle_t, POINTER(ur_device_native_properties_t), POINTER(ur_device_handle_t) )
 else:
-    _urDeviceCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, ur_platform_handle_t, POINTER(ur_device_handle_t) )
+    _urDeviceCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, ur_platform_handle_t, POINTER(ur_device_native_properties_t), POINTER(ur_device_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urDeviceGetGlobalTimestamps

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -245,6 +245,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES = 19,           ///< ::ur_mem_native_properties_t
     UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES = 20,         ///< ::ur_event_native_properties_t
     UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES = 21,      ///< ::ur_platform_native_properties_t
+    UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES = 22,        ///< ::ur_device_native_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1204,6 +1205,18 @@ urDeviceGetNativeHandle(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Native device creation properties
+typedef struct ur_device_native_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
+                               ///< interoperability operation in the application that asked to not
+                               ///< transfer the ownership to the unified-runtime.
+
+} ur_device_native_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime device object from native device handle.
 ///
 /// @details
@@ -1223,9 +1236,10 @@ urDeviceGetNativeHandle(
 ///         + `NULL == phDevice`
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceCreateWithNativeHandle(
-    ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
-    ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
-    ur_device_handle_t *phDevice      ///< [out] pointer to the handle of the device object created.
+    ur_native_handle_t hNativeDevice,                 ///< [in] the native handle of the device.
+    ur_platform_handle_t hPlatform,                   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *pProperties, ///< [in][optional] pointer to native device properties struct.
+    ur_device_handle_t *phDevice                      ///< [out] pointer to the handle of the device object created.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7056,6 +7070,7 @@ typedef struct ur_device_get_native_handle_params_t {
 typedef struct ur_device_create_with_native_handle_params_t {
     ur_native_handle_t *phNativeDevice;
     ur_platform_handle_t *phPlatform;
+    const ur_device_native_properties_t **ppProperties;
     ur_device_handle_t **pphDevice;
 } ur_device_create_with_native_handle_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1400,6 +1400,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnDeviceGetNativeHandle_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnDeviceCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_platform_handle_t,
+    const ur_device_native_properties_t *,
     ur_device_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -306,6 +306,8 @@ etors:
       desc: $x_event_native_properties_t
     - name: PLATFORM_NATIVE_PROPERTIES
       desc: $x_platform_native_properties_t
+    - name: DEVICE_NATIVE_PROPERTIES
+      desc: $x_device_native_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -679,6 +679,19 @@ params:
       desc: |
             [out] a pointer to the native handle of the device.
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Native device creation properties"
+class: $xDevice
+name: $x_device_native_properties_t
+base: $x_base_properties_t
+members:
+    - type: bool
+      name: isNativeHandleOwned
+      desc: >
+          [in] Indicates UR owns the native handle or if it came from an
+          interoperability operation in the application that asked to not
+          transfer the ownership to the unified-runtime.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create runtime device object from native device handle."
 class: $xDevice
@@ -692,15 +705,16 @@ details:
 params:
     - type: $x_native_handle_t
       name: hNativeDevice
-      desc: |
-            [in] the native handle of the device.
+      desc: "[in] the native handle of the device."
     - type: $x_platform_handle_t
       name: hPlatform
       desc: "[in] handle of the platform instance"
+    - type: const $x_device_native_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to native device properties struct."
     - type: "$x_device_handle_t*"
       name: phDevice
-      desc: |
-            [out] pointer to the handle of the device object created.
+      desc: "[out] pointer to the handle of the device object created."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Returns synchronized Host and Device global timestamps."

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -442,6 +442,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native device properties struct.
     ur_device_handle_t
         *phDevice ///< [out] pointer to the handle of the device object created.
     ) try {
@@ -451,7 +453,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Device.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
-        result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
+        result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform,
+                                           pProperties, phDevice);
     } else {
         // generic implementation
         *phDevice = reinterpret_cast<ur_device_handle_t>(d_context.get());

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -152,6 +152,8 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_exec_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_affinity_domain_flag_t value);
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_device_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_memory_order_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -645,6 +647,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -782,6 +788,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES: {
         const ur_platform_native_properties_t *pstruct =
             (const ur_platform_native_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES: {
+        const ur_device_native_properties_t *pstruct =
+            (const ur_device_native_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -3542,6 +3554,28 @@ inline void serializeFlag_ur_device_affinity_domain_flags_t(
     }
 }
 } // namespace ur_params
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_device_native_properties_t params) {
+    os << "(struct ur_device_native_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".isNativeHandleOwned = ";
+
+    os << (params.isNativeHandleOwned);
+
+    os << "}";
+    return os;
+}
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_memory_order_capability_flag_t value) {
     switch (value) {
@@ -11426,6 +11460,11 @@ operator<<(std::ostream &os,
     os << ".hPlatform = ";
 
     ur_params::serializePtr(os, *(params->phPlatform));
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
     os << ".phDevice = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -491,6 +491,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native device properties struct.
     ur_device_handle_t
         *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
@@ -502,13 +504,13 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     }
 
     ur_device_create_with_native_handle_params_t params = {
-        &hNativeDevice, &hPlatform, &phDevice};
+        &hNativeDevice, &hPlatform, &pProperties, &phDevice};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE,
                              "urDeviceCreateWithNativeHandle", &params);
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform,
+                                                   pProperties, phDevice);
 
     context.notify_end(UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE,
                        "urDeviceCreateWithNativeHandle", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -525,6 +525,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native device properties struct.
     ur_device_handle_t
         *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
@@ -549,8 +551,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
         }
     }
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform,
+                                                   pProperties, phDevice);
 
     if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
         refCountContext.createRefCount(*phDevice);

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -587,6 +587,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native device properties struct.
     ur_device_handle_t
         *phDevice ///< [out] pointer to the handle of the device object created.
 ) {
@@ -609,7 +611,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     hPlatform = reinterpret_cast<ur_platform_object_t *>(hPlatform)->handle;
 
     // forward to device-platform
-    result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
+    result = pfnCreateWithNativeHandle(hNativeDevice, hPlatform, pProperties,
+                                       phDevice);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -669,6 +669,8 @@ ur_result_t UR_APICALL urDeviceGetNativeHandle(
 ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native device properties struct.
     ur_device_handle_t
         *phDevice ///< [out] pointer to the handle of the device object created.
     ) try {
@@ -678,7 +680,8 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithNativeHandle(hNativeDevice, hPlatform, phDevice);
+    return pfnCreateWithNativeHandle(hNativeDevice, hPlatform, pProperties,
+                                     phDevice);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -555,6 +555,8 @@ ur_result_t UR_APICALL urDeviceGetNativeHandle(
 ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ///< [in] the native handle of the device.
     ur_platform_handle_t hPlatform,   ///< [in] handle of the platform instance
+    const ur_device_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native device properties struct.
     ur_device_handle_t
         *phDevice ///< [out] pointer to the handle of the device object created.
 ) {

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -8,5 +8,5 @@ TEST_F(urDeviceCreateWithNativeHandleTest, InvalidNullHandleNativeDevice) {
     ur_device_handle_t device = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urDeviceCreateWithNativeHandle(nullptr, platform, &device));
+        urDeviceCreateWithNativeHandle(nullptr, platform, nullptr, &device));
 }

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -14,8 +14,8 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
         // We can however convert the native_handle back into a unified-runtime handle
         // and perform some query on it to verify that it works.
         ur_device_handle_t dev = nullptr;
-        ASSERT_SUCCESS(
-            urDeviceCreateWithNativeHandle(native_handle, platform, &dev));
+        ASSERT_SUCCESS(urDeviceCreateWithNativeHandle(native_handle, platform,
+                                                      nullptr, &dev));
         ASSERT_NE(dev, nullptr);
 
         uint32_t dev_id = 0;


### PR DESCRIPTION
Introduces the `ur_device_native_properties_t` struct which may be
passed into `urDeviceCreateWithNativeHandle`. This enables extensibility
of platform creation from native handles.

Relates to #392.
