### PR TITLE
[ci] Add CodeQL scans

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: "CodeQL"
+
+on: [push, pull_request]
+
+jobs:
+  analyze-ubuntu:
+    name: Analyze on Ubuntu
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Install pip packages
+      run: pip install -r third_party/requirements.txt
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DUR_DEVELOPER_MODE=ON -DUR_BUILD_TESTS=ON -DUR_ENABLE_TRACING=ON -DUR_BUILD_TOOLS=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build -j $(nproc)
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"
+
+  analyze-windows:
+    name: Analyze on Windows
+    runs-on: windows-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Install pip packages
+      run: python3 -m pip install -r third_party/requirements.txt
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DUR_DEVELOPER_MODE=ON -DUR_BUILD_TESTS=ON -DUR_ENABLE_TRACING=ON -DUR_BUILD_TOOLS=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build -j $(nproc) --config Release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Add CodeQL scans to make it possible to catch issues during the PR refinement as opposed to Coverity scans, which can run on the main branch only.

A sample execution of this workflow: https://github.com/PatKamin/unified-runtime/actions/runs/5011460219/jobs/8982314529