### PR TITLE
[logger/coverity] Replace logger exceptions with error messages

### DIFF
--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -51,6 +51,7 @@ class Sink {
     std::string logger_name;
     bool skip_prefix;
     std::mutex output_mutex;
+    const char *error_prefix = "Log message syntax error: ";
 
     void format(std::ostringstream &buffer, const char *fmt) {
         while (*fmt != '\0') {
@@ -62,15 +63,16 @@ class Sink {
                 if (*(++fmt) == '{') {
                     buffer << *fmt++;
                 } else {
-                    throw std::runtime_error(
-                        "No arguments provided and braces not escaped!");
+                    std::cerr
+                        << error_prefix
+                        << "No arguments provided and braces not escaped!";
                 }
             } else if (*fmt == '}') {
                 if (*(++fmt) == '}') {
                     buffer << *fmt++;
                 } else {
-                    throw std::runtime_error(
-                        "Closing curly brace not escaped!");
+                    std::cerr << error_prefix
+                              << "Closing curly brace not escaped!";
                 }
             }
         }
@@ -90,7 +92,8 @@ class Sink {
                 if (*(++fmt) == '{') {
                     buffer << *fmt++;
                 } else if (*fmt != '}') {
-                    throw std::runtime_error("Only empty braces are allowed!");
+                    std::cerr << error_prefix
+                              << "Only empty braces are allowed!";
                 } else {
                     buffer << arg;
                     arg_printed = true;
@@ -99,8 +102,8 @@ class Sink {
                 if (*(++fmt) == '}') {
                     buffer << *fmt++;
                 } else {
-                    throw std::runtime_error(
-                        "Closing curly brace not escaped!");
+                    std::cerr << error_prefix
+                              << "Closing curly brace not escaped!";
                 }
             }
         }


### PR DESCRIPTION
Wrapping every log message in a try-catch can be annoying. Reducing exceptions throws with a message to std::cerr in cases where messages have wrong syntax.