### PR TITLE
[ci] Add CI Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 project(unified-runtime VERSION 0.6.0)
 
 include(GNUInstallDirs)
@@ -70,10 +70,9 @@ if(NOT MSVC)
         link_libraries(stdc++fs)
     endif()
 elseif(MSVC)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-    add_compile_options(/MP /W3)
+    add_compile_options(/MP /W3 /MD$<$<CONFIG:Debug>:d>)
 
     if(UR_DEVELOPER_MODE)
         add_compile_options(/WX)
@@ -101,8 +100,6 @@ if(UR_ENABLE_TRACING)
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     )
     if (MSVC)
-        set_property(TARGET xpti PROPERTY MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
-        set_property(TARGET xptifw PROPERTY MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
         set(TARGET_XPTI $<IF:$<CONFIG:Release>,xpti,xptid>)
 
         # disable warning C4267: The compiler detected a conversion from size_t to a smaller type.

--- a/test/tools/urtrace/CMakeLists.txt
+++ b/test/tools/urtrace/CMakeLists.txt
@@ -8,7 +8,7 @@ function(add_trace_test name CLI_ARGS)
     add_test(NAME ${TEST_NAME}
         COMMAND ${CMAKE_COMMAND}
         -D TEST_FILE=${Python3_EXECUTABLE}
-        -D TEST_ARGS="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/urtrace --stdout ${CLI_ARGS} $<TARGET_FILE:hello_world>"
+        -D TEST_ARGS="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/urtrace --stdout ${CLI_ARGS} --flush info $<TARGET_FILE:hello_world>"
         -D MODE=stdout
         -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}.match
         -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake

--- a/tools/urtrace/urtrace
+++ b/tools/urtrace/urtrace
@@ -56,6 +56,7 @@ parser.add_argument("--time-unit", choices=['ns', 'us', 'ms', 's', 'auto'], defa
 parser.add_argument("--libpath", default=['.', '../lib/', '/lib/', '/usr/local/lib/', '/usr/lib/'], action="append", help="Search path for adapters and xpti libraries.")
 parser.add_argument("--recursive", help="Use recursive library search.", action="store_true")
 parser.add_argument("--debug", help="Print tool debug information.", action="store_true")
+parser.add_argument("--flush", choices=['debug', 'info', 'warning', 'error'], default='error', help="Set the flushing level of messages.", )
 args = parser.parse_args()
 config = vars(args)
 if args.debug:
@@ -80,10 +81,9 @@ env['UR_COLLECTOR_ARGS'] = collector_args
 log_collector = ""
 if args.debug:
     log_collector += "level:debug;"
-    log_collector += "flush:debug;"
 else:
     log_collector += "level:info;"
-    log_collector += "flush:info;"
+log_collector += f"flush:{args.flush};"
 if args.file:
     log_collector += "output:file," + args.file + ";"
 elif args.stdout:


### PR DESCRIPTION
- add Debug build type builds to a workflow
- use multiple threads to build, as $(nproc) would have no effect on
  Windows, setting the number of cores to 2 as this is the current max
  for Github Actions jobs
- hide message about libbacktrace not found on Windows builds.
- change the flush level of tracing messages in tracing tests to have certainty
for the order of messages