### PR TITLE
Fix how CTS gets memory access properties

### DIFF
--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -33,7 +33,7 @@ struct urEnqueueUSMFillTestWithParam
         pattern = std::vector<uint8_t>(pattern_size);
         generatePattern();
 
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";
@@ -122,7 +122,7 @@ struct urEnqueueUSMFillNegativeTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
 
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -122,7 +122,7 @@ struct urEnqueueUSMFillNegativeTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
 
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -33,7 +33,7 @@ struct urEnqueueUSMFillTestWithParam
         pattern = std::vector<uint8_t>(pattern_size);
         generatePattern();
 
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -40,7 +40,7 @@ struct urEnqueueUSMFill2DTestWithParam
         allocation_size = pitch * height;
         host_mem = std::vector<uint8_t>(allocation_size);
 
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";
@@ -154,7 +154,7 @@ struct urEnqueueUSMFill2DNegativeTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
 
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -40,7 +40,7 @@ struct urEnqueueUSMFill2DTestWithParam
         allocation_size = pitch * height;
         host_mem = std::vector<uint8_t>(allocation_size);
 
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -154,7 +154,7 @@ struct urEnqueueUSMFill2DNegativeTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
 
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -8,7 +8,7 @@ struct urEnqueueUSMMemcpyTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
 
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -8,7 +8,7 @@ struct urEnqueueUSMMemcpyTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
 
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -9,7 +9,7 @@ struct urEnqueueUSMMemcpy2DTestWithParam
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(
             uur::urQueueTestWithParam<uur::TestParameters2D>::SetUp());
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -9,7 +9,7 @@ struct urEnqueueUSMMemcpy2DTestWithParam
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(
             uur::urQueueTestWithParam<uur::TestParameters2D>::SetUp());
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM is not supported";

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -496,7 +496,7 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(GetDeviceUSMDeviceSupport(this->device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM in not supported";

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -424,7 +424,7 @@ struct urMemBufferQueueTest : urQueueTest {
 struct urUSMDeviceAllocTest : urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
-        ur_device_usm_access_capability_flags_t device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = 0;
         ASSERT_SUCCESS(GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM in not supported";

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -424,7 +424,7 @@ struct urMemBufferQueueTest : urQueueTest {
 struct urUSMDeviceAllocTest : urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(GetDeviceUSMDeviceSupport(device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM in not supported";
@@ -496,7 +496,7 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
 
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
-        bool device_usm = false;
+        ur_device_usm_access_capability_flags_t device_usm = false;
         ASSERT_SUCCESS(GetDeviceUSMDeviceSupport(this->device, device_usm));
         if (!device_usm) {
             GTEST_SKIP() << "Device USM in not supported";

--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -326,14 +326,21 @@ GetDeviceSubGroupIndependentForwardProgress(ur_device_handle_t device,
                                             bool &progress);
 ur_result_t GetDeviceSubGroupSizesIntel(ur_device_handle_t device,
                                         std::vector<uint32_t> &sizes);
-ur_result_t GetDeviceUSMHostSupport(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceUSMDeviceSupport(ur_device_handle_t device, bool &support);
-ur_result_t GetDeviceUSMSingleSharedSupport(ur_device_handle_t device,
-                                            bool &support);
-ur_result_t GetDeviceUSMCrossSharedSupport(ur_device_handle_t device,
-                                           bool &support);
-ur_result_t GetDeviceUSMSystemSharedSupport(ur_device_handle_t device,
-                                            bool &support);
+ur_result_t
+GetDeviceUSMHostSupport(ur_device_handle_t device,
+                        ur_device_usm_access_capability_flags_t &support);
+ur_result_t
+GetDeviceUSMDeviceSupport(ur_device_handle_t device,
+                          ur_device_usm_access_capability_flags_t &support);
+ur_result_t GetDeviceUSMSingleSharedSupport(
+    ur_device_handle_t device,
+    ur_device_usm_access_capability_flags_t &support);
+ur_result_t GetDeviceUSMCrossSharedSupport(
+    ur_device_handle_t device,
+    ur_device_usm_access_capability_flags_t &support);
+ur_result_t GetDeviceUSMSystemSharedSupport(
+    ur_device_handle_t device,
+    ur_device_usm_access_capability_flags_t &support);
 ur_result_t GetDeviceUUID(ur_device_handle_t device, std::string &uuid);
 ur_result_t GetDevicePCIAddress(ur_device_handle_t device,
                                 std::string &address);

--- a/test/conformance/testing/source/utils.cpp
+++ b/test/conformance/testing/source/utils.cpp
@@ -525,33 +525,39 @@ ur_result_t GetDeviceSubGroupSizesIntel(ur_device_handle_t device,
         device, UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL, sizes);
 }
 
-ur_result_t GetDeviceUSMHostSupport(ur_device_handle_t device, bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_HOST_SUPPORT,
-                               support);
+ur_result_t
+GetDeviceUSMHostSupport(ur_device_handle_t device,
+                        ur_device_usm_access_capability_flags_t &support) {
+    return GetDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        device, UR_DEVICE_INFO_USM_HOST_SUPPORT, support);
 }
 
-ur_result_t GetDeviceUSMDeviceSupport(ur_device_handle_t device,
-                                      bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_DEVICE_SUPPORT,
-                               support);
+ur_result_t
+GetDeviceUSMDeviceSupport(ur_device_handle_t device,
+                          ur_device_usm_access_capability_flags_t &support) {
+    return GetDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        device, UR_DEVICE_INFO_USM_DEVICE_SUPPORT, support);
 }
 
-ur_result_t GetDeviceUSMSingleSharedSupport(ur_device_handle_t device,
-                                            bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,
-                               support);
+ur_result_t GetDeviceUSMSingleSharedSupport(
+    ur_device_handle_t device,
+    ur_device_usm_access_capability_flags_t &support) {
+    return GetDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        device, UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT, support);
 }
 
-ur_result_t GetDeviceUSMCrossSharedSupport(ur_device_handle_t device,
-                                           bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,
-                               support);
+ur_result_t GetDeviceUSMCrossSharedSupport(
+    ur_device_handle_t device,
+    ur_device_usm_access_capability_flags_t &support) {
+    return GetDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        device, UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT, support);
 }
 
-ur_result_t GetDeviceUSMSystemSharedSupport(ur_device_handle_t device,
-                                            bool &support) {
-    return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,
-                               support);
+ur_result_t GetDeviceUSMSystemSharedSupport(
+    ur_device_handle_t device,
+    ur_device_usm_access_capability_flags_t &support) {
+    return GetDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        device, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT, support);
 }
 
 ur_result_t GetDeviceUUID(ur_device_handle_t device, std::string &uuid) {

--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -6,7 +6,7 @@
 struct urUSMDeviceAllocTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
-        bool deviceUSMSupport = false;
+        ur_device_usm_access_capability_flags_t deviceUSMSupport = 0;
         ASSERT_SUCCESS(
             uur::GetDeviceUSMDeviceSupport(device, deviceUSMSupport));
         if (!deviceUSMSupport) {

--- a/test/conformance/usm/urUSMFree.cpp
+++ b/test/conformance/usm/urUSMFree.cpp
@@ -30,7 +30,7 @@ TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
     ASSERT_SUCCESS(urUSMFree(context, ptr));
 }
 TEST_P(urUSMFreeTest, SuccessHostAlloc) {
-    ur_device_usm_access_capability_flags_t hostUSMSupport = false;
+    ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
     ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, hostUSMSupport));
     if (!hostUSMSupport) {
         GTEST_SKIP() << "Host USM not supported.";

--- a/test/conformance/usm/urUSMFree.cpp
+++ b/test/conformance/usm/urUSMFree.cpp
@@ -7,7 +7,7 @@ using urUSMFreeTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMFreeTest);
 
 TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
-    bool deviceUSMSupport = false;
+    ur_device_usm_access_capability_flags_t deviceUSMSupport = 0;
     ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, deviceUSMSupport));
     if (!deviceUSMSupport) {
         GTEST_SKIP() << "Device USM not supported.";
@@ -30,7 +30,7 @@ TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
     ASSERT_SUCCESS(urUSMFree(context, ptr));
 }
 TEST_P(urUSMFreeTest, SuccessHostAlloc) {
-    bool hostUSMSupport = false;
+    ur_device_usm_access_capability_flags_t hostUSMSupport = false;
     ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, hostUSMSupport));
     if (!hostUSMSupport) {
         GTEST_SKIP() << "Host USM not supported.";
@@ -53,8 +53,8 @@ TEST_P(urUSMFreeTest, SuccessHostAlloc) {
 }
 
 TEST_P(urUSMFreeTest, SuccessSharedAlloc) {
-    bool shared_usm_cross = false;
-    bool shared_usm_single = false;
+    ur_device_usm_access_capability_flags_t shared_usm_cross = 0;
+    ur_device_usm_access_capability_flags_t shared_usm_single = 0;
 
     ASSERT_SUCCESS(
         uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -7,7 +7,7 @@
 struct urUSMHostAllocTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
-        bool hostUSMSupport = false;
+        ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMHostSupport(device, hostUSMSupport));
         if (!hostUSMSupport) {
             GTEST_SKIP() << "Device USM is not supported.";
@@ -17,7 +17,7 @@ struct urUSMHostAllocTest : uur::urQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMHostAllocTest);
 
 TEST_P(urUSMHostAllocTest, Success) {
-    bool hostUSMSupport = false;
+    ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
     ASSERT_SUCCESS(uur::GetDeviceUSMHostSupport(device, hostUSMSupport));
     if (!hostUSMSupport) {
         GTEST_SKIP() << "Host USM is not supported.";

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -6,8 +6,8 @@
 struct urUSMSharedAllocTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
-        bool shared_usm_cross = false;
-        bool shared_usm_single = false;
+        ur_device_usm_access_capability_flags_t shared_usm_cross = false;
+        ur_device_usm_access_capability_flags_t shared_usm_single = false;
 
         ASSERT_SUCCESS(
             uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -6,8 +6,8 @@
 struct urUSMSharedAllocTest : uur::urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
-        ur_device_usm_access_capability_flags_t shared_usm_cross = false;
-        ur_device_usm_access_capability_flags_t shared_usm_single = false;
+        ur_device_usm_access_capability_flags_t shared_usm_cross = 0;
+        ur_device_usm_access_capability_flags_t shared_usm_single = 0;
 
         ASSERT_SUCCESS(
             uur::GetDeviceUSMCrossSharedSupport(device, shared_usm_cross));


### PR DESCRIPTION
https://github.com/oneapi-src/unified-runtime/pull/464 Changes memory access caps from bool to
ur_device_usm_access_capability_flags_t. CTS was still
using bool in several places which caused tests to fail

Signed-off-by: Brandon Yates <brandon.yates@intel.com> 