### PR TITLE
[coverity] Fix Coverity minor performance issues

### DIFF
--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -15,11 +15,11 @@ namespace logger {
 Logger create_logger(std::string logger_name, bool skip_prefix = false);
 
 inline Logger &get_logger(std::string name = "common") {
-    static Logger logger = create_logger(name);
+    static Logger logger = create_logger(std::move(name));
     return logger;
 }
 
-inline void init(std::string name) { get_logger(name); }
+inline void init(std::string name) { get_logger(std::move(name)); }
 
 template <typename... Args>
 inline void debug(const char *format, Args &&...args) {
@@ -81,21 +81,21 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix) {
     try {
         auto map = getenv_to_map(env_var_name.str().c_str());
         if (!map.has_value()) {
-            return Logger(
-                std::make_unique<logger::StderrSink>(logger_name, skip_prefix));
+            return Logger(std::make_unique<logger::StderrSink>(
+                std::move(logger_name), skip_prefix));
         }
 
         auto kv = map->find("level");
         if (kv != map->end()) {
             auto value = kv->second.front();
-            level = str_to_level(value);
+            level = str_to_level(std::move(value));
             map->erase(kv);
         }
 
         kv = map->find("flush");
         if (kv != map->end()) {
             auto value = kv->second.front();
-            flush_level = str_to_level(value);
+            flush_level = str_to_level(std::move(value));
             map->erase(kv);
         }
 
@@ -110,8 +110,8 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix) {
             std::cerr << "Wrong logger environment variable parameter: '"
                       << map->begin()->first
                       << "'. Default logger options are set.";
-            return Logger(
-                std::make_unique<logger::StderrSink>(logger_name, skip_prefix));
+            return Logger(std::make_unique<logger::StderrSink>(
+                std::move(logger_name), skip_prefix));
         }
 
         sink =
@@ -122,8 +122,8 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix) {
         std::cerr << "Error when creating a logger instance from the '"
                   << env_var_name.str() << "' environment variable:\n"
                   << e.what() << std::endl;
-        return Logger(
-            std::make_unique<logger::StderrSink>(logger_name, skip_prefix));
+        return Logger(std::make_unique<logger::StderrSink>(
+            std::move(logger_name), skip_prefix));
     }
     sink->setFlushLevel(flush_level);
 

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -37,7 +37,8 @@ class Sink {
     logger::Level flush_level;
 
     Sink(std::string logger_name, bool skip_prefix = false)
-        : logger_name(logger_name), skip_prefix(skip_prefix) {
+        : logger_name(std::move(logger_name)), skip_prefix(skip_prefix) {
+        ostream = nullptr;
         flush_level = logger::Level::ERR;
     }
 
@@ -103,13 +104,13 @@ class Sink {
 class StdoutSink : public Sink {
   public:
     StdoutSink(std::string logger_name, bool skip_prefix = false)
-        : Sink(logger_name, skip_prefix) {
+        : Sink(std::move(logger_name), skip_prefix) {
         this->ostream = &std::cout;
     }
 
     StdoutSink(std::string logger_name, Level flush_lvl,
                bool skip_prefix = false)
-        : StdoutSink(logger_name, skip_prefix) {
+        : StdoutSink(std::move(logger_name), skip_prefix) {
         this->flush_level = flush_lvl;
     }
 
@@ -119,12 +120,12 @@ class StdoutSink : public Sink {
 class StderrSink : public Sink {
   public:
     StderrSink(std::string logger_name, bool skip_prefix = false)
-        : Sink(logger_name, skip_prefix) {
+        : Sink(std::move(logger_name), skip_prefix) {
         this->ostream = &std::cerr;
     }
 
     StderrSink(std::string logger_name, Level flush_lvl, bool skip_prefix)
-        : StderrSink(logger_name, skip_prefix) {
+        : StderrSink(std::move(logger_name), skip_prefix) {
         this->flush_level = flush_lvl;
     }
 
@@ -135,7 +136,7 @@ class FileSink : public Sink {
   public:
     FileSink(std::string logger_name, filesystem::path file_path,
              bool skip_prefix = false)
-        : Sink(logger_name, skip_prefix) {
+        : Sink(std::move(logger_name), skip_prefix) {
         ofstream = std::ofstream(file_path);
         if (!ofstream.good()) {
             std::stringstream ss;
@@ -148,7 +149,7 @@ class FileSink : public Sink {
 
     FileSink(std::string logger_name, filesystem::path file_path,
              Level flush_lvl, bool skip_prefix = false)
-        : FileSink(logger_name, file_path, skip_prefix) {
+        : FileSink(std::move(logger_name), std::move(file_path), skip_prefix) {
         this->flush_level = flush_lvl;
     }
 


### PR DESCRIPTION
- use std::move() on strings in Logger where appropriate.