### PR TITLE
[cmake] Make cppformat faster with multiple build dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,17 +150,19 @@ if(UR_FORMAT_CPP_STYLE)
 endif()
 
 # Obtain files for clang-format
-file(GLOB_RECURSE format_src
-    "*.h"
-    "*.c"
-    "*.hpp"
-    "*.cpp"
-)
-
-set(UR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}.")
-EscapeRegex(UR_BINARY_DIR)
-# Exclude files from build directory to ensure they're not passed to the formatter
-list(FILTER format_src EXCLUDE REGEX ${UR_BINARY_DIR})
+set(format_glob)
+foreach(dir examples include source test tools)
+    list(APPEND format_glob
+        "${dir}/*.h"
+        "${dir}/*.hpp"
+        "${dir}/*.c"
+        "${dir}/*.cpp"
+        "${dir}/**/*.h"
+        "${dir}/**/*.hpp"
+        "${dir}/**/*.c"
+        "${dir}/**/*.cpp")
+endforeach()
+file(GLOB_RECURSE format_src ${format_glob})
 
 # Add code formatter target
 add_custom_target(cppformat)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -76,17 +76,3 @@ function(FetchContentSparse_Declare name GIT_REPOSITORY GIT_TAG GIT_DIR)
         WORKING_DIRECTORY ${content-build-dir})
     FetchContent_Declare(${name} SOURCE_DIR ${content-build-dir}/${GIT_DIR})
 endfunction()
-
-# Escape a string to be able to be processed by REGEX
-macro(EscapeRegex IN_OUT_STR)
-    set(PY_REGEX_ESCAPE_PROGRAM 
-"from re import escape
-print(escape('${${IN_OUT_STR}}'))")
-
-    execute_process(
-        COMMAND ${Python3_EXECUTABLE} -c ${PY_REGEX_ESCAPE_PROGRAM}
-        OUTPUT_VARIABLE PY_RESULT
-    )
-
-    set(${IN_OUT_STR} ${PY_RESULT})
-endmacro()


### PR DESCRIPTION
The `cppformat` target can sometimes be very slow, especially if a user
has multiple build directories, e.g.

```
.
├── build-d
└── build-r
```

When configuring `build-r`, the recursive globing pattern used before
this patch would include all the source files in `build-d` and format
them in the `cppformat` target. This is not desirable, we should only be
formatting our own source files.

This patch instead only recursively globs in directories which are known
to contain our own source code:

```
.
├── examples
├── include
├── source
├── test
└── tools
```

Before this patch, with 2 adjacent build directories:

```console
$ time ninja -C ~build cppformat
ninja: Entering directory `build-r'
[1/1] Format CXX source files
ninja -C ~build cppformat  37.49s user 0.33s system 99% cpu 37.825 total
```

After this patch:

```console
$ time ninja -C ~build cppformat
ninja: Entering directory `build-r'
[1/1] Format CXX source files
ninja -C ~build cppformat  0.81s user 0.04s system 99% cpu 0.852 total
```

This patch also removes the necessity for the `EscapeRegex` utility and
the regex based list filter of the current binary directory, switching
from an *out-out* to an *opt-in* approach to globing.
