### PR TITLE
[ur] Make urProgramCreateWithNativeHandle extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -222,6 +222,7 @@ class ur_structure_type_v(IntEnum):
     EVENT_NATIVE_PROPERTIES = 20                    ## ::ur_event_native_properties_t
     PLATFORM_NATIVE_PROPERTIES = 21                 ## ::ur_platform_native_properties_t
     DEVICE_NATIVE_PROPERTIES = 22                   ## ::ur_device_native_properties_t
+    PROGRAM_NATIVE_PROPERTIES = 23                  ## ::ur_program_native_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -1330,6 +1331,18 @@ class ur_specialization_constant_info_t(Structure):
     ]
 
 ###############################################################################
+## @brief Native program creation properties
+class ur_program_native_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("isNativeHandleOwned", c_bool)                                 ## [in] Indicates UR owns the native handle or if it came from an
+                                                                        ## interoperability operation in the application that asked to not
+                                                                        ## transfer the ownership to the unified-runtime.
+    ]
+
+###############################################################################
 ## @brief Get Kernel object information
 class ur_kernel_info_v(IntEnum):
     FUNCTION_NAME = 0                               ## [char[]] Return null-terminated kernel function name.
@@ -2033,9 +2046,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urProgramCreateWithNativeHandle
 if __use_win_types:
-    _urProgramCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_program_handle_t) )
+    _urProgramCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_program_native_properties_t), POINTER(ur_program_handle_t) )
 else:
-    _urProgramCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_program_handle_t) )
+    _urProgramCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_program_native_properties_t), POINTER(ur_program_handle_t) )
 
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -246,6 +246,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES = 20,         ///< ::ur_event_native_properties_t
     UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES = 21,      ///< ::ur_platform_native_properties_t
     UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES = 22,        ///< ::ur_device_native_properties_t
+    UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES = 23,       ///< ::ur_program_native_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3246,6 +3247,18 @@ urProgramGetNativeHandle(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Native program creation properties
+typedef struct ur_program_native_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
+                               ///< interoperability operation in the application that asked to not
+                               ///< transfer the ownership to the unified-runtime.
+
+} ur_program_native_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime program object from native program handle.
 ///
 /// @details
@@ -3265,9 +3278,10 @@ urProgramGetNativeHandle(
 ///         + `NULL == phProgram`
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreateWithNativeHandle(
-    ur_native_handle_t hNativeProgram, ///< [in] the native handle of the program.
-    ur_context_handle_t hContext,      ///< [in] handle of the context instance
-    ur_program_handle_t *phProgram     ///< [out] pointer to the handle of the program object created.
+    ur_native_handle_t hNativeProgram,                 ///< [in] the native handle of the program.
+    ur_context_handle_t hContext,                      ///< [in] handle of the context instance
+    const ur_program_native_properties_t *pProperties, ///< [in][optional] pointer to native program properties struct.
+    ur_program_handle_t *phProgram                     ///< [out] pointer to the handle of the program object created.
 );
 
 #if !defined(__GNUC__)
@@ -6081,6 +6095,7 @@ typedef struct ur_program_get_native_handle_params_t {
 typedef struct ur_program_create_with_native_handle_params_t {
     ur_native_handle_t *phNativeProgram;
     ur_context_handle_t *phContext;
+    const ur_program_native_properties_t **ppProperties;
     ur_program_handle_t **pphProgram;
 } ur_program_create_with_native_handle_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -362,6 +362,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnProgramGetNativeHandle_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnProgramCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
+    const ur_program_native_properties_t *,
     ur_program_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -308,6 +308,8 @@ etors:
       desc: $x_platform_native_properties_t
     - name: DEVICE_NATIVE_PROPERTIES
       desc: $x_device_native_properties_t
+    - name: PROGRAM_NATIVE_PROPERTIES
+      desc: $x_program_native_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -494,6 +494,19 @@ params:
       desc: |
             [out] a pointer to the native handle of the program.
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Native program creation properties"
+class: $xProgram
+name: $x_program_native_properties_t
+base: $x_base_properties_t
+members:
+    - type: bool
+      name: isNativeHandleOwned
+      desc: >
+          [in] Indicates UR owns the native handle or if it came from an
+          interoperability operation in the application that asked to not
+          transfer the ownership to the unified-runtime.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create runtime program object from native program handle."
 class: $xProgram
@@ -507,12 +520,13 @@ details:
 params:
     - type: $x_native_handle_t
       name: hNativeProgram
-      desc: |
-            [in] the native handle of the program.
+      desc: "[in] the native handle of the program."
     - type: $x_context_handle_t
       name: hContext
       desc: "[in] handle of the context instance"
+    - type: const $x_program_native_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to native program properties struct."
     - type: "$x_program_handle_t*"
       name: phProgram
-      desc: |
-            [out] pointer to the handle of the program object created.
+      desc: "[out] pointer to the handle of the program object created."

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -1594,6 +1594,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram,           ///< [in] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const ur_program_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native program properties struct.
     ur_program_handle_t *
         phProgram ///< [out] pointer to the handle of the program object created.
     ) try {
@@ -1603,7 +1605,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Program.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
-        result = pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
+        result = pfnCreateWithNativeHandle(hNativeProgram, hContext,
+                                           pProperties, phProgram);
     } else {
         // generic implementation
         *phProgram = reinterpret_cast<ur_program_handle_t>(d_context.get());

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -239,6 +239,9 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_specialization_constant_info_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_program_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_kernel_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_group_info_t value);
@@ -651,6 +654,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -794,6 +801,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES: {
         const ur_device_native_properties_t *pstruct =
             (const ur_device_native_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES: {
+        const ur_program_native_properties_t *pstruct =
+            (const ur_program_native_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -6126,6 +6139,28 @@ operator<<(std::ostream &os,
     os << "}";
     return os;
 }
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_program_native_properties_t params) {
+    os << "(struct ur_program_native_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".isNativeHandleOwned = ";
+
+    os << (params.isNativeHandleOwned);
+
+    os << "}";
+    return os;
+}
 inline std::ostream &operator<<(std::ostream &os, enum ur_kernel_info_t value) {
     switch (value) {
 
@@ -10833,6 +10868,11 @@ operator<<(std::ostream &os,
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
     os << ".phProgram = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -1814,6 +1814,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram,           ///< [in] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const ur_program_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native program properties struct.
     ur_program_handle_t *
         phProgram ///< [out] pointer to the handle of the program object created.
 ) {
@@ -1825,13 +1827,13 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     }
 
     ur_program_create_with_native_handle_params_t params = {
-        &hNativeProgram, &hContext, &phProgram};
+        &hNativeProgram, &hContext, &pProperties, &phProgram};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE,
                              "urProgramCreateWithNativeHandle", &params);
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativeProgram, hContext,
+                                                   pProperties, phProgram);
 
     context.notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE,
                        "urProgramCreateWithNativeHandle", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2166,6 +2166,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram,           ///< [in] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const ur_program_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native program properties struct.
     ur_program_handle_t *
         phProgram ///< [out] pointer to the handle of the program object created.
 ) {
@@ -2190,8 +2192,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
         }
     }
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativeProgram, hContext,
+                                                   pProperties, phProgram);
 
     if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
         refCountContext.createRefCount(*phProgram);

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2136,6 +2136,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram,           ///< [in] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const ur_program_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native program properties struct.
     ur_program_handle_t *
         phProgram ///< [out] pointer to the handle of the program object created.
 ) {
@@ -2158,7 +2160,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
+    result = pfnCreateWithNativeHandle(hNativeProgram, hContext, pProperties,
+                                       phProgram);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2447,6 +2447,8 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram,           ///< [in] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const ur_program_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native program properties struct.
     ur_program_handle_t *
         phProgram ///< [out] pointer to the handle of the program object created.
     ) try {
@@ -2456,7 +2458,8 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithNativeHandle(hNativeProgram, hContext, phProgram);
+    return pfnCreateWithNativeHandle(hNativeProgram, hContext, pProperties,
+                                     phProgram);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2043,6 +2043,8 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram,           ///< [in] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
+    const ur_program_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native program properties struct.
     ur_program_handle_t *
         phProgram ///< [out] pointer to the handle of the program object created.
 ) {


### PR DESCRIPTION
Introduces the `ur_program_native_properties_t` struct which may be
passed into `urProgramCreateWithNativeHandle`. This enables
extensibility of platform creation from native handles.

Relates to #392.
