### PR TITLE
Add adapter-specific data in new ur_queue_native_desc_t

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -224,6 +224,7 @@ class ur_structure_type_v(IntEnum):
     DEVICE_NATIVE_PROPERTIES = 22                   ## ::ur_device_native_properties_t
     PROGRAM_NATIVE_PROPERTIES = 23                  ## ::ur_program_native_properties_t
     SAMPLER_NATIVE_PROPERTIES = 24                  ## ::ur_sampler_native_properties_t
+    QUEUE_NATIVE_DESC = 25                          ## ::ur_queue_native_desc_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -1521,6 +1522,22 @@ class ur_queue_index_properties_t(Structure):
     ]
 
 ###############################################################################
+## @brief Descriptor for ::urQueueGetNativeHandle and
+##        ::urQueueCreateWithNativeHandle.
+## 
+## @details
+##     - Specify this descriptor in ::urQueueGetNativeHandle directly or
+##       ::urQueueCreateWithNativeHandle via ::ur_queue_native_properties_t as
+##       part of a `pNext` chain.
+class ur_queue_native_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("pNativeData", c_void_p)                                       ## [in][optional] Adapter-specific metadata needed to create the handle.
+    ]
+
+###############################################################################
 ## @brief Properties for for ::urQueueCreateWithNativeHandle.
 class ur_queue_native_properties_t(Structure):
     _fields_ = [
@@ -2607,9 +2624,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urQueueGetNativeHandle
 if __use_win_types:
-    _urQueueGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, POINTER(ur_native_handle_t) )
+    _urQueueGetNativeHandle_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, POINTER(ur_queue_native_desc_t), POINTER(ur_native_handle_t) )
 else:
-    _urQueueGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, POINTER(ur_native_handle_t) )
+    _urQueueGetNativeHandle_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, POINTER(ur_queue_native_desc_t), POINTER(ur_native_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urQueueCreateWithNativeHandle

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -248,6 +248,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES = 22,        ///< ::ur_device_native_properties_t
     UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES = 23,       ///< ::ur_program_native_properties_t
     UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES = 24,       ///< ::ur_sampler_native_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC = 25,               ///< ::ur_queue_native_desc_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -4035,6 +4036,22 @@ urQueueRelease(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Descriptor for ::urQueueGetNativeHandle and
+///        ::urQueueCreateWithNativeHandle.
+///
+/// @details
+///     - Specify this descriptor in ::urQueueGetNativeHandle directly or
+///       ::urQueueCreateWithNativeHandle via ::ur_queue_native_properties_t as
+///       part of a `pNext` chain.
+typedef struct ur_queue_native_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    void *pNativeData;         ///< [in][optional] Adapter-specific metadata needed to create the handle.
+
+} ur_queue_native_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Return queue native queue handle.
 ///
 /// @details
@@ -4057,6 +4074,7 @@ urQueueRelease(
 UR_APIEXPORT ur_result_t UR_APICALL
 urQueueGetNativeHandle(
     ur_queue_handle_t hQueue,         ///< [in] handle of the queue.
+    ur_queue_native_desc_t *pDesc,    ///< [in][optional] pointer to native descriptor
     ur_native_handle_t *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 );
 
@@ -6940,6 +6958,7 @@ typedef struct ur_queue_release_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_queue_get_native_handle_params_t {
     ur_queue_handle_t *phQueue;
+    ur_queue_native_desc_t **ppDesc;
     ur_native_handle_t **pphNativeQueue;
 } ur_queue_get_native_handle_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1155,6 +1155,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnQueueRelease_t)(
 /// @brief Function-pointer for urQueueGetNativeHandle
 typedef ur_result_t(UR_APICALL *ur_pfnQueueGetNativeHandle_t)(
     ur_queue_handle_t,
+    ur_queue_native_desc_t *,
     ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -312,6 +312,8 @@ etors:
       desc: $x_program_native_properties_t
     - name: SAMPLER_NATIVE_PROPERTIES
       desc: $x_sampler_native_properties_t
+    - name: QUEUE_NATIVE_DESC
+      desc: $x_queue_native_desc_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -185,6 +185,21 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES    
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Descriptor for $xQueueGetNativeHandle and $xQueueCreateWithNativeHandle."
+details:
+    - Specify this descriptor in $xQueueGetNativeHandle directly or
+      $xQueueCreateWithNativeHandle via $x_queue_native_properties_t
+      as part of a `pNext` chain.
+class: $xQueue
+name: $x_queue_native_desc_t
+base: $x_base_desc_t
+members:
+    - type: "void*"
+      name: pNativeData
+      desc: |
+            [in][optional] Adapter-specific metadata needed to create the handle.
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Return queue native queue handle."
 class: $xQueue
@@ -201,6 +216,10 @@ params:
       name: hQueue
       desc: |
             [in] handle of the queue.
+    - type: $x_queue_native_desc_t*
+      name: pDesc
+      desc: |
+            [in][optional] pointer to native descriptor
     - type: $x_native_handle_t*
       name: phNativeQueue
       desc: |

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -2141,6 +2141,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 /// @brief Intercept function for urQueueGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_queue_native_desc_t
+        *pDesc, ///< [in][optional] pointer to native descriptor
     ur_native_handle_t
         *phNativeQueue ///< [out] a pointer to the native handle of the queue.
     ) try {
@@ -2149,7 +2151,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGetNativeHandle = d_context.urDdiTable.Queue.pfnGetNativeHandle;
     if (nullptr != pfnGetNativeHandle) {
-        result = pfnGetNativeHandle(hQueue, phNativeQueue);
+        result = pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
     } else {
         // generic implementation
         *phNativeQueue = reinterpret_cast<ur_native_handle_t>(d_context.get());

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -268,6 +268,8 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_queue_properties_t params);
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_queue_index_properties_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_queue_native_desc_t params);
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_queue_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value);
@@ -671,6 +673,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC:
+        os << "UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -826,6 +832,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES: {
         const ur_sampler_native_properties_t *pstruct =
             (const ur_sampler_native_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC: {
+        const ur_queue_native_desc_t *pstruct =
+            (const ur_queue_native_desc_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -7096,6 +7108,27 @@ operator<<(std::ostream &os, const struct ur_queue_index_properties_t params) {
     os << "}";
     return os;
 }
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_queue_native_desc_t params) {
+    os << "(struct ur_queue_native_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".pNativeData = ";
+
+    ur_params::serializePtr(os, (params.pNativeData));
+
+    os << "}";
+    return os;
+}
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_queue_native_properties_t params) {
     os << "(struct ur_queue_native_properties_t){";
@@ -11093,6 +11126,11 @@ operator<<(std::ostream &os,
     os << ".hQueue = ";
 
     ur_params::serializePtr(os, *(params->phQueue));
+
+    os << ", ";
+    os << ".pDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppDesc));
 
     os << ", ";
     os << ".phNativeQueue = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -2445,6 +2445,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 /// @brief Intercept function for urQueueGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_queue_native_desc_t
+        *pDesc, ///< [in][optional] pointer to native descriptor
     ur_native_handle_t
         *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
@@ -2454,11 +2456,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_queue_get_native_handle_params_t params = {&hQueue, &phNativeQueue};
+    ur_queue_get_native_handle_params_t params = {&hQueue, &pDesc,
+                                                  &phNativeQueue};
     uint64_t instance = context.notify_begin(
         UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, "urQueueGetNativeHandle", &params);
 
-    ur_result_t result = pfnGetNativeHandle(hQueue, phNativeQueue);
+    ur_result_t result = pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
 
     context.notify_end(UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE,
                        "urQueueGetNativeHandle", &params, &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2897,6 +2897,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 /// @brief Intercept function for urQueueGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_queue_native_desc_t
+        *pDesc, ///< [in][optional] pointer to native descriptor
     ur_native_handle_t
         *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
@@ -2916,7 +2918,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
         }
     }
 
-    ur_result_t result = pfnGetNativeHandle(hQueue, phNativeQueue);
+    ur_result_t result = pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2827,6 +2827,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 /// @brief Intercept function for urQueueGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_queue_native_desc_t
+        *pDesc, ///< [in][optional] pointer to native descriptor
     ur_native_handle_t
         *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
@@ -2843,7 +2845,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
 
     // forward to device-platform
-    result = pfnGetNativeHandle(hQueue, phNativeQueue);
+    result = pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3243,6 +3243,8 @@ ur_result_t UR_APICALL urQueueRelease(
 ///         + `NULL == phNativeQueue`
 ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_queue_native_desc_t
+        *pDesc, ///< [in][optional] pointer to native descriptor
     ur_native_handle_t
         *phNativeQueue ///< [out] a pointer to the native handle of the queue.
     ) try {
@@ -3252,7 +3254,7 @@ ur_result_t UR_APICALL urQueueGetNativeHandle(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetNativeHandle(hQueue, phNativeQueue);
+    return pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2697,6 +2697,8 @@ ur_result_t UR_APICALL urQueueRelease(
 ///         + `NULL == phNativeQueue`
 ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
+    ur_queue_native_desc_t
+        *pDesc, ///< [in][optional] pointer to native descriptor
     ur_native_handle_t
         *phNativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {

--- a/test/conformance/queue/urQueueGetNativeHandle.cpp
+++ b/test/conformance/queue/urQueueGetNativeHandle.cpp
@@ -7,7 +7,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetNativeHandleTest);
 
 TEST_P(urQueueGetNativeHandleTest, Success) {
     ur_native_handle_t native_handle = nullptr;
-    ASSERT_SUCCESS(urQueueGetNativeHandle(queue, &native_handle));
+    ASSERT_SUCCESS(urQueueGetNativeHandle(queue, nullptr, &native_handle));
 
     // We cannot assume anything about a native_handle, not even if it's
     // `nullptr` since this could be a valid representation within a backend.
@@ -29,10 +29,10 @@ TEST_P(urQueueGetNativeHandleTest, Success) {
 TEST_P(urQueueGetNativeHandleTest, InvalidNullHandleQueue) {
     ur_native_handle_t native_handle = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueGetNativeHandle(nullptr, &native_handle));
+                     urQueueGetNativeHandle(nullptr, nullptr, &native_handle));
 }
 
 TEST_P(urQueueGetNativeHandleTest, InvalidNullPointerNativeHandle) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urQueueGetNativeHandle(queue, nullptr));
+                     urQueueGetNativeHandle(queue, nullptr, nullptr));
 }


### PR DESCRIPTION
Add adapter-specific data in new ur_queue_native_desc_t

A high-level queue, like sycl::queue, could be translated into
different types of adapter streams. For instance, a sycl::queue
could be translated into an L0 command queue or an L0 command list.

So define a new descriptor for urQueueCreateWithNativeHandle and
urQueueGetNativehandle with an opaque pointer, which can be used to
pass adapter-specific data.

Resolves: https://github.com/oneapi-src/unified-runtime/issues/533