### PR TITLE
[UR][CTS] Fix device tests

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -555,7 +555,7 @@ class ur_device_info_v(IntEnum):
     MEMORY_BUS_WIDTH = 107                          ## [::ur_bool_t] Return 1 if the device doesn't have a notion of a "queue
                                                     ## index". Otherwise,
                                                     ## return the number of queue indices that are available for this device.
-    MAX_WORK_GROUPS_3D = 108                        ## [uint32_t] return max 3D work groups
+    MAX_WORK_GROUPS_3D = 108                        ## [size_t[3]] return max 3D work groups
     ASYNC_BARRIER = 109                             ## [::ur_bool_t] return true if Async Barrier is supported
     MEM_CHANNEL_SUPPORT = 110                       ## [::ur_bool_t] return true if specifying memory channels is supported
     HOST_PIPE_READ_WRITE_SUPPORTED = 111            ## [::ur_bool_t] Return true if the device supports enqueing commands to
@@ -660,7 +660,7 @@ class ur_device_affinity_domain_flags_v(IntEnum):
                                                     ## ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE,
                                                     ## ::UR_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE, 
                                                     ## and partition the device into sub devices comprised of compute units
-                                                    ## that share memory subsystems at this level. 
+                                                    ## that share memory subsystems at this level.
 
 class ur_device_affinity_domain_flags_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -904,7 +904,7 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_MEMORY_BUS_WIDTH = 107,                      ///< [::ur_bool_t] Return 1 if the device doesn't have a notion of a "queue
                                                                 ///< index". Otherwise,
                                                                 ///< return the number of queue indices that are available for this device.
-    UR_DEVICE_INFO_MAX_WORK_GROUPS_3D = 108,                    ///< [uint32_t] return max 3D work groups
+    UR_DEVICE_INFO_MAX_WORK_GROUPS_3D = 108,                    ///< [size_t[3]] return max 3D work groups
     UR_DEVICE_INFO_ASYNC_BARRIER = 109,                         ///< [::ur_bool_t] return true if Async Barrier is supported
     UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT = 110,                   ///< [::ur_bool_t] return true if specifying memory channels is supported
     UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED = 111,        ///< [::ur_bool_t] Return true if the device supports enqueing commands to
@@ -935,6 +935,7 @@ typedef enum ur_device_info_t {
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
+///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGetInfo(
@@ -955,6 +956,10 @@ urDeviceGetInfo(
 ///        paired ::urDeviceRelease is called
 ///
 /// @details
+///     - Increments the device reference count if `hDevice` is a valid
+///       sub-device created by a call to `urDevicePartition`. If `hDevice` is a
+///       root level device (e.g. obtained with `urDeviceGet`), the reference
+///       count remains unchanged.
 ///     - It is not valid to use the device handle, which has all of its
 ///       references released.
 ///     - The application may call this function from simultaneous threads for
@@ -980,6 +985,10 @@ urDeviceRetain(
 /// @brief Releases the device handle reference indicating end of its usage
 ///
 /// @details
+///     - Decrements the device reference count if `hDevice` is a valid
+///       sub-device created by a call to `urDevicePartition`. If `hDevice` is a
+///       root level device (e.g. obtained with `urDeviceGet`), the reference
+///       count remains unchanged.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -429,7 +429,7 @@ analogue:
     - "**clRetainDevice**"
 details:
     - "Increments the device reference count if `hDevice` is a valid sub-device created by a call to `urDevicePartition`.
-    If `hDevice` is a root level device (e.g. obtained with `urDeviceGet`), the reference count remains unchanged."
+      If `hDevice` is a root level device (e.g. obtained with `urDeviceGet`), the reference count remains unchanged."
     - "It is not valid to use the device handle, which has all of its references released."
     - "The application may call this function from simultaneous threads for the same device."
     - "The implementation of this function should be thread-safe."

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -372,7 +372,7 @@ etors:
             [$x_bool_t] Return 1 if the device doesn't have a notion of a "queue index". Otherwise,
             return the number of queue indices that are available for this device.
     - name: MAX_WORK_GROUPS_3D
-      desc: "[uint32_t] return max 3D work groups"
+      desc: "[size_t[3]] return max 3D work groups"
     - name: ASYNC_BARRIER
       desc: "[$x_bool_t] return true if Async Barrier is supported"
     - name: MEM_CHANNEL_SUPPORT
@@ -415,6 +415,8 @@ params:
       desc: |
             [out][optional] pointer to the actual size in bytes of the queried propName.
 returns:
+    - $X_RESULT_ERROR_INVALID_ENUMERATION:
+        - "If `propName` is not supported by the adapter."
     - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: function
@@ -426,6 +428,8 @@ ordinal: "0"
 analogue:
     - "**clRetainDevice**"
 details:
+    - "Increments the device reference count if `hDevice` is a valid sub-device created by a call to `urDevicePartition`.
+    If `hDevice` is a root level device (e.g. obtained with `urDeviceGet`), the reference count remains unchanged."
     - "It is not valid to use the device handle, which has all of its references released."
     - "The application may call this function from simultaneous threads for the same device."
     - "The implementation of this function should be thread-safe."
@@ -444,7 +448,8 @@ ordinal: "0"
 analogue:
     - "**clReleaseDevice**"
 details:
-    
+    - "Decrements the device reference count if `hDevice` is a valid sub-device created by a call to `urDevicePartition`.
+      If `hDevice` is a root level device (e.g. obtained with `urDeviceGet`), the reference count remains unchanged."
     - "The application may call this function from simultaneous threads for the same device."
     - "The implementation of this function should be thread-safe."
 params:
@@ -560,7 +565,7 @@ etors:
     - name: CORRECTLY_ROUNDED_DIVIDE_SQRT
       desc: "Support correctly rounded divide and sqrt"
       value: "$X_BIT(0)"
-    - name: ROUND_TO_NEAREST      
+    - name: ROUND_TO_NEAREST
       desc: "Support round to nearest"
       value: "$X_BIT(1)"
     - name: ROUND_TO_ZERO
@@ -614,7 +619,7 @@ etors:
     - name: KERNEL
       desc: "Support kernel execution"
       value: "$X_BIT(0)"
-    - name: NATIVE_KERNEL      
+    - name: NATIVE_KERNEL
       desc: "Support native kernel execution"
       value: "$X_BIT(1)"
 --- #--------------------------------------------------------------------------
@@ -644,7 +649,7 @@ etors:
             The implementation shall find the first level along which the device
             or sub device may be further subdivided in the order: 
             $X_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L3_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L2_CACHE, $X_DEVICE_AFFINITY_DOMAIN_FLAG_L1_CACHE, 
-            and partition the device into sub devices comprised of compute units that share memory subsystems at this level. 
+            and partition the device into sub devices comprised of compute units that share memory subsystems at this level.
       value: "$X_BIT(5)"
 --- #--------------------------------------------------------------------------
 type: class

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -3143,17 +3143,18 @@ inline void serializeTaggedTyped_ur_device_info_t(std::ostream &os,
     } break;
 
     case UR_DEVICE_INFO_MAX_WORK_GROUPS_3D: {
-        const uint32_t *tptr = (const uint32_t *)ptr;
-        if (sizeof(uint32_t) > size) {
-            os << "invalid size (is: " << size
-               << ", expected: >=" << sizeof(uint32_t) << ")";
-            return;
+
+        const size_t *tptr = (const size_t *)ptr;
+        os << "[";
+        size_t nelems = size / sizeof(size_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
         }
-        os << (void *)(tptr) << " (";
-
-        os << *tptr;
-
-        os << ")";
+        os << "]";
     } break;
 
     case UR_DEVICE_INFO_ASYNC_BARRIER: {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -424,6 +424,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
+///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
@@ -454,6 +455,10 @@ ur_result_t UR_APICALL urDeviceGetInfo(
 ///        paired ::urDeviceRelease is called
 ///
 /// @details
+///     - Increments the device reference count if `hDevice` is a valid
+///       sub-device created by a call to `urDevicePartition`. If `hDevice` is a
+///       root level device (e.g. obtained with `urDeviceGet`), the reference
+///       count remains unchanged.
 ///     - It is not valid to use the device handle, which has all of its
 ///       references released.
 ///     - The application may call this function from simultaneous threads for
@@ -488,6 +493,10 @@ ur_result_t UR_APICALL urDeviceRetain(
 /// @brief Releases the device handle reference indicating end of its usage
 ///
 /// @details
+///     - Decrements the device reference count if `hDevice` is a valid
+///       sub-device created by a call to `urDevicePartition`. If `hDevice` is a
+///       root level device (e.g. obtained with `urDeviceGet`), the reference
+///       count remains unchanged.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -348,6 +348,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
+///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
@@ -372,6 +373,10 @@ ur_result_t UR_APICALL urDeviceGetInfo(
 ///        paired ::urDeviceRelease is called
 ///
 /// @details
+///     - Increments the device reference count if `hDevice` is a valid
+///       sub-device created by a call to `urDevicePartition`. If `hDevice` is a
+///       root level device (e.g. obtained with `urDeviceGet`), the reference
+///       count remains unchanged.
 ///     - It is not valid to use the device handle, which has all of its
 ///       references released.
 ///     - The application may call this function from simultaneous threads for
@@ -400,6 +405,10 @@ ur_result_t UR_APICALL urDeviceRetain(
 /// @brief Releases the device handle reference indicating end of its usage
 ///
 /// @details
+///     - Decrements the device reference count if `hDevice` is a valid
+///       sub-device created by a call to `urDevicePartition`. If `hDevice` is a
+///       root level device (e.g. obtained with `urDeviceGet`), the reference
+///       count remains unchanged.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -11,9 +11,10 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
     {UR_DEVICE_INFO_MAX_COMPUTE_UNITS, sizeof(uint32_t)},
     {UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS, sizeof(uint32_t)},
     {UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE, sizeof(size_t)},
-    {UR_DEVICE_INFO_SINGLE_FP_CONFIG, sizeof(ur_device_fp_capability_flag_t)},
-    {UR_DEVICE_INFO_HALF_FP_CONFIG, sizeof(ur_device_fp_capability_flag_t)},
-    {UR_DEVICE_INFO_DOUBLE_FP_CONFIG, sizeof(ur_device_fp_capability_flag_t)},
+    {UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE, sizeof(size_t)},
+    {UR_DEVICE_INFO_SINGLE_FP_CONFIG, sizeof(ur_device_fp_capability_flags_t)},
+    {UR_DEVICE_INFO_HALF_FP_CONFIG, sizeof(ur_device_fp_capability_flags_t)},
+    {UR_DEVICE_INFO_DOUBLE_FP_CONFIG, sizeof(ur_device_fp_capability_flags_t)},
     {UR_DEVICE_INFO_QUEUE_PROPERTIES, sizeof(ur_queue_flags_t)},
     {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR, sizeof(uint32_t)},
     {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT, sizeof(uint32_t)},
@@ -105,7 +106,7 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
     {UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, sizeof(uint32_t)},
     {UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_MEMORY_BUS_WIDTH, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(size_t) * 3u},
     {UR_DEVICE_INFO_ASYNC_BARRIER, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED, sizeof(ur_bool_t)},
@@ -241,16 +242,22 @@ TEST_P(urDeviceGetInfoTest, Success) {
     ur_device_info_t info_type = GetParam();
     for (auto device : devices) {
         size_t size = 0;
-        ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, 0, nullptr, &size));
-        ASSERT_NE(size, 0);
-        if (const auto expected_size = device_info_size_map.find(info_type);
-            expected_size != device_info_size_map.end()) {
-            ASSERT_EQ(expected_size->second, size);
+        ur_result_t result =
+            urDeviceGetInfo(device, info_type, 0, nullptr, &size);
+
+        if (result == UR_RESULT_SUCCESS) {
+            ASSERT_NE(size, 0);
+            if (const auto expected_size = device_info_size_map.find(info_type);
+                expected_size != device_info_size_map.end()) {
+                ASSERT_EQ(expected_size->second, size);
+            }
+            void *info_data = alloca(size);
+            ASSERT_SUCCESS(
+                urDeviceGetInfo(device, info_type, size, info_data, nullptr));
+            ASSERT_NE(info_data, nullptr);
+        } else {
+            ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_INVALID_ENUMERATION);
         }
-        void *info_data = alloca(size);
-        ASSERT_SUCCESS(
-            urDeviceGetInfo(device, info_type, size, info_data, nullptr));
-        ASSERT_NE(info_data, nullptr);
     }
 }
 

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -251,10 +251,10 @@ TEST_P(urDeviceGetInfoTest, Success) {
                 expected_size != device_info_size_map.end()) {
                 ASSERT_EQ(expected_size->second, size);
             }
-            void *info_data = alloca(size);
-            ASSERT_SUCCESS(
-                urDeviceGetInfo(device, info_type, size, info_data, nullptr));
-            ASSERT_NE(info_data, nullptr);
+
+            std::vector<char> info_data(size);
+            ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, size,
+                                           info_data.data(), nullptr));
         } else {
             ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_INVALID_ENUMERATION);
         }

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -106,7 +106,7 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
     {UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, sizeof(uint32_t)},
     {UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_MEMORY_BUS_WIDTH, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(size_t) * 3u},
+    {UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(size_t[3])},
     {UR_DEVICE_INFO_ASYNC_BARRIER, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED, sizeof(ur_bool_t)},

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -19,7 +19,7 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
         ASSERT_NE(dev, nullptr);
 
         uint32_t dev_id = 0;
-        ASSERT_SUCCESS(urDeviceGetInfo(dev, UR_DEVICE_INFO_DEVICE_ID,
+        ASSERT_SUCCESS(urDeviceGetInfo(dev, UR_DEVICE_INFO_TYPE,
                                        sizeof(uint32_t), &dev_id, nullptr));
     }
 }

--- a/test/conformance/device/urDevicePartition.cpp
+++ b/test/conformance/device/urDevicePartition.cpp
@@ -64,9 +64,6 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
         uint32_t n_cu_in_device = 0;
         ASSERT_NO_FATAL_FAILURE(getNumberComputeUnits(device, n_cu_in_device));
 
-        std::vector<ur_device_partition_property_t> properties = {
-            UR_DEVICE_PARTITION_BY_COUNTS};
-
         enum class Combination { ONE, HALF, ALL_MINUS_ONE, ALL };
 
         std::vector<Combination> combinations{Combination::ONE,
@@ -79,6 +76,10 @@ TEST_F(urDevicePartitionTest, PartitionByCounts) {
 
         uint32_t n_cu_across_sub_devices;
         for (const auto Combination : combinations) {
+
+            std::vector<ur_device_partition_property_t> properties = {
+                UR_DEVICE_PARTITION_BY_COUNTS};
+
             switch (Combination) {
             case Combination::ONE: {
                 n_cu_across_sub_devices = 1;

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -16,6 +16,32 @@ TEST_F(urDeviceReleaseTest, Success) {
         uint32_t refCount = 0;
         ASSERT_SUCCESS(uur::GetObjectReferenceCount(device, refCount));
 
+        /* If device is a root level device, the device reference counts should
+         * remain unchanged */
+        ASSERT_EQ(prevRefCount, refCount);
+    }
+}
+
+TEST_F(urDeviceReleaseTest, SuccessSubdevices) {
+    for (auto device : devices) {
+
+        ur_device_partition_property_t properties[] = {
+            UR_DEVICE_PARTITION_BY_COUNTS, 1, 0};
+
+        ur_device_handle_t sub_device;
+        ASSERT_SUCCESS(
+            urDevicePartition(device, properties, 1, &sub_device, nullptr));
+
+        ASSERT_SUCCESS(urDeviceRetain(sub_device));
+
+        uint32_t prevRefCount = 0;
+        ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, prevRefCount));
+
+        EXPECT_SUCCESS(urDeviceRelease(sub_device));
+
+        uint32_t refCount = 0;
+        ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, refCount));
+
         ASSERT_GT(prevRefCount, refCount);
     }
 }

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -15,9 +15,35 @@ TEST_F(urDeviceRetainTest, Success) {
         uint32_t refCount = 0;
         ASSERT_SUCCESS(uur::GetObjectReferenceCount(device, refCount));
 
-        ASSERT_LT(prevRefCount, refCount);
+        /* If device is a root level device, the device reference counts should
+         * remain unchanged */
+        ASSERT_EQ(prevRefCount, refCount);
 
         EXPECT_SUCCESS(urDeviceRelease(device));
+    }
+}
+
+TEST_F(urDeviceRetainTest, SuccessSubdevices) {
+    for (auto device : devices) {
+
+        ur_device_partition_property_t properties[] = {
+            UR_DEVICE_PARTITION_BY_COUNTS, 1, 0};
+
+        ur_device_handle_t sub_device;
+        ASSERT_SUCCESS(
+            urDevicePartition(device, properties, 1, &sub_device, nullptr));
+
+        uint32_t prevRefCount = 0;
+        ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, prevRefCount));
+
+        ASSERT_SUCCESS(urDeviceRetain(sub_device));
+
+        uint32_t refCount = 0;
+        ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, refCount));
+
+        ASSERT_LT(prevRefCount, refCount);
+
+        EXPECT_SUCCESS(urDeviceRelease(sub_device));
     }
 }
 


### PR DESCRIPTION
- Update spec to show that MAX_WORK_GROUPS_3D returns an array of 3 elements
- Make it clear the urDeviceGetInfo can return UR_RESULT_ERROR_INVALID_ENUMERATION if the adapter does not support the query.
- Fix bug in urDevicePartition test
- Update urDeviceRelease and urDeviceRetain tests to take into account the differences betwen root devices and subdevices.
- Update the specification to make clear that the behaviour of urDeviceRelease and urDeviceRetain changes depending on the type of device.