### PR TITLE
[ur] Make urSamplerCreateWithNativeHandle extensible

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -223,6 +223,7 @@ class ur_structure_type_v(IntEnum):
     PLATFORM_NATIVE_PROPERTIES = 21                 ## ::ur_platform_native_properties_t
     DEVICE_NATIVE_PROPERTIES = 22                   ## ::ur_device_native_properties_t
     PROGRAM_NATIVE_PROPERTIES = 23                  ## ::ur_program_native_properties_t
+    SAMPLER_NATIVE_PROPERTIES = 24                  ## ::ur_sampler_native_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -1051,6 +1052,18 @@ class ur_sampler_desc_t(Structure):
         ("normalizedCoords", c_bool),                                   ## [in] Specify if image coordinates are normalized (true) or not (false)
         ("addressingMode", ur_sampler_addressing_mode_t),               ## [in] Specify the address mode of the sampler
         ("filterMode", ur_sampler_filter_mode_t)                        ## [in] Specify the filter mode of the sampler
+    ]
+
+###############################################################################
+## @brief Native sampler creation properties
+class ur_sampler_native_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("isNativeHandleOwned", c_bool)                                 ## [in] Indicates UR owns the native handle or if it came from an
+                                                                        ## interoperability operation in the application that asked to not
+                                                                        ## transfer the ownership to the unified-runtime.
     ]
 
 ###############################################################################
@@ -2235,9 +2248,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urSamplerCreateWithNativeHandle
 if __use_win_types:
-    _urSamplerCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_sampler_handle_t) )
+    _urSamplerCreateWithNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_sampler_native_properties_t), POINTER(ur_sampler_handle_t) )
 else:
-    _urSamplerCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_sampler_handle_t) )
+    _urSamplerCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, ur_context_handle_t, POINTER(ur_sampler_native_properties_t), POINTER(ur_sampler_handle_t) )
 
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -247,6 +247,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES = 21,      ///< ::ur_platform_native_properties_t
     UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES = 22,        ///< ::ur_device_native_properties_t
     UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES = 23,       ///< ::ur_program_native_properties_t
+    UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES = 24,       ///< ::ur_sampler_native_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2320,6 +2321,18 @@ urSamplerGetNativeHandle(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Native sampler creation properties
+typedef struct ur_sampler_native_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
+                               ///< interoperability operation in the application that asked to not
+                               ///< transfer the ownership to the unified-runtime.
+
+} ur_sampler_native_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime sampler object from native sampler handle.
 ///
 /// @details
@@ -2339,9 +2352,10 @@ urSamplerGetNativeHandle(
 ///         + `NULL == phSampler`
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerCreateWithNativeHandle(
-    ur_native_handle_t hNativeSampler, ///< [in] the native handle of the sampler.
-    ur_context_handle_t hContext,      ///< [in] handle of the context object
-    ur_sampler_handle_t *phSampler     ///< [out] pointer to the handle of the sampler object created.
+    ur_native_handle_t hNativeSampler,                 ///< [in] the native handle of the sampler.
+    ur_context_handle_t hContext,                      ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *pProperties, ///< [in][optional] pointer to native sampler properties struct.
+    ur_sampler_handle_t *phSampler                     ///< [out] pointer to the handle of the sampler object created.
 );
 
 #if !defined(__GNUC__)
@@ -6310,6 +6324,7 @@ typedef struct ur_sampler_get_native_handle_params_t {
 typedef struct ur_sampler_create_with_native_handle_params_t {
     ur_native_handle_t *phNativeSampler;
     ur_context_handle_t *phContext;
+    const ur_sampler_native_properties_t **ppProperties;
     ur_sampler_handle_t **pphSampler;
 } ur_sampler_create_with_native_handle_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -594,6 +594,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnSamplerGetNativeHandle_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnSamplerCreateWithNativeHandle_t)(
     ur_native_handle_t,
     ur_context_handle_t,
+    const ur_sampler_native_properties_t *,
     ur_sampler_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -310,6 +310,8 @@ etors:
       desc: $x_device_native_properties_t
     - name: PROGRAM_NATIVE_PROPERTIES
       desc: $x_program_native_properties_t
+    - name: SAMPLER_NATIVE_PROPERTIES
+      desc: $x_sampler_native_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -186,6 +186,19 @@ params:
       desc: |
             [out] a pointer to the native handle of the sampler.
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Native sampler creation properties"
+class: $xSampler
+name: $x_sampler_native_properties_t
+base: $x_base_properties_t
+members:
+    - type: bool
+      name: isNativeHandleOwned
+      desc: >
+          [in] Indicates UR owns the native handle or if it came from an
+          interoperability operation in the application that asked to not
+          transfer the ownership to the unified-runtime.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Create runtime sampler object from native sampler handle."
 class: $xSampler
@@ -199,12 +212,13 @@ details:
 params:
     - type: $x_native_handle_t
       name: hNativeSampler
-      desc: |
-            [in] the native handle of the sampler.
+      desc: "[in] the native handle of the sampler."
     - type: $x_context_handle_t
       name: hContext
       desc: "[in] handle of the context object"
+    - type: const $x_sampler_native_properties_t*
+      name: pProperties
+      desc: "[in][optional] pointer to native sampler properties struct."
     - type: "$x_sampler_handle_t*"
       name: phSampler
-      desc: |
-            [out] pointer to the handle of the sampler object created.
+      desc: "[out] pointer to the handle of the sampler object created."

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -1069,6 +1069,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler,           ///< [in] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native sampler properties struct.
     ur_sampler_handle_t *
         phSampler ///< [out] pointer to the handle of the sampler object created.
     ) try {
@@ -1078,7 +1080,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Sampler.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
-        result = pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
+        result = pfnCreateWithNativeHandle(hNativeSampler, hContext,
+                                           pProperties, phSampler);
     } else {
         // generic implementation
         *phSampler = reinterpret_cast<ur_sampler_handle_t>(d_context.get());

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -200,6 +200,9 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os, enum ur_sampler_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_sampler_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_sampler_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_host_mem_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -658,6 +661,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -807,6 +814,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES: {
         const ur_program_native_properties_t *pstruct =
             (const ur_program_native_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES: {
+        const ur_sampler_native_properties_t *pstruct =
+            (const ur_sampler_native_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -5047,6 +5060,28 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ".filterMode = ";
 
     os << (params.filterMode);
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_sampler_native_properties_t params) {
+    os << "(struct ur_sampler_native_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".isNativeHandleOwned = ";
+
+    os << (params.isNativeHandleOwned);
 
     os << "}";
     return os;
@@ -11123,6 +11158,11 @@ operator<<(std::ostream &os,
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
     os << ".phSampler = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -1209,6 +1209,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler,           ///< [in] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native sampler properties struct.
     ur_sampler_handle_t *
         phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
@@ -1220,13 +1222,13 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     }
 
     ur_sampler_create_with_native_handle_params_t params = {
-        &hNativeSampler, &hContext, &phSampler};
+        &hNativeSampler, &hContext, &pProperties, &phSampler};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE,
                              "urSamplerCreateWithNativeHandle", &params);
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativeSampler, hContext,
+                                                   pProperties, phSampler);
 
     context.notify_end(UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE,
                        "urSamplerCreateWithNativeHandle", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1403,6 +1403,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler,           ///< [in] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native sampler properties struct.
     ur_sampler_handle_t *
         phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
@@ -1427,8 +1429,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
         }
     }
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativeSampler, hContext,
+                                                   pProperties, phSampler);
 
     if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
         refCountContext.createRefCount(*phSampler);

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1439,6 +1439,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler,           ///< [in] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native sampler properties struct.
     ur_sampler_handle_t *
         phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {
@@ -1461,7 +1463,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
+    result = pfnCreateWithNativeHandle(hNativeSampler, hContext, pProperties,
+                                       phSampler);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1614,6 +1614,8 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler,           ///< [in] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native sampler properties struct.
     ur_sampler_handle_t *
         phSampler ///< [out] pointer to the handle of the sampler object created.
     ) try {
@@ -1623,7 +1625,8 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithNativeHandle(hNativeSampler, hContext, phSampler);
+    return pfnCreateWithNativeHandle(hNativeSampler, hContext, pProperties,
+                                     phSampler);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1340,6 +1340,8 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler,           ///< [in] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_sampler_native_properties_t *
+        pProperties, ///< [in][optional] pointer to native sampler properties struct.
     ur_sampler_handle_t *
         phSampler ///< [out] pointer to the handle of the sampler object created.
 ) {


### PR DESCRIPTION
Introduces the `ur_sampler_native_properties_t` struct which may be
passed into `urSamplerCreateWithNativeHandle`. This enables
extensibility of platform creation from native handles.

Relates to #392.
