### PR TITLE
[Experimental] Add command-buffers

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -188,12 +188,12 @@ class ur_result_v(IntEnum):
                                                     ## memory
     ERROR_INVALID_HOST_PTR = 64                     ## Invalid host pointer
     ERROR_INVALID_USM_SIZE = 65                     ## Invalid USM size
-    ERROR_INVALID_COMMAND_BUFFER_EXP = 66           ## Invalid Command-Buffer
-    ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 67## Sync point is not valid for the command-buffer
-    ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 68  ## Sync point wait list is invalid
-    ERROR_OBJECT_ALLOCATION_FAILURE = 69            ## Objection allocation failure
-    ERROR_ADAPTER_SPECIFIC = 70                     ## An adapter specific warning/error has been reported and can be
+    ERROR_OBJECT_ALLOCATION_FAILURE = 66            ## Objection allocation failure
+    ERROR_ADAPTER_SPECIFIC = 67                     ## An adapter specific warning/error has been reported and can be
                                                     ## retrieved via the urGetLastResult entry point.
+    ERROR_INVALID_COMMAND_BUFFER_EXP = 0x1000       ## Invalid Command-Buffer
+    ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 0x1001## Sync point is not valid for the command-buffer
+    ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 0x1002  ## Sync point wait list is invalid
     ERROR_UNKNOWN = 0x7ffffffe                      ## Unknown or internal error
 
 class ur_result_t(c_int):
@@ -271,26 +271,6 @@ class ur_rect_region_t(Structure):
         ("height", c_ulonglong),                                        ## [in] height (scalar)
         ("depth", c_ulonglong)                                          ## [in] scalar (scalar)
     ]
-
-###############################################################################
-## @brief Command-Buffer Descriptor Type
-class ur_exp_command_buffer_desc_t(Structure):
-    _fields_ = [
-        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
-                                                                        ## ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
-        ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
-    ]
-
-###############################################################################
-## @brief A value that identifies a command inside of a command-buffer, used for
-##        defining dependencies between commands in the same command-buffer.
-class ur_exp_command_buffer_sync_point_t(c_ulong):
-    pass
-
-###############################################################################
-## @brief Handle of Command-Buffer object
-class ur_exp_command_buffer_handle_t(c_void_p):
-    pass
 
 ###############################################################################
 ## @brief Supported device initialization flags
@@ -1846,7 +1826,7 @@ class ur_function_v(IntEnum):
     COMMAND_BUFFER_RETAIN_EXP = 121                 ## Enumerator for ::urCommandBufferRetainExp
     COMMAND_BUFFER_RELEASE_EXP = 122                ## Enumerator for ::urCommandBufferReleaseExp
     COMMAND_BUFFER_FINALIZE_EXP = 123               ## Enumerator for ::urCommandBufferFinalizeExp
-    COMMAND_BUFFER_APPEND_KERNEL_EXP = 124          ## Enumerator for ::urCommandBufferAppendKernelExp
+    COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP = 125   ## Enumerator for ::urCommandBufferAppendKernelLaunchExp
     COMMAND_BUFFER_ENQUEUE_EXP = 128                ## Enumerator for ::urCommandBufferEnqueueExp
     COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129      ## Enumerator for ::urCommandBufferAppendMemcpyUSMExp
     COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130  ## Enumerator for ::urCommandBufferAppendMembufferCopyExp
@@ -1878,6 +1858,26 @@ class ur_usm_migration_flags_t(c_int):
     def __str__(self):
         return hex(self.value)
 
+
+###############################################################################
+## @brief Command-Buffer Descriptor Type
+class ur_exp_command_buffer_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
+        ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
+    ]
+
+###############################################################################
+## @brief A value that identifies a command inside of a command-buffer, used for
+##        defining dependencies between commands in the same command-buffer.
+class ur_exp_command_buffer_sync_point_t(c_ulong):
+    pass
+
+###############################################################################
+## @brief Handle of Command-Buffer object
+class ur_exp_command_buffer_handle_t(c_void_p):
+    pass
 
 ###############################################################################
 __use_win_types = "Windows" == platform.uname()[0]
@@ -2758,11 +2758,11 @@ else:
     _urCommandBufferFinalizeExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
 
 ###############################################################################
-## @brief Function-pointer for urCommandBufferAppendKernelExp
+## @brief Function-pointer for urCommandBufferAppendKernelLaunchExp
 if __use_win_types:
-    _urCommandBufferAppendKernelExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendKernelLaunchExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 else:
-    _urCommandBufferAppendKernelExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendKernelLaunchExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urCommandBufferAppendMemcpyUSMExp
@@ -2801,7 +2801,7 @@ class ur_command_buffer_exp_dditable_t(Structure):
         ("pfnRetainExp", c_void_p),                                     ## _urCommandBufferRetainExp_t
         ("pfnReleaseExp", c_void_p),                                    ## _urCommandBufferReleaseExp_t
         ("pfnFinalizeExp", c_void_p),                                   ## _urCommandBufferFinalizeExp_t
-        ("pfnAppendKernelExp", c_void_p),                               ## _urCommandBufferAppendKernelExp_t
+        ("pfnAppendKernelLaunchExp", c_void_p),                         ## _urCommandBufferAppendKernelLaunchExp_t
         ("pfnAppendMemcpyUSMExp", c_void_p),                            ## _urCommandBufferAppendMemcpyUSMExp_t
         ("pfnAppendMembufferCopyExp", c_void_p),                        ## _urCommandBufferAppendMembufferCopyExp_t
         ("pfnAppendMembufferCopyRectExp", c_void_p),                    ## _urCommandBufferAppendMembufferCopyRectExp_t
@@ -3222,7 +3222,7 @@ class UR_DDI:
         self.urCommandBufferRetainExp = _urCommandBufferRetainExp_t(self.__dditable.CommandBufferExp.pfnRetainExp)
         self.urCommandBufferReleaseExp = _urCommandBufferReleaseExp_t(self.__dditable.CommandBufferExp.pfnReleaseExp)
         self.urCommandBufferFinalizeExp = _urCommandBufferFinalizeExp_t(self.__dditable.CommandBufferExp.pfnFinalizeExp)
-        self.urCommandBufferAppendKernelExp = _urCommandBufferAppendKernelExp_t(self.__dditable.CommandBufferExp.pfnAppendKernelExp)
+        self.urCommandBufferAppendKernelLaunchExp = _urCommandBufferAppendKernelLaunchExp_t(self.__dditable.CommandBufferExp.pfnAppendKernelLaunchExp)
         self.urCommandBufferAppendMemcpyUSMExp = _urCommandBufferAppendMemcpyUSMExp_t(self.__dditable.CommandBufferExp.pfnAppendMemcpyUSMExp)
         self.urCommandBufferAppendMembufferCopyExp = _urCommandBufferAppendMembufferCopyExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferCopyExp)
         self.urCommandBufferAppendMembufferCopyRectExp = _urCommandBufferAppendMembufferCopyRectExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferCopyRectExp)

--- a/include/ur.py
+++ b/include/ur.py
@@ -188,8 +188,9 @@ class ur_result_v(IntEnum):
                                                     ## memory
     ERROR_INVALID_HOST_PTR = 64                     ## Invalid host pointer
     ERROR_INVALID_USM_SIZE = 65                     ## Invalid USM size
-    ERROR_OBJECT_ALLOCATION_FAILURE = 66            ## Objection allocation failure
-    ERROR_ADAPTER_SPECIFIC = 67                     ## An adapter specific warning/error has been reported and can be
+    ERROR_INVALID_COMMAND_BUFFER_EXP = 66           ## Invalid Command-Buffer
+    ERROR_OBJECT_ALLOCATION_FAILURE = 67            ## Objection allocation failure
+    ERROR_ADAPTER_SPECIFIC = 68                     ## An adapter specific warning/error has been reported and can be
                                                     ## retrieved via the urGetLastResult entry point.
     ERROR_UNKNOWN = 0x7ffffffe                      ## Unknown or internal error
 
@@ -1640,6 +1641,7 @@ class ur_command_v(IntEnum):
     DEVICE_GLOBAL_VARIABLE_READ = 24                ## Event created by ::urEnqueueDeviceGlobalVariableRead
     READ_HOST_PIPE = 25                             ## Event created by ::urEnqueueReadHostPipe
     WRITE_HOST_PIPE = 26                            ## Event created by ::urEnqueueWriteHostPipe
+    COMMAND_BUFFER_ENQUEUE_EXP = 27                 ## Event created by ::urCommandBufferEnqueueExp
 
 class ur_command_t(c_int):
     def __str__(self):
@@ -2798,9 +2800,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urCommandBufferEnqueueExp
 if __use_win_types:
-    _urCommandBufferEnqueueExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+    _urCommandBufferEnqueueExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_queue_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 else:
-    _urCommandBufferEnqueueExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+    _urCommandBufferEnqueueExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_queue_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 
 
 ###############################################################################

--- a/include/ur.py
+++ b/include/ur.py
@@ -273,18 +273,6 @@ class ur_rect_region_t(Structure):
     ]
 
 ###############################################################################
-## @brief Command buffer support level for device info queries.
-class ur_exp_command_buffer_support_level_v(IntEnum):
-    UNSUPPORTED = 0                                 ## No support for command-buffers.
-    EMULATED = 1                                    ## Emulated support for command-buffers.
-    NATIVE = 2                                      ## Native support for command-buffers.
-
-class ur_exp_command_buffer_support_level_t(c_int):
-    def __str__(self):
-        return str(ur_exp_command_buffer_support_level_v(self.value))
-
-
-###############################################################################
 ## @brief Command-Buffer Descriptor Type
 class ur_exp_command_buffer_desc_t(Structure):
     _fields_ = [
@@ -601,8 +589,6 @@ class ur_device_info_v(IntEnum):
     HOST_PIPE_READ_WRITE_SUPPORTED = 111            ## [::ur_bool_t] Return true if the device supports enqueing commands to
                                                     ## read and write pipes from the host.
     MAX_REGISTERS_PER_WORK_GROUP = 112              ## [uint32_t] The maximum number of registers available per block.
-    EXP_COMMAND_BUFFER_SUPPORT = 113                ## [::ur_exp_command_buffer_support_level_t] Level of experimental
-                                                    ## command-buffer support.
 
 class ur_device_info_t(c_int):
     def __str__(self):

--- a/include/ur.py
+++ b/include/ur.py
@@ -189,8 +189,10 @@ class ur_result_v(IntEnum):
     ERROR_INVALID_HOST_PTR = 64                     ## Invalid host pointer
     ERROR_INVALID_USM_SIZE = 65                     ## Invalid USM size
     ERROR_INVALID_COMMAND_BUFFER_EXP = 66           ## Invalid Command-Buffer
-    ERROR_OBJECT_ALLOCATION_FAILURE = 67            ## Objection allocation failure
-    ERROR_ADAPTER_SPECIFIC = 68                     ## An adapter specific warning/error has been reported and can be
+    ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 67## Sync point is not valid for the command-buffer
+    ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 68  ## Sync point wait list is invalid
+    ERROR_OBJECT_ALLOCATION_FAILURE = 69            ## Objection allocation failure
+    ERROR_ADAPTER_SPECIFIC = 70                     ## An adapter specific warning/error has been reported and can be
                                                     ## retrieved via the urGetLastResult entry point.
     ERROR_UNKNOWN = 0x7ffffffe                      ## Unknown or internal error
 
@@ -1859,10 +1861,10 @@ class ur_function_v(IntEnum):
     COMMAND_BUFFER_RELEASE_EXP = 122                ## Enumerator for ::urCommandBufferReleaseExp
     COMMAND_BUFFER_FINALIZE_EXP = 123               ## Enumerator for ::urCommandBufferFinalizeExp
     COMMAND_BUFFER_APPEND_KERNEL_EXP = 124          ## Enumerator for ::urCommandBufferAppendKernelExp
-    COMMAND_BUFFER_MEMCPY_USM_EXP = 125             ## Enumerator for ::urCommandBufferMemcpyUSMExp
-    COMMAND_BUFFER_MEMBUFFER_COPY_EXP = 126         ## Enumerator for ::urCommandBufferMembufferCopyExp
-    COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP = 127    ## Enumerator for ::urCommandBufferMembufferCopyRectExp
     COMMAND_BUFFER_ENQUEUE_EXP = 128                ## Enumerator for ::urCommandBufferEnqueueExp
+    COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129      ## Enumerator for ::urCommandBufferAppendMemcpyUSMExp
+    COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130  ## Enumerator for ::urCommandBufferAppendMembufferCopyExp
+    COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP = 131 ## Enumerator for ::urCommandBufferAppendMembufferCopyRectExp
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -2777,25 +2779,25 @@ else:
     _urCommandBufferAppendKernelExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
-## @brief Function-pointer for urCommandBufferMemcpyUSMExp
+## @brief Function-pointer for urCommandBufferAppendMemcpyUSMExp
 if __use_win_types:
-    _urCommandBufferMemcpyUSMExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendMemcpyUSMExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 else:
-    _urCommandBufferMemcpyUSMExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendMemcpyUSMExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
-## @brief Function-pointer for urCommandBufferMembufferCopyExp
+## @brief Function-pointer for urCommandBufferAppendMembufferCopyExp
 if __use_win_types:
-    _urCommandBufferMembufferCopyExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendMembufferCopyExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 else:
-    _urCommandBufferMembufferCopyExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendMembufferCopyExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
-## @brief Function-pointer for urCommandBufferMembufferCopyRectExp
+## @brief Function-pointer for urCommandBufferAppendMembufferCopyRectExp
 if __use_win_types:
-    _urCommandBufferMembufferCopyRectExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendMembufferCopyRectExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 else:
-    _urCommandBufferMembufferCopyRectExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+    _urCommandBufferAppendMembufferCopyRectExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urCommandBufferEnqueueExp
@@ -2814,9 +2816,9 @@ class ur_command_buffer_exp_dditable_t(Structure):
         ("pfnReleaseExp", c_void_p),                                    ## _urCommandBufferReleaseExp_t
         ("pfnFinalizeExp", c_void_p),                                   ## _urCommandBufferFinalizeExp_t
         ("pfnAppendKernelExp", c_void_p),                               ## _urCommandBufferAppendKernelExp_t
-        ("pfnMemcpyUSMExp", c_void_p),                                  ## _urCommandBufferMemcpyUSMExp_t
-        ("pfnMembufferCopyExp", c_void_p),                              ## _urCommandBufferMembufferCopyExp_t
-        ("pfnMembufferCopyRectExp", c_void_p),                          ## _urCommandBufferMembufferCopyRectExp_t
+        ("pfnAppendMemcpyUSMExp", c_void_p),                            ## _urCommandBufferAppendMemcpyUSMExp_t
+        ("pfnAppendMembufferCopyExp", c_void_p),                        ## _urCommandBufferAppendMembufferCopyExp_t
+        ("pfnAppendMembufferCopyRectExp", c_void_p),                    ## _urCommandBufferAppendMembufferCopyRectExp_t
         ("pfnEnqueueExp", c_void_p)                                     ## _urCommandBufferEnqueueExp_t
     ]
 
@@ -3235,9 +3237,9 @@ class UR_DDI:
         self.urCommandBufferReleaseExp = _urCommandBufferReleaseExp_t(self.__dditable.CommandBufferExp.pfnReleaseExp)
         self.urCommandBufferFinalizeExp = _urCommandBufferFinalizeExp_t(self.__dditable.CommandBufferExp.pfnFinalizeExp)
         self.urCommandBufferAppendKernelExp = _urCommandBufferAppendKernelExp_t(self.__dditable.CommandBufferExp.pfnAppendKernelExp)
-        self.urCommandBufferMemcpyUSMExp = _urCommandBufferMemcpyUSMExp_t(self.__dditable.CommandBufferExp.pfnMemcpyUSMExp)
-        self.urCommandBufferMembufferCopyExp = _urCommandBufferMembufferCopyExp_t(self.__dditable.CommandBufferExp.pfnMembufferCopyExp)
-        self.urCommandBufferMembufferCopyRectExp = _urCommandBufferMembufferCopyRectExp_t(self.__dditable.CommandBufferExp.pfnMembufferCopyRectExp)
+        self.urCommandBufferAppendMemcpyUSMExp = _urCommandBufferAppendMemcpyUSMExp_t(self.__dditable.CommandBufferExp.pfnAppendMemcpyUSMExp)
+        self.urCommandBufferAppendMembufferCopyExp = _urCommandBufferAppendMembufferCopyExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferCopyExp)
+        self.urCommandBufferAppendMembufferCopyRectExp = _urCommandBufferAppendMembufferCopyRectExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferCopyRectExp)
         self.urCommandBufferEnqueueExp = _urCommandBufferEnqueueExp_t(self.__dditable.CommandBufferExp.pfnEnqueueExp)
 
         # call driver to get function pointers

--- a/include/ur.py
+++ b/include/ur.py
@@ -228,6 +228,7 @@ class ur_structure_type_v(IntEnum):
     SAMPLER_NATIVE_PROPERTIES = 24                  ## ::ur_sampler_native_properties_t
     QUEUE_NATIVE_DESC = 25                          ## ::ur_queue_native_desc_t
     DEVICE_PARTITION_PROPERTIES = 26                ## ::ur_device_partition_properties_t
+    EXP_COMMAND_BUFFER_DESC = 27                    ## ::ur_exp_command_buffer_desc_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -267,6 +268,38 @@ class ur_rect_region_t(Structure):
         ("height", c_ulonglong),                                        ## [in] height (scalar)
         ("depth", c_ulonglong)                                          ## [in] scalar (scalar)
     ]
+
+###############################################################################
+## @brief Command buffer support level for device info queries.
+class ur_exp_command_buffer_support_level_v(IntEnum):
+    UNSUPPORTED = 0                                 ## No support for command-buffers.
+    EMULATED = 1                                    ## Emulated support for command-buffers.
+    NATIVE = 2                                      ## Native support for command-buffers.
+
+class ur_exp_command_buffer_support_level_t(c_int):
+    def __str__(self):
+        return str(ur_exp_command_buffer_support_level_v(self.value))
+
+
+###############################################################################
+## @brief Command-Buffer Descriptor Type
+class ur_exp_command_buffer_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
+        ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
+    ]
+
+###############################################################################
+## @brief A value that identifies a command inside of a command-buffer, used for
+##        defining dependencies between commands in the same command-buffer.
+class ur_exp_command_buffer_sync_point_t(c_ulong):
+    pass
+
+###############################################################################
+## @brief Handle of Command-Buffer object
+class ur_exp_command_buffer_handle_t(c_void_p):
+    pass
 
 ###############################################################################
 ## @brief Supported device initialization flags
@@ -565,6 +598,8 @@ class ur_device_info_v(IntEnum):
     HOST_PIPE_READ_WRITE_SUPPORTED = 111            ## [::ur_bool_t] Return true if the device supports enqueing commands to
                                                     ## read and write pipes from the host.
     MAX_REGISTERS_PER_WORK_GROUP = 112              ## [uint32_t] The maximum number of registers available per block.
+    EXP_COMMAND_BUFFER_SUPPORT = 113                ## [::ur_exp_command_buffer_support_level_t] Level of experimental
+                                                    ## command-buffer support.
 
 class ur_device_info_t(c_int):
     def __str__(self):
@@ -1810,6 +1845,7 @@ class ur_function_v(IntEnum):
     USM_FREE = 110                                  ## Enumerator for ::urUSMFree
     USM_GET_MEM_ALLOC_INFO = 111                    ## Enumerator for ::urUSMGetMemAllocInfo
     USM_POOL_CREATE = 112                           ## Enumerator for ::urUSMPoolCreate
+    COMMAND_BUFFER_CREATE_EXP = 113                 ## Enumerator for ::urCommandBufferCreateExp
     PLATFORM_GET_BACKEND_OPTION = 114               ## Enumerator for ::urPlatformGetBackendOption
     MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115      ## Enumerator for ::urMemBufferCreateWithNativeHandle
     MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116       ## Enumerator for ::urMemImageCreateWithNativeHandle
@@ -1817,6 +1853,14 @@ class ur_function_v(IntEnum):
     USM_POOL_RETAIN = 118                           ## Enumerator for ::urUSMPoolRetain
     USM_POOL_RELEASE = 119                          ## Enumerator for ::urUSMPoolRelease
     USM_POOL_GET_INFO = 120                         ## Enumerator for ::urUSMPoolGetInfo
+    COMMAND_BUFFER_RETAIN_EXP = 121                 ## Enumerator for ::urCommandBufferRetainExp
+    COMMAND_BUFFER_RELEASE_EXP = 122                ## Enumerator for ::urCommandBufferReleaseExp
+    COMMAND_BUFFER_FINALIZE_EXP = 123               ## Enumerator for ::urCommandBufferFinalizeExp
+    COMMAND_BUFFER_APPEND_KERNEL_EXP = 124          ## Enumerator for ::urCommandBufferAppendKernelExp
+    COMMAND_BUFFER_MEMCPY_USM_EXP = 125             ## Enumerator for ::urCommandBufferMemcpyUSMExp
+    COMMAND_BUFFER_MEMBUFFER_COPY_EXP = 126         ## Enumerator for ::urCommandBufferMembufferCopyExp
+    COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP = 127    ## Enumerator for ::urCommandBufferMembufferCopyRectExp
+    COMMAND_BUFFER_ENQUEUE_EXP = 128                ## Enumerator for ::urCommandBufferEnqueueExp
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -2696,6 +2740,85 @@ class ur_queue_dditable_t(Structure):
     ]
 
 ###############################################################################
+## @brief Function-pointer for urCommandBufferCreateExp
+if __use_win_types:
+    _urCommandBufferCreateExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_exp_command_buffer_desc_t), POINTER(ur_exp_command_buffer_handle_t) )
+else:
+    _urCommandBufferCreateExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_exp_command_buffer_desc_t), POINTER(ur_exp_command_buffer_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferRetainExp
+if __use_win_types:
+    _urCommandBufferRetainExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
+else:
+    _urCommandBufferRetainExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferReleaseExp
+if __use_win_types:
+    _urCommandBufferReleaseExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
+else:
+    _urCommandBufferReleaseExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferFinalizeExp
+if __use_win_types:
+    _urCommandBufferFinalizeExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
+else:
+    _urCommandBufferFinalizeExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferAppendKernelExp
+if __use_win_types:
+    _urCommandBufferAppendKernelExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferAppendKernelExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_kernel_handle_t, c_ulong, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferMemcpyUSMExp
+if __use_win_types:
+    _urCommandBufferMemcpyUSMExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferMemcpyUSMExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_void_p, c_void_p, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferMembufferCopyExp
+if __use_win_types:
+    _urCommandBufferMembufferCopyExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferMembufferCopyExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferMembufferCopyRectExp
+if __use_win_types:
+    _urCommandBufferMembufferCopyRectExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferMembufferCopyRectExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferEnqueueExp
+if __use_win_types:
+    _urCommandBufferEnqueueExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urCommandBufferEnqueueExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+
+###############################################################################
+## @brief Table of CommandBufferExp functions pointers
+class ur_command_buffer_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnCreateExp", c_void_p),                                     ## _urCommandBufferCreateExp_t
+        ("pfnRetainExp", c_void_p),                                     ## _urCommandBufferRetainExp_t
+        ("pfnReleaseExp", c_void_p),                                    ## _urCommandBufferReleaseExp_t
+        ("pfnFinalizeExp", c_void_p),                                   ## _urCommandBufferFinalizeExp_t
+        ("pfnAppendKernelExp", c_void_p),                               ## _urCommandBufferAppendKernelExp_t
+        ("pfnMemcpyUSMExp", c_void_p),                                  ## _urCommandBufferMemcpyUSMExp_t
+        ("pfnMembufferCopyExp", c_void_p),                              ## _urCommandBufferMembufferCopyExp_t
+        ("pfnMembufferCopyRectExp", c_void_p),                          ## _urCommandBufferMembufferCopyRectExp_t
+        ("pfnEnqueueExp", c_void_p)                                     ## _urCommandBufferEnqueueExp_t
+    ]
+
+###############################################################################
 ## @brief Function-pointer for urInit
 if __use_win_types:
     _urInit_t = WINFUNCTYPE( ur_result_t, ur_device_init_flags_t )
@@ -2896,6 +3019,7 @@ class ur_dditable_t(Structure):
         ("Mem", ur_mem_dditable_t),
         ("Enqueue", ur_enqueue_dditable_t),
         ("Queue", ur_queue_dditable_t),
+        ("CommandBufferExp", ur_command_buffer_exp_dditable_t),
         ("Global", ur_global_dditable_t),
         ("USM", ur_usm_dditable_t),
         ("Device", ur_device_dditable_t)
@@ -3095,6 +3219,24 @@ class UR_DDI:
         self.urQueueCreateWithNativeHandle = _urQueueCreateWithNativeHandle_t(self.__dditable.Queue.pfnCreateWithNativeHandle)
         self.urQueueFinish = _urQueueFinish_t(self.__dditable.Queue.pfnFinish)
         self.urQueueFlush = _urQueueFlush_t(self.__dditable.Queue.pfnFlush)
+
+        # call driver to get function pointers
+        CommandBufferExp = ur_command_buffer_exp_dditable_t()
+        r = ur_result_v(self.__dll.urGetCommandBufferExpProcAddrTable(version, byref(CommandBufferExp)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.CommandBufferExp = CommandBufferExp
+
+        # attach function interface to function address
+        self.urCommandBufferCreateExp = _urCommandBufferCreateExp_t(self.__dditable.CommandBufferExp.pfnCreateExp)
+        self.urCommandBufferRetainExp = _urCommandBufferRetainExp_t(self.__dditable.CommandBufferExp.pfnRetainExp)
+        self.urCommandBufferReleaseExp = _urCommandBufferReleaseExp_t(self.__dditable.CommandBufferExp.pfnReleaseExp)
+        self.urCommandBufferFinalizeExp = _urCommandBufferFinalizeExp_t(self.__dditable.CommandBufferExp.pfnFinalizeExp)
+        self.urCommandBufferAppendKernelExp = _urCommandBufferAppendKernelExp_t(self.__dditable.CommandBufferExp.pfnAppendKernelExp)
+        self.urCommandBufferMemcpyUSMExp = _urCommandBufferMemcpyUSMExp_t(self.__dditable.CommandBufferExp.pfnMemcpyUSMExp)
+        self.urCommandBufferMembufferCopyExp = _urCommandBufferMembufferCopyExp_t(self.__dditable.CommandBufferExp.pfnMembufferCopyExp)
+        self.urCommandBufferMembufferCopyRectExp = _urCommandBufferMembufferCopyRectExp_t(self.__dditable.CommandBufferExp.pfnMembufferCopyRectExp)
+        self.urCommandBufferEnqueueExp = _urCommandBufferEnqueueExp_t(self.__dditable.CommandBufferExp.pfnEnqueueExp)
 
         # call driver to get function pointers
         Global = ur_global_dditable_t()

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -252,6 +252,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES = 24,       ///< ::ur_sampler_native_properties_t
     UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC = 25,               ///< ::ur_queue_native_desc_t
     UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES = 26,     ///< ::ur_device_partition_properties_t
+    UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC = 27,         ///< ::ur_exp_command_buffer_desc_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -291,6 +292,249 @@ typedef struct ur_rect_region_t {
     uint64_t depth;  ///< [in] scalar (scalar)
 
 } ur_rect_region_t;
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Command-Buffer Extension APIs
+#if !defined(__GNUC__)
+#pragma region exp -command-buffer
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command buffer support level for device info queries.
+typedef enum ur_exp_command_buffer_support_level_t {
+    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_UNSUPPORTED = 0, ///< No support for command-buffers.
+    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_EMULATED = 1,    ///< Emulated support for command-buffers.
+    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_NATIVE = 2,      ///< Native support for command-buffers.
+    /// @cond
+    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_command_buffer_support_level_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command-Buffer Descriptor Type
+typedef struct ur_exp_command_buffer_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+
+} ur_exp_command_buffer_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief A value that identifies a command inside of a command-buffer, used for
+///        defining dependencies between commands in the same command-buffer.
+typedef uint32_t ur_exp_command_buffer_sync_point_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of Command-Buffer object
+typedef struct ur_exp_command_buffer_handle_t_ *ur_exp_command_buffer_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a Command-Buffer object
+///
+/// @details
+///     - Create a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phCommandBuffer`
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferCreateExp(
+    ur_context_handle_t hContext,                           ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                             ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t *phCommandBuffer         ///< [out] pointer to Command-Buffer handle
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Increment the command-buffer object's reference count.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command-buffer object's reference count and delete the
+///        command-buffer object if the reference count becomes zero.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop recording on a command-buffer object such that no more commands
+///        can be appended and make it ready to enqueue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a kernel execution command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == pLocalWorkSize`
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel,                              ///< [in] kernel to append
+    uint32_t WorkDim,                                        ///< [in] dimension of the kernel execution
+    const size_t *pGlobalWorkOffset,                         ///< [in] Offset to use when executing kernel.
+    const size_t *pGlobalWorkSize,                           ///< [in] Global work size to use when executing kernel.
+    const size_t *pLocalWorkSize,                            ///< [in] Local work size to use when executing kernel.
+    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a USM memcpy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    void *pDst,                                              ///< [in] Location the data will be copied to.
+    void *pSrc,                                              ///< [in] The data to be copied.
+    size_t size,                                             ///< [in] The number of bytes to copy
+    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem,                                 ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem,                                 ///< [in] The location the data will be copied to.
+    size_t srcOffset,                                        ///< [in] Offset into the source memory.
+    size_t dstOffset,                                        ///< [in] Offset into the destination memory
+    size_t size,                                             ///< [in] The number of bytes to be copied.
+    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem,                                 ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem,                                 ///< [in] The location the data will be copied to.
+    ur_rect_offset_t SrcOrigin,                              ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t DstOrigin,                              ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t Region,                                 ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,                                      ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch,                                    ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,                                      ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch,                                    ///< [in] Slice pitch of the destination memory.
+    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Submit a command-buffer for execution on a queue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer, ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList,                  ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList,      ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                   ///< events that must be complete before the command-buffer execution.
+                                                   ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+                                                   ///< events.
+    ur_event_handle_t *phEvent                     ///< [out][optional] return an event object that identifies this particular
+                                                   ///< command-buffer execution instance.
+);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -925,6 +1169,8 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED = 111,        ///< [::ur_bool_t] Return true if the device supports enqueing commands to
                                                                 ///< read and write pipes from the host.
     UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP = 112,          ///< [uint32_t] The maximum number of registers available per block.
+    UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT = 113,            ///< [::ur_exp_command_buffer_support_level_t] Level of experimental
+                                                                ///< command-buffer support.
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -949,7 +1195,7 @@ typedef enum ur_device_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
+///         + `::UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -4650,125 +4896,134 @@ urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines unique stable identifiers for all functions
 typedef enum ur_function_t {
-    UR_FUNCTION_CONTEXT_CREATE = 1,                         ///< Enumerator for ::urContextCreate
-    UR_FUNCTION_CONTEXT_RETAIN = 2,                         ///< Enumerator for ::urContextRetain
-    UR_FUNCTION_CONTEXT_RELEASE = 3,                        ///< Enumerator for ::urContextRelease
-    UR_FUNCTION_CONTEXT_GET_INFO = 4,                       ///< Enumerator for ::urContextGetInfo
-    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,              ///< Enumerator for ::urContextGetNativeHandle
-    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,      ///< Enumerator for ::urContextCreateWithNativeHandle
-    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,           ///< Enumerator for ::urContextSetExtendedDeleter
-    UR_FUNCTION_DEVICE_GET = 8,                             ///< Enumerator for ::urDeviceGet
-    UR_FUNCTION_DEVICE_GET_INFO = 9,                        ///< Enumerator for ::urDeviceGetInfo
-    UR_FUNCTION_DEVICE_RETAIN = 10,                         ///< Enumerator for ::urDeviceRetain
-    UR_FUNCTION_DEVICE_RELEASE = 11,                        ///< Enumerator for ::urDeviceRelease
-    UR_FUNCTION_DEVICE_PARTITION = 12,                      ///< Enumerator for ::urDevicePartition
-    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                  ///< Enumerator for ::urDeviceSelectBinary
-    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,              ///< Enumerator for ::urDeviceGetNativeHandle
-    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,      ///< Enumerator for ::urDeviceCreateWithNativeHandle
-    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,          ///< Enumerator for ::urDeviceGetGlobalTimestamps
-    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                 ///< Enumerator for ::urEnqueueKernelLaunch
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                   ///< Enumerator for ::urEnqueueEventsWait
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,      ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,               ///< Enumerator for ::urEnqueueMemBufferRead
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,              ///< Enumerator for ::urEnqueueMemBufferWrite
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,          ///< Enumerator for ::urEnqueueMemBufferReadRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,         ///< Enumerator for ::urEnqueueMemBufferWriteRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,               ///< Enumerator for ::urEnqueueMemBufferCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,          ///< Enumerator for ::urEnqueueMemBufferCopyRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,               ///< Enumerator for ::urEnqueueMemBufferFill
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                ///< Enumerator for ::urEnqueueMemImageRead
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,               ///< Enumerator for ::urEnqueueMemImageWrite
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                ///< Enumerator for ::urEnqueueMemImageCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                ///< Enumerator for ::urEnqueueMemBufferMap
-    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                     ///< Enumerator for ::urEnqueueMemUnmap
-    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                      ///< Enumerator for ::urEnqueueUSMFill
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                    ///< Enumerator for ::urEnqueueUSMMemcpy
-    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                  ///< Enumerator for ::urEnqueueUSMPrefetch
-    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                    ///< Enumerator for ::urEnqueueUSMAdvise
-    UR_FUNCTION_ENQUEUE_USM_FILL2_D = 36,                   ///< Enumerator for ::urEnqueueUSMFill2D
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D = 37,                 ///< Enumerator for ::urEnqueueUSMMemcpy2D
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,  ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,   ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
-    UR_FUNCTION_EVENT_GET_INFO = 40,                        ///< Enumerator for ::urEventGetInfo
-    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,              ///< Enumerator for ::urEventGetProfilingInfo
-    UR_FUNCTION_EVENT_WAIT = 42,                            ///< Enumerator for ::urEventWait
-    UR_FUNCTION_EVENT_RETAIN = 43,                          ///< Enumerator for ::urEventRetain
-    UR_FUNCTION_EVENT_RELEASE = 44,                         ///< Enumerator for ::urEventRelease
-    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,               ///< Enumerator for ::urEventGetNativeHandle
-    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,       ///< Enumerator for ::urEventCreateWithNativeHandle
-    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                    ///< Enumerator for ::urEventSetCallback
-    UR_FUNCTION_KERNEL_CREATE = 48,                         ///< Enumerator for ::urKernelCreate
-    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                  ///< Enumerator for ::urKernelSetArgValue
-    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                  ///< Enumerator for ::urKernelSetArgLocal
-    UR_FUNCTION_KERNEL_GET_INFO = 51,                       ///< Enumerator for ::urKernelGetInfo
-    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                 ///< Enumerator for ::urKernelGetGroupInfo
-    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,             ///< Enumerator for ::urKernelGetSubGroupInfo
-    UR_FUNCTION_KERNEL_RETAIN = 54,                         ///< Enumerator for ::urKernelRetain
-    UR_FUNCTION_KERNEL_RELEASE = 55,                        ///< Enumerator for ::urKernelRelease
-    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                ///< Enumerator for ::urKernelSetArgPointer
-    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                  ///< Enumerator for ::urKernelSetExecInfo
-    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                ///< Enumerator for ::urKernelSetArgSampler
-    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                ///< Enumerator for ::urKernelSetArgMemObj
-    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,   ///< Enumerator for ::urKernelSetSpecializationConstants
-    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,              ///< Enumerator for ::urKernelGetNativeHandle
-    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,      ///< Enumerator for ::urKernelCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                      ///< Enumerator for ::urMemImageCreate
-    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                     ///< Enumerator for ::urMemBufferCreate
-    UR_FUNCTION_MEM_RETAIN = 65,                            ///< Enumerator for ::urMemRetain
-    UR_FUNCTION_MEM_RELEASE = 66,                           ///< Enumerator for ::urMemRelease
-    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                  ///< Enumerator for ::urMemBufferPartition
-    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                 ///< Enumerator for ::urMemGetNativeHandle
-    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                ///< Enumerator for ::urEnqueueReadHostPipe
-    UR_FUNCTION_MEM_GET_INFO = 70,                          ///< Enumerator for ::urMemGetInfo
-    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                    ///< Enumerator for ::urMemImageGetInfo
-    UR_FUNCTION_PLATFORM_GET = 72,                          ///< Enumerator for ::urPlatformGet
-    UR_FUNCTION_PLATFORM_GET_INFO = 73,                     ///< Enumerator for ::urPlatformGetInfo
-    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,              ///< Enumerator for ::urPlatformGetApiVersion
-    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,            ///< Enumerator for ::urPlatformGetNativeHandle
-    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,    ///< Enumerator for ::urPlatformCreateWithNativeHandle
-    UR_FUNCTION_GET_LAST_RESULT = 77,                       ///< Enumerator for ::urGetLastResult
-    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                ///< Enumerator for ::urProgramCreateWithIL
-    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,            ///< Enumerator for ::urProgramCreateWithBinary
-    UR_FUNCTION_PROGRAM_BUILD = 80,                         ///< Enumerator for ::urProgramBuild
-    UR_FUNCTION_PROGRAM_COMPILE = 81,                       ///< Enumerator for ::urProgramCompile
-    UR_FUNCTION_PROGRAM_LINK = 82,                          ///< Enumerator for ::urProgramLink
-    UR_FUNCTION_PROGRAM_RETAIN = 83,                        ///< Enumerator for ::urProgramRetain
-    UR_FUNCTION_PROGRAM_RELEASE = 84,                       ///< Enumerator for ::urProgramRelease
-    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,          ///< Enumerator for ::urProgramGetFunctionPointer
-    UR_FUNCTION_PROGRAM_GET_INFO = 86,                      ///< Enumerator for ::urProgramGetInfo
-    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                ///< Enumerator for ::urProgramGetBuildInfo
-    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,  ///< Enumerator for ::urProgramSetSpecializationConstants
-    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,             ///< Enumerator for ::urProgramGetNativeHandle
-    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,     ///< Enumerator for ::urProgramCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_GET_INFO = 91,                        ///< Enumerator for ::urQueueGetInfo
-    UR_FUNCTION_QUEUE_CREATE = 92,                          ///< Enumerator for ::urQueueCreate
-    UR_FUNCTION_QUEUE_RETAIN = 93,                          ///< Enumerator for ::urQueueRetain
-    UR_FUNCTION_QUEUE_RELEASE = 94,                         ///< Enumerator for ::urQueueRelease
-    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,               ///< Enumerator for ::urQueueGetNativeHandle
-    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,       ///< Enumerator for ::urQueueCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_FINISH = 97,                          ///< Enumerator for ::urQueueFinish
-    UR_FUNCTION_QUEUE_FLUSH = 98,                           ///< Enumerator for ::urQueueFlush
-    UR_FUNCTION_INIT = 99,                                  ///< Enumerator for ::urInit
-    UR_FUNCTION_TEAR_DOWN = 100,                            ///< Enumerator for ::urTearDown
-    UR_FUNCTION_SAMPLER_CREATE = 101,                       ///< Enumerator for ::urSamplerCreate
-    UR_FUNCTION_SAMPLER_RETAIN = 102,                       ///< Enumerator for ::urSamplerRetain
-    UR_FUNCTION_SAMPLER_RELEASE = 103,                      ///< Enumerator for ::urSamplerRelease
-    UR_FUNCTION_SAMPLER_GET_INFO = 104,                     ///< Enumerator for ::urSamplerGetInfo
-    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,            ///< Enumerator for ::urSamplerGetNativeHandle
-    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,    ///< Enumerator for ::urSamplerCreateWithNativeHandle
-    UR_FUNCTION_USM_HOST_ALLOC = 107,                       ///< Enumerator for ::urUSMHostAlloc
-    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                     ///< Enumerator for ::urUSMDeviceAlloc
-    UR_FUNCTION_USM_SHARED_ALLOC = 109,                     ///< Enumerator for ::urUSMSharedAlloc
-    UR_FUNCTION_USM_FREE = 110,                             ///< Enumerator for ::urUSMFree
-    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,               ///< Enumerator for ::urUSMGetMemAllocInfo
-    UR_FUNCTION_USM_POOL_CREATE = 112,                      ///< Enumerator for ::urUSMPoolCreate
-    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,          ///< Enumerator for ::urPlatformGetBackendOption
-    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115, ///< Enumerator for ::urMemBufferCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,  ///< Enumerator for ::urMemImageCreateWithNativeHandle
-    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,              ///< Enumerator for ::urEnqueueWriteHostPipe
-    UR_FUNCTION_USM_POOL_RETAIN = 118,                      ///< Enumerator for ::urUSMPoolRetain
-    UR_FUNCTION_USM_POOL_RELEASE = 119,                     ///< Enumerator for ::urUSMPoolRelease
-    UR_FUNCTION_USM_POOL_GET_INFO = 120,                    ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_CONTEXT_CREATE = 1,                           ///< Enumerator for ::urContextCreate
+    UR_FUNCTION_CONTEXT_RETAIN = 2,                           ///< Enumerator for ::urContextRetain
+    UR_FUNCTION_CONTEXT_RELEASE = 3,                          ///< Enumerator for ::urContextRelease
+    UR_FUNCTION_CONTEXT_GET_INFO = 4,                         ///< Enumerator for ::urContextGetInfo
+    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                ///< Enumerator for ::urContextGetNativeHandle
+    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,        ///< Enumerator for ::urContextCreateWithNativeHandle
+    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,             ///< Enumerator for ::urContextSetExtendedDeleter
+    UR_FUNCTION_DEVICE_GET = 8,                               ///< Enumerator for ::urDeviceGet
+    UR_FUNCTION_DEVICE_GET_INFO = 9,                          ///< Enumerator for ::urDeviceGetInfo
+    UR_FUNCTION_DEVICE_RETAIN = 10,                           ///< Enumerator for ::urDeviceRetain
+    UR_FUNCTION_DEVICE_RELEASE = 11,                          ///< Enumerator for ::urDeviceRelease
+    UR_FUNCTION_DEVICE_PARTITION = 12,                        ///< Enumerator for ::urDevicePartition
+    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                    ///< Enumerator for ::urDeviceSelectBinary
+    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                ///< Enumerator for ::urDeviceGetNativeHandle
+    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,        ///< Enumerator for ::urDeviceCreateWithNativeHandle
+    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,            ///< Enumerator for ::urDeviceGetGlobalTimestamps
+    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                   ///< Enumerator for ::urEnqueueKernelLaunch
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                     ///< Enumerator for ::urEnqueueEventsWait
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,        ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                 ///< Enumerator for ::urEnqueueMemBufferRead
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                ///< Enumerator for ::urEnqueueMemBufferWrite
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,            ///< Enumerator for ::urEnqueueMemBufferReadRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,           ///< Enumerator for ::urEnqueueMemBufferWriteRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                 ///< Enumerator for ::urEnqueueMemBufferCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,            ///< Enumerator for ::urEnqueueMemBufferCopyRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                 ///< Enumerator for ::urEnqueueMemBufferFill
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                  ///< Enumerator for ::urEnqueueMemImageRead
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                 ///< Enumerator for ::urEnqueueMemImageWrite
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                  ///< Enumerator for ::urEnqueueMemImageCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                  ///< Enumerator for ::urEnqueueMemBufferMap
+    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                       ///< Enumerator for ::urEnqueueMemUnmap
+    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                        ///< Enumerator for ::urEnqueueUSMFill
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                      ///< Enumerator for ::urEnqueueUSMMemcpy
+    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                    ///< Enumerator for ::urEnqueueUSMPrefetch
+    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                      ///< Enumerator for ::urEnqueueUSMAdvise
+    UR_FUNCTION_ENQUEUE_USM_FILL2_D = 36,                     ///< Enumerator for ::urEnqueueUSMFill2D
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D = 37,                   ///< Enumerator for ::urEnqueueUSMMemcpy2D
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,    ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,     ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
+    UR_FUNCTION_EVENT_GET_INFO = 40,                          ///< Enumerator for ::urEventGetInfo
+    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                ///< Enumerator for ::urEventGetProfilingInfo
+    UR_FUNCTION_EVENT_WAIT = 42,                              ///< Enumerator for ::urEventWait
+    UR_FUNCTION_EVENT_RETAIN = 43,                            ///< Enumerator for ::urEventRetain
+    UR_FUNCTION_EVENT_RELEASE = 44,                           ///< Enumerator for ::urEventRelease
+    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                 ///< Enumerator for ::urEventGetNativeHandle
+    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,         ///< Enumerator for ::urEventCreateWithNativeHandle
+    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                      ///< Enumerator for ::urEventSetCallback
+    UR_FUNCTION_KERNEL_CREATE = 48,                           ///< Enumerator for ::urKernelCreate
+    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                    ///< Enumerator for ::urKernelSetArgValue
+    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                    ///< Enumerator for ::urKernelSetArgLocal
+    UR_FUNCTION_KERNEL_GET_INFO = 51,                         ///< Enumerator for ::urKernelGetInfo
+    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                   ///< Enumerator for ::urKernelGetGroupInfo
+    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,               ///< Enumerator for ::urKernelGetSubGroupInfo
+    UR_FUNCTION_KERNEL_RETAIN = 54,                           ///< Enumerator for ::urKernelRetain
+    UR_FUNCTION_KERNEL_RELEASE = 55,                          ///< Enumerator for ::urKernelRelease
+    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                  ///< Enumerator for ::urKernelSetArgPointer
+    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                    ///< Enumerator for ::urKernelSetExecInfo
+    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                  ///< Enumerator for ::urKernelSetArgSampler
+    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                  ///< Enumerator for ::urKernelSetArgMemObj
+    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,     ///< Enumerator for ::urKernelSetSpecializationConstants
+    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                ///< Enumerator for ::urKernelGetNativeHandle
+    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,        ///< Enumerator for ::urKernelCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                        ///< Enumerator for ::urMemImageCreate
+    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                       ///< Enumerator for ::urMemBufferCreate
+    UR_FUNCTION_MEM_RETAIN = 65,                              ///< Enumerator for ::urMemRetain
+    UR_FUNCTION_MEM_RELEASE = 66,                             ///< Enumerator for ::urMemRelease
+    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                    ///< Enumerator for ::urMemBufferPartition
+    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                   ///< Enumerator for ::urMemGetNativeHandle
+    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                  ///< Enumerator for ::urEnqueueReadHostPipe
+    UR_FUNCTION_MEM_GET_INFO = 70,                            ///< Enumerator for ::urMemGetInfo
+    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                      ///< Enumerator for ::urMemImageGetInfo
+    UR_FUNCTION_PLATFORM_GET = 72,                            ///< Enumerator for ::urPlatformGet
+    UR_FUNCTION_PLATFORM_GET_INFO = 73,                       ///< Enumerator for ::urPlatformGetInfo
+    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                ///< Enumerator for ::urPlatformGetApiVersion
+    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,              ///< Enumerator for ::urPlatformGetNativeHandle
+    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,      ///< Enumerator for ::urPlatformCreateWithNativeHandle
+    UR_FUNCTION_GET_LAST_RESULT = 77,                         ///< Enumerator for ::urGetLastResult
+    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                  ///< Enumerator for ::urProgramCreateWithIL
+    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,              ///< Enumerator for ::urProgramCreateWithBinary
+    UR_FUNCTION_PROGRAM_BUILD = 80,                           ///< Enumerator for ::urProgramBuild
+    UR_FUNCTION_PROGRAM_COMPILE = 81,                         ///< Enumerator for ::urProgramCompile
+    UR_FUNCTION_PROGRAM_LINK = 82,                            ///< Enumerator for ::urProgramLink
+    UR_FUNCTION_PROGRAM_RETAIN = 83,                          ///< Enumerator for ::urProgramRetain
+    UR_FUNCTION_PROGRAM_RELEASE = 84,                         ///< Enumerator for ::urProgramRelease
+    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,            ///< Enumerator for ::urProgramGetFunctionPointer
+    UR_FUNCTION_PROGRAM_GET_INFO = 86,                        ///< Enumerator for ::urProgramGetInfo
+    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                  ///< Enumerator for ::urProgramGetBuildInfo
+    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,    ///< Enumerator for ::urProgramSetSpecializationConstants
+    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,               ///< Enumerator for ::urProgramGetNativeHandle
+    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,       ///< Enumerator for ::urProgramCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_GET_INFO = 91,                          ///< Enumerator for ::urQueueGetInfo
+    UR_FUNCTION_QUEUE_CREATE = 92,                            ///< Enumerator for ::urQueueCreate
+    UR_FUNCTION_QUEUE_RETAIN = 93,                            ///< Enumerator for ::urQueueRetain
+    UR_FUNCTION_QUEUE_RELEASE = 94,                           ///< Enumerator for ::urQueueRelease
+    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                 ///< Enumerator for ::urQueueGetNativeHandle
+    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,         ///< Enumerator for ::urQueueCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_FINISH = 97,                            ///< Enumerator for ::urQueueFinish
+    UR_FUNCTION_QUEUE_FLUSH = 98,                             ///< Enumerator for ::urQueueFlush
+    UR_FUNCTION_INIT = 99,                                    ///< Enumerator for ::urInit
+    UR_FUNCTION_TEAR_DOWN = 100,                              ///< Enumerator for ::urTearDown
+    UR_FUNCTION_SAMPLER_CREATE = 101,                         ///< Enumerator for ::urSamplerCreate
+    UR_FUNCTION_SAMPLER_RETAIN = 102,                         ///< Enumerator for ::urSamplerRetain
+    UR_FUNCTION_SAMPLER_RELEASE = 103,                        ///< Enumerator for ::urSamplerRelease
+    UR_FUNCTION_SAMPLER_GET_INFO = 104,                       ///< Enumerator for ::urSamplerGetInfo
+    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,              ///< Enumerator for ::urSamplerGetNativeHandle
+    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,      ///< Enumerator for ::urSamplerCreateWithNativeHandle
+    UR_FUNCTION_USM_HOST_ALLOC = 107,                         ///< Enumerator for ::urUSMHostAlloc
+    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                       ///< Enumerator for ::urUSMDeviceAlloc
+    UR_FUNCTION_USM_SHARED_ALLOC = 109,                       ///< Enumerator for ::urUSMSharedAlloc
+    UR_FUNCTION_USM_FREE = 110,                               ///< Enumerator for ::urUSMFree
+    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                 ///< Enumerator for ::urUSMGetMemAllocInfo
+    UR_FUNCTION_USM_POOL_CREATE = 112,                        ///< Enumerator for ::urUSMPoolCreate
+    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,              ///< Enumerator for ::urCommandBufferCreateExp
+    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,            ///< Enumerator for ::urPlatformGetBackendOption
+    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,   ///< Enumerator for ::urMemBufferCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,    ///< Enumerator for ::urMemImageCreateWithNativeHandle
+    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                ///< Enumerator for ::urEnqueueWriteHostPipe
+    UR_FUNCTION_USM_POOL_RETAIN = 118,                        ///< Enumerator for ::urUSMPoolRetain
+    UR_FUNCTION_USM_POOL_RELEASE = 119,                       ///< Enumerator for ::urUSMPoolRelease
+    UR_FUNCTION_USM_POOL_GET_INFO = 120,                      ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,              ///< Enumerator for ::urCommandBufferRetainExp
+    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,             ///< Enumerator for ::urCommandBufferReleaseExp
+    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,            ///< Enumerator for ::urCommandBufferFinalizeExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP = 124,       ///< Enumerator for ::urCommandBufferAppendKernelExp
+    UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP = 125,          ///< Enumerator for ::urCommandBufferMemcpyUSMExp
+    UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP = 126,      ///< Enumerator for ::urCommandBufferMembufferCopyExp
+    UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP = 127, ///< Enumerator for ::urCommandBufferMembufferCopyRectExp
+    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,             ///< Enumerator for ::urCommandBufferEnqueueExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7120,6 +7375,118 @@ typedef struct ur_queue_finish_params_t {
 typedef struct ur_queue_flush_params_t {
     ur_queue_handle_t *phQueue;
 } ur_queue_flush_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferCreateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_create_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_exp_command_buffer_desc_t **ppCommandBufferDesc;
+    ur_exp_command_buffer_handle_t **pphCommandBuffer;
+} ur_command_buffer_create_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferRetainExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_retain_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+} ur_command_buffer_retain_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferReleaseExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_release_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+} ur_command_buffer_release_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferFinalizeExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_finalize_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+} ur_command_buffer_finalize_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferAppendKernelExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_append_kernel_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_kernel_handle_t *phKernel;
+    uint32_t *pWorkDim;
+    const size_t **ppGlobalWorkOffset;
+    const size_t **ppGlobalWorkSize;
+    const size_t **ppLocalWorkSize;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_append_kernel_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferMemcpyUSMExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_memcpy_usm_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    void **ppDst;
+    void **ppSrc;
+    size_t *psize;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_memcpy_usm_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferMembufferCopyExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_membuffer_copy_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_mem_handle_t *phSrcMem;
+    ur_mem_handle_t *phDstMem;
+    size_t *psrcOffset;
+    size_t *pdstOffset;
+    size_t *psize;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_membuffer_copy_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferMembufferCopyRectExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_membuffer_copy_rect_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_mem_handle_t *phSrcMem;
+    ur_mem_handle_t *phDstMem;
+    ur_rect_offset_t *pSrcOrigin;
+    ur_rect_offset_t *pDstOrigin;
+    ur_rect_region_t *pRegion;
+    size_t *pSrcRowPitch;
+    size_t *pSrcSlicePitch;
+    size_t *pDstRowPitch;
+    size_t *pDstSlicePitch;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_membuffer_copy_rect_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferEnqueueExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_enqueue_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
+} ur_command_buffer_enqueue_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urInit

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -137,88 +137,88 @@ typedef struct ur_mem_handle_t_ *ur_mem_handle_t;
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines Return/Error codes
 typedef enum ur_result_t {
-    UR_RESULT_SUCCESS = 0,                                                ///< Success
-    UR_RESULT_ERROR_INVALID_OPERATION = 1,                                ///< Invalid operation
-    UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES = 2,                         ///< Invalid queue properties
-    UR_RESULT_ERROR_INVALID_QUEUE = 3,                                    ///< Invalid queue
-    UR_RESULT_ERROR_INVALID_VALUE = 4,                                    ///< Invalid Value
-    UR_RESULT_ERROR_INVALID_CONTEXT = 5,                                  ///< Invalid context
-    UR_RESULT_ERROR_INVALID_PLATFORM = 6,                                 ///< Invalid platform
-    UR_RESULT_ERROR_INVALID_BINARY = 7,                                   ///< Invalid binary
-    UR_RESULT_ERROR_INVALID_PROGRAM = 8,                                  ///< Invalid program
-    UR_RESULT_ERROR_INVALID_SAMPLER = 9,                                  ///< Invalid sampler
-    UR_RESULT_ERROR_INVALID_BUFFER_SIZE = 10,                             ///< Invalid buffer size
-    UR_RESULT_ERROR_INVALID_MEM_OBJECT = 11,                              ///< Invalid memory object
-    UR_RESULT_ERROR_INVALID_EVENT = 12,                                   ///< Invalid event
-    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST = 13,                         ///< Returned when the event wait list or the events in the wait list are
-                                                                          ///< invalid.
-    UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET = 14,                    ///< Misaligned sub buffer offset
-    UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE = 15,                         ///< Invalid work group size
-    UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE = 16,                          ///< Compiler not available
-    UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE = 17,                    ///< Profiling info not available
-    UR_RESULT_ERROR_DEVICE_NOT_FOUND = 18,                                ///< Device not found
-    UR_RESULT_ERROR_INVALID_DEVICE = 19,                                  ///< Invalid device
-    UR_RESULT_ERROR_DEVICE_LOST = 20,                                     ///< Device hung, reset, was removed, or adapter update occurred
-    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 21,                           ///< Device requires a reset
-    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 22,                       ///< Device currently in low power state
-    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 23,                         ///< Device paritioning failed
-    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 24,                  ///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
-    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 25,                          ///< Invalid work item size
-    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 26,                          ///< Invalid work dimension
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 27,                             ///< Invalid kernel args
-    UR_RESULT_ERROR_INVALID_KERNEL = 28,                                  ///< Invalid kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 29,                             ///< [Validation] kernel name is not found in the program
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 30,                   ///< [Validation] kernel argument index is not valid for kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 31,                    ///< [Validation] kernel argument size does not match kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 32,                  ///< [Validation] value of kernel attribute is not valid for the kernel or
-                                                                          ///< device
-    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 33,                              ///< Invalid image size
-    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 34,                 ///< Invalid image format descriptor
-    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 35,                      ///< Image format not supported
-    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 36,                   ///< Memory object allocation failure
-    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 37,                      ///< Program object parameter is invalid.
-    UR_RESULT_ERROR_UNINITIALIZED = 38,                                   ///< [Validation] adapter is not initialized
-    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 39,                              ///< Insufficient host memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 40,                            ///< Insufficient device memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_RESOURCES = 41,                                ///< Out of resources
-    UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE = 42,                           ///< Error occurred when building program, see build log for details
-    UR_RESULT_ERROR_PROGRAM_LINK_FAILURE = 43,                            ///< Error occurred when linking programs, see build log for details
-    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 44,                             ///< [Validation] generic error code for unsupported versions
-    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 45,                             ///< [Validation] generic error code for unsupported features
-    UR_RESULT_ERROR_INVALID_ARGUMENT = 46,                                ///< [Validation] generic error code for invalid arguments
-    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 47,                             ///< [Validation] handle argument is not valid
-    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 48,                            ///< [Validation] object pointed to by handle still in-use by device
-    UR_RESULT_ERROR_INVALID_NULL_POINTER = 49,                            ///< [Validation] pointer argument may not be nullptr
-    UR_RESULT_ERROR_INVALID_SIZE = 50,                                    ///< [Validation] invalid size or dimensions (e.g., must not be zero, or is
-                                                                          ///< out of bounds)
-    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 51,                                ///< [Validation] size argument is not supported by the device (e.g., too
-                                                                          ///< large)
-    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 52,                           ///< [Validation] alignment argument is not supported by the device (e.g.,
-                                                                          ///< too small)
-    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 53,                  ///< [Validation] synchronization object in invalid state
-    UR_RESULT_ERROR_INVALID_ENUMERATION = 54,                             ///< [Validation] enumerator argument is not valid
-    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 55,                         ///< [Validation] enumerator argument is not supported by the device
-    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 56,                        ///< [Validation] image format is not supported by the device
-    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 57,                           ///< [Validation] native binary is not supported by the device
-    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 58,                             ///< [Validation] global variable is not found in the program
-    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 59,                           ///< [Validation] function name is not found in the program
-    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 60,                    ///< [Validation] group size dimension is not valid for the kernel or
-                                                                          ///< device
-    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 61,                  ///< [Validation] global width dimension is not valid for the kernel or
-                                                                          ///< device
-    UR_RESULT_ERROR_PROGRAM_UNLINKED = 62,                                ///< [Validation] compiled program or program with imports needs to be
-                                                                          ///< linked before kernels can be created from it.
-    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 63,                             ///< [Validation] copy operations do not support overlapping regions of
-                                                                          ///< memory
-    UR_RESULT_ERROR_INVALID_HOST_PTR = 64,                                ///< Invalid host pointer
-    UR_RESULT_ERROR_INVALID_USM_SIZE = 65,                                ///< Invalid USM size
-    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 66,                      ///< Invalid Command-Buffer
-    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 67,           ///< Sync point is not valid for the command-buffer
-    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 68, ///< Sync point wait list is invalid
-    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 69,                       ///< Objection allocation failure
-    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 70,                                ///< An adapter specific warning/error has been reported and can be
-                                                                          ///< retrieved via the urGetLastResult entry point.
-    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                                 ///< Unknown or internal error
+    UR_RESULT_SUCCESS = 0,                                                    ///< Success
+    UR_RESULT_ERROR_INVALID_OPERATION = 1,                                    ///< Invalid operation
+    UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES = 2,                             ///< Invalid queue properties
+    UR_RESULT_ERROR_INVALID_QUEUE = 3,                                        ///< Invalid queue
+    UR_RESULT_ERROR_INVALID_VALUE = 4,                                        ///< Invalid Value
+    UR_RESULT_ERROR_INVALID_CONTEXT = 5,                                      ///< Invalid context
+    UR_RESULT_ERROR_INVALID_PLATFORM = 6,                                     ///< Invalid platform
+    UR_RESULT_ERROR_INVALID_BINARY = 7,                                       ///< Invalid binary
+    UR_RESULT_ERROR_INVALID_PROGRAM = 8,                                      ///< Invalid program
+    UR_RESULT_ERROR_INVALID_SAMPLER = 9,                                      ///< Invalid sampler
+    UR_RESULT_ERROR_INVALID_BUFFER_SIZE = 10,                                 ///< Invalid buffer size
+    UR_RESULT_ERROR_INVALID_MEM_OBJECT = 11,                                  ///< Invalid memory object
+    UR_RESULT_ERROR_INVALID_EVENT = 12,                                       ///< Invalid event
+    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST = 13,                             ///< Returned when the event wait list or the events in the wait list are
+                                                                              ///< invalid.
+    UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET = 14,                        ///< Misaligned sub buffer offset
+    UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE = 15,                             ///< Invalid work group size
+    UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE = 16,                              ///< Compiler not available
+    UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE = 17,                        ///< Profiling info not available
+    UR_RESULT_ERROR_DEVICE_NOT_FOUND = 18,                                    ///< Device not found
+    UR_RESULT_ERROR_INVALID_DEVICE = 19,                                      ///< Invalid device
+    UR_RESULT_ERROR_DEVICE_LOST = 20,                                         ///< Device hung, reset, was removed, or adapter update occurred
+    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 21,                               ///< Device requires a reset
+    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 22,                           ///< Device currently in low power state
+    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 23,                             ///< Device paritioning failed
+    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 24,                      ///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
+    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 25,                              ///< Invalid work item size
+    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 26,                              ///< Invalid work dimension
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 27,                                 ///< Invalid kernel args
+    UR_RESULT_ERROR_INVALID_KERNEL = 28,                                      ///< Invalid kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 29,                                 ///< [Validation] kernel name is not found in the program
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 30,                       ///< [Validation] kernel argument index is not valid for kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 31,                        ///< [Validation] kernel argument size does not match kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 32,                      ///< [Validation] value of kernel attribute is not valid for the kernel or
+                                                                              ///< device
+    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 33,                                  ///< Invalid image size
+    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 34,                     ///< Invalid image format descriptor
+    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 35,                          ///< Image format not supported
+    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 36,                       ///< Memory object allocation failure
+    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 37,                          ///< Program object parameter is invalid.
+    UR_RESULT_ERROR_UNINITIALIZED = 38,                                       ///< [Validation] adapter is not initialized
+    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 39,                                  ///< Insufficient host memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 40,                                ///< Insufficient device memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_RESOURCES = 41,                                    ///< Out of resources
+    UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE = 42,                               ///< Error occurred when building program, see build log for details
+    UR_RESULT_ERROR_PROGRAM_LINK_FAILURE = 43,                                ///< Error occurred when linking programs, see build log for details
+    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 44,                                 ///< [Validation] generic error code for unsupported versions
+    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 45,                                 ///< [Validation] generic error code for unsupported features
+    UR_RESULT_ERROR_INVALID_ARGUMENT = 46,                                    ///< [Validation] generic error code for invalid arguments
+    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 47,                                 ///< [Validation] handle argument is not valid
+    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 48,                                ///< [Validation] object pointed to by handle still in-use by device
+    UR_RESULT_ERROR_INVALID_NULL_POINTER = 49,                                ///< [Validation] pointer argument may not be nullptr
+    UR_RESULT_ERROR_INVALID_SIZE = 50,                                        ///< [Validation] invalid size or dimensions (e.g., must not be zero, or is
+                                                                              ///< out of bounds)
+    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 51,                                    ///< [Validation] size argument is not supported by the device (e.g., too
+                                                                              ///< large)
+    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 52,                               ///< [Validation] alignment argument is not supported by the device (e.g.,
+                                                                              ///< too small)
+    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 53,                      ///< [Validation] synchronization object in invalid state
+    UR_RESULT_ERROR_INVALID_ENUMERATION = 54,                                 ///< [Validation] enumerator argument is not valid
+    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 55,                             ///< [Validation] enumerator argument is not supported by the device
+    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 56,                            ///< [Validation] image format is not supported by the device
+    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 57,                               ///< [Validation] native binary is not supported by the device
+    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 58,                                 ///< [Validation] global variable is not found in the program
+    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 59,                               ///< [Validation] function name is not found in the program
+    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 60,                        ///< [Validation] group size dimension is not valid for the kernel or
+                                                                              ///< device
+    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 61,                      ///< [Validation] global width dimension is not valid for the kernel or
+                                                                              ///< device
+    UR_RESULT_ERROR_PROGRAM_UNLINKED = 62,                                    ///< [Validation] compiled program or program with imports needs to be
+                                                                              ///< linked before kernels can be created from it.
+    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 63,                                 ///< [Validation] copy operations do not support overlapping regions of
+                                                                              ///< memory
+    UR_RESULT_ERROR_INVALID_HOST_PTR = 64,                                    ///< Invalid host pointer
+    UR_RESULT_ERROR_INVALID_USM_SIZE = 65,                                    ///< Invalid USM size
+    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 66,                           ///< Objection allocation failure
+    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 67,                                    ///< An adapter specific warning/error has been reported and can be
+                                                                              ///< retrieved via the urGetLastResult entry point.
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 0x1000,                      ///< Invalid Command-Buffer
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 0x1001,           ///< Sync point is not valid for the command-buffer
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 0x1002, ///< Sync point wait list is invalid
+    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                                     ///< Unknown or internal error
     /// @cond
     UR_RESULT_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -295,285 +295,6 @@ typedef struct ur_rect_region_t {
     uint64_t depth;  ///< [in] scalar (scalar)
 
 } ur_rect_region_t;
-
-#if !defined(__GNUC__)
-#pragma endregion
-#endif
-// Intel 'oneAPI' Command-Buffer Extension APIs
-#if !defined(__GNUC__)
-#pragma region exp -command-buffer
-#endif
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Command-Buffer Descriptor Type
-typedef struct ur_exp_command_buffer_desc_t {
-    ur_structure_type_t stype; ///< [in] type of this structure, must be
-                               ///< ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
-    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
-
-} ur_exp_command_buffer_desc_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief A value that identifies a command inside of a command-buffer, used for
-///        defining dependencies between commands in the same command-buffer.
-typedef uint32_t ur_exp_command_buffer_sync_point_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Handle of Command-Buffer object
-typedef struct ur_exp_command_buffer_handle_t_ *ur_exp_command_buffer_handle_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Create a Command-Buffer object
-///
-/// @details
-///     - Create a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///         + `NULL == hDevice`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_INVALID_DEVICE
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferCreateExp(
-    ur_context_handle_t hContext,                           ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                             ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t *phCommandBuffer         ///< [out] pointer to Command-Buffer handle
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Increment the command-buffer object's reference count.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Decrement the command-buffer object's reference count and delete the
-///        command-buffer object if the reference count becomes zero.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Stop recording on a command-buffer object such that no more commands
-///        can be appended and make it ready to enqueue.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a kernel execution command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hKernel`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pGlobalWorkOffset`
-///         + `NULL == pGlobalWorkSize`
-///         + `NULL == pLocalWorkSize`
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL
-///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
-///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
-///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel,                                   ///< [in] kernel to append
-    uint32_t WorkDim,                                             ///< [in] dimension of the kernel execution
-    const size_t *pGlobalWorkOffset,                              ///< [in] Offset to use when executing kernel.
-    const size_t *pGlobalWorkSize,                                ///< [in] Global work size to use when executing kernel.
-    const size_t *pLocalWorkSize,                                 ///< [in] Local work size to use when executing kernel.
-    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a USM memcpy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDst`
-///         + `NULL == pSrc`
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
-    void *pDst,                                                   ///< [in] Location the data will be copied to.
-    const void *pSrc,                                             ///< [in] The data to be copied.
-    size_t size,                                                  ///< [in] The number of bytes to copy
-    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a memory copy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hSrcMem`
-///         + `NULL == hDstMem`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem,                                      ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem,                                      ///< [in] The location the data will be copied to.
-    size_t srcOffset,                                             ///< [in] Offset into the source memory.
-    size_t dstOffset,                                             ///< [in] Offset into the destination memory
-    size_t size,                                                  ///< [in] The number of bytes to be copied.
-    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a rectangular memory copy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hSrcMem`
-///         + `NULL == hDstMem`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem,                                      ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem,                                      ///< [in] The location the data will be copied to.
-    ur_rect_offset_t SrcOrigin,                                   ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t DstOrigin,                                   ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t Region,                                      ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,                                           ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch,                                         ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,                                           ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch,                                         ///< [in] Slice pitch of the destination memory.
-    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Submit a command-buffer for execution on a queue.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_QUEUE
-///     - ::UR_RESULT_ERROR_INVALID_EVENT
-///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
-///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
-///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
-///         + If event objects in phEventWaitList are not valid events.
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t hQueue,                      ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList,                  ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList,      ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                   ///< events that must be complete before the command-buffer execution.
-                                                   ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-                                                   ///< events.
-    ur_event_handle_t *phEvent                     ///< [out][optional] return an event object that identifies this particular
-                                                   ///< command-buffer execution instance.
-);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -5057,7 +4778,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,                     ///< Enumerator for ::urCommandBufferRetainExp
     UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,                    ///< Enumerator for ::urCommandBufferReleaseExp
     UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,                   ///< Enumerator for ::urCommandBufferFinalizeExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP = 124,              ///< Enumerator for ::urCommandBufferAppendKernelExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP = 125,       ///< Enumerator for ::urCommandBufferAppendKernelLaunchExp
     UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,                    ///< Enumerator for ::urCommandBufferEnqueueExp
     UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129,          ///< Enumerator for ::urCommandBufferAppendMemcpyUSMExp
     UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130,      ///< Enumerator for ::urCommandBufferAppendMembufferCopyExp
@@ -6251,6 +5972,275 @@ urEnqueueWriteHostPipe(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait event.
     ur_event_handle_t *phEvent                ///< [out] returns an event object that identifies this write command
                                               ///< and can be used to query or queue a wait for this command to complete.
+);
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' Unified Runtime Experimental APIs for Command-Buffers
+#if !defined(__GNUC__)
+#pragma region command buffer(experimental)
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Command-Buffer Descriptor Type
+typedef struct ur_exp_command_buffer_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+
+} ur_exp_command_buffer_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief A value that identifies a command inside of a command-buffer, used for
+///        defining dependencies between commands in the same command-buffer.
+typedef uint32_t ur_exp_command_buffer_sync_point_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of Command-Buffer object
+typedef struct ur_exp_command_buffer_handle_t_ *ur_exp_command_buffer_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a Command-Buffer object
+///
+/// @details
+///     - Create a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferCreateExp(
+    ur_context_handle_t hContext,                           ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                             ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t *phCommandBuffer         ///< [out] pointer to Command-Buffer handle
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Increment the command-buffer object's reference count.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command-buffer object's reference count and delete the
+///        command-buffer object if the reference count becomes zero.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop recording on a command-buffer object such that no more commands
+///        can be appended and make it ready to enqueue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a kernel execution command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == pLocalWorkSize`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL
+///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel,                                   ///< [in] kernel to append
+    uint32_t workDim,                                             ///< [in] dimension of the kernel execution
+    const size_t *pGlobalWorkOffset,                              ///< [in] Offset to use when executing kernel.
+    const size_t *pGlobalWorkSize,                                ///< [in] Global work size to use when executing kernel.
+    const size_t *pLocalWorkSize,                                 ///< [in] Local work size to use when executing kernel.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a USM memcpy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `size == 0`
+///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    void *pDst,                                                   ///< [in] Location the data will be copied to.
+    const void *pSrc,                                             ///< [in] The data to be copied.
+    size_t size,                                                  ///< [in] The number of bytes to copy
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem,                                      ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem,                                      ///< [in] The location the data will be copied to.
+    size_t srcOffset,                                             ///< [in] Offset into the source memory.
+    size_t dstOffset,                                             ///< [in] Offset into the destination memory
+    size_t size,                                                  ///< [in] The number of bytes to be copied.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem,                                      ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem,                                      ///< [in] The location the data will be copied to.
+    ur_rect_offset_t srcOrigin,                                   ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t dstOrigin,                                   ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t region,                                      ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,                                           ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch,                                         ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,                                           ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch,                                         ///< [in] Slice pitch of the destination memory.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Submit a command-buffer for execution on a queue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_EVENT
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
+///         + If event objects in phEventWaitList are not valid events.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t hQueue,                      ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList,                  ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList,      ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                   ///< events that must be complete before the command-buffer execution.
+                                                   ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+                                                   ///< events.
+    ur_event_handle_t *phEvent                     ///< [out][optional] return an event object that identifies this particular
+                                                   ///< command-buffer execution instance.
 );
 
 #if !defined(__GNUC__)
@@ -7450,20 +7440,20 @@ typedef struct ur_command_buffer_finalize_exp_params_t {
 } ur_command_buffer_finalize_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urCommandBufferAppendKernelExp
+/// @brief Function parameters for urCommandBufferAppendKernelLaunchExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_command_buffer_append_kernel_exp_params_t {
+typedef struct ur_command_buffer_append_kernel_launch_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
     ur_kernel_handle_t *phKernel;
-    uint32_t *pWorkDim;
+    uint32_t *pworkDim;
     const size_t **ppGlobalWorkOffset;
     const size_t **ppGlobalWorkSize;
     const size_t **ppLocalWorkSize;
     uint32_t *pnumSyncPointsInWaitList;
     const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;
-} ur_command_buffer_append_kernel_exp_params_t;
+} ur_command_buffer_append_kernel_launch_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urCommandBufferAppendMemcpyUSMExp
@@ -7503,13 +7493,13 @@ typedef struct ur_command_buffer_append_membuffer_copy_rect_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
     ur_mem_handle_t *phSrcMem;
     ur_mem_handle_t *phDstMem;
-    ur_rect_offset_t *pSrcOrigin;
-    ur_rect_offset_t *pDstOrigin;
-    ur_rect_region_t *pRegion;
-    size_t *pSrcRowPitch;
-    size_t *pSrcSlicePitch;
-    size_t *pDstRowPitch;
-    size_t *pDstSlicePitch;
+    ur_rect_offset_t *psrcOrigin;
+    ur_rect_offset_t *pdstOrigin;
+    ur_rect_region_t *pregion;
+    size_t *psrcRowPitch;
+    size_t *psrcSlicePitch;
+    size_t *pdstRowPitch;
+    size_t *pdstSlicePitch;
     uint32_t *pnumSyncPointsInWaitList;
     const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -212,8 +212,9 @@ typedef enum ur_result_t {
                                                           ///< memory
     UR_RESULT_ERROR_INVALID_HOST_PTR = 64,                ///< Invalid host pointer
     UR_RESULT_ERROR_INVALID_USM_SIZE = 65,                ///< Invalid USM size
-    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 66,       ///< Objection allocation failure
-    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 67,                ///< An adapter specific warning/error has been reported and can be
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 66,      ///< Invalid Command-Buffer
+    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 67,       ///< Objection allocation failure
+    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 68,                ///< An adapter specific warning/error has been reported and can be
                                                           ///< retrieved via the urGetLastResult entry point.
     UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                 ///< Unknown or internal error
     /// @cond
@@ -450,7 +451,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
     void *pDst,                                              ///< [in] Location the data will be copied to.
-    void *pSrc,                                              ///< [in] The data to be copied.
+    const void *pSrc,                                        ///< [in] The data to be copied.
     size_t size,                                             ///< [in] The number of bytes to copy
     uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
@@ -524,9 +525,11 @@ urCommandBufferMembufferCopyRectExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///         + `NULL == hQueue`
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t hQueue,                      ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList,                  ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList,      ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                    ///< events that must be complete before the command-buffer execution.
@@ -4576,6 +4579,7 @@ typedef enum ur_command_t {
     UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 24,  ///< Event created by ::urEnqueueDeviceGlobalVariableRead
     UR_COMMAND_READ_HOST_PIPE = 25,               ///< Event created by ::urEnqueueReadHostPipe
     UR_COMMAND_WRITE_HOST_PIPE = 26,              ///< Event created by ::urEnqueueWriteHostPipe
+    UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP = 27,   ///< Event created by ::urCommandBufferEnqueueExp
     /// @cond
     UR_COMMAND_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7434,7 +7438,7 @@ typedef struct ur_command_buffer_append_kernel_exp_params_t {
 typedef struct ur_command_buffer_memcpy_usm_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
     void **ppDst;
-    void **ppSrc;
+    const void **ppSrc;
     size_t *psize;
     uint32_t *pnumSyncPointsInWaitList;
     const ur_exp_command_buffer_sync_point_t **ppDependencies;
@@ -7483,6 +7487,7 @@ typedef struct ur_command_buffer_membuffer_copy_rect_exp_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_command_buffer_enqueue_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_queue_handle_t *phQueue;
     uint32_t *pnumEventsInWaitList;
     const ur_event_handle_t **pphEventWaitList;
     ur_event_handle_t **pphEvent;

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -6099,7 +6099,9 @@ urCommandBufferFinalizeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -6133,7 +6135,9 @@ urCommandBufferAppendKernelLaunchExp(
 ///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -6160,7 +6164,9 @@ urCommandBufferAppendMemcpyUSMExp(
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -6190,7 +6196,9 @@ urCommandBufferAppendMembufferCopyExp(
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -137,86 +137,88 @@ typedef struct ur_mem_handle_t_ *ur_mem_handle_t;
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines Return/Error codes
 typedef enum ur_result_t {
-    UR_RESULT_SUCCESS = 0,                                ///< Success
-    UR_RESULT_ERROR_INVALID_OPERATION = 1,                ///< Invalid operation
-    UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES = 2,         ///< Invalid queue properties
-    UR_RESULT_ERROR_INVALID_QUEUE = 3,                    ///< Invalid queue
-    UR_RESULT_ERROR_INVALID_VALUE = 4,                    ///< Invalid Value
-    UR_RESULT_ERROR_INVALID_CONTEXT = 5,                  ///< Invalid context
-    UR_RESULT_ERROR_INVALID_PLATFORM = 6,                 ///< Invalid platform
-    UR_RESULT_ERROR_INVALID_BINARY = 7,                   ///< Invalid binary
-    UR_RESULT_ERROR_INVALID_PROGRAM = 8,                  ///< Invalid program
-    UR_RESULT_ERROR_INVALID_SAMPLER = 9,                  ///< Invalid sampler
-    UR_RESULT_ERROR_INVALID_BUFFER_SIZE = 10,             ///< Invalid buffer size
-    UR_RESULT_ERROR_INVALID_MEM_OBJECT = 11,              ///< Invalid memory object
-    UR_RESULT_ERROR_INVALID_EVENT = 12,                   ///< Invalid event
-    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST = 13,         ///< Returned when the event wait list or the events in the wait list are
-                                                          ///< invalid.
-    UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET = 14,    ///< Misaligned sub buffer offset
-    UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE = 15,         ///< Invalid work group size
-    UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE = 16,          ///< Compiler not available
-    UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE = 17,    ///< Profiling info not available
-    UR_RESULT_ERROR_DEVICE_NOT_FOUND = 18,                ///< Device not found
-    UR_RESULT_ERROR_INVALID_DEVICE = 19,                  ///< Invalid device
-    UR_RESULT_ERROR_DEVICE_LOST = 20,                     ///< Device hung, reset, was removed, or adapter update occurred
-    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 21,           ///< Device requires a reset
-    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 22,       ///< Device currently in low power state
-    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 23,         ///< Device paritioning failed
-    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 24,  ///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
-    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 25,          ///< Invalid work item size
-    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 26,          ///< Invalid work dimension
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 27,             ///< Invalid kernel args
-    UR_RESULT_ERROR_INVALID_KERNEL = 28,                  ///< Invalid kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 29,             ///< [Validation] kernel name is not found in the program
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 30,   ///< [Validation] kernel argument index is not valid for kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 31,    ///< [Validation] kernel argument size does not match kernel
-    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 32,  ///< [Validation] value of kernel attribute is not valid for the kernel or
-                                                          ///< device
-    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 33,              ///< Invalid image size
-    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 34, ///< Invalid image format descriptor
-    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 35,      ///< Image format not supported
-    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 36,   ///< Memory object allocation failure
-    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 37,      ///< Program object parameter is invalid.
-    UR_RESULT_ERROR_UNINITIALIZED = 38,                   ///< [Validation] adapter is not initialized
-    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 39,              ///< Insufficient host memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 40,            ///< Insufficient device memory to satisfy call
-    UR_RESULT_ERROR_OUT_OF_RESOURCES = 41,                ///< Out of resources
-    UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE = 42,           ///< Error occurred when building program, see build log for details
-    UR_RESULT_ERROR_PROGRAM_LINK_FAILURE = 43,            ///< Error occurred when linking programs, see build log for details
-    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 44,             ///< [Validation] generic error code for unsupported versions
-    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 45,             ///< [Validation] generic error code for unsupported features
-    UR_RESULT_ERROR_INVALID_ARGUMENT = 46,                ///< [Validation] generic error code for invalid arguments
-    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 47,             ///< [Validation] handle argument is not valid
-    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 48,            ///< [Validation] object pointed to by handle still in-use by device
-    UR_RESULT_ERROR_INVALID_NULL_POINTER = 49,            ///< [Validation] pointer argument may not be nullptr
-    UR_RESULT_ERROR_INVALID_SIZE = 50,                    ///< [Validation] invalid size or dimensions (e.g., must not be zero, or is
-                                                          ///< out of bounds)
-    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 51,                ///< [Validation] size argument is not supported by the device (e.g., too
-                                                          ///< large)
-    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 52,           ///< [Validation] alignment argument is not supported by the device (e.g.,
-                                                          ///< too small)
-    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 53,  ///< [Validation] synchronization object in invalid state
-    UR_RESULT_ERROR_INVALID_ENUMERATION = 54,             ///< [Validation] enumerator argument is not valid
-    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 55,         ///< [Validation] enumerator argument is not supported by the device
-    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 56,        ///< [Validation] image format is not supported by the device
-    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 57,           ///< [Validation] native binary is not supported by the device
-    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 58,             ///< [Validation] global variable is not found in the program
-    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 59,           ///< [Validation] function name is not found in the program
-    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 60,    ///< [Validation] group size dimension is not valid for the kernel or
-                                                          ///< device
-    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 61,  ///< [Validation] global width dimension is not valid for the kernel or
-                                                          ///< device
-    UR_RESULT_ERROR_PROGRAM_UNLINKED = 62,                ///< [Validation] compiled program or program with imports needs to be
-                                                          ///< linked before kernels can be created from it.
-    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 63,             ///< [Validation] copy operations do not support overlapping regions of
-                                                          ///< memory
-    UR_RESULT_ERROR_INVALID_HOST_PTR = 64,                ///< Invalid host pointer
-    UR_RESULT_ERROR_INVALID_USM_SIZE = 65,                ///< Invalid USM size
-    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 66,      ///< Invalid Command-Buffer
-    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 67,       ///< Objection allocation failure
-    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 68,                ///< An adapter specific warning/error has been reported and can be
-                                                          ///< retrieved via the urGetLastResult entry point.
-    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                 ///< Unknown or internal error
+    UR_RESULT_SUCCESS = 0,                                                ///< Success
+    UR_RESULT_ERROR_INVALID_OPERATION = 1,                                ///< Invalid operation
+    UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES = 2,                         ///< Invalid queue properties
+    UR_RESULT_ERROR_INVALID_QUEUE = 3,                                    ///< Invalid queue
+    UR_RESULT_ERROR_INVALID_VALUE = 4,                                    ///< Invalid Value
+    UR_RESULT_ERROR_INVALID_CONTEXT = 5,                                  ///< Invalid context
+    UR_RESULT_ERROR_INVALID_PLATFORM = 6,                                 ///< Invalid platform
+    UR_RESULT_ERROR_INVALID_BINARY = 7,                                   ///< Invalid binary
+    UR_RESULT_ERROR_INVALID_PROGRAM = 8,                                  ///< Invalid program
+    UR_RESULT_ERROR_INVALID_SAMPLER = 9,                                  ///< Invalid sampler
+    UR_RESULT_ERROR_INVALID_BUFFER_SIZE = 10,                             ///< Invalid buffer size
+    UR_RESULT_ERROR_INVALID_MEM_OBJECT = 11,                              ///< Invalid memory object
+    UR_RESULT_ERROR_INVALID_EVENT = 12,                                   ///< Invalid event
+    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST = 13,                         ///< Returned when the event wait list or the events in the wait list are
+                                                                          ///< invalid.
+    UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET = 14,                    ///< Misaligned sub buffer offset
+    UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE = 15,                         ///< Invalid work group size
+    UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE = 16,                          ///< Compiler not available
+    UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE = 17,                    ///< Profiling info not available
+    UR_RESULT_ERROR_DEVICE_NOT_FOUND = 18,                                ///< Device not found
+    UR_RESULT_ERROR_INVALID_DEVICE = 19,                                  ///< Invalid device
+    UR_RESULT_ERROR_DEVICE_LOST = 20,                                     ///< Device hung, reset, was removed, or adapter update occurred
+    UR_RESULT_ERROR_DEVICE_REQUIRES_RESET = 21,                           ///< Device requires a reset
+    UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE = 22,                       ///< Device currently in low power state
+    UR_RESULT_ERROR_DEVICE_PARTITION_FAILED = 23,                         ///< Device paritioning failed
+    UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT = 24,                  ///< Invalid counts provided with ::UR_DEVICE_PARTITION_BY_COUNTS
+    UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE = 25,                          ///< Invalid work item size
+    UR_RESULT_ERROR_INVALID_WORK_DIMENSION = 26,                          ///< Invalid work dimension
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGS = 27,                             ///< Invalid kernel args
+    UR_RESULT_ERROR_INVALID_KERNEL = 28,                                  ///< Invalid kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_NAME = 29,                             ///< [Validation] kernel name is not found in the program
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX = 30,                   ///< [Validation] kernel argument index is not valid for kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE = 31,                    ///< [Validation] kernel argument size does not match kernel
+    UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE = 32,                  ///< [Validation] value of kernel attribute is not valid for the kernel or
+                                                                          ///< device
+    UR_RESULT_ERROR_INVALID_IMAGE_SIZE = 33,                              ///< Invalid image size
+    UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR = 34,                 ///< Invalid image format descriptor
+    UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED = 35,                      ///< Image format not supported
+    UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE = 36,                   ///< Memory object allocation failure
+    UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE = 37,                      ///< Program object parameter is invalid.
+    UR_RESULT_ERROR_UNINITIALIZED = 38,                                   ///< [Validation] adapter is not initialized
+    UR_RESULT_ERROR_OUT_OF_HOST_MEMORY = 39,                              ///< Insufficient host memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY = 40,                            ///< Insufficient device memory to satisfy call
+    UR_RESULT_ERROR_OUT_OF_RESOURCES = 41,                                ///< Out of resources
+    UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE = 42,                           ///< Error occurred when building program, see build log for details
+    UR_RESULT_ERROR_PROGRAM_LINK_FAILURE = 43,                            ///< Error occurred when linking programs, see build log for details
+    UR_RESULT_ERROR_UNSUPPORTED_VERSION = 44,                             ///< [Validation] generic error code for unsupported versions
+    UR_RESULT_ERROR_UNSUPPORTED_FEATURE = 45,                             ///< [Validation] generic error code for unsupported features
+    UR_RESULT_ERROR_INVALID_ARGUMENT = 46,                                ///< [Validation] generic error code for invalid arguments
+    UR_RESULT_ERROR_INVALID_NULL_HANDLE = 47,                             ///< [Validation] handle argument is not valid
+    UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE = 48,                            ///< [Validation] object pointed to by handle still in-use by device
+    UR_RESULT_ERROR_INVALID_NULL_POINTER = 49,                            ///< [Validation] pointer argument may not be nullptr
+    UR_RESULT_ERROR_INVALID_SIZE = 50,                                    ///< [Validation] invalid size or dimensions (e.g., must not be zero, or is
+                                                                          ///< out of bounds)
+    UR_RESULT_ERROR_UNSUPPORTED_SIZE = 51,                                ///< [Validation] size argument is not supported by the device (e.g., too
+                                                                          ///< large)
+    UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT = 52,                           ///< [Validation] alignment argument is not supported by the device (e.g.,
+                                                                          ///< too small)
+    UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT = 53,                  ///< [Validation] synchronization object in invalid state
+    UR_RESULT_ERROR_INVALID_ENUMERATION = 54,                             ///< [Validation] enumerator argument is not valid
+    UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION = 55,                         ///< [Validation] enumerator argument is not supported by the device
+    UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT = 56,                        ///< [Validation] image format is not supported by the device
+    UR_RESULT_ERROR_INVALID_NATIVE_BINARY = 57,                           ///< [Validation] native binary is not supported by the device
+    UR_RESULT_ERROR_INVALID_GLOBAL_NAME = 58,                             ///< [Validation] global variable is not found in the program
+    UR_RESULT_ERROR_INVALID_FUNCTION_NAME = 59,                           ///< [Validation] function name is not found in the program
+    UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION = 60,                    ///< [Validation] group size dimension is not valid for the kernel or
+                                                                          ///< device
+    UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION = 61,                  ///< [Validation] global width dimension is not valid for the kernel or
+                                                                          ///< device
+    UR_RESULT_ERROR_PROGRAM_UNLINKED = 62,                                ///< [Validation] compiled program or program with imports needs to be
+                                                                          ///< linked before kernels can be created from it.
+    UR_RESULT_ERROR_OVERLAPPING_REGIONS = 63,                             ///< [Validation] copy operations do not support overlapping regions of
+                                                                          ///< memory
+    UR_RESULT_ERROR_INVALID_HOST_PTR = 64,                                ///< Invalid host pointer
+    UR_RESULT_ERROR_INVALID_USM_SIZE = 65,                                ///< Invalid USM size
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 66,                      ///< Invalid Command-Buffer
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 67,           ///< Sync point is not valid for the command-buffer
+    UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 68, ///< Sync point wait list is invalid
+    UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 69,                       ///< Objection allocation failure
+    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 70,                                ///< An adapter specific warning/error has been reported and can be
+                                                                          ///< retrieved via the urGetLastResult entry point.
+    UR_RESULT_ERROR_UNKNOWN = 0x7ffffffe,                                 ///< Unknown or internal error
     /// @cond
     UR_RESULT_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -346,6 +348,10 @@ typedef struct ur_exp_command_buffer_handle_t_ *ur_exp_command_buffer_handle_t;
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferCreateExp(
     ur_context_handle_t hContext,                           ///< [in] handle of the context object
@@ -363,6 +369,7 @@ urCommandBufferCreateExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -380,6 +387,7 @@ urCommandBufferRetainExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -397,8 +405,9 @@ urCommandBufferReleaseExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t hCommandBuffer ///< [in] handle of the command-buffer object
@@ -418,19 +427,28 @@ urCommandBufferFinalizeExp(
 ///         + `NULL == pGlobalWorkOffset`
 ///         + `NULL == pGlobalWorkSize`
 ///         + `NULL == pLocalWorkSize`
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL
+///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel,                              ///< [in] kernel to append
-    uint32_t WorkDim,                                        ///< [in] dimension of the kernel execution
-    const size_t *pGlobalWorkOffset,                         ///< [in] Offset to use when executing kernel.
-    const size_t *pGlobalWorkSize,                           ///< [in] Global work size to use when executing kernel.
-    const size_t *pLocalWorkSize,                            ///< [in] Local work size to use when executing kernel.
-    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel,                                   ///< [in] kernel to append
+    uint32_t WorkDim,                                             ///< [in] dimension of the kernel execution
+    const size_t *pGlobalWorkOffset,                              ///< [in] Offset to use when executing kernel.
+    const size_t *pGlobalWorkSize,                                ///< [in] Global work size to use when executing kernel.
+    const size_t *pLocalWorkSize,                                 ///< [in] Local work size to use when executing kernel.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -445,17 +463,26 @@ urCommandBufferAppendKernelExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `size == 0`
+///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
-    void *pDst,                                              ///< [in] Location the data will be copied to.
-    const void *pSrc,                                        ///< [in] The data to be copied.
-    size_t size,                                             ///< [in] The number of bytes to copy
-    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    void *pDst,                                                   ///< [in] Location the data will be copied to.
+    const void *pSrc,                                             ///< [in] The data to be copied.
+    size_t size,                                                  ///< [in] The number of bytes to copy
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -470,19 +497,25 @@ urCommandBufferMemcpyUSMExp(
 ///         + `NULL == hSrcMem`
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferMembufferCopyExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem,                                 ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem,                                 ///< [in] The location the data will be copied to.
-    size_t srcOffset,                                        ///< [in] Offset into the source memory.
-    size_t dstOffset,                                        ///< [in] Offset into the destination memory
-    size_t size,                                             ///< [in] The number of bytes to be copied.
-    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem,                                      ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem,                                      ///< [in] The location the data will be copied to.
+    size_t srcOffset,                                             ///< [in] Offset into the source memory.
+    size_t dstOffset,                                             ///< [in] Offset into the destination memory
+    size_t size,                                                  ///< [in] The number of bytes to be copied.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -497,23 +530,29 @@ urCommandBufferMembufferCopyExp(
 ///         + `NULL == hSrcMem`
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer,           ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem,                                 ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem,                                 ///< [in] The location the data will be copied to.
-    ur_rect_offset_t SrcOrigin,                              ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t DstOrigin,                              ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t Region,                                 ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,                                      ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch,                                    ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,                                      ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch,                                    ///< [in] Slice pitch of the destination memory.
-    uint32_t numSyncPointsInWaitList,                        ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *pDependencies, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t *pSyncPoint           ///< [out] sync point associated with this command
+urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem,                                      ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem,                                      ///< [in] The location the data will be copied to.
+    ur_rect_offset_t SrcOrigin,                                   ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t DstOrigin,                                   ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t Region,                                      ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,                                           ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch,                                         ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,                                           ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch,                                         ///< [in] Slice pitch of the destination memory.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out] sync point associated with this command
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -526,6 +565,15 @@ urCommandBufferMembufferCopyRectExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
 ///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_EVENT
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
+///         + If event objects in phEventWaitList are not valid events.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t hCommandBuffer, ///< [in] handle of the command-buffer object.
@@ -4900,134 +4948,134 @@ urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines unique stable identifiers for all functions
 typedef enum ur_function_t {
-    UR_FUNCTION_CONTEXT_CREATE = 1,                           ///< Enumerator for ::urContextCreate
-    UR_FUNCTION_CONTEXT_RETAIN = 2,                           ///< Enumerator for ::urContextRetain
-    UR_FUNCTION_CONTEXT_RELEASE = 3,                          ///< Enumerator for ::urContextRelease
-    UR_FUNCTION_CONTEXT_GET_INFO = 4,                         ///< Enumerator for ::urContextGetInfo
-    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                ///< Enumerator for ::urContextGetNativeHandle
-    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,        ///< Enumerator for ::urContextCreateWithNativeHandle
-    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,             ///< Enumerator for ::urContextSetExtendedDeleter
-    UR_FUNCTION_DEVICE_GET = 8,                               ///< Enumerator for ::urDeviceGet
-    UR_FUNCTION_DEVICE_GET_INFO = 9,                          ///< Enumerator for ::urDeviceGetInfo
-    UR_FUNCTION_DEVICE_RETAIN = 10,                           ///< Enumerator for ::urDeviceRetain
-    UR_FUNCTION_DEVICE_RELEASE = 11,                          ///< Enumerator for ::urDeviceRelease
-    UR_FUNCTION_DEVICE_PARTITION = 12,                        ///< Enumerator for ::urDevicePartition
-    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                    ///< Enumerator for ::urDeviceSelectBinary
-    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                ///< Enumerator for ::urDeviceGetNativeHandle
-    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,        ///< Enumerator for ::urDeviceCreateWithNativeHandle
-    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,            ///< Enumerator for ::urDeviceGetGlobalTimestamps
-    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                   ///< Enumerator for ::urEnqueueKernelLaunch
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                     ///< Enumerator for ::urEnqueueEventsWait
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,        ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                 ///< Enumerator for ::urEnqueueMemBufferRead
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                ///< Enumerator for ::urEnqueueMemBufferWrite
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,            ///< Enumerator for ::urEnqueueMemBufferReadRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,           ///< Enumerator for ::urEnqueueMemBufferWriteRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                 ///< Enumerator for ::urEnqueueMemBufferCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,            ///< Enumerator for ::urEnqueueMemBufferCopyRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                 ///< Enumerator for ::urEnqueueMemBufferFill
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                  ///< Enumerator for ::urEnqueueMemImageRead
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                 ///< Enumerator for ::urEnqueueMemImageWrite
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                  ///< Enumerator for ::urEnqueueMemImageCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                  ///< Enumerator for ::urEnqueueMemBufferMap
-    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                       ///< Enumerator for ::urEnqueueMemUnmap
-    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                        ///< Enumerator for ::urEnqueueUSMFill
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                      ///< Enumerator for ::urEnqueueUSMMemcpy
-    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                    ///< Enumerator for ::urEnqueueUSMPrefetch
-    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                      ///< Enumerator for ::urEnqueueUSMAdvise
-    UR_FUNCTION_ENQUEUE_USM_FILL2_D = 36,                     ///< Enumerator for ::urEnqueueUSMFill2D
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D = 37,                   ///< Enumerator for ::urEnqueueUSMMemcpy2D
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,    ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,     ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
-    UR_FUNCTION_EVENT_GET_INFO = 40,                          ///< Enumerator for ::urEventGetInfo
-    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                ///< Enumerator for ::urEventGetProfilingInfo
-    UR_FUNCTION_EVENT_WAIT = 42,                              ///< Enumerator for ::urEventWait
-    UR_FUNCTION_EVENT_RETAIN = 43,                            ///< Enumerator for ::urEventRetain
-    UR_FUNCTION_EVENT_RELEASE = 44,                           ///< Enumerator for ::urEventRelease
-    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                 ///< Enumerator for ::urEventGetNativeHandle
-    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,         ///< Enumerator for ::urEventCreateWithNativeHandle
-    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                      ///< Enumerator for ::urEventSetCallback
-    UR_FUNCTION_KERNEL_CREATE = 48,                           ///< Enumerator for ::urKernelCreate
-    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                    ///< Enumerator for ::urKernelSetArgValue
-    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                    ///< Enumerator for ::urKernelSetArgLocal
-    UR_FUNCTION_KERNEL_GET_INFO = 51,                         ///< Enumerator for ::urKernelGetInfo
-    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                   ///< Enumerator for ::urKernelGetGroupInfo
-    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,               ///< Enumerator for ::urKernelGetSubGroupInfo
-    UR_FUNCTION_KERNEL_RETAIN = 54,                           ///< Enumerator for ::urKernelRetain
-    UR_FUNCTION_KERNEL_RELEASE = 55,                          ///< Enumerator for ::urKernelRelease
-    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                  ///< Enumerator for ::urKernelSetArgPointer
-    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                    ///< Enumerator for ::urKernelSetExecInfo
-    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                  ///< Enumerator for ::urKernelSetArgSampler
-    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                  ///< Enumerator for ::urKernelSetArgMemObj
-    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,     ///< Enumerator for ::urKernelSetSpecializationConstants
-    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                ///< Enumerator for ::urKernelGetNativeHandle
-    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,        ///< Enumerator for ::urKernelCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                        ///< Enumerator for ::urMemImageCreate
-    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                       ///< Enumerator for ::urMemBufferCreate
-    UR_FUNCTION_MEM_RETAIN = 65,                              ///< Enumerator for ::urMemRetain
-    UR_FUNCTION_MEM_RELEASE = 66,                             ///< Enumerator for ::urMemRelease
-    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                    ///< Enumerator for ::urMemBufferPartition
-    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                   ///< Enumerator for ::urMemGetNativeHandle
-    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                  ///< Enumerator for ::urEnqueueReadHostPipe
-    UR_FUNCTION_MEM_GET_INFO = 70,                            ///< Enumerator for ::urMemGetInfo
-    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                      ///< Enumerator for ::urMemImageGetInfo
-    UR_FUNCTION_PLATFORM_GET = 72,                            ///< Enumerator for ::urPlatformGet
-    UR_FUNCTION_PLATFORM_GET_INFO = 73,                       ///< Enumerator for ::urPlatformGetInfo
-    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                ///< Enumerator for ::urPlatformGetApiVersion
-    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,              ///< Enumerator for ::urPlatformGetNativeHandle
-    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,      ///< Enumerator for ::urPlatformCreateWithNativeHandle
-    UR_FUNCTION_GET_LAST_RESULT = 77,                         ///< Enumerator for ::urGetLastResult
-    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                  ///< Enumerator for ::urProgramCreateWithIL
-    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,              ///< Enumerator for ::urProgramCreateWithBinary
-    UR_FUNCTION_PROGRAM_BUILD = 80,                           ///< Enumerator for ::urProgramBuild
-    UR_FUNCTION_PROGRAM_COMPILE = 81,                         ///< Enumerator for ::urProgramCompile
-    UR_FUNCTION_PROGRAM_LINK = 82,                            ///< Enumerator for ::urProgramLink
-    UR_FUNCTION_PROGRAM_RETAIN = 83,                          ///< Enumerator for ::urProgramRetain
-    UR_FUNCTION_PROGRAM_RELEASE = 84,                         ///< Enumerator for ::urProgramRelease
-    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,            ///< Enumerator for ::urProgramGetFunctionPointer
-    UR_FUNCTION_PROGRAM_GET_INFO = 86,                        ///< Enumerator for ::urProgramGetInfo
-    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                  ///< Enumerator for ::urProgramGetBuildInfo
-    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,    ///< Enumerator for ::urProgramSetSpecializationConstants
-    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,               ///< Enumerator for ::urProgramGetNativeHandle
-    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,       ///< Enumerator for ::urProgramCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_GET_INFO = 91,                          ///< Enumerator for ::urQueueGetInfo
-    UR_FUNCTION_QUEUE_CREATE = 92,                            ///< Enumerator for ::urQueueCreate
-    UR_FUNCTION_QUEUE_RETAIN = 93,                            ///< Enumerator for ::urQueueRetain
-    UR_FUNCTION_QUEUE_RELEASE = 94,                           ///< Enumerator for ::urQueueRelease
-    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                 ///< Enumerator for ::urQueueGetNativeHandle
-    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,         ///< Enumerator for ::urQueueCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_FINISH = 97,                            ///< Enumerator for ::urQueueFinish
-    UR_FUNCTION_QUEUE_FLUSH = 98,                             ///< Enumerator for ::urQueueFlush
-    UR_FUNCTION_INIT = 99,                                    ///< Enumerator for ::urInit
-    UR_FUNCTION_TEAR_DOWN = 100,                              ///< Enumerator for ::urTearDown
-    UR_FUNCTION_SAMPLER_CREATE = 101,                         ///< Enumerator for ::urSamplerCreate
-    UR_FUNCTION_SAMPLER_RETAIN = 102,                         ///< Enumerator for ::urSamplerRetain
-    UR_FUNCTION_SAMPLER_RELEASE = 103,                        ///< Enumerator for ::urSamplerRelease
-    UR_FUNCTION_SAMPLER_GET_INFO = 104,                       ///< Enumerator for ::urSamplerGetInfo
-    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,              ///< Enumerator for ::urSamplerGetNativeHandle
-    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,      ///< Enumerator for ::urSamplerCreateWithNativeHandle
-    UR_FUNCTION_USM_HOST_ALLOC = 107,                         ///< Enumerator for ::urUSMHostAlloc
-    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                       ///< Enumerator for ::urUSMDeviceAlloc
-    UR_FUNCTION_USM_SHARED_ALLOC = 109,                       ///< Enumerator for ::urUSMSharedAlloc
-    UR_FUNCTION_USM_FREE = 110,                               ///< Enumerator for ::urUSMFree
-    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                 ///< Enumerator for ::urUSMGetMemAllocInfo
-    UR_FUNCTION_USM_POOL_CREATE = 112,                        ///< Enumerator for ::urUSMPoolCreate
-    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,              ///< Enumerator for ::urCommandBufferCreateExp
-    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,            ///< Enumerator for ::urPlatformGetBackendOption
-    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,   ///< Enumerator for ::urMemBufferCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,    ///< Enumerator for ::urMemImageCreateWithNativeHandle
-    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                ///< Enumerator for ::urEnqueueWriteHostPipe
-    UR_FUNCTION_USM_POOL_RETAIN = 118,                        ///< Enumerator for ::urUSMPoolRetain
-    UR_FUNCTION_USM_POOL_RELEASE = 119,                       ///< Enumerator for ::urUSMPoolRelease
-    UR_FUNCTION_USM_POOL_GET_INFO = 120,                      ///< Enumerator for ::urUSMPoolGetInfo
-    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,              ///< Enumerator for ::urCommandBufferRetainExp
-    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,             ///< Enumerator for ::urCommandBufferReleaseExp
-    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,            ///< Enumerator for ::urCommandBufferFinalizeExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP = 124,       ///< Enumerator for ::urCommandBufferAppendKernelExp
-    UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP = 125,          ///< Enumerator for ::urCommandBufferMemcpyUSMExp
-    UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP = 126,      ///< Enumerator for ::urCommandBufferMembufferCopyExp
-    UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP = 127, ///< Enumerator for ::urCommandBufferMembufferCopyRectExp
-    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,             ///< Enumerator for ::urCommandBufferEnqueueExp
+    UR_FUNCTION_CONTEXT_CREATE = 1,                                  ///< Enumerator for ::urContextCreate
+    UR_FUNCTION_CONTEXT_RETAIN = 2,                                  ///< Enumerator for ::urContextRetain
+    UR_FUNCTION_CONTEXT_RELEASE = 3,                                 ///< Enumerator for ::urContextRelease
+    UR_FUNCTION_CONTEXT_GET_INFO = 4,                                ///< Enumerator for ::urContextGetInfo
+    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                       ///< Enumerator for ::urContextGetNativeHandle
+    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,               ///< Enumerator for ::urContextCreateWithNativeHandle
+    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,                    ///< Enumerator for ::urContextSetExtendedDeleter
+    UR_FUNCTION_DEVICE_GET = 8,                                      ///< Enumerator for ::urDeviceGet
+    UR_FUNCTION_DEVICE_GET_INFO = 9,                                 ///< Enumerator for ::urDeviceGetInfo
+    UR_FUNCTION_DEVICE_RETAIN = 10,                                  ///< Enumerator for ::urDeviceRetain
+    UR_FUNCTION_DEVICE_RELEASE = 11,                                 ///< Enumerator for ::urDeviceRelease
+    UR_FUNCTION_DEVICE_PARTITION = 12,                               ///< Enumerator for ::urDevicePartition
+    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                           ///< Enumerator for ::urDeviceSelectBinary
+    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                       ///< Enumerator for ::urDeviceGetNativeHandle
+    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,               ///< Enumerator for ::urDeviceCreateWithNativeHandle
+    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,                   ///< Enumerator for ::urDeviceGetGlobalTimestamps
+    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                          ///< Enumerator for ::urEnqueueKernelLaunch
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                            ///< Enumerator for ::urEnqueueEventsWait
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,               ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                        ///< Enumerator for ::urEnqueueMemBufferRead
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                       ///< Enumerator for ::urEnqueueMemBufferWrite
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,                   ///< Enumerator for ::urEnqueueMemBufferReadRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,                  ///< Enumerator for ::urEnqueueMemBufferWriteRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                        ///< Enumerator for ::urEnqueueMemBufferCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,                   ///< Enumerator for ::urEnqueueMemBufferCopyRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                        ///< Enumerator for ::urEnqueueMemBufferFill
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                         ///< Enumerator for ::urEnqueueMemImageRead
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                        ///< Enumerator for ::urEnqueueMemImageWrite
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                         ///< Enumerator for ::urEnqueueMemImageCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                         ///< Enumerator for ::urEnqueueMemBufferMap
+    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                              ///< Enumerator for ::urEnqueueMemUnmap
+    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                               ///< Enumerator for ::urEnqueueUSMFill
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                             ///< Enumerator for ::urEnqueueUSMMemcpy
+    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                           ///< Enumerator for ::urEnqueueUSMPrefetch
+    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                             ///< Enumerator for ::urEnqueueUSMAdvise
+    UR_FUNCTION_ENQUEUE_USM_FILL2_D = 36,                            ///< Enumerator for ::urEnqueueUSMFill2D
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D = 37,                          ///< Enumerator for ::urEnqueueUSMMemcpy2D
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,           ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,            ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
+    UR_FUNCTION_EVENT_GET_INFO = 40,                                 ///< Enumerator for ::urEventGetInfo
+    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                       ///< Enumerator for ::urEventGetProfilingInfo
+    UR_FUNCTION_EVENT_WAIT = 42,                                     ///< Enumerator for ::urEventWait
+    UR_FUNCTION_EVENT_RETAIN = 43,                                   ///< Enumerator for ::urEventRetain
+    UR_FUNCTION_EVENT_RELEASE = 44,                                  ///< Enumerator for ::urEventRelease
+    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                        ///< Enumerator for ::urEventGetNativeHandle
+    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,                ///< Enumerator for ::urEventCreateWithNativeHandle
+    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                             ///< Enumerator for ::urEventSetCallback
+    UR_FUNCTION_KERNEL_CREATE = 48,                                  ///< Enumerator for ::urKernelCreate
+    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                           ///< Enumerator for ::urKernelSetArgValue
+    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                           ///< Enumerator for ::urKernelSetArgLocal
+    UR_FUNCTION_KERNEL_GET_INFO = 51,                                ///< Enumerator for ::urKernelGetInfo
+    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                          ///< Enumerator for ::urKernelGetGroupInfo
+    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,                      ///< Enumerator for ::urKernelGetSubGroupInfo
+    UR_FUNCTION_KERNEL_RETAIN = 54,                                  ///< Enumerator for ::urKernelRetain
+    UR_FUNCTION_KERNEL_RELEASE = 55,                                 ///< Enumerator for ::urKernelRelease
+    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                         ///< Enumerator for ::urKernelSetArgPointer
+    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                           ///< Enumerator for ::urKernelSetExecInfo
+    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                         ///< Enumerator for ::urKernelSetArgSampler
+    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                         ///< Enumerator for ::urKernelSetArgMemObj
+    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,            ///< Enumerator for ::urKernelSetSpecializationConstants
+    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                       ///< Enumerator for ::urKernelGetNativeHandle
+    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,               ///< Enumerator for ::urKernelCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                               ///< Enumerator for ::urMemImageCreate
+    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                              ///< Enumerator for ::urMemBufferCreate
+    UR_FUNCTION_MEM_RETAIN = 65,                                     ///< Enumerator for ::urMemRetain
+    UR_FUNCTION_MEM_RELEASE = 66,                                    ///< Enumerator for ::urMemRelease
+    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                           ///< Enumerator for ::urMemBufferPartition
+    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                          ///< Enumerator for ::urMemGetNativeHandle
+    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                         ///< Enumerator for ::urEnqueueReadHostPipe
+    UR_FUNCTION_MEM_GET_INFO = 70,                                   ///< Enumerator for ::urMemGetInfo
+    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                             ///< Enumerator for ::urMemImageGetInfo
+    UR_FUNCTION_PLATFORM_GET = 72,                                   ///< Enumerator for ::urPlatformGet
+    UR_FUNCTION_PLATFORM_GET_INFO = 73,                              ///< Enumerator for ::urPlatformGetInfo
+    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                       ///< Enumerator for ::urPlatformGetApiVersion
+    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,                     ///< Enumerator for ::urPlatformGetNativeHandle
+    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,             ///< Enumerator for ::urPlatformCreateWithNativeHandle
+    UR_FUNCTION_GET_LAST_RESULT = 77,                                ///< Enumerator for ::urGetLastResult
+    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                         ///< Enumerator for ::urProgramCreateWithIL
+    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,                     ///< Enumerator for ::urProgramCreateWithBinary
+    UR_FUNCTION_PROGRAM_BUILD = 80,                                  ///< Enumerator for ::urProgramBuild
+    UR_FUNCTION_PROGRAM_COMPILE = 81,                                ///< Enumerator for ::urProgramCompile
+    UR_FUNCTION_PROGRAM_LINK = 82,                                   ///< Enumerator for ::urProgramLink
+    UR_FUNCTION_PROGRAM_RETAIN = 83,                                 ///< Enumerator for ::urProgramRetain
+    UR_FUNCTION_PROGRAM_RELEASE = 84,                                ///< Enumerator for ::urProgramRelease
+    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,                   ///< Enumerator for ::urProgramGetFunctionPointer
+    UR_FUNCTION_PROGRAM_GET_INFO = 86,                               ///< Enumerator for ::urProgramGetInfo
+    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                         ///< Enumerator for ::urProgramGetBuildInfo
+    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,           ///< Enumerator for ::urProgramSetSpecializationConstants
+    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,                      ///< Enumerator for ::urProgramGetNativeHandle
+    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,              ///< Enumerator for ::urProgramCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_GET_INFO = 91,                                 ///< Enumerator for ::urQueueGetInfo
+    UR_FUNCTION_QUEUE_CREATE = 92,                                   ///< Enumerator for ::urQueueCreate
+    UR_FUNCTION_QUEUE_RETAIN = 93,                                   ///< Enumerator for ::urQueueRetain
+    UR_FUNCTION_QUEUE_RELEASE = 94,                                  ///< Enumerator for ::urQueueRelease
+    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                        ///< Enumerator for ::urQueueGetNativeHandle
+    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,                ///< Enumerator for ::urQueueCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_FINISH = 97,                                   ///< Enumerator for ::urQueueFinish
+    UR_FUNCTION_QUEUE_FLUSH = 98,                                    ///< Enumerator for ::urQueueFlush
+    UR_FUNCTION_INIT = 99,                                           ///< Enumerator for ::urInit
+    UR_FUNCTION_TEAR_DOWN = 100,                                     ///< Enumerator for ::urTearDown
+    UR_FUNCTION_SAMPLER_CREATE = 101,                                ///< Enumerator for ::urSamplerCreate
+    UR_FUNCTION_SAMPLER_RETAIN = 102,                                ///< Enumerator for ::urSamplerRetain
+    UR_FUNCTION_SAMPLER_RELEASE = 103,                               ///< Enumerator for ::urSamplerRelease
+    UR_FUNCTION_SAMPLER_GET_INFO = 104,                              ///< Enumerator for ::urSamplerGetInfo
+    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,                     ///< Enumerator for ::urSamplerGetNativeHandle
+    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,             ///< Enumerator for ::urSamplerCreateWithNativeHandle
+    UR_FUNCTION_USM_HOST_ALLOC = 107,                                ///< Enumerator for ::urUSMHostAlloc
+    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                              ///< Enumerator for ::urUSMDeviceAlloc
+    UR_FUNCTION_USM_SHARED_ALLOC = 109,                              ///< Enumerator for ::urUSMSharedAlloc
+    UR_FUNCTION_USM_FREE = 110,                                      ///< Enumerator for ::urUSMFree
+    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                        ///< Enumerator for ::urUSMGetMemAllocInfo
+    UR_FUNCTION_USM_POOL_CREATE = 112,                               ///< Enumerator for ::urUSMPoolCreate
+    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,                     ///< Enumerator for ::urCommandBufferCreateExp
+    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,                   ///< Enumerator for ::urPlatformGetBackendOption
+    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,          ///< Enumerator for ::urMemBufferCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,           ///< Enumerator for ::urMemImageCreateWithNativeHandle
+    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                       ///< Enumerator for ::urEnqueueWriteHostPipe
+    UR_FUNCTION_USM_POOL_RETAIN = 118,                               ///< Enumerator for ::urUSMPoolRetain
+    UR_FUNCTION_USM_POOL_RELEASE = 119,                              ///< Enumerator for ::urUSMPoolRelease
+    UR_FUNCTION_USM_POOL_GET_INFO = 120,                             ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,                     ///< Enumerator for ::urCommandBufferRetainExp
+    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,                    ///< Enumerator for ::urCommandBufferReleaseExp
+    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,                   ///< Enumerator for ::urCommandBufferFinalizeExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP = 124,              ///< Enumerator for ::urCommandBufferAppendKernelExp
+    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,                    ///< Enumerator for ::urCommandBufferEnqueueExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129,          ///< Enumerator for ::urCommandBufferAppendMemcpyUSMExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130,      ///< Enumerator for ::urCommandBufferAppendMembufferCopyExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP = 131, ///< Enumerator for ::urCommandBufferAppendMembufferCopyRectExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7427,29 +7475,29 @@ typedef struct ur_command_buffer_append_kernel_exp_params_t {
     const size_t **ppGlobalWorkSize;
     const size_t **ppLocalWorkSize;
     uint32_t *pnumSyncPointsInWaitList;
-    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;
 } ur_command_buffer_append_kernel_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urCommandBufferMemcpyUSMExp
+/// @brief Function parameters for urCommandBufferAppendMemcpyUSMExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_command_buffer_memcpy_usm_exp_params_t {
+typedef struct ur_command_buffer_append_memcpy_usm_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
     void **ppDst;
     const void **ppSrc;
     size_t *psize;
     uint32_t *pnumSyncPointsInWaitList;
-    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;
-} ur_command_buffer_memcpy_usm_exp_params_t;
+} ur_command_buffer_append_memcpy_usm_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urCommandBufferMembufferCopyExp
+/// @brief Function parameters for urCommandBufferAppendMembufferCopyExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_command_buffer_membuffer_copy_exp_params_t {
+typedef struct ur_command_buffer_append_membuffer_copy_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
     ur_mem_handle_t *phSrcMem;
     ur_mem_handle_t *phDstMem;
@@ -7457,15 +7505,15 @@ typedef struct ur_command_buffer_membuffer_copy_exp_params_t {
     size_t *pdstOffset;
     size_t *psize;
     uint32_t *pnumSyncPointsInWaitList;
-    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;
-} ur_command_buffer_membuffer_copy_exp_params_t;
+} ur_command_buffer_append_membuffer_copy_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urCommandBufferMembufferCopyRectExp
+/// @brief Function parameters for urCommandBufferAppendMembufferCopyRectExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_command_buffer_membuffer_copy_rect_exp_params_t {
+typedef struct ur_command_buffer_append_membuffer_copy_rect_exp_params_t {
     ur_exp_command_buffer_handle_t *phCommandBuffer;
     ur_mem_handle_t *phSrcMem;
     ur_mem_handle_t *phDstMem;
@@ -7477,9 +7525,9 @@ typedef struct ur_command_buffer_membuffer_copy_rect_exp_params_t {
     size_t *pDstRowPitch;
     size_t *pDstSlicePitch;
     uint32_t *pnumSyncPointsInWaitList;
-    const ur_exp_command_buffer_sync_point_t **ppDependencies;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;
-} ur_command_buffer_membuffer_copy_rect_exp_params_t;
+} ur_command_buffer_append_membuffer_copy_rect_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urCommandBufferEnqueueExp

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -304,18 +304,6 @@ typedef struct ur_rect_region_t {
 #pragma region exp -command-buffer
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Command buffer support level for device info queries.
-typedef enum ur_exp_command_buffer_support_level_t {
-    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_UNSUPPORTED = 0, ///< No support for command-buffers.
-    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_EMULATED = 1,    ///< Emulated support for command-buffers.
-    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_NATIVE = 2,      ///< Native support for command-buffers.
-    /// @cond
-    UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_FORCE_UINT32 = 0x7fffffff
-    /// @endcond
-
-} ur_exp_command_buffer_support_level_t;
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Command-Buffer Descriptor Type
 typedef struct ur_exp_command_buffer_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
@@ -1220,8 +1208,6 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED = 111,        ///< [::ur_bool_t] Return true if the device supports enqueing commands to
                                                                 ///< read and write pipes from the host.
     UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP = 112,          ///< [uint32_t] The maximum number of registers available per block.
-    UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT = 113,            ///< [::ur_exp_command_buffer_support_level_t] Level of experimental
-                                                                ///< command-buffer support.
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1246,7 +1232,7 @@ typedef enum ur_device_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName`
+///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1254,7 +1254,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendKernelExp_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMemcpyUSMExp_t)(
     ur_exp_command_buffer_handle_t,
     void *,
-    void *,
+    const void *,
     size_t,
     uint32_t,
     const ur_exp_command_buffer_sync_point_t *,
@@ -1294,6 +1294,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMembufferCopyRectExp_t)(
 /// @brief Function-pointer for urCommandBufferEnqueueExp
 typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferEnqueueExp_t)(
     ur_exp_command_buffer_handle_t,
+    ur_queue_handle_t,
     uint32_t,
     const ur_event_handle_t *,
     ur_event_handle_t *);

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1237,8 +1237,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferFinalizeExp_t)(
     ur_exp_command_buffer_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urCommandBufferAppendKernelExp
-typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendKernelExp_t)(
+/// @brief Function-pointer for urCommandBufferAppendKernelLaunchExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendKernelLaunchExp_t)(
     ur_exp_command_buffer_handle_t,
     ur_kernel_handle_t,
     uint32_t,
@@ -1306,7 +1306,7 @@ typedef struct ur_command_buffer_exp_dditable_t {
     ur_pfnCommandBufferRetainExp_t pfnRetainExp;
     ur_pfnCommandBufferReleaseExp_t pfnReleaseExp;
     ur_pfnCommandBufferFinalizeExp_t pfnFinalizeExp;
-    ur_pfnCommandBufferAppendKernelExp_t pfnAppendKernelExp;
+    ur_pfnCommandBufferAppendKernelLaunchExp_t pfnAppendKernelLaunchExp;
     ur_pfnCommandBufferAppendMemcpyUSMExp_t pfnAppendMemcpyUSMExp;
     ur_pfnCommandBufferAppendMembufferCopyExp_t pfnAppendMembufferCopyExp;
     ur_pfnCommandBufferAppendMembufferCopyRectExp_t pfnAppendMembufferCopyRectExp;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1214,6 +1214,126 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
     ur_queue_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferCreateExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferCreateExp_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    const ur_exp_command_buffer_desc_t *,
+    ur_exp_command_buffer_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferRetainExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferRetainExp_t)(
+    ur_exp_command_buffer_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferReleaseExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferReleaseExp_t)(
+    ur_exp_command_buffer_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferFinalizeExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferFinalizeExp_t)(
+    ur_exp_command_buffer_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferAppendKernelExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendKernelExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_kernel_handle_t,
+    uint32_t,
+    const size_t *,
+    const size_t *,
+    const size_t *,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferMemcpyUSMExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMemcpyUSMExp_t)(
+    ur_exp_command_buffer_handle_t,
+    void *,
+    void *,
+    size_t,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferMembufferCopyExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMembufferCopyExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_mem_handle_t,
+    ur_mem_handle_t,
+    size_t,
+    size_t,
+    size_t,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferMembufferCopyRectExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMembufferCopyRectExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_mem_handle_t,
+    ur_mem_handle_t,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    size_t,
+    size_t,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferEnqueueExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferEnqueueExp_t)(
+    ur_exp_command_buffer_handle_t,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of CommandBufferExp functions pointers
+typedef struct ur_command_buffer_exp_dditable_t {
+    ur_pfnCommandBufferCreateExp_t pfnCreateExp;
+    ur_pfnCommandBufferRetainExp_t pfnRetainExp;
+    ur_pfnCommandBufferReleaseExp_t pfnReleaseExp;
+    ur_pfnCommandBufferFinalizeExp_t pfnFinalizeExp;
+    ur_pfnCommandBufferAppendKernelExp_t pfnAppendKernelExp;
+    ur_pfnCommandBufferMemcpyUSMExp_t pfnMemcpyUSMExp;
+    ur_pfnCommandBufferMembufferCopyExp_t pfnMembufferCopyExp;
+    ur_pfnCommandBufferMembufferCopyRectExp_t pfnMembufferCopyRectExp;
+    ur_pfnCommandBufferEnqueueExp_t pfnEnqueueExp;
+} ur_command_buffer_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandBufferExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetCommandBufferExpProcAddrTable(
+    ur_api_version_t version,                   ///< [in] API version requested
+    ur_command_buffer_exp_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetCommandBufferExpProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetCommandBufferExpProcAddrTable_t)(
+    ur_api_version_t,
+    ur_command_buffer_exp_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urInit
 typedef ur_result_t(UR_APICALL *ur_pfnInit_t)(
     ur_device_init_flags_t);
@@ -1477,6 +1597,7 @@ typedef struct ur_dditable_t {
     ur_mem_dditable_t Mem;
     ur_enqueue_dditable_t Enqueue;
     ur_queue_dditable_t Queue;
+    ur_command_buffer_exp_dditable_t CommandBufferExp;
     ur_global_dditable_t Global;
     ur_usm_dditable_t USM;
     ur_device_dditable_t Device;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1250,8 +1250,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendKernelExp_t)(
     ur_exp_command_buffer_sync_point_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urCommandBufferMemcpyUSMExp
-typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMemcpyUSMExp_t)(
+/// @brief Function-pointer for urCommandBufferAppendMemcpyUSMExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMemcpyUSMExp_t)(
     ur_exp_command_buffer_handle_t,
     void *,
     const void *,
@@ -1261,8 +1261,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMemcpyUSMExp_t)(
     ur_exp_command_buffer_sync_point_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urCommandBufferMembufferCopyExp
-typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMembufferCopyExp_t)(
+/// @brief Function-pointer for urCommandBufferAppendMembufferCopyExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferCopyExp_t)(
     ur_exp_command_buffer_handle_t,
     ur_mem_handle_t,
     ur_mem_handle_t,
@@ -1274,8 +1274,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMembufferCopyExp_t)(
     ur_exp_command_buffer_sync_point_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urCommandBufferMembufferCopyRectExp
-typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferMembufferCopyRectExp_t)(
+/// @brief Function-pointer for urCommandBufferAppendMembufferCopyRectExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferCopyRectExp_t)(
     ur_exp_command_buffer_handle_t,
     ur_mem_handle_t,
     ur_mem_handle_t,
@@ -1307,9 +1307,9 @@ typedef struct ur_command_buffer_exp_dditable_t {
     ur_pfnCommandBufferReleaseExp_t pfnReleaseExp;
     ur_pfnCommandBufferFinalizeExp_t pfnFinalizeExp;
     ur_pfnCommandBufferAppendKernelExp_t pfnAppendKernelExp;
-    ur_pfnCommandBufferMemcpyUSMExp_t pfnMemcpyUSMExp;
-    ur_pfnCommandBufferMembufferCopyExp_t pfnMembufferCopyExp;
-    ur_pfnCommandBufferMembufferCopyRectExp_t pfnMembufferCopyRectExp;
+    ur_pfnCommandBufferAppendMemcpyUSMExp_t pfnAppendMemcpyUSMExp;
+    ur_pfnCommandBufferAppendMembufferCopyExp_t pfnAppendMembufferCopyExp;
+    ur_pfnCommandBufferAppendMembufferCopyRectExp_t pfnAppendMembufferCopyRectExp;
     ur_pfnCommandBufferEnqueueExp_t pfnEnqueueExp;
 } ur_command_buffer_exp_dditable_t;
 

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -251,6 +251,8 @@ etors:
       desc: "Invalid host pointer"
     - name: ERROR_INVALID_USM_SIZE
       desc: "Invalid USM size"
+    - name: ERROR_INVALID_COMMAND_BUFFER_EXP
+      desc: "Invalid Command-Buffer"
     - name: ERROR_OBJECT_ALLOCATION_FAILURE
       desc: "Objection allocation failure"
     - name: ERROR_ADAPTER_SPECIFIC

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -253,6 +253,10 @@ etors:
       desc: "Invalid USM size"
     - name: ERROR_INVALID_COMMAND_BUFFER_EXP
       desc: "Invalid Command-Buffer"
+    - name: ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+      desc: "Sync point is not valid for the command-buffer"
+    - name: ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+      desc: "Sync point wait list is invalid"
     - name: ERROR_OBJECT_ALLOCATION_FAILURE
       desc: "Objection allocation failure"
     - name: ERROR_ADAPTER_SPECIFIC

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -318,6 +318,8 @@ etors:
       desc: $x_queue_native_desc_t
     - name: DEVICE_PARTITION_PROPERTIES
       desc: $x_device_partition_properties_t
+    - name: EXP_COMMAND_BUFFER_DESC
+      desc: $x_exp_command_buffer_desc_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -251,17 +251,20 @@ etors:
       desc: "Invalid host pointer"
     - name: ERROR_INVALID_USM_SIZE
       desc: "Invalid USM size"
-    - name: ERROR_INVALID_COMMAND_BUFFER_EXP
-      desc: "Invalid Command-Buffer"
-    - name: ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-      desc: "Sync point is not valid for the command-buffer"
-    - name: ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
-      desc: "Sync point wait list is invalid"
     - name: ERROR_OBJECT_ALLOCATION_FAILURE
       desc: "Objection allocation failure"
     - name: ERROR_ADAPTER_SPECIFIC
       desc: "An adapter specific warning/error has been reported and can be retrieved
              via the urGetLastResult entry point."
+    - name: ERROR_INVALID_COMMAND_BUFFER_EXP
+      value: "0x1000"
+      desc: "Invalid Command-Buffer"
+    - name: ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+      value: "0x1001"
+      desc: "Sync point is not valid for the command-buffer"
+    - name: ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+      value: "0x1002"
+      desc: "Sync point wait list is invalid"
     - name: ERROR_UNKNOWN
       value: "0x7ffffffe"
       desc: "Unknown or internal error"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -383,8 +383,6 @@ etors:
       desc: "[$x_bool_t] Return true if the device supports enqueing commands to read and write pipes from the host."
     - name: MAX_REGISTERS_PER_WORK_GROUP
       desc: "[uint32_t] The maximum number of registers available per block."
-    - name: EXP_COMMAND_BUFFER_SUPPORT
-      desc: "[$x_exp_command_buffer_support_level_t] Level of experimental command-buffer support."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -383,6 +383,8 @@ etors:
       desc: "[$x_bool_t] Return true if the device supports enqueing commands to read and write pipes from the host."
     - name: MAX_REGISTERS_PER_WORK_GROUP
       desc: "[uint32_t] The maximum number of registers available per block."
+    - name: EXP_COMMAND_BUFFER_SUPPORT
+      desc: "[$x_exp_command_buffer_support_level_t] Level of experimental command-buffer support."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -73,6 +73,8 @@ etors:
       desc: Event created by $xEnqueueReadHostPipe
     - name: WRITE_HOST_PIPE
       desc: Event created by $xEnqueueWriteHostPipe
+    - name: COMMAND_BUFFER_ENQUEUE_EXP
+      desc: Event created by $xCommandBufferEnqueueExp
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Event Status"

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -134,7 +134,7 @@ params:
     - type: "void*"
       name: pDst
       desc: "[in] Location the data will be copied to."
-    - type: "void*"
+    - type: "const void*"
       name: pSrc
       desc: "[in] The data to be copied."
     - type: "size_t"
@@ -236,6 +236,9 @@ params:
     - type: $x_exp_command_buffer_handle_t
       name: hCommandBuffer
       desc: "[in] handle of the command-buffer object."
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] the queue to submit this command-buffer for execution."
     - type: uint32_t
       name: numEventsInWaitList
       desc: "[in] size of the event wait list"

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -3,19 +3,6 @@ type: header
 desc: "Intel $OneApi Command-Buffer Extension APIs"
 ordinal: "0"
 --- #--------------------------------------------------------------------------
-type: enum
-desc: "Command buffer support level for device info queries."
-class: $xCommandBuffer
-name: $x_exp_command_buffer_support_level_t
-etors:
-    - name: UNSUPPORTED
-      desc: "No support for command-buffers."
-      value: "0"
-    - name: EMULATED
-      desc: "Emulated support for command-buffers."
-    - name: NATIVE
-      desc: "Native support for command-buffers."
---- #--------------------------------------------------------------------------
 type: struct
 desc: "Command-Buffer Descriptor Type"
 name: $x_exp_command_buffer_desc_t

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -53,6 +53,11 @@ params:
     - type: "$x_exp_command_buffer_handle_t*"
       name: phCommandBuffer
       desc: "[out] pointer to Command-Buffer handle"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_DEVICE
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Increment the command-buffer object's reference count."
@@ -63,6 +68,7 @@ params:
       name: hCommandBuffer
       desc: "[in] handle of the command-buffer object"
 returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
 --- #--------------------------------------------------------------------------
@@ -75,6 +81,7 @@ params:
       name: hCommandBuffer
       desc: "[in] handle of the command-buffer object"
 returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
 --- #--------------------------------------------------------------------------
@@ -87,8 +94,9 @@ params:
       name: hCommandBuffer
       desc: "[in] handle of the command-buffer object"
 returns:
-    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Append a kernel execution command to a command-buffer object"
@@ -117,16 +125,28 @@ params:
       name: numSyncPointsInWaitList
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
-      name: pDependencies
+      name: pSyncPointWaitList
       desc: "[in] A list of sync points that this command depends on."
     - type: "$x_exp_command_buffer_sync_point_t*"
       name: pSyncPoint
       desc: "[out] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_KERNEL
+    - $X_RESULT_ERROR_INVALID_WORK_DIMENSION
+    - $X_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Append a USM memcpy command to a command-buffer object"
 class: $xCommandBuffer
-name: MemcpyUSMExp
+name: AppendMemcpyUSMExp
 params:
     - type: $x_exp_command_buffer_handle_t
       name: hCommandBuffer
@@ -144,16 +164,28 @@ params:
       name: numSyncPointsInWaitList
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
-      name: pDependencies
+      name: pSyncPointWaitList
       desc: "[in] A list of sync points that this command depends on."
     - type: "$x_exp_command_buffer_sync_point_t*"
       name: pSyncPoint
       desc: "[out] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`size == 0`"
+        - "If `size` is higher than the allocation size of `pSrc` or `pDst`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Append a memory copy command to a command-buffer object"
 class: $xCommandBuffer
-name: MembufferCopyExp
+name: AppendMembufferCopyExp
 params:
     - type: $x_exp_command_buffer_handle_t
       name: hCommandBuffer
@@ -177,16 +209,25 @@ params:
       name: numSyncPointsInWaitList
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
-      name: pDependencies
+      name: pSyncPointWaitList
       desc: "[in] A list of sync points that this command depends on."
     - type: "$x_exp_command_buffer_sync_point_t*"
       name: pSyncPoint
       desc: "[out] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Append a rectangular memory copy command to a command-buffer object"
 class: $xCommandBuffer
-name: MembufferCopyRectExp
+name: AppendMembufferCopyRectExp
 params:
     - type: $x_exp_command_buffer_handle_t
       name: hCommandBuffer
@@ -222,11 +263,20 @@ params:
       name: numSyncPointsInWaitList
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
-      name: pDependencies
+      name: pSyncPointWaitList
       desc: "[in] A list of sync points that this command depends on."
     - type: $x_exp_command_buffer_sync_point_t*
       name: pSyncPoint
       desc: "[out] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Submit a command-buffer for execution on a queue."
@@ -251,3 +301,13 @@ params:
       name: phEvent
       desc: |
             [out][optional] return an event object that identifies this particular command-buffer execution instance.
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_QUEUE
+    - $X_RESULT_ERROR_INVALID_EVENT
+    - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
+        - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
+        - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
+        - "If event objects in phEventWaitList are not valid events."
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -1,0 +1,250 @@
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Command-Buffer Extension APIs"
+ordinal: "0"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Command buffer support level for device info queries."
+class: $xCommandBuffer
+name: $x_exp_command_buffer_support_level_t
+etors:
+    - name: UNSUPPORTED
+      desc: "No support for command-buffers."
+      value: "0"
+    - name: EMULATED
+      desc: "Emulated support for command-buffers."
+    - name: NATIVE
+      desc: "Native support for command-buffers."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Command-Buffer Descriptor Type"
+name: $x_exp_command_buffer_desc_t
+base: $x_base_desc_t
+members: []
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "A value that identifies a command inside of a command-buffer, used for defining dependencies between commands in the same command-buffer."
+class: $xCommandBuffer
+name: $x_exp_command_buffer_sync_point_t
+value: uint32_t
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of Command-Buffer object"
+class: $xCommandBuffer
+name: "$x_exp_command_buffer_handle_t"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Create a Command-Buffer object"
+class: $xCommandBuffer
+name: CreateExp
+decl: static
+details:
+    - "Create a command-buffer object"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_device_handle_t
+      name: hDevice
+      desc: "[in] handle of the device object"
+    - type: "const $x_exp_command_buffer_desc_t*"
+      name: pCommandBufferDesc
+      desc: "[in][optional] CommandBuffer descriptor"
+    - type: "$x_exp_command_buffer_handle_t*"
+      name: phCommandBuffer
+      desc: "[out] pointer to Command-Buffer handle"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Increment the command-buffer object's reference count."
+class: $xCommandBuffer
+name: RetainExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object"
+returns:
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Decrement the command-buffer object's reference count and delete the command-buffer object if the reference count becomes zero."
+class: $xCommandBuffer
+name: ReleaseExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object"
+returns:
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Stop recording on a command-buffer object such that no more commands can be appended and make it ready to enqueue."
+class: $xCommandBuffer
+name: FinalizeExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object"
+returns:
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a kernel execution command to a command-buffer object"
+class: $xCommandBuffer
+name: AppendKernelExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object"
+    - type: $x_kernel_handle_t
+      name: hKernel
+      desc: "[in] kernel to append"
+    - type: uint32_t
+      name: WorkDim
+      desc: "[in] dimension of the kernel execution"
+    - type: "const size_t*"
+      name: pGlobalWorkOffset
+      desc: "[in] Offset to use when executing kernel."
+    - type: "const size_t*"
+      name: pGlobalWorkSize
+      desc: "[in] Global work size to use when executing kernel."
+    - type: "const size_t*"
+      name: pLocalWorkSize
+      desc: "[in] Local work size to use when executing kernel."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pDependencies
+      desc: "[in] A list of sync points that this command depends on."
+    - type: "$x_exp_command_buffer_sync_point_t*"
+      name: pSyncPoint
+      desc: "[out] sync point associated with this command"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a USM memcpy command to a command-buffer object"
+class: $xCommandBuffer
+name: MemcpyUSMExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: "void*"
+      name: pDst
+      desc: "[in] Location the data will be copied to."
+    - type: "void*"
+      name: pSrc
+      desc: "[in] The data to be copied."
+    - type: "size_t"
+      name: size
+      desc: "[in] The number of bytes to copy"
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pDependencies
+      desc: "[in] A list of sync points that this command depends on."
+    - type: "$x_exp_command_buffer_sync_point_t*"
+      name: pSyncPoint
+      desc: "[out] sync point associated with this command"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a memory copy command to a command-buffer object"
+class: $xCommandBuffer
+name: MembufferCopyExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: $x_mem_handle_t
+      name: hSrcMem
+      desc: "[in] The data to be copied."
+    - type: $x_mem_handle_t
+      name: hDstMem
+      desc: "[in] The location the data will be copied to."
+    - type: "size_t"
+      name: srcOffset
+      desc: "[in] Offset into the source memory."
+    - type: "size_t"
+      name: dstOffset
+      desc: "[in] Offset into the destination memory"
+    - type: "size_t"
+      name: size
+      desc: "[in] The number of bytes to be copied."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pDependencies
+      desc: "[in] A list of sync points that this command depends on."
+    - type: "$x_exp_command_buffer_sync_point_t*"
+      name: pSyncPoint
+      desc: "[out] sync point associated with this command"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a rectangular memory copy command to a command-buffer object"
+class: $xCommandBuffer
+name: MembufferCopyRectExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: $x_mem_handle_t
+      name: hSrcMem
+      desc: "[in] The data to be copied."
+    - type: $x_mem_handle_t
+      name: hDstMem
+      desc: "[in] The location the data will be copied to."
+    - type: $x_rect_offset_t
+      name: SrcOrigin
+      desc: "[in] Origin for the region of data to be copied from the source."
+    - type: $x_rect_offset_t
+      name: DstOrigin
+      desc: "[in] Origin for the region of data to be copied to in the destination."
+    - type: $x_rect_region_t
+      name: Region
+      desc: "[in] The extents describing the region to be copied."
+    - type: "size_t"
+      name: SrcRowPitch
+      desc: "[in] Row pitch of the source memory."
+    - type: "size_t"
+      name: SrcSlicePitch
+      desc: "[in] Slice pitch of the source memory."
+    - type: "size_t"
+      name: DstRowPitch
+      desc: "[in] Row pitch of the destination memory."
+    - type: "size_t"
+      name: DstSlicePitch
+      desc: "[in] Slice pitch of the destination memory."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pDependencies
+      desc: "[in] A list of sync points that this command depends on."
+    - type: $x_exp_command_buffer_sync_point_t*
+      name: pSyncPoint
+      desc: "[out] sync point associated with this command"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Submit a command-buffer for execution on a queue."
+class: $xCommandBuffer
+name: EnqueueExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before the command-buffer execution.
+            If nullptr, the numEventsInWaitList must be 0, indicating no wait events. 
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [out][optional] return an event object that identifies this particular command-buffer execution instance.

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -1,7 +1,14 @@
+#
+# Copyright (C) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+# See YaML.md for syntax definition
+#
 --- #--------------------------------------------------------------------------
 type: header
-desc: "Intel $OneApi Command-Buffer Extension APIs"
-ordinal: "0"
+desc: "Intel $OneApi Unified Runtime Experimental APIs for Command-Buffers"
+ordinal: "99"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Command-Buffer Descriptor Type"
@@ -88,7 +95,7 @@ returns:
 type: function
 desc: "Append a kernel execution command to a command-buffer object"
 class: $xCommandBuffer
-name: AppendKernelExp
+name: AppendKernelLaunchExp
 params:
     - type: $x_exp_command_buffer_handle_t
       name: hCommandBuffer
@@ -97,7 +104,7 @@ params:
       name: hKernel
       desc: "[in] kernel to append"
     - type: uint32_t
-      name: WorkDim
+      name: workDim
       desc: "[in] dimension of the kernel execution"
     - type: "const size_t*"
       name: pGlobalWorkOffset
@@ -113,10 +120,10 @@ params:
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
       name: pSyncPointWaitList
-      desc: "[in] A list of sync points that this command depends on."
+      desc: "[in][optional] A list of sync points that this command depends on."
     - type: "$x_exp_command_buffer_sync_point_t*"
       name: pSyncPoint
-      desc: "[out] sync point associated with this command"
+      desc: "[out][optional] sync point associated with this command"
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_KERNEL
@@ -152,10 +159,10 @@ params:
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
       name: pSyncPointWaitList
-      desc: "[in] A list of sync points that this command depends on."
+      desc: "[in][optional] A list of sync points that this command depends on."
     - type: "$x_exp_command_buffer_sync_point_t*"
       name: pSyncPoint
-      desc: "[out] sync point associated with this command"
+      desc: "[out][optional] sync point associated with this command"
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_SIZE:
@@ -197,10 +204,10 @@ params:
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
       name: pSyncPointWaitList
-      desc: "[in] A list of sync points that this command depends on."
+      desc: "[in][optional] A list of sync points that this command depends on."
     - type: "$x_exp_command_buffer_sync_point_t*"
       name: pSyncPoint
-      desc: "[out] sync point associated with this command"
+      desc: "[out][optional] sync point associated with this command"
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -226,35 +233,35 @@ params:
       name: hDstMem
       desc: "[in] The location the data will be copied to."
     - type: $x_rect_offset_t
-      name: SrcOrigin
+      name: srcOrigin
       desc: "[in] Origin for the region of data to be copied from the source."
     - type: $x_rect_offset_t
-      name: DstOrigin
+      name: dstOrigin
       desc: "[in] Origin for the region of data to be copied to in the destination."
     - type: $x_rect_region_t
-      name: Region
+      name: region
       desc: "[in] The extents describing the region to be copied."
     - type: "size_t"
-      name: SrcRowPitch
+      name: srcRowPitch
       desc: "[in] Row pitch of the source memory."
     - type: "size_t"
-      name: SrcSlicePitch
+      name: srcSlicePitch
       desc: "[in] Slice pitch of the source memory."
     - type: "size_t"
-      name: DstRowPitch
+      name: dstRowPitch
       desc: "[in] Row pitch of the destination memory."
     - type: "size_t"
-      name: DstSlicePitch
+      name: dstSlicePitch
       desc: "[in] Slice pitch of the destination memory."
     - type: uint32_t
       name: numSyncPointsInWaitList
       desc: "[in] The number of sync points in the provided dependency list."
     - type: "const $x_exp_command_buffer_sync_point_t*"
       name: pSyncPointWaitList
-      desc: "[in] A list of sync points that this command depends on."
+      desc: "[in][optional] A list of sync points that this command depends on."
     - type: $x_exp_command_buffer_sync_point_t*
       name: pSyncPoint
-      desc: "[out] sync point associated with this command"
+      desc: "[out][optional] sync point associated with this command"
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -1,7 +1,9 @@
 #
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2022 Intel Corporation
 #
-# SPDX-License-Identifier: MIT
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # See YaML.md for syntax definition
 #

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -133,7 +133,7 @@ returns:
     - $X_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
         - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
         - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -172,7 +172,7 @@ returns:
         - "If `size` is higher than the allocation size of `pSrc` or `pDst`"
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
         - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
         - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
@@ -213,7 +213,7 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
         - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
         - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -267,7 +267,7 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
         - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
         - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -343,6 +343,9 @@ etors:
 - name: USM_POOL_CREATE
   desc: Enumerator for $xUSMPoolCreate
   value: '112'
+- name: COMMAND_BUFFER_CREATE_EXP
+  desc: Enumerator for $xCommandBufferCreateExp
+  value: '113'
 - name: PLATFORM_GET_BACKEND_OPTION
   desc: Enumerator for $xPlatformGetBackendOption
   value: '114'
@@ -364,3 +367,27 @@ etors:
 - name: USM_POOL_GET_INFO
   desc: Enumerator for $xUSMPoolGetInfo
   value: '120'
+- name: COMMAND_BUFFER_RETAIN_EXP
+  desc: Enumerator for $xCommandBufferRetainExp
+  value: '121'
+- name: COMMAND_BUFFER_RELEASE_EXP
+  desc: Enumerator for $xCommandBufferReleaseExp
+  value: '122'
+- name: COMMAND_BUFFER_FINALIZE_EXP
+  desc: Enumerator for $xCommandBufferFinalizeExp
+  value: '123'
+- name: COMMAND_BUFFER_APPEND_KERNEL_EXP
+  desc: Enumerator for $xCommandBufferAppendKernelExp
+  value: '124'
+- name: COMMAND_BUFFER_MEMCPY_USM_EXP
+  desc: Enumerator for $xCommandBufferMemcpyUSMExp
+  value: '125'
+- name: COMMAND_BUFFER_MEMBUFFER_COPY_EXP
+  desc: Enumerator for $xCommandBufferMembufferCopyExp
+  value: '126'
+- name: COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP
+  desc: Enumerator for $xCommandBufferMembufferCopyRectExp
+  value: '127'
+- name: COMMAND_BUFFER_ENQUEUE_EXP
+  desc: Enumerator for $xCommandBufferEnqueueExp
+  value: '128'

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -379,15 +379,15 @@ etors:
 - name: COMMAND_BUFFER_APPEND_KERNEL_EXP
   desc: Enumerator for $xCommandBufferAppendKernelExp
   value: '124'
-- name: COMMAND_BUFFER_MEMCPY_USM_EXP
-  desc: Enumerator for $xCommandBufferMemcpyUSMExp
-  value: '125'
-- name: COMMAND_BUFFER_MEMBUFFER_COPY_EXP
-  desc: Enumerator for $xCommandBufferMembufferCopyExp
-  value: '126'
-- name: COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP
-  desc: Enumerator for $xCommandBufferMembufferCopyRectExp
-  value: '127'
 - name: COMMAND_BUFFER_ENQUEUE_EXP
   desc: Enumerator for $xCommandBufferEnqueueExp
   value: '128'
+- name: COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP
+  desc: Enumerator for $xCommandBufferAppendMemcpyUSMExp
+  value: '129'
+- name: COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP
+  desc: Enumerator for $xCommandBufferAppendMembufferCopyExp
+  value: '130'
+- name: COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP
+  desc: Enumerator for $xCommandBufferAppendMembufferCopyRectExp
+  value: '131'

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -376,9 +376,9 @@ etors:
 - name: COMMAND_BUFFER_FINALIZE_EXP
   desc: Enumerator for $xCommandBufferFinalizeExp
   value: '123'
-- name: COMMAND_BUFFER_APPEND_KERNEL_EXP
-  desc: Enumerator for $xCommandBufferAppendKernelExp
-  value: '124'
+- name: COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP
+  desc: Enumerator for $xCommandBufferAppendKernelLaunchExp
+  value: '125'
 - name: COMMAND_BUFFER_ENQUEUE_EXP
   desc: Enumerator for $xCommandBufferEnqueueExp
   value: '128'

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -119,7 +119,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
@@ -132,7 +132,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
         result = pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
                                     pGlobalWorkOffset, pGlobalWorkSize,
                                     pLocalWorkSize, numSyncPointsInWaitList,
-                                    pDependencies, pSyncPoint);
+                                    pSyncPointWaitList, pSyncPoint);
     } else {
         // generic implementation
     }
@@ -143,8 +143,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -153,19 +153,19 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMemcpyUSMExp =
-        d_context.urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
-    if (nullptr != pfnMemcpyUSMExp) {
-        result =
-            pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                            numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    auto pfnAppendMemcpyUSMExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
+    if (nullptr != pfnAppendMemcpyUSMExp) {
+        result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                       numSyncPointsInWaitList,
+                                       pSyncPointWaitList, pSyncPoint);
     } else {
         // generic implementation
     }
@@ -176,8 +176,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -188,19 +188,19 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMembufferCopyExp =
-        d_context.urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
-    if (nullptr != pfnMembufferCopyExp) {
-        result = pfnMembufferCopyExp(
+    auto pfnAppendMembufferCopyExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
+    if (nullptr != pfnAppendMembufferCopyExp) {
+        result = pfnAppendMembufferCopyExp(
             hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-            numSyncPointsInWaitList, pDependencies, pSyncPoint);
+            numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
     } else {
         // generic implementation
     }
@@ -211,8 +211,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -230,20 +230,20 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnMembufferCopyRectExp =
-        d_context.urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
-    if (nullptr != pfnMembufferCopyRectExp) {
-        result = pfnMembufferCopyRectExp(
+    auto pfnAppendMembufferCopyRectExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
+    if (nullptr != pfnAppendMembufferCopyRectExp) {
+        result = pfnAppendMembufferCopyRectExp(
             hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
             SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-            numSyncPointsInWaitList, pDependencies, pSyncPoint);
+            numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
     } else {
         // generic implementation
     }
@@ -3839,12 +3839,14 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
 
     pDdiTable->pfnAppendKernelExp = driver::urCommandBufferAppendKernelExp;
 
-    pDdiTable->pfnMemcpyUSMExp = driver::urCommandBufferMemcpyUSMExp;
+    pDdiTable->pfnAppendMemcpyUSMExp =
+        driver::urCommandBufferAppendMemcpyUSMExp;
 
-    pDdiTable->pfnMembufferCopyExp = driver::urCommandBufferMembufferCopyExp;
+    pDdiTable->pfnAppendMembufferCopyExp =
+        driver::urCommandBufferAppendMembufferCopyExp;
 
-    pDdiTable->pfnMembufferCopyRectExp =
-        driver::urCommandBufferMembufferCopyRectExp;
+    pDdiTable->pfnAppendMembufferCopyRectExp =
+        driver::urCommandBufferAppendMembufferCopyRectExp;
 
     pDdiTable->pfnEnqueueExp = driver::urCommandBufferEnqueueExp;
 

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -13,6 +13,281 @@
 
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnCreateExp = d_context.urDdiTable.CommandBufferExp.pfnCreateExp;
+    if (nullptr != pfnCreateExp) {
+        result = pfnCreateExp(hContext, hDevice, pCommandBufferDesc,
+                              phCommandBuffer);
+    } else {
+        // generic implementation
+        *phCommandBuffer =
+            reinterpret_cast<ur_exp_command_buffer_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnRetainExp = d_context.urDdiTable.CommandBufferExp.pfnRetainExp;
+    if (nullptr != pfnRetainExp) {
+        result = pfnRetainExp(hCommandBuffer);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnReleaseExp = d_context.urDdiTable.CommandBufferExp.pfnReleaseExp;
+    if (nullptr != pfnReleaseExp) {
+        result = pfnReleaseExp(hCommandBuffer);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnFinalizeExp = d_context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
+    if (nullptr != pfnFinalizeExp) {
+        result = pfnFinalizeExp(hCommandBuffer);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendKernelExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendKernelExp;
+    if (nullptr != pfnAppendKernelExp) {
+        result = pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
+                                    pGlobalWorkOffset, pGlobalWorkSize,
+                                    pLocalWorkSize, numSyncPointsInWaitList,
+                                    pDependencies, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    void *pSrc,         ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnMemcpyUSMExp =
+        d_context.urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
+    if (nullptr != pfnMemcpyUSMExp) {
+        result =
+            pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                            numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnMembufferCopyExp =
+        d_context.urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
+    if (nullptr != pfnMembufferCopyExp) {
+        result = pfnMembufferCopyExp(
+            hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+            numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        Region, ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnMembufferCopyRectExp =
+        d_context.urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
+    if (nullptr != pfnMembufferCopyRectExp) {
+        result = pfnMembufferCopyRectExp(
+            hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
+            SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
+            numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnEnqueueExp = d_context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
+    if (nullptr != pfnEnqueueExp) {
+        result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList,
+                               phEventWaitList, phEvent);
+    } else {
+        // generic implementation
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
+        }
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -3523,6 +3798,53 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     pDdiTable->pfnGetLastResult = driver::urGetLastResult;
 
     pDdiTable->pfnTearDown = driver::urTearDown;
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandBufferExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_command_buffer_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+    ) try {
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (driver::d_context.version < version) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    pDdiTable->pfnCreateExp = driver::urCommandBufferCreateExp;
+
+    pDdiTable->pfnRetainExp = driver::urCommandBufferRetainExp;
+
+    pDdiTable->pfnReleaseExp = driver::urCommandBufferReleaseExp;
+
+    pDdiTable->pfnFinalizeExp = driver::urCommandBufferFinalizeExp;
+
+    pDdiTable->pfnAppendKernelExp = driver::urCommandBufferAppendKernelExp;
+
+    pDdiTable->pfnMemcpyUSMExp = driver::urCommandBufferMemcpyUSMExp;
+
+    pDdiTable->pfnMembufferCopyExp = driver::urCommandBufferMembufferCopyExp;
+
+    pDdiTable->pfnMembufferCopyRectExp =
+        driver::urCommandBufferMembufferCopyRectExp;
+
+    pDdiTable->pfnEnqueueExp = driver::urCommandBufferEnqueueExp;
 
     return result;
 } catch (...) {

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -13,283 +13,6 @@
 
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t
-        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t
-        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnCreateExp = d_context.urDdiTable.CommandBufferExp.pfnCreateExp;
-    if (nullptr != pfnCreateExp) {
-        result = pfnCreateExp(hContext, hDevice, pCommandBufferDesc,
-                              phCommandBuffer);
-    } else {
-        // generic implementation
-        *phCommandBuffer =
-            reinterpret_cast<ur_exp_command_buffer_handle_t>(d_context.get());
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnRetainExp = d_context.urDdiTable.CommandBufferExp.pfnRetainExp;
-    if (nullptr != pfnRetainExp) {
-        result = pfnRetainExp(hCommandBuffer);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnReleaseExp = d_context.urDdiTable.CommandBufferExp.pfnReleaseExp;
-    if (nullptr != pfnReleaseExp) {
-        result = pfnReleaseExp(hCommandBuffer);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnFinalizeExp = d_context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
-    if (nullptr != pfnFinalizeExp) {
-        result = pfnFinalizeExp(hCommandBuffer);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendKernelExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,         ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel, ///< [in] kernel to append
-    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
-    const size_t
-        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
-    const size_t *
-        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
-    const size_t
-        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnAppendKernelExp =
-        d_context.urDdiTable.CommandBufferExp.pfnAppendKernelExp;
-    if (nullptr != pfnAppendKernelExp) {
-        result = pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
-                                    pGlobalWorkOffset, pGlobalWorkSize,
-                                    pLocalWorkSize, numSyncPointsInWaitList,
-                                    pSyncPointWaitList, pSyncPoint);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    void *pDst,         ///< [in] Location the data will be copied to.
-    const void *pSrc,   ///< [in] The data to be copied.
-    size_t size,        ///< [in] The number of bytes to copy
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnAppendMemcpyUSMExp =
-        d_context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
-    if (nullptr != pfnAppendMemcpyUSMExp) {
-        result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                                       numSyncPointsInWaitList,
-                                       pSyncPointWaitList, pSyncPoint);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    size_t srcOffset,        ///< [in] Offset into the source memory.
-    size_t dstOffset,        ///< [in] Offset into the destination memory
-    size_t size,             ///< [in] The number of bytes to be copied.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnAppendMembufferCopyExp =
-        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
-    if (nullptr != pfnAppendMembufferCopyExp) {
-        result = pfnAppendMembufferCopyExp(
-            hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-            numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    ur_rect_offset_t
-        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t
-        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t
-        Region, ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnAppendMembufferCopyRectExp =
-        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
-    if (nullptr != pfnAppendMembufferCopyRectExp) {
-        result = pfnAppendMembufferCopyRectExp(
-            hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
-            SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-            numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t
-        hQueue, ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the command-buffer execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-    ///< events.
-    ur_event_handle_t *
-        phEvent ///< [out][optional] return an event object that identifies this particular
-                ///< command-buffer execution instance.
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnEnqueueExp = d_context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
-    if (nullptr != pfnEnqueueExp) {
-        result = pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
-                               phEventWaitList, phEvent);
-    } else {
-        // generic implementation
-        if (nullptr != phEvent) {
-            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
-        }
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -3766,6 +3489,283 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     return exceptionToResult(std::current_exception());
 }
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnCreateExp = d_context.urDdiTable.CommandBufferExp.pfnCreateExp;
+    if (nullptr != pfnCreateExp) {
+        result = pfnCreateExp(hContext, hDevice, pCommandBufferDesc,
+                              phCommandBuffer);
+    } else {
+        // generic implementation
+        *phCommandBuffer =
+            reinterpret_cast<ur_exp_command_buffer_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnRetainExp = d_context.urDdiTable.CommandBufferExp.pfnRetainExp;
+    if (nullptr != pfnRetainExp) {
+        result = pfnRetainExp(hCommandBuffer);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnReleaseExp = d_context.urDdiTable.CommandBufferExp.pfnReleaseExp;
+    if (nullptr != pfnReleaseExp) {
+        result = pfnReleaseExp(hCommandBuffer);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnFinalizeExp = d_context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
+    if (nullptr != pfnFinalizeExp) {
+        result = pfnFinalizeExp(hCommandBuffer);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t workDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendKernelLaunchExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendKernelLaunchExp;
+    if (nullptr != pfnAppendKernelLaunchExp) {
+        result = pfnAppendKernelLaunchExp(
+            hCommandBuffer, hKernel, workDim, pGlobalWorkOffset,
+            pGlobalWorkSize, pLocalWorkSize, numSyncPointsInWaitList,
+            pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    const void *pSrc,   ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMemcpyUSMExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
+    if (nullptr != pfnAppendMemcpyUSMExp) {
+        result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                       numSyncPointsInWaitList,
+                                       pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMembufferCopyExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
+    if (nullptr != pfnAppendMembufferCopyExp) {
+        result = pfnAppendMembufferCopyExp(
+            hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+            numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        srcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        dstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        region, ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMembufferCopyRectExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
+    if (nullptr != pfnAppendMembufferCopyRectExp) {
+        result = pfnAppendMembufferCopyRectExp(
+            hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
+            srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+            numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnEnqueueExp = d_context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
+    if (nullptr != pfnEnqueueExp) {
+        result = pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
+                               phEventWaitList, phEvent);
+    } else {
+        // generic implementation
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
+        }
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
 } // namespace driver
 
 #if defined(__cplusplus)
@@ -3837,7 +3837,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
 
     pDdiTable->pfnFinalizeExp = driver::urCommandBufferFinalizeExp;
 
-    pDdiTable->pfnAppendKernelExp = driver::urCommandBufferAppendKernelExp;
+    pDdiTable->pfnAppendKernelLaunchExp =
+        driver::urCommandBufferAppendKernelLaunchExp;
 
     pDdiTable->pfnAppendMemcpyUSMExp =
         driver::urCommandBufferAppendMemcpyUSMExp;

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -148,7 +148,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
-    void *pSrc,         ///< [in] The data to be copied.
+    const void *pSrc,   ///< [in] The data to be copied.
     size_t size,        ///< [in] The number of bytes to copy
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
@@ -257,7 +257,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 /// @brief Intercept function for urCommandBufferEnqueueExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -273,7 +275,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnEnqueueExp = d_context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
     if (nullptr != pfnEnqueueExp) {
-        result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList,
+        result = pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
                                phEventWaitList, phEvent);
     } else {
         // generic implementation

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -167,8 +167,6 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_rect_offset_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_rect_region_t params);
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_init_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -332,6 +330,8 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_map_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_migration_flag_t value);
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 
 inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
     switch (value) {
@@ -600,6 +600,14 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
         os << "UR_RESULT_ERROR_INVALID_USM_SIZE";
         break;
 
+    case UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE:
+        os << "UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE";
+        break;
+
+    case UR_RESULT_ERROR_ADAPTER_SPECIFIC:
+        os << "UR_RESULT_ERROR_ADAPTER_SPECIFIC";
+        break;
+
     case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP:
         os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP";
         break;
@@ -610,14 +618,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
 
     case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
         os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP";
-        break;
-
-    case UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE:
-        os << "UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE";
-        break;
-
-    case UR_RESULT_ERROR_ADAPTER_SPECIFIC:
-        os << "UR_RESULT_ERROR_ADAPTER_SPECIFIC";
         break;
 
     case UR_RESULT_ERROR_UNKNOWN:
@@ -995,22 +995,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ".depth = ";
 
     os << (params.depth);
-
-    os << "}";
-    return os;
-}
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
-    os << "(struct ur_exp_command_buffer_desc_t){";
-
-    os << ".stype = ";
-
-    os << (params.stype);
-
-    os << ", ";
-    os << ".pNext = ";
-
-    ur_params::serializeStruct(os, (params.pNext));
 
     os << "}";
     return os;
@@ -8223,8 +8207,8 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP";
         break;
 
-    case UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP:
-        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP";
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP";
         break;
 
     case UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP:
@@ -8358,6 +8342,22 @@ inline void serializeFlag<ur_usm_migration_flag_t>(std::ostream &os,
     }
 }
 } // namespace ur_params
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
+    os << "(struct ur_exp_command_buffer_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << "}";
+    return os;
+}
 
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_init_params_t *params) {
@@ -8454,9 +8454,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_append_kernel_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_append_kernel_launch_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -8468,9 +8468,9 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-    os << ".WorkDim = ";
+    os << ".workDim = ";
 
-    os << *(params->pWorkDim);
+    os << *(params->pworkDim);
 
     os << ", ";
     os << ".pGlobalWorkOffset = ";
@@ -8617,39 +8617,39 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phDstMem));
 
     os << ", ";
-    os << ".SrcOrigin = ";
+    os << ".srcOrigin = ";
 
-    os << *(params->pSrcOrigin);
-
-    os << ", ";
-    os << ".DstOrigin = ";
-
-    os << *(params->pDstOrigin);
+    os << *(params->psrcOrigin);
 
     os << ", ";
-    os << ".Region = ";
+    os << ".dstOrigin = ";
 
-    os << *(params->pRegion);
-
-    os << ", ";
-    os << ".SrcRowPitch = ";
-
-    os << *(params->pSrcRowPitch);
+    os << *(params->pdstOrigin);
 
     os << ", ";
-    os << ".SrcSlicePitch = ";
+    os << ".region = ";
 
-    os << *(params->pSrcSlicePitch);
-
-    os << ", ";
-    os << ".DstRowPitch = ";
-
-    os << *(params->pDstRowPitch);
+    os << *(params->pregion);
 
     os << ", ";
-    os << ".DstSlicePitch = ";
+    os << ".srcRowPitch = ";
 
-    os << *(params->pDstSlicePitch);
+    os << *(params->psrcRowPitch);
+
+    os << ", ";
+    os << ".srcSlicePitch = ";
+
+    os << *(params->psrcSlicePitch);
+
+    os << ", ";
+    os << ".dstRowPitch = ";
+
+    os << *(params->pdstRowPitch);
+
+    os << ", ";
+    os << ".dstSlicePitch = ";
+
+    os << *(params->pdstSlicePitch);
 
     os << ", ";
     os << ".numSyncPointsInWaitList = ";
@@ -12330,9 +12330,9 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     case UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP: {
         os << (const struct ur_command_buffer_finalize_exp_params_t *)params;
     } break;
-    case UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP: {
-        os << (const struct ur_command_buffer_append_kernel_exp_params_t *)
-                params;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP: {
+        os << (const struct ur_command_buffer_append_kernel_launch_exp_params_t
+                   *)params;
     } break;
     case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP: {
         os << (const struct ur_command_buffer_append_memcpy_usm_exp_params_t *)

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -167,6 +167,10 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_rect_offset_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_rect_region_t params);
+inline std::ostream &
+operator<<(std::ostream &os, enum ur_exp_command_buffer_support_level_t value);
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_init_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -726,6 +730,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC:
+        os << "UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -895,6 +903,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
             (const ur_device_partition_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
+
+    case UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC: {
+        const ur_exp_command_buffer_desc_t *pstruct =
+            (const ur_exp_command_buffer_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
     default:
         os << "unknown enumerator";
         break;
@@ -971,6 +985,43 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ".depth = ";
 
     os << (params.depth);
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os, enum ur_exp_command_buffer_support_level_t value) {
+    switch (value) {
+
+    case UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_UNSUPPORTED:
+        os << "UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_UNSUPPORTED";
+        break;
+
+    case UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_EMULATED:
+        os << "UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_EMULATED";
+        break;
+
+    case UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_NATIVE:
+        os << "UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_NATIVE";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
+    os << "(struct ur_exp_command_buffer_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
 
     os << "}";
     return os;
@@ -1731,6 +1782,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
 
     case UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP:
         os << "UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP";
+        break;
+
+    case UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT:
+        os << "UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT";
         break;
     default:
         os << "unknown enumerator";
@@ -3270,6 +3325,21 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
         if (sizeof(uint32_t) > size) {
             os << "invalid size (is: " << size
                << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT: {
+        const ur_exp_command_buffer_support_level_t *tptr =
+            (const ur_exp_command_buffer_support_level_t *)ptr;
+        if (sizeof(ur_exp_command_buffer_support_level_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >="
+               << sizeof(ur_exp_command_buffer_support_level_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -8135,6 +8205,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_USM_POOL_CREATE";
         break;
 
+    case UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP";
+        break;
+
     case UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION:
         os << "UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION";
         break;
@@ -8161,6 +8235,38 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
 
     case UR_FUNCTION_USM_POOL_GET_INFO:
         os << "UR_FUNCTION_USM_POOL_GET_INFO";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -8311,6 +8417,313 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ".pParams = ";
 
     ur_params::serializePtr(os, *(params->ppParams));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_create_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur_params::serializePtr(os, *(params->phDevice));
+
+    os << ", ";
+    os << ".pCommandBufferDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppCommandBufferDesc));
+
+    os << ", ";
+    os << ".phCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->pphCommandBuffer));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_retain_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_release_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_finalize_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_append_kernel_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hKernel = ";
+
+    ur_params::serializePtr(os, *(params->phKernel));
+
+    os << ", ";
+    os << ".WorkDim = ";
+
+    os << *(params->pWorkDim);
+
+    os << ", ";
+    os << ".pGlobalWorkOffset = ";
+
+    ur_params::serializePtr(os, *(params->ppGlobalWorkOffset));
+
+    os << ", ";
+    os << ".pGlobalWorkSize = ";
+
+    ur_params::serializePtr(os, *(params->ppGlobalWorkSize));
+
+    os << ", ";
+    os << ".pLocalWorkSize = ";
+
+    ur_params::serializePtr(os, *(params->ppLocalWorkSize));
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pDependencies = ";
+
+    ur_params::serializePtr(os, *(params->ppDependencies));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_memcpy_usm_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".pDst = ";
+
+    ur_params::serializePtr(os, *(params->ppDst));
+
+    os << ", ";
+    os << ".pSrc = ";
+
+    ur_params::serializePtr(os, *(params->ppSrc));
+
+    os << ", ";
+    os << ".size = ";
+
+    os << *(params->psize);
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pDependencies = ";
+
+    ur_params::serializePtr(os, *(params->ppDependencies));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_membuffer_copy_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hSrcMem = ";
+
+    ur_params::serializePtr(os, *(params->phSrcMem));
+
+    os << ", ";
+    os << ".hDstMem = ";
+
+    ur_params::serializePtr(os, *(params->phDstMem));
+
+    os << ", ";
+    os << ".srcOffset = ";
+
+    os << *(params->psrcOffset);
+
+    os << ", ";
+    os << ".dstOffset = ";
+
+    os << *(params->pdstOffset);
+
+    os << ", ";
+    os << ".size = ";
+
+    os << *(params->psize);
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pDependencies = ";
+
+    ur_params::serializePtr(os, *(params->ppDependencies));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_membuffer_copy_rect_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hSrcMem = ";
+
+    ur_params::serializePtr(os, *(params->phSrcMem));
+
+    os << ", ";
+    os << ".hDstMem = ";
+
+    ur_params::serializePtr(os, *(params->phDstMem));
+
+    os << ", ";
+    os << ".SrcOrigin = ";
+
+    os << *(params->pSrcOrigin);
+
+    os << ", ";
+    os << ".DstOrigin = ";
+
+    os << *(params->pDstOrigin);
+
+    os << ", ";
+    os << ".Region = ";
+
+    os << *(params->pRegion);
+
+    os << ", ";
+    os << ".SrcRowPitch = ";
+
+    os << *(params->pSrcRowPitch);
+
+    os << ", ";
+    os << ".SrcSlicePitch = ";
+
+    os << *(params->pSrcSlicePitch);
+
+    os << ", ";
+    os << ".DstRowPitch = ";
+
+    os << *(params->pDstRowPitch);
+
+    os << ", ";
+    os << ".DstSlicePitch = ";
+
+    os << *(params->pDstSlicePitch);
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pDependencies = ";
+
+    ur_params::serializePtr(os, *(params->ppDependencies));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_enqueue_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".numEventsInWaitList = ";
+
+    os << *(params->pnumEventsInWaitList);
+
+    os << ", ";
+    os << ".phEventWaitList = {";
+    for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
+                       i < *params->pnumEventsInWaitList;
+         ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur_params::serializePtr(os, (*(params->pphEventWaitList))[i]);
+    }
+    os << "}";
+
+    os << ", ";
+    os << ".phEvent = ";
+
+    ur_params::serializePtr(os, *(params->pphEvent));
 
     return os;
 }
@@ -11924,6 +12337,36 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     } break;
     case UR_FUNCTION_TEAR_DOWN: {
         os << (const struct ur_tear_down_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP: {
+        os << (const struct ur_command_buffer_create_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP: {
+        os << (const struct ur_command_buffer_retain_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP: {
+        os << (const struct ur_command_buffer_release_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP: {
+        os << (const struct ur_command_buffer_finalize_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP: {
+        os << (const struct ur_command_buffer_append_kernel_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP: {
+        os << (const struct ur_command_buffer_memcpy_usm_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP: {
+        os << (const struct ur_command_buffer_membuffer_copy_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP: {
+        os << (const struct ur_command_buffer_membuffer_copy_rect_exp_params_t
+                   *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP: {
+        os << (const struct ur_command_buffer_enqueue_exp_params_t *)params;
     } break;
     case UR_FUNCTION_CONTEXT_CREATE: {
         os << (const struct ur_context_create_params_t *)params;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -168,8 +168,6 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_rect_region_t params);
 inline std::ostream &
-operator<<(std::ostream &os, enum ur_exp_command_buffer_support_level_t value);
-inline std::ostream &
 operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_init_flag_t value);
@@ -1002,27 +1000,6 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 inline std::ostream &
-operator<<(std::ostream &os, enum ur_exp_command_buffer_support_level_t value) {
-    switch (value) {
-
-    case UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_UNSUPPORTED:
-        os << "UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_UNSUPPORTED";
-        break;
-
-    case UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_EMULATED:
-        os << "UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_EMULATED";
-        break;
-
-    case UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_NATIVE:
-        os << "UR_EXP_COMMAND_BUFFER_SUPPORT_LEVEL_NATIVE";
-        break;
-    default:
-        os << "unknown enumerator";
-        break;
-    }
-    return os;
-}
-inline std::ostream &
 operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
     os << "(struct ur_exp_command_buffer_desc_t){";
 
@@ -1794,10 +1771,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
 
     case UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP:
         os << "UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP";
-        break;
-
-    case UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT:
-        os << "UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT";
         break;
     default:
         os << "unknown enumerator";
@@ -3337,21 +3310,6 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
         if (sizeof(uint32_t) > size) {
             os << "invalid size (is: " << size
                << ", expected: >=" << sizeof(uint32_t) << ")";
-            return;
-        }
-        os << (void *)(tptr) << " (";
-
-        os << *tptr;
-
-        os << ")";
-    } break;
-
-    case UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT: {
-        const ur_exp_command_buffer_support_level_t *tptr =
-            (const ur_exp_command_buffer_support_level_t *)ptr;
-        if (sizeof(ur_exp_command_buffer_support_level_t) > size) {
-            os << "invalid size (is: " << size << ", expected: >="
-               << sizeof(ur_exp_command_buffer_support_level_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -606,6 +606,14 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
         os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP";
         break;
 
+    case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP:
+        os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP";
+        break;
+
+    case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
+        os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP";
+        break;
+
     case UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE:
         os << "UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE";
         break;
@@ -8261,20 +8269,20 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP";
         break;
 
-    case UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP:
-        os << "UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP";
-        break;
-
-    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP:
-        os << "UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP";
-        break;
-
-    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP:
-        os << "UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP";
-        break;
-
     case UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -8527,9 +8535,9 @@ operator<<(std::ostream &os,
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-    os << ".pDependencies = ";
+    os << ".pSyncPointWaitList = ";
 
-    ur_params::serializePtr(os, *(params->ppDependencies));
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
     os << ".pSyncPoint = ";
@@ -8539,9 +8547,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_memcpy_usm_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_append_memcpy_usm_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -8568,9 +8576,9 @@ operator<<(std::ostream &os,
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-    os << ".pDependencies = ";
+    os << ".pSyncPointWaitList = ";
 
-    ur_params::serializePtr(os, *(params->ppDependencies));
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
     os << ".pSyncPoint = ";
@@ -8580,9 +8588,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_membuffer_copy_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_append_membuffer_copy_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -8619,9 +8627,9 @@ operator<<(std::ostream &os,
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-    os << ".pDependencies = ";
+    os << ".pSyncPointWaitList = ";
 
-    ur_params::serializePtr(os, *(params->ppDependencies));
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
     os << ".pSyncPoint = ";
@@ -8633,7 +8641,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_command_buffer_membuffer_copy_rect_exp_params_t *params) {
+    const struct ur_command_buffer_append_membuffer_copy_rect_exp_params_t
+        *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -8690,9 +8699,9 @@ inline std::ostream &operator<<(
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-    os << ".pDependencies = ";
+    os << ".pSyncPointWaitList = ";
 
-    ur_params::serializePtr(os, *(params->ppDependencies));
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
     os << ".pSyncPoint = ";
@@ -12367,16 +12376,18 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
         os << (const struct ur_command_buffer_append_kernel_exp_params_t *)
                 params;
     } break;
-    case UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP: {
-        os << (const struct ur_command_buffer_memcpy_usm_exp_params_t *)params;
-    } break;
-    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP: {
-        os << (const struct ur_command_buffer_membuffer_copy_exp_params_t *)
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP: {
+        os << (const struct ur_command_buffer_append_memcpy_usm_exp_params_t *)
                 params;
     } break;
-    case UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP: {
-        os << (const struct ur_command_buffer_membuffer_copy_rect_exp_params_t
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP: {
+        os << (const struct ur_command_buffer_append_membuffer_copy_exp_params_t
                    *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP: {
+        os << (const struct
+               ur_command_buffer_append_membuffer_copy_rect_exp_params_t *)
+                params;
     } break;
     case UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP: {
         os << (const struct ur_command_buffer_enqueue_exp_params_t *)params;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -602,6 +602,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
         os << "UR_RESULT_ERROR_INVALID_USM_SIZE";
         break;
 
+    case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP:
+        os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP";
+        break;
+
     case UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE:
         os << "UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE";
         break;
@@ -7448,6 +7452,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value) {
     case UR_COMMAND_WRITE_HOST_PIPE:
         os << "UR_COMMAND_WRITE_HOST_PIPE";
         break;
+
+    case UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP:
+        os << "UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -8701,6 +8709,11 @@ operator<<(std::ostream &os,
     os << ".hCommandBuffer = ";
 
     ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hQueue = ";
+
+    ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
     os << ".numEventsInWaitList = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -174,7 +174,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
-    void *pSrc,         ///< [in] The data to be copied.
+    const void *pSrc,   ///< [in] The data to be copied.
     size_t size,        ///< [in] The number of bytes to copy
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
@@ -321,7 +321,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 /// @brief Intercept function for urCommandBufferEnqueueExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -339,13 +341,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     }
 
     ur_command_buffer_enqueue_exp_params_t params = {
-        &hCommandBuffer, &numEventsInWaitList, &phEventWaitList, &phEvent};
+        &hCommandBuffer, &hQueue, &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
                              "urCommandBufferEnqueueExp", &params);
 
-    ur_result_t result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList,
-                                       phEventWaitList, phEvent);
+    ur_result_t result = pfnEnqueueExp(
+        hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
                        "urCommandBufferEnqueueExp", &params, &result, instance);

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -16,6 +16,344 @@
 
 namespace ur_tracing_layer {
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    auto pfnCreateExp = context.urDdiTable.CommandBufferExp.pfnCreateExp;
+
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_create_exp_params_t params = {
+        &hContext, &hDevice, &pCommandBufferDesc, &phCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP,
+                             "urCommandBufferCreateExp", &params);
+
+    ur_result_t result =
+        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP,
+                       "urCommandBufferCreateExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnRetainExp = context.urDdiTable.CommandBufferExp.pfnRetainExp;
+
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_retain_exp_params_t params = {&hCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP,
+                             "urCommandBufferRetainExp", &params);
+
+    ur_result_t result = pfnRetainExp(hCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP,
+                       "urCommandBufferRetainExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnReleaseExp = context.urDdiTable.CommandBufferExp.pfnReleaseExp;
+
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_release_exp_params_t params = {&hCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP,
+                             "urCommandBufferReleaseExp", &params);
+
+    ur_result_t result = pfnReleaseExp(hCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP,
+                       "urCommandBufferReleaseExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnFinalizeExp = context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
+
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_finalize_exp_params_t params = {&hCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP,
+                             "urCommandBufferFinalizeExp", &params);
+
+    ur_result_t result = pfnFinalizeExp(hCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP,
+                       "urCommandBufferFinalizeExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnAppendKernelExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendKernelExp;
+
+    if (nullptr == pfnAppendKernelExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_kernel_exp_params_t params = {
+        &hCommandBuffer,          &hKernel,         &WorkDim,
+        &pGlobalWorkOffset,       &pGlobalWorkSize, &pLocalWorkSize,
+        &numSyncPointsInWaitList, &pDependencies,   &pSyncPoint};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP,
+                             "urCommandBufferAppendKernelExp", &params);
+
+    ur_result_t result = pfnAppendKernelExp(
+        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP,
+                       "urCommandBufferAppendKernelExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    void *pSrc,         ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnMemcpyUSMExp = context.urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
+
+    if (nullptr == pfnMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_memcpy_usm_exp_params_t params = {
+        &hCommandBuffer,          &pDst,          &pSrc,      &size,
+        &numSyncPointsInWaitList, &pDependencies, &pSyncPoint};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP,
+                             "urCommandBufferMemcpyUSMExp", &params);
+
+    ur_result_t result =
+        pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP,
+                       "urCommandBufferMemcpyUSMExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnMembufferCopyExp =
+        context.urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
+
+    if (nullptr == pfnMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_membuffer_copy_exp_params_t params = {
+        &hCommandBuffer,
+        &hSrcMem,
+        &hDstMem,
+        &srcOffset,
+        &dstOffset,
+        &size,
+        &numSyncPointsInWaitList,
+        &pDependencies,
+        &pSyncPoint};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP,
+                             "urCommandBufferMembufferCopyExp", &params);
+
+    ur_result_t result = pfnMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP,
+                       "urCommandBufferMembufferCopyExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        Region, ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnMembufferCopyRectExp =
+        context.urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
+
+    if (nullptr == pfnMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_membuffer_copy_rect_exp_params_t params = {
+        &hCommandBuffer,
+        &hSrcMem,
+        &hDstMem,
+        &SrcOrigin,
+        &DstOrigin,
+        &Region,
+        &SrcRowPitch,
+        &SrcSlicePitch,
+        &DstRowPitch,
+        &DstSlicePitch,
+        &numSyncPointsInWaitList,
+        &pDependencies,
+        &pSyncPoint};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP,
+                             "urCommandBufferMembufferCopyRectExp", &params);
+
+    ur_result_t result = pfnMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
+        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
+        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP,
+                       "urCommandBufferMembufferCopyRectExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    auto pfnEnqueueExp = context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
+
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_enqueue_exp_params_t params = {
+        &hCommandBuffer, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
+                             "urCommandBufferEnqueueExp", &params);
+
+    ur_result_t result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList,
+                                       phEventWaitList, phEvent);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
+                       "urCommandBufferEnqueueExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -3992,6 +4330,66 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     return result;
 }
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandBufferExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+__urdlllocal ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_command_buffer_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_tracing_layer::context.urDdiTable.CommandBufferExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreateExp = pDdiTable->pfnCreateExp;
+    pDdiTable->pfnCreateExp = ur_tracing_layer::urCommandBufferCreateExp;
+
+    dditable.pfnRetainExp = pDdiTable->pfnRetainExp;
+    pDdiTable->pfnRetainExp = ur_tracing_layer::urCommandBufferRetainExp;
+
+    dditable.pfnReleaseExp = pDdiTable->pfnReleaseExp;
+    pDdiTable->pfnReleaseExp = ur_tracing_layer::urCommandBufferReleaseExp;
+
+    dditable.pfnFinalizeExp = pDdiTable->pfnFinalizeExp;
+    pDdiTable->pfnFinalizeExp = ur_tracing_layer::urCommandBufferFinalizeExp;
+
+    dditable.pfnAppendKernelExp = pDdiTable->pfnAppendKernelExp;
+    pDdiTable->pfnAppendKernelExp =
+        ur_tracing_layer::urCommandBufferAppendKernelExp;
+
+    dditable.pfnMemcpyUSMExp = pDdiTable->pfnMemcpyUSMExp;
+    pDdiTable->pfnMemcpyUSMExp = ur_tracing_layer::urCommandBufferMemcpyUSMExp;
+
+    dditable.pfnMembufferCopyExp = pDdiTable->pfnMembufferCopyExp;
+    pDdiTable->pfnMembufferCopyExp =
+        ur_tracing_layer::urCommandBufferMembufferCopyExp;
+
+    dditable.pfnMembufferCopyRectExp = pDdiTable->pfnMembufferCopyRectExp;
+    pDdiTable->pfnMembufferCopyRectExp =
+        ur_tracing_layer::urCommandBufferMembufferCopyRectExp;
+
+    dditable.pfnEnqueueExp = pDdiTable->pfnEnqueueExp;
+    pDdiTable->pfnEnqueueExp = ur_tracing_layer::urCommandBufferEnqueueExp;
+
+    return result;
+}
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Context table
 ///        with current process' addresses
 ///
@@ -4705,6 +5103,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     if (UR_RESULT_SUCCESS == result) {
         result = ur_tracing_layer::urGetGlobalProcAddrTable(
             UR_API_VERSION_CURRENT, &dditable->Global);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        result = ur_tracing_layer::urGetCommandBufferExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->CommandBufferExp);
     }
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -138,7 +138,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -150,16 +150,23 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     }
 
     ur_command_buffer_append_kernel_exp_params_t params = {
-        &hCommandBuffer,          &hKernel,         &WorkDim,
-        &pGlobalWorkOffset,       &pGlobalWorkSize, &pLocalWorkSize,
-        &numSyncPointsInWaitList, &pDependencies,   &pSyncPoint};
+        &hCommandBuffer,
+        &hKernel,
+        &WorkDim,
+        &pGlobalWorkOffset,
+        &pGlobalWorkSize,
+        &pLocalWorkSize,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP,
                              "urCommandBufferAppendKernelExp", &params);
 
     ur_result_t result = pfnAppendKernelExp(
         hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
-        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        pLocalWorkSize, numSyncPointsInWaitList, pSyncPointWaitList,
+        pSyncPoint);
 
     context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP,
                        "urCommandBufferAppendKernelExp", &params, &result,
@@ -169,8 +176,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -179,37 +186,38 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
-    auto pfnMemcpyUSMExp = context.urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
+    auto pfnAppendMemcpyUSMExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
 
-    if (nullptr == pfnMemcpyUSMExp) {
+    if (nullptr == pfnAppendMemcpyUSMExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_command_buffer_memcpy_usm_exp_params_t params = {
-        &hCommandBuffer,          &pDst,          &pSrc,      &size,
-        &numSyncPointsInWaitList, &pDependencies, &pSyncPoint};
+    ur_command_buffer_append_memcpy_usm_exp_params_t params = {
+        &hCommandBuffer,     &pDst,      &pSrc, &size, &numSyncPointsInWaitList,
+        &pSyncPointWaitList, &pSyncPoint};
     uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP,
-                             "urCommandBufferMemcpyUSMExp", &params);
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP,
+                             "urCommandBufferAppendMemcpyUSMExp", &params);
 
-    ur_result_t result =
-        pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                               numSyncPointsInWaitList,
+                                               pSyncPointWaitList, pSyncPoint);
 
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_MEMCPY_USM_EXP,
-                       "urCommandBufferMemcpyUSMExp", &params, &result,
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP,
+                       "urCommandBufferAppendMemcpyUSMExp", &params, &result,
                        instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -220,18 +228,18 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
-    auto pfnMembufferCopyExp =
-        context.urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
+    auto pfnAppendMembufferCopyExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
 
-    if (nullptr == pfnMembufferCopyExp) {
+    if (nullptr == pfnAppendMembufferCopyExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_command_buffer_membuffer_copy_exp_params_t params = {
+    ur_command_buffer_append_membuffer_copy_exp_params_t params = {
         &hCommandBuffer,
         &hSrcMem,
         &hDstMem,
@@ -239,26 +247,26 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
         &dstOffset,
         &size,
         &numSyncPointsInWaitList,
-        &pDependencies,
+        &pSyncPointWaitList,
         &pSyncPoint};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP,
-                             "urCommandBufferMembufferCopyExp", &params);
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP,
+        "urCommandBufferAppendMembufferCopyExp", &params);
 
-    ur_result_t result = pfnMembufferCopyExp(
+    ur_result_t result = pfnAppendMembufferCopyExp(
         hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_EXP,
-                       "urCommandBufferMembufferCopyExp", &params, &result,
-                       instance);
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP,
+                       "urCommandBufferAppendMembufferCopyExp", &params,
+                       &result, instance);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -276,18 +284,18 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
-    auto pfnMembufferCopyRectExp =
-        context.urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
+    auto pfnAppendMembufferCopyRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
 
-    if (nullptr == pfnMembufferCopyRectExp) {
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_command_buffer_membuffer_copy_rect_exp_params_t params = {
+    ur_command_buffer_append_membuffer_copy_rect_exp_params_t params = {
         &hCommandBuffer,
         &hSrcMem,
         &hDstMem,
@@ -299,20 +307,21 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
         &DstRowPitch,
         &DstSlicePitch,
         &numSyncPointsInWaitList,
-        &pDependencies,
+        &pSyncPointWaitList,
         &pSyncPoint};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP,
-                             "urCommandBufferMembufferCopyRectExp", &params);
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
+        "urCommandBufferAppendMembufferCopyRectExp", &params);
 
-    ur_result_t result = pfnMembufferCopyRectExp(
+    ur_result_t result = pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
         SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_MEMBUFFER_COPY_RECT_EXP,
-                       "urCommandBufferMembufferCopyRectExp", &params, &result,
-                       instance);
+    context.notify_end(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
+        "urCommandBufferAppendMembufferCopyRectExp", &params, &result,
+        instance);
 
     return result;
 }
@@ -4376,16 +4385,18 @@ __urdlllocal ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     pDdiTable->pfnAppendKernelExp =
         ur_tracing_layer::urCommandBufferAppendKernelExp;
 
-    dditable.pfnMemcpyUSMExp = pDdiTable->pfnMemcpyUSMExp;
-    pDdiTable->pfnMemcpyUSMExp = ur_tracing_layer::urCommandBufferMemcpyUSMExp;
+    dditable.pfnAppendMemcpyUSMExp = pDdiTable->pfnAppendMemcpyUSMExp;
+    pDdiTable->pfnAppendMemcpyUSMExp =
+        ur_tracing_layer::urCommandBufferAppendMemcpyUSMExp;
 
-    dditable.pfnMembufferCopyExp = pDdiTable->pfnMembufferCopyExp;
-    pDdiTable->pfnMembufferCopyExp =
-        ur_tracing_layer::urCommandBufferMembufferCopyExp;
+    dditable.pfnAppendMembufferCopyExp = pDdiTable->pfnAppendMembufferCopyExp;
+    pDdiTable->pfnAppendMembufferCopyExp =
+        ur_tracing_layer::urCommandBufferAppendMembufferCopyExp;
 
-    dditable.pfnMembufferCopyRectExp = pDdiTable->pfnMembufferCopyRectExp;
-    pDdiTable->pfnMembufferCopyRectExp =
-        ur_tracing_layer::urCommandBufferMembufferCopyRectExp;
+    dditable.pfnAppendMembufferCopyRectExp =
+        pDdiTable->pfnAppendMembufferCopyRectExp;
+    pDdiTable->pfnAppendMembufferCopyRectExp =
+        ur_tracing_layer::urCommandBufferAppendMembufferCopyRectExp;
 
     dditable.pfnEnqueueExp = pDdiTable->pfnEnqueueExp;
     pDdiTable->pfnEnqueueExp = ur_tracing_layer::urCommandBufferEnqueueExp;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -16,356 +16,6 @@
 
 namespace ur_tracing_layer {
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t
-        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t
-        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
-) {
-    auto pfnCreateExp = context.urDdiTable.CommandBufferExp.pfnCreateExp;
-
-    if (nullptr == pfnCreateExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_create_exp_params_t params = {
-        &hContext, &hDevice, &pCommandBufferDesc, &phCommandBuffer};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP,
-                             "urCommandBufferCreateExp", &params);
-
-    ur_result_t result =
-        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP,
-                       "urCommandBufferCreateExp", &params, &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    auto pfnRetainExp = context.urDdiTable.CommandBufferExp.pfnRetainExp;
-
-    if (nullptr == pfnRetainExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_retain_exp_params_t params = {&hCommandBuffer};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP,
-                             "urCommandBufferRetainExp", &params);
-
-    ur_result_t result = pfnRetainExp(hCommandBuffer);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP,
-                       "urCommandBufferRetainExp", &params, &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    auto pfnReleaseExp = context.urDdiTable.CommandBufferExp.pfnReleaseExp;
-
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_release_exp_params_t params = {&hCommandBuffer};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP,
-                             "urCommandBufferReleaseExp", &params);
-
-    ur_result_t result = pfnReleaseExp(hCommandBuffer);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP,
-                       "urCommandBufferReleaseExp", &params, &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    auto pfnFinalizeExp = context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
-
-    if (nullptr == pfnFinalizeExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_finalize_exp_params_t params = {&hCommandBuffer};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP,
-                             "urCommandBufferFinalizeExp", &params);
-
-    ur_result_t result = pfnFinalizeExp(hCommandBuffer);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP,
-                       "urCommandBufferFinalizeExp", &params, &result,
-                       instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendKernelExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,         ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel, ///< [in] kernel to append
-    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
-    const size_t
-        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
-    const size_t *
-        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
-    const size_t
-        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendKernelExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendKernelExp;
-
-    if (nullptr == pfnAppendKernelExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_append_kernel_exp_params_t params = {
-        &hCommandBuffer,
-        &hKernel,
-        &WorkDim,
-        &pGlobalWorkOffset,
-        &pGlobalWorkSize,
-        &pLocalWorkSize,
-        &numSyncPointsInWaitList,
-        &pSyncPointWaitList,
-        &pSyncPoint};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP,
-                             "urCommandBufferAppendKernelExp", &params);
-
-    ur_result_t result = pfnAppendKernelExp(
-        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
-        pLocalWorkSize, numSyncPointsInWaitList, pSyncPointWaitList,
-        pSyncPoint);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_EXP,
-                       "urCommandBufferAppendKernelExp", &params, &result,
-                       instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    void *pDst,         ///< [in] Location the data will be copied to.
-    const void *pSrc,   ///< [in] The data to be copied.
-    size_t size,        ///< [in] The number of bytes to copy
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendMemcpyUSMExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
-
-    if (nullptr == pfnAppendMemcpyUSMExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_append_memcpy_usm_exp_params_t params = {
-        &hCommandBuffer,     &pDst,      &pSrc, &size, &numSyncPointsInWaitList,
-        &pSyncPointWaitList, &pSyncPoint};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP,
-                             "urCommandBufferAppendMemcpyUSMExp", &params);
-
-    ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                                               numSyncPointsInWaitList,
-                                               pSyncPointWaitList, pSyncPoint);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP,
-                       "urCommandBufferAppendMemcpyUSMExp", &params, &result,
-                       instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    size_t srcOffset,        ///< [in] Offset into the source memory.
-    size_t dstOffset,        ///< [in] Offset into the destination memory
-    size_t size,             ///< [in] The number of bytes to be copied.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendMembufferCopyExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
-
-    if (nullptr == pfnAppendMembufferCopyExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_append_membuffer_copy_exp_params_t params = {
-        &hCommandBuffer,
-        &hSrcMem,
-        &hDstMem,
-        &srcOffset,
-        &dstOffset,
-        &size,
-        &numSyncPointsInWaitList,
-        &pSyncPointWaitList,
-        &pSyncPoint};
-    uint64_t instance = context.notify_begin(
-        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP,
-        "urCommandBufferAppendMembufferCopyExp", &params);
-
-    ur_result_t result = pfnAppendMembufferCopyExp(
-        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP,
-                       "urCommandBufferAppendMembufferCopyExp", &params,
-                       &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    ur_rect_offset_t
-        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t
-        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t
-        Region, ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendMembufferCopyRectExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
-
-    if (nullptr == pfnAppendMembufferCopyRectExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_append_membuffer_copy_rect_exp_params_t params = {
-        &hCommandBuffer,
-        &hSrcMem,
-        &hDstMem,
-        &SrcOrigin,
-        &DstOrigin,
-        &Region,
-        &SrcRowPitch,
-        &SrcSlicePitch,
-        &DstRowPitch,
-        &DstSlicePitch,
-        &numSyncPointsInWaitList,
-        &pSyncPointWaitList,
-        &pSyncPoint};
-    uint64_t instance = context.notify_begin(
-        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
-        "urCommandBufferAppendMembufferCopyRectExp", &params);
-
-    ur_result_t result = pfnAppendMembufferCopyRectExp(
-        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
-        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-
-    context.notify_end(
-        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
-        "urCommandBufferAppendMembufferCopyRectExp", &params, &result,
-        instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t
-        hQueue, ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the command-buffer execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-    ///< events.
-    ur_event_handle_t *
-        phEvent ///< [out][optional] return an event object that identifies this particular
-                ///< command-buffer execution instance.
-) {
-    auto pfnEnqueueExp = context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
-
-    if (nullptr == pfnEnqueueExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_command_buffer_enqueue_exp_params_t params = {
-        &hCommandBuffer, &hQueue, &numEventsInWaitList, &phEventWaitList,
-        &phEvent};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
-                             "urCommandBufferEnqueueExp", &params);
-
-    ur_result_t result = pfnEnqueueExp(
-        hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
-
-    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
-                       "urCommandBufferEnqueueExp", &params, &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -4303,6 +3953,356 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    auto pfnCreateExp = context.urDdiTable.CommandBufferExp.pfnCreateExp;
+
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_create_exp_params_t params = {
+        &hContext, &hDevice, &pCommandBufferDesc, &phCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP,
+                             "urCommandBufferCreateExp", &params);
+
+    ur_result_t result =
+        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP,
+                       "urCommandBufferCreateExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnRetainExp = context.urDdiTable.CommandBufferExp.pfnRetainExp;
+
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_retain_exp_params_t params = {&hCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP,
+                             "urCommandBufferRetainExp", &params);
+
+    ur_result_t result = pfnRetainExp(hCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP,
+                       "urCommandBufferRetainExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnReleaseExp = context.urDdiTable.CommandBufferExp.pfnReleaseExp;
+
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_release_exp_params_t params = {&hCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP,
+                             "urCommandBufferReleaseExp", &params);
+
+    ur_result_t result = pfnReleaseExp(hCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP,
+                       "urCommandBufferReleaseExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnFinalizeExp = context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
+
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_finalize_exp_params_t params = {&hCommandBuffer};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP,
+                             "urCommandBufferFinalizeExp", &params);
+
+    ur_result_t result = pfnFinalizeExp(hCommandBuffer);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP,
+                       "urCommandBufferFinalizeExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t workDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendKernelLaunchExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendKernelLaunchExp;
+
+    if (nullptr == pfnAppendKernelLaunchExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_kernel_launch_exp_params_t params = {
+        &hCommandBuffer,
+        &hKernel,
+        &workDim,
+        &pGlobalWorkOffset,
+        &pGlobalWorkSize,
+        &pLocalWorkSize,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP,
+        "urCommandBufferAppendKernelLaunchExp", &params);
+
+    ur_result_t result = pfnAppendKernelLaunchExp(
+        hCommandBuffer, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numSyncPointsInWaitList, pSyncPointWaitList,
+        pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP,
+                       "urCommandBufferAppendKernelLaunchExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    const void *pSrc,   ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMemcpyUSMExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
+
+    if (nullptr == pfnAppendMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_memcpy_usm_exp_params_t params = {
+        &hCommandBuffer,     &pDst,      &pSrc, &size, &numSyncPointsInWaitList,
+        &pSyncPointWaitList, &pSyncPoint};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP,
+                             "urCommandBufferAppendMemcpyUSMExp", &params);
+
+    ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                               numSyncPointsInWaitList,
+                                               pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP,
+                       "urCommandBufferAppendMemcpyUSMExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferCopyExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
+
+    if (nullptr == pfnAppendMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_membuffer_copy_exp_params_t params = {
+        &hCommandBuffer,
+        &hSrcMem,
+        &hDstMem,
+        &srcOffset,
+        &dstOffset,
+        &size,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP,
+        "urCommandBufferAppendMembufferCopyExp", &params);
+
+    ur_result_t result = pfnAppendMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP,
+                       "urCommandBufferAppendMembufferCopyExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        srcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        dstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        region, ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferCopyRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
+
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_membuffer_copy_rect_exp_params_t params = {
+        &hCommandBuffer,
+        &hSrcMem,
+        &hDstMem,
+        &srcOrigin,
+        &dstOrigin,
+        &region,
+        &srcRowPitch,
+        &srcSlicePitch,
+        &dstRowPitch,
+        &dstSlicePitch,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
+        "urCommandBufferAppendMembufferCopyRectExp", &params);
+
+    ur_result_t result = pfnAppendMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
+        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
+        "urCommandBufferAppendMembufferCopyRectExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    auto pfnEnqueueExp = context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
+
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_enqueue_exp_params_t params = {
+        &hCommandBuffer, &hQueue, &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
+                             "urCommandBufferEnqueueExp", &params);
+
+    ur_result_t result = pfnEnqueueExp(
+        hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP,
+                       "urCommandBufferEnqueueExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Global table
 ///        with current process' addresses
 ///
@@ -4381,9 +4381,9 @@ __urdlllocal ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     dditable.pfnFinalizeExp = pDdiTable->pfnFinalizeExp;
     pDdiTable->pfnFinalizeExp = ur_tracing_layer::urCommandBufferFinalizeExp;
 
-    dditable.pfnAppendKernelExp = pDdiTable->pfnAppendKernelExp;
-    pDdiTable->pfnAppendKernelExp =
-        ur_tracing_layer::urCommandBufferAppendKernelExp;
+    dditable.pfnAppendKernelLaunchExp = pDdiTable->pfnAppendKernelLaunchExp;
+    pDdiTable->pfnAppendKernelLaunchExp =
+        ur_tracing_layer::urCommandBufferAppendKernelLaunchExp;
 
     dditable.pfnAppendMemcpyUSMExp = pDdiTable->pfnAppendMemcpyUSMExp;
     pDdiTable->pfnAppendMemcpyUSMExp =

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -5189,6 +5189,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         if (NULL == pLocalWorkSize) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
     }
 
     ur_result_t result = pfnAppendKernelLaunchExp(
@@ -5237,6 +5245,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
         if (size == 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
     }
 
     ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
@@ -5281,6 +5297,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 
         if (NULL == hDstMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
         }
     }
 
@@ -5333,6 +5357,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
 
         if (NULL == hDstMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
         }
     }
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -197,7 +197,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
-    void *pSrc,         ///< [in] The data to be copied.
+    const void *pSrc,   ///< [in] The data to be copied.
     size_t size,        ///< [in] The number of bytes to copy
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
@@ -359,7 +359,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 /// @brief Intercept function for urCommandBufferEnqueueExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -380,10 +382,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         if (NULL == hCommandBuffer) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
+
+        if (NULL == hQueue) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
     }
 
-    ur_result_t result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList,
-                                       phEventWaitList, phEvent);
+    ur_result_t result = pfnEnqueueExp(
+        hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
 
     return result;
 }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -15,400 +15,6 @@
 namespace ur_validation_layer {
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t
-        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t
-        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
-) {
-    auto pfnCreateExp = context.urDdiTable.CommandBufferExp.pfnCreateExp;
-
-    if (nullptr == pfnCreateExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hContext) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == phCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-    }
-
-    ur_result_t result =
-        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    auto pfnRetainExp = context.urDdiTable.CommandBufferExp.pfnRetainExp;
-
-    if (nullptr == pfnRetainExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-    }
-
-    ur_result_t result = pfnRetainExp(hCommandBuffer);
-
-    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
-        refCountContext.incrementRefCount(hCommandBuffer);
-    }
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    auto pfnReleaseExp = context.urDdiTable.CommandBufferExp.pfnReleaseExp;
-
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-    }
-
-    ur_result_t result = pfnReleaseExp(hCommandBuffer);
-
-    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
-        refCountContext.decrementRefCount(hCommandBuffer);
-    }
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    auto pfnFinalizeExp = context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
-
-    if (nullptr == pfnFinalizeExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-    }
-
-    ur_result_t result = pfnFinalizeExp(hCommandBuffer);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendKernelExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,         ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel, ///< [in] kernel to append
-    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
-    const size_t
-        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
-    const size_t *
-        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
-    const size_t
-        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendKernelExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendKernelExp;
-
-    if (nullptr == pfnAppendKernelExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hKernel) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == pGlobalWorkOffset) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pGlobalWorkSize) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pLocalWorkSize) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSyncPointWaitList) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSyncPoint) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-    }
-
-    ur_result_t result = pfnAppendKernelExp(
-        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
-        pLocalWorkSize, numSyncPointsInWaitList, pSyncPointWaitList,
-        pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    void *pDst,         ///< [in] Location the data will be copied to.
-    const void *pSrc,   ///< [in] The data to be copied.
-    size_t size,        ///< [in] The number of bytes to copy
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendMemcpyUSMExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
-
-    if (nullptr == pfnAppendMemcpyUSMExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == pDst) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSrc) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSyncPointWaitList) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSyncPoint) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (size == 0) {
-            return UR_RESULT_ERROR_INVALID_SIZE;
-        }
-    }
-
-    ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                                               numSyncPointsInWaitList,
-                                               pSyncPointWaitList, pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    size_t srcOffset,        ///< [in] Offset into the source memory.
-    size_t dstOffset,        ///< [in] Offset into the destination memory
-    size_t size,             ///< [in] The number of bytes to be copied.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendMembufferCopyExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
-
-    if (nullptr == pfnAppendMembufferCopyExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hSrcMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hDstMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == pSyncPointWaitList) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSyncPoint) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-    }
-
-    ur_result_t result = pfnAppendMembufferCopyExp(
-        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    ur_rect_offset_t
-        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t
-        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t
-        Region, ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    auto pfnAppendMembufferCopyRectExp =
-        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
-
-    if (nullptr == pfnAppendMembufferCopyRectExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hSrcMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hDstMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == pSyncPointWaitList) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (NULL == pSyncPoint) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-    }
-
-    ur_result_t result = pfnAppendMembufferCopyRectExp(
-        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
-        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t
-        hQueue, ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the command-buffer execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-    ///< events.
-    ur_event_handle_t *
-        phEvent ///< [out][optional] return an event object that identifies this particular
-                ///< command-buffer execution instance.
-) {
-    auto pfnEnqueueExp = context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
-
-    if (nullptr == pfnEnqueueExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hCommandBuffer) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hQueue) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (phEventWaitList == NULL && numEventsInWaitList > 0) {
-            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
-        }
-
-        if (phEventWaitList != NULL && numEventsInWaitList == 0) {
-            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
-        }
-    }
-
-    ur_result_t result = pfnEnqueueExp(
-        hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -5424,6 +5030,368 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    auto pfnCreateExp = context.urDdiTable.CommandBufferExp.pfnCreateExp;
+
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDevice) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result =
+        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnRetainExp = context.urDdiTable.CommandBufferExp.pfnRetainExp;
+
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnRetainExp(hCommandBuffer);
+
+    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
+        refCountContext.incrementRefCount(hCommandBuffer);
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnReleaseExp = context.urDdiTable.CommandBufferExp.pfnReleaseExp;
+
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnReleaseExp(hCommandBuffer);
+
+    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
+        refCountContext.decrementRefCount(hCommandBuffer);
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnFinalizeExp = context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
+
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnFinalizeExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t workDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendKernelLaunchExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendKernelLaunchExp;
+
+    if (nullptr == pfnAppendKernelLaunchExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hKernel) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pGlobalWorkOffset) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pGlobalWorkSize) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pLocalWorkSize) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnAppendKernelLaunchExp(
+        hCommandBuffer, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numSyncPointsInWaitList, pSyncPointWaitList,
+        pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    const void *pSrc,   ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMemcpyUSMExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
+
+    if (nullptr == pfnAppendMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDst) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSrc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (size == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+    }
+
+    ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                               numSyncPointsInWaitList,
+                                               pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferCopyExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
+
+    if (nullptr == pfnAppendMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSrcMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDstMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnAppendMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        srcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        dstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        region, ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferCopyRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
+
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSrcMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDstMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnAppendMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
+        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    auto pfnEnqueueExp = context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
+
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hQueue) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (phEventWaitList == NULL && numEventsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+    }
+
+    ur_result_t result = pfnEnqueueExp(
+        hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Global table
 ///        with current process' addresses
 ///
@@ -5503,9 +5471,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     dditable.pfnFinalizeExp = pDdiTable->pfnFinalizeExp;
     pDdiTable->pfnFinalizeExp = ur_validation_layer::urCommandBufferFinalizeExp;
 
-    dditable.pfnAppendKernelExp = pDdiTable->pfnAppendKernelExp;
-    pDdiTable->pfnAppendKernelExp =
-        ur_validation_layer::urCommandBufferAppendKernelExp;
+    dditable.pfnAppendKernelLaunchExp = pDdiTable->pfnAppendKernelLaunchExp;
+    pDdiTable->pfnAppendKernelLaunchExp =
+        ur_validation_layer::urCommandBufferAppendKernelLaunchExp;
 
     dditable.pfnAppendMemcpyUSMExp = pDdiTable->pfnAppendMemcpyUSMExp;
     pDdiTable->pfnAppendMemcpyUSMExp =

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -15,6 +15,380 @@
 namespace ur_validation_layer {
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    auto pfnCreateExp = context.urDdiTable.CommandBufferExp.pfnCreateExp;
+
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDevice) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result =
+        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnRetainExp = context.urDdiTable.CommandBufferExp.pfnRetainExp;
+
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnRetainExp(hCommandBuffer);
+
+    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
+        refCountContext.incrementRefCount(hCommandBuffer);
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnReleaseExp = context.urDdiTable.CommandBufferExp.pfnReleaseExp;
+
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnReleaseExp(hCommandBuffer);
+
+    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
+        refCountContext.decrementRefCount(hCommandBuffer);
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    auto pfnFinalizeExp = context.urDdiTable.CommandBufferExp.pfnFinalizeExp;
+
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnFinalizeExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnAppendKernelExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendKernelExp;
+
+    if (nullptr == pfnAppendKernelExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hKernel) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pGlobalWorkOffset) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pGlobalWorkSize) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pLocalWorkSize) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pDependencies) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSyncPoint) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnAppendKernelExp(
+        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    void *pSrc,         ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnMemcpyUSMExp = context.urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
+
+    if (nullptr == pfnMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDst) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSrc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pDependencies) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSyncPoint) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result =
+        pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnMembufferCopyExp =
+        context.urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
+
+    if (nullptr == pfnMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSrcMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDstMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDependencies) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSyncPoint) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        Region, ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    auto pfnMembufferCopyRectExp =
+        context.urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
+
+    if (nullptr == pfnMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSrcMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDstMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDependencies) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSyncPoint) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
+        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
+        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    auto pfnEnqueueExp = context.urDdiTable.CommandBufferExp.pfnEnqueueExp;
+
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList,
+                                       phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -369,7 +743,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName) {
+        if (UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -5070,6 +5444,68 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandBufferExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_command_buffer_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_validation_layer::context.urDdiTable.CommandBufferExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnCreateExp = pDdiTable->pfnCreateExp;
+    pDdiTable->pfnCreateExp = ur_validation_layer::urCommandBufferCreateExp;
+
+    dditable.pfnRetainExp = pDdiTable->pfnRetainExp;
+    pDdiTable->pfnRetainExp = ur_validation_layer::urCommandBufferRetainExp;
+
+    dditable.pfnReleaseExp = pDdiTable->pfnReleaseExp;
+    pDdiTable->pfnReleaseExp = ur_validation_layer::urCommandBufferReleaseExp;
+
+    dditable.pfnFinalizeExp = pDdiTable->pfnFinalizeExp;
+    pDdiTable->pfnFinalizeExp = ur_validation_layer::urCommandBufferFinalizeExp;
+
+    dditable.pfnAppendKernelExp = pDdiTable->pfnAppendKernelExp;
+    pDdiTable->pfnAppendKernelExp =
+        ur_validation_layer::urCommandBufferAppendKernelExp;
+
+    dditable.pfnMemcpyUSMExp = pDdiTable->pfnMemcpyUSMExp;
+    pDdiTable->pfnMemcpyUSMExp =
+        ur_validation_layer::urCommandBufferMemcpyUSMExp;
+
+    dditable.pfnMembufferCopyExp = pDdiTable->pfnMembufferCopyExp;
+    pDdiTable->pfnMembufferCopyExp =
+        ur_validation_layer::urCommandBufferMembufferCopyExp;
+
+    dditable.pfnMembufferCopyRectExp = pDdiTable->pfnMembufferCopyRectExp;
+    pDdiTable->pfnMembufferCopyRectExp =
+        ur_validation_layer::urCommandBufferMembufferCopyRectExp;
+
+    dditable.pfnEnqueueExp = pDdiTable->pfnEnqueueExp;
+    pDdiTable->pfnEnqueueExp = ur_validation_layer::urCommandBufferEnqueueExp;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Context table
 ///        with current process' addresses
 ///
@@ -5801,6 +6237,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     if (UR_RESULT_SUCCESS == result) {
         result = ur_validation_layer::urGetGlobalProcAddrTable(
             UR_API_VERSION_CURRENT, &dditable->Global);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        result = ur_validation_layer::urGetCommandBufferExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->CommandBufferExp);
     }
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -763,7 +763,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName) {
+        if (UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -143,7 +143,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -175,7 +175,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL == pDependencies) {
+        if (NULL == pSyncPointWaitList) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -186,14 +186,15 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
 
     ur_result_t result = pfnAppendKernelExp(
         hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
-        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        pLocalWorkSize, numSyncPointsInWaitList, pSyncPointWaitList,
+        pSyncPoint);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -202,13 +203,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
-    auto pfnMemcpyUSMExp = context.urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
+    auto pfnAppendMemcpyUSMExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
 
-    if (nullptr == pfnMemcpyUSMExp) {
+    if (nullptr == pfnAppendMemcpyUSMExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
@@ -225,25 +227,29 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL == pDependencies) {
+        if (NULL == pSyncPointWaitList) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
         if (NULL == pSyncPoint) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (size == 0) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
     }
 
-    ur_result_t result =
-        pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    ur_result_t result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                               numSyncPointsInWaitList,
+                                               pSyncPointWaitList, pSyncPoint);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -254,14 +260,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
-    auto pfnMembufferCopyExp =
-        context.urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
+    auto pfnAppendMembufferCopyExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
 
-    if (nullptr == pfnMembufferCopyExp) {
+    if (nullptr == pfnAppendMembufferCopyExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
@@ -278,7 +284,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == pDependencies) {
+        if (NULL == pSyncPointWaitList) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -287,16 +293,16 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
         }
     }
 
-    ur_result_t result = pfnMembufferCopyExp(
+    ur_result_t result = pfnAppendMembufferCopyExp(
         hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -314,14 +320,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
-    auto pfnMembufferCopyRectExp =
-        context.urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
+    auto pfnAppendMembufferCopyRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferCopyRectExp;
 
-    if (nullptr == pfnMembufferCopyRectExp) {
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
@@ -338,7 +344,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == pDependencies) {
+        if (NULL == pSyncPointWaitList) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -347,10 +353,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
         }
     }
 
-    ur_result_t result = pfnMembufferCopyRectExp(
+    ur_result_t result = pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
         SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
     return result;
 }
@@ -385,6 +391,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
         if (NULL == hQueue) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (phEventWaitList == NULL && numEventsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
     }
 
@@ -5493,17 +5507,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     pDdiTable->pfnAppendKernelExp =
         ur_validation_layer::urCommandBufferAppendKernelExp;
 
-    dditable.pfnMemcpyUSMExp = pDdiTable->pfnMemcpyUSMExp;
-    pDdiTable->pfnMemcpyUSMExp =
-        ur_validation_layer::urCommandBufferMemcpyUSMExp;
+    dditable.pfnAppendMemcpyUSMExp = pDdiTable->pfnAppendMemcpyUSMExp;
+    pDdiTable->pfnAppendMemcpyUSMExp =
+        ur_validation_layer::urCommandBufferAppendMemcpyUSMExp;
 
-    dditable.pfnMembufferCopyExp = pDdiTable->pfnMembufferCopyExp;
-    pDdiTable->pfnMembufferCopyExp =
-        ur_validation_layer::urCommandBufferMembufferCopyExp;
+    dditable.pfnAppendMembufferCopyExp = pDdiTable->pfnAppendMembufferCopyExp;
+    pDdiTable->pfnAppendMembufferCopyExp =
+        ur_validation_layer::urCommandBufferAppendMembufferCopyExp;
 
-    dditable.pfnMembufferCopyRectExp = pDdiTable->pfnMembufferCopyRectExp;
-    pDdiTable->pfnMembufferCopyRectExp =
-        ur_validation_layer::urCommandBufferMembufferCopyRectExp;
+    dditable.pfnAppendMembufferCopyRectExp =
+        pDdiTable->pfnAppendMembufferCopyRectExp;
+    pDdiTable->pfnAppendMembufferCopyRectExp =
+        ur_validation_layer::urCommandBufferAppendMembufferCopyRectExp;
 
     dditable.pfnEnqueueExp = pDdiTable->pfnEnqueueExp;
     pDdiTable->pfnEnqueueExp = ur_validation_layer::urCommandBufferEnqueueExp;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -24,395 +24,8 @@ ur_queue_factory_t ur_queue_factory;
 ur_native_factory_t ur_native_factory;
 ur_sampler_factory_t ur_sampler_factory;
 ur_mem_factory_t ur_mem_factory;
-ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
 ur_usm_pool_factory_t ur_usm_pool_factory;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t
-        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t
-        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnCreateExp = dditable->ur.CommandBufferExp.pfnCreateExp;
-    if (nullptr == pfnCreateExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
-
-    // convert loader handle to platform handle
-    hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
-
-    // forward to device-platform
-    result =
-        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
-
-    if (UR_RESULT_SUCCESS != result) {
-        return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        *phCommandBuffer = reinterpret_cast<ur_exp_command_buffer_handle_t>(
-            ur_exp_command_buffer_factory.getInstance(*phCommandBuffer,
-                                                      dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnRetainExp = dditable->ur.CommandBufferExp.pfnRetainExp;
-    if (nullptr == pfnRetainExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // forward to device-platform
-    result = pfnRetainExp(hCommandBuffer);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnReleaseExp = dditable->ur.CommandBufferExp.pfnReleaseExp;
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // forward to device-platform
-    result = pfnReleaseExp(hCommandBuffer);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnFinalizeExp = dditable->ur.CommandBufferExp.pfnFinalizeExp;
-    if (nullptr == pfnFinalizeExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // forward to device-platform
-    result = pfnFinalizeExp(hCommandBuffer);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendKernelExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,         ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel, ///< [in] kernel to append
-    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
-    const size_t
-        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
-    const size_t *
-        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
-    const size_t
-        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnAppendKernelExp = dditable->ur.CommandBufferExp.pfnAppendKernelExp;
-    if (nullptr == pfnAppendKernelExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // convert loader handle to platform handle
-    hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
-
-    // forward to device-platform
-    result = pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
-                                pGlobalWorkOffset, pGlobalWorkSize,
-                                pLocalWorkSize, numSyncPointsInWaitList,
-                                pSyncPointWaitList, pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    void *pDst,         ///< [in] Location the data will be copied to.
-    const void *pSrc,   ///< [in] The data to be copied.
-    size_t size,        ///< [in] The number of bytes to copy
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnAppendMemcpyUSMExp =
-        dditable->ur.CommandBufferExp.pfnAppendMemcpyUSMExp;
-    if (nullptr == pfnAppendMemcpyUSMExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // forward to device-platform
-    result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                                   numSyncPointsInWaitList, pSyncPointWaitList,
-                                   pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    size_t srcOffset,        ///< [in] Offset into the source memory.
-    size_t dstOffset,        ///< [in] Offset into the destination memory
-    size_t size,             ///< [in] The number of bytes to be copied.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnAppendMembufferCopyExp =
-        dditable->ur.CommandBufferExp.pfnAppendMembufferCopyExp;
-    if (nullptr == pfnAppendMembufferCopyExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // convert loader handle to platform handle
-    hSrcMem = reinterpret_cast<ur_mem_object_t *>(hSrcMem)->handle;
-
-    // convert loader handle to platform handle
-    hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
-
-    // forward to device-platform
-    result = pfnAppendMembufferCopyExp(
-        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    ur_rect_offset_t
-        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t
-        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t
-        Region, ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnAppendMembufferCopyRectExp =
-        dditable->ur.CommandBufferExp.pfnAppendMembufferCopyRectExp;
-    if (nullptr == pfnAppendMembufferCopyRectExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // convert loader handle to platform handle
-    hSrcMem = reinterpret_cast<ur_mem_object_t *>(hSrcMem)->handle;
-
-    // convert loader handle to platform handle
-    hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
-
-    // forward to device-platform
-    result = pfnAppendMembufferCopyRectExp(
-        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
-        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t
-        hQueue, ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the command-buffer execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-    ///< events.
-    ur_event_handle_t *
-        phEvent ///< [out][optional] return an event object that identifies this particular
-                ///< command-buffer execution instance.
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->dditable;
-    auto pfnEnqueueExp = dditable->ur.CommandBufferExp.pfnEnqueueExp;
-    if (nullptr == pfnEnqueueExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hCommandBuffer =
-        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
-            ->handle;
-
-    // convert loader handle to platform handle
-    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
-
-    // convert loader handles to platform handles
-    auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
-    for (size_t i = 0;
-         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
-    }
-
-    // forward to device-platform
-    result = pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
-                           phEventWaitList, phEvent);
-    delete[] phEventWaitListLocal;
-
-    if (UR_RESULT_SUCCESS != result) {
-        return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        if (nullptr != phEvent) {
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance(*phEvent, dditable));
-        }
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    return result;
-}
+ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
@@ -5252,6 +4865,393 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     return result;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnCreateExp = dditable->ur.CommandBufferExp.pfnCreateExp;
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
+
+    // forward to device-platform
+    result =
+        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phCommandBuffer = reinterpret_cast<ur_exp_command_buffer_handle_t>(
+            ur_exp_command_buffer_factory.getInstance(*phCommandBuffer,
+                                                      dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnRetainExp = dditable->ur.CommandBufferExp.pfnRetainExp;
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnRetainExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnReleaseExp = dditable->ur.CommandBufferExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnReleaseExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnFinalizeExp = dditable->ur.CommandBufferExp.pfnFinalizeExp;
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnFinalizeExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t workDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendKernelLaunchExp =
+        dditable->ur.CommandBufferExp.pfnAppendKernelLaunchExp;
+    if (nullptr == pfnAppendKernelLaunchExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
+
+    // forward to device-platform
+    result = pfnAppendKernelLaunchExp(hCommandBuffer, hKernel, workDim,
+                                      pGlobalWorkOffset, pGlobalWorkSize,
+                                      pLocalWorkSize, numSyncPointsInWaitList,
+                                      pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    const void *pSrc,   ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMemcpyUSMExp =
+        dditable->ur.CommandBufferExp.pfnAppendMemcpyUSMExp;
+    if (nullptr == pfnAppendMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                   numSyncPointsInWaitList, pSyncPointWaitList,
+                                   pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMembufferCopyExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferCopyExp;
+    if (nullptr == pfnAppendMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hSrcMem = reinterpret_cast<ur_mem_object_t *>(hSrcMem)->handle;
+
+    // convert loader handle to platform handle
+    hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
+
+    // forward to device-platform
+    result = pfnAppendMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        srcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        dstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        region, ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMembufferCopyRectExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferCopyRectExp;
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hSrcMem = reinterpret_cast<ur_mem_object_t *>(hSrcMem)->handle;
+
+    // convert loader handle to platform handle
+    hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
+
+    // forward to device-platform
+    result = pfnAppendMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
+        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnEnqueueExp = dditable->ur.CommandBufferExp.pfnEnqueueExp;
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
+    for (size_t i = 0; i < numEventsInWaitList; ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result = pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
+                           phEventWaitList, phEvent);
+    delete[] phEventWaitListLocal;
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(
+                ur_event_factory.getInstance(*phEvent, dditable));
+        }
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
 } // namespace ur_loader
 
 #if defined(__cplusplus)
@@ -5362,8 +5362,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
             pDdiTable->pfnRetainExp = ur_loader::urCommandBufferRetainExp;
             pDdiTable->pfnReleaseExp = ur_loader::urCommandBufferReleaseExp;
             pDdiTable->pfnFinalizeExp = ur_loader::urCommandBufferFinalizeExp;
-            pDdiTable->pfnAppendKernelExp =
-                ur_loader::urCommandBufferAppendKernelExp;
+            pDdiTable->pfnAppendKernelLaunchExp =
+                ur_loader::urCommandBufferAppendKernelLaunchExp;
             pDdiTable->pfnAppendMemcpyUSMExp =
                 ur_loader::urCommandBufferAppendMemcpyUSMExp;
             pDdiTable->pfnAppendMembufferCopyExp =

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -172,7 +172,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -196,16 +196,17 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
 
     // forward to device-platform
-    result = pfnAppendKernelExp(
-        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
-        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    result = pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
+                                pGlobalWorkOffset, pGlobalWorkSize,
+                                pLocalWorkSize, numSyncPointsInWaitList,
+                                pSyncPointWaitList, pSyncPoint);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMemcpyUSMExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+/// @brief Intercept function for urCommandBufferAppendMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -214,7 +215,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -224,8 +225,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     auto dditable =
         reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
             ->dditable;
-    auto pfnMemcpyUSMExp = dditable->ur.CommandBufferExp.pfnMemcpyUSMExp;
-    if (nullptr == pfnMemcpyUSMExp) {
+    auto pfnAppendMemcpyUSMExp =
+        dditable->ur.CommandBufferExp.pfnAppendMemcpyUSMExp;
+    if (nullptr == pfnAppendMemcpyUSMExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -235,16 +237,16 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
             ->handle;
 
     // forward to device-platform
-    result =
-        pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    result = pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                   numSyncPointsInWaitList, pSyncPointWaitList,
+                                   pSyncPoint);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -255,7 +257,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -265,9 +267,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     auto dditable =
         reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
             ->dditable;
-    auto pfnMembufferCopyExp =
-        dditable->ur.CommandBufferExp.pfnMembufferCopyExp;
-    if (nullptr == pfnMembufferCopyExp) {
+    auto pfnAppendMembufferCopyExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferCopyExp;
+    if (nullptr == pfnAppendMembufferCopyExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -283,16 +285,16 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
 
     // forward to device-platform
-    result = pfnMembufferCopyExp(hCommandBuffer, hSrcMem, hDstMem, srcOffset,
-                                 dstOffset, size, numSyncPointsInWaitList,
-                                 pDependencies, pSyncPoint);
+    result = pfnAppendMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+/// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -310,7 +312,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -320,9 +322,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     auto dditable =
         reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
             ->dditable;
-    auto pfnMembufferCopyRectExp =
-        dditable->ur.CommandBufferExp.pfnMembufferCopyRectExp;
-    if (nullptr == pfnMembufferCopyRectExp) {
+    auto pfnAppendMembufferCopyRectExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferCopyRectExp;
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -338,10 +340,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
 
     // forward to device-platform
-    result = pfnMembufferCopyRectExp(
+    result = pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
         SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
     return result;
 }
@@ -5362,11 +5364,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
             pDdiTable->pfnFinalizeExp = ur_loader::urCommandBufferFinalizeExp;
             pDdiTable->pfnAppendKernelExp =
                 ur_loader::urCommandBufferAppendKernelExp;
-            pDdiTable->pfnMemcpyUSMExp = ur_loader::urCommandBufferMemcpyUSMExp;
-            pDdiTable->pfnMembufferCopyExp =
-                ur_loader::urCommandBufferMembufferCopyExp;
-            pDdiTable->pfnMembufferCopyRectExp =
-                ur_loader::urCommandBufferMembufferCopyRectExp;
+            pDdiTable->pfnAppendMemcpyUSMExp =
+                ur_loader::urCommandBufferAppendMemcpyUSMExp;
+            pDdiTable->pfnAppendMembufferCopyExp =
+                ur_loader::urCommandBufferAppendMembufferCopyExp;
+            pDdiTable->pfnAppendMembufferCopyRectExp =
+                ur_loader::urCommandBufferAppendMembufferCopyRectExp;
             pDdiTable->pfnEnqueueExp = ur_loader::urCommandBufferEnqueueExp;
         } else {
             // return pointers directly to platform's DDIs

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -24,7 +24,388 @@ ur_queue_factory_t ur_queue_factory;
 ur_native_factory_t ur_native_factory;
 ur_sampler_factory_t ur_sampler_factory;
 ur_mem_factory_t ur_mem_factory;
+ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
 ur_usm_pool_factory_t ur_usm_pool_factory;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferCreateExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnCreateExp = dditable->ur.CommandBufferExp.pfnCreateExp;
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
+
+    // forward to device-platform
+    result =
+        pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phCommandBuffer = reinterpret_cast<ur_exp_command_buffer_handle_t>(
+            ur_exp_command_buffer_factory.getInstance(*phCommandBuffer,
+                                                      dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferRetainExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnRetainExp = dditable->ur.CommandBufferExp.pfnRetainExp;
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnRetainExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferReleaseExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnReleaseExp = dditable->ur.CommandBufferExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnReleaseExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferFinalizeExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnFinalizeExp = dditable->ur.CommandBufferExp.pfnFinalizeExp;
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnFinalizeExp(hCommandBuffer);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendKernelExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendKernelExp = dditable->ur.CommandBufferExp.pfnAppendKernelExp;
+    if (nullptr == pfnAppendKernelExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
+
+    // forward to device-platform
+    result = pfnAppendKernelExp(
+        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMemcpyUSMExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    void *pSrc,         ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnMemcpyUSMExp = dditable->ur.CommandBufferExp.pfnMemcpyUSMExp;
+    if (nullptr == pfnMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // forward to device-platform
+    result =
+        pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnMembufferCopyExp =
+        dditable->ur.CommandBufferExp.pfnMembufferCopyExp;
+    if (nullptr == pfnMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hSrcMem = reinterpret_cast<ur_mem_object_t *>(hSrcMem)->handle;
+
+    // convert loader handle to platform handle
+    hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
+
+    // forward to device-platform
+    result = pfnMembufferCopyExp(hCommandBuffer, hSrcMem, hDstMem, srcOffset,
+                                 dstOffset, size, numSyncPointsInWaitList,
+                                 pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferMembufferCopyRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        Region, ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnMembufferCopyRectExp =
+        dditable->ur.CommandBufferExp.pfnMembufferCopyRectExp;
+    if (nullptr == pfnMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hSrcMem = reinterpret_cast<ur_mem_object_t *>(hSrcMem)->handle;
+
+    // convert loader handle to platform handle
+    hDstMem = reinterpret_cast<ur_mem_object_t *>(hDstMem)->handle;
+
+    // forward to device-platform
+    result = pfnMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
+        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
+        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferEnqueueExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnEnqueueExp = dditable->ur.CommandBufferExp.pfnEnqueueExp;
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
+    for (size_t i = 0;
+         (nullptr != phEventWaitList) && (i < numEventsInWaitList); ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList, phEventWaitList,
+                           phEvent);
+    delete[] phEventWaitListLocal;
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(
+                ur_event_factory.getInstance(*phEvent, dditable));
+        }
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
@@ -4919,6 +5300,73 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable =
                 ur_loader::context->platforms.front().dditable.ur.Global;
+        }
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's CommandBufferExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_command_buffer_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (ur_loader::context->version < version) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // Load the device-platform DDI tables
+    for (auto &platform : ur_loader::context->platforms) {
+        if (platform.initStatus != UR_RESULT_SUCCESS) {
+            continue;
+        }
+        auto getTable =
+            reinterpret_cast<ur_pfnGetCommandBufferExpProcAddrTable_t>(
+                ur_loader::LibLoader::getFunctionPtr(
+                    platform.handle.get(),
+                    "urGetCommandBufferExpProcAddrTable"));
+        if (!getTable) {
+            continue;
+        }
+        platform.initStatus =
+            getTable(version, &platform.dditable.ur.CommandBufferExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        if (ur_loader::context->platforms.size() != 1 ||
+            ur_loader::context->forceIntercept) {
+            // return pointers to loader's DDIs
+            pDdiTable->pfnCreateExp = ur_loader::urCommandBufferCreateExp;
+            pDdiTable->pfnRetainExp = ur_loader::urCommandBufferRetainExp;
+            pDdiTable->pfnReleaseExp = ur_loader::urCommandBufferReleaseExp;
+            pDdiTable->pfnFinalizeExp = ur_loader::urCommandBufferFinalizeExp;
+            pDdiTable->pfnAppendKernelExp =
+                ur_loader::urCommandBufferAppendKernelExp;
+            pDdiTable->pfnMemcpyUSMExp = ur_loader::urCommandBufferMemcpyUSMExp;
+            pDdiTable->pfnMembufferCopyExp =
+                ur_loader::urCommandBufferMembufferCopyExp;
+            pDdiTable->pfnMembufferCopyRectExp =
+                ur_loader::urCommandBufferMembufferCopyRectExp;
+            pDdiTable->pfnEnqueueExp = ur_loader::urCommandBufferEnqueueExp;
+        } else {
+            // return pointers directly to platform's DDIs
+            *pDdiTable = ur_loader::context->platforms.front()
+                             .dditable.ur.CommandBufferExp;
         }
     }
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -209,7 +209,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
-    void *pSrc,         ///< [in] The data to be copied.
+    const void *pSrc,   ///< [in] The data to be copied.
     size_t size,        ///< [in] The number of bytes to copy
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
@@ -350,7 +350,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 /// @brief Intercept function for urCommandBufferEnqueueExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -377,6 +379,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
             ->handle;
 
+    // convert loader handle to platform handle
+    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
+
     // convert loader handles to platform handles
     auto phEventWaitListLocal = new ur_event_handle_t[numEventsInWaitList];
     for (size_t i = 0;
@@ -386,8 +391,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     }
 
     // forward to device-platform
-    result = pfnEnqueueExp(hCommandBuffer, numEventsInWaitList, phEventWaitList,
-                           phEvent);
+    result = pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
+                           phEventWaitList, phEvent);
     delete[] phEventWaitListLocal;
 
     if (UR_RESULT_SUCCESS != result) {

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -56,6 +56,11 @@ using ur_sampler_factory_t =
 using ur_mem_object_t = object_t<ur_mem_handle_t>;
 using ur_mem_factory_t = singleton_factory_t<ur_mem_object_t, ur_mem_handle_t>;
 
+using ur_exp_command_buffer_object_t = object_t<ur_exp_command_buffer_handle_t>;
+using ur_exp_command_buffer_factory_t =
+    singleton_factory_t<ur_exp_command_buffer_object_t,
+                        ur_exp_command_buffer_handle_t>;
+
 using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
 using ur_usm_pool_factory_t =
     singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -56,14 +56,14 @@ using ur_sampler_factory_t =
 using ur_mem_object_t = object_t<ur_mem_handle_t>;
 using ur_mem_factory_t = singleton_factory_t<ur_mem_object_t, ur_mem_handle_t>;
 
+using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
+using ur_usm_pool_factory_t =
+    singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
+
 using ur_exp_command_buffer_object_t = object_t<ur_exp_command_buffer_handle_t>;
 using ur_exp_command_buffer_factory_t =
     singleton_factory_t<ur_exp_command_buffer_object_t,
                         ur_exp_command_buffer_handle_t>;
-
-using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
-using ur_usm_pool_factory_t =
-    singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
 
 } // namespace ur_loader
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -5411,7 +5411,9 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
@@ -5464,7 +5466,9 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 ///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
@@ -5506,7 +5510,9 @@ ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -5551,7 +5557,9 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -16,6 +16,332 @@
 extern "C" {
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a Command-Buffer object
+///
+/// @details
+///     - Create a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phCommandBuffer`
+ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+    ) try {
+    auto pfnCreateExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnCreateExp;
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Increment the command-buffer object's reference count.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    auto pfnRetainExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnRetainExp;
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnRetainExp(hCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command-buffer object's reference count and delete the
+///        command-buffer object if the reference count becomes zero.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    auto pfnReleaseExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnReleaseExp(hCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop recording on a command-buffer object such that no more commands
+///        can be appended and make it ready to enqueue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    auto pfnFinalizeExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnFinalizeExp;
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnFinalizeExp(hCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a kernel execution command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == pLocalWorkSize`
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    auto pfnAppendKernelExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendKernelExp;
+    if (nullptr == pfnAppendKernelExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendKernelExp(
+        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
+        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a USM memcpy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    void *pSrc,         ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    auto pfnMemcpyUSMExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
+    if (nullptr == pfnMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                           numSyncPointsInWaitList, pDependencies, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    auto pfnMembufferCopyExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
+    if (nullptr == pfnMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnMembufferCopyExp(hCommandBuffer, hSrcMem, hDstMem, srcOffset,
+                               dstOffset, size, numSyncPointsInWaitList,
+                               pDependencies, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        Region, ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+    ) try {
+    auto pfnMembufferCopyRectExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
+    if (nullptr == pfnMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
+        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
+        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Submit a command-buffer for execution on a queue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+    ) try {
+    auto pfnEnqueueExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnEnqueueExp;
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnEnqueueExp(hCommandBuffer, numEventsInWaitList, phEventWaitList,
+                         phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details
@@ -436,7 +762,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
+///         + `::UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -30,6 +30,10 @@ extern "C" {
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -58,6 +62,7 @@ ur_result_t UR_APICALL urCommandBufferCreateExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urCommandBufferRetainExp(
@@ -85,6 +90,7 @@ ur_result_t UR_APICALL urCommandBufferRetainExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urCommandBufferReleaseExp(
@@ -112,8 +118,9 @@ ur_result_t UR_APICALL urCommandBufferReleaseExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in] handle of the command-buffer object
@@ -143,8 +150,17 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 ///         + `NULL == pGlobalWorkOffset`
 ///         + `NULL == pGlobalWorkSize`
 ///         + `NULL == pLocalWorkSize`
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL
+///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] handle of the command-buffer object
@@ -159,7 +175,7 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
@@ -169,9 +185,10 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnAppendKernelExp(
-        hCommandBuffer, hKernel, WorkDim, pGlobalWorkOffset, pGlobalWorkSize,
-        pLocalWorkSize, numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    return pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
+                              pGlobalWorkOffset, pGlobalWorkSize,
+                              pLocalWorkSize, numSyncPointsInWaitList,
+                              pSyncPointWaitList, pSyncPoint);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -188,9 +205,18 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
-ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `size == 0`
+///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -199,18 +225,19 @@ ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
-    auto pfnMemcpyUSMExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnMemcpyUSMExp;
-    if (nullptr == pfnMemcpyUSMExp) {
+    auto pfnAppendMemcpyUSMExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
+    if (nullptr == pfnAppendMemcpyUSMExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                           numSyncPointsInWaitList, pDependencies, pSyncPoint);
+    return pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                 numSyncPointsInWaitList, pSyncPointWaitList,
+                                 pSyncPoint);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -227,9 +254,15 @@ ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
 ///         + `NULL == hSrcMem`
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
-ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -240,19 +273,19 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
-    auto pfnMembufferCopyExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnMembufferCopyExp;
-    if (nullptr == pfnMembufferCopyExp) {
+    auto pfnAppendMembufferCopyExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
+    if (nullptr == pfnAppendMembufferCopyExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMembufferCopyExp(hCommandBuffer, hSrcMem, hDstMem, srcOffset,
-                               dstOffset, size, numSyncPointsInWaitList,
-                               pDependencies, pSyncPoint);
+    return pfnAppendMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -269,9 +302,15 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
 ///         + `NULL == hSrcMem`
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
-ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -289,20 +328,21 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
     ) try {
-    auto pfnMembufferCopyRectExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnMembufferCopyRectExp;
-    if (nullptr == pfnMembufferCopyRectExp) {
+    auto pfnAppendMembufferCopyRectExp =
+        ur_lib::context->urDdiTable.CommandBufferExp
+            .pfnAppendMembufferCopyRectExp;
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnMembufferCopyRectExp(
+    return pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
         SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pDependencies, pSyncPoint);
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -317,6 +357,15 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
 ///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_EVENT
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
+///         + If event objects in phEventWaitList are not valid events.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -16,384 +16,6 @@
 extern "C" {
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Create a Command-Buffer object
-///
-/// @details
-///     - Create a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///         + `NULL == hDevice`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_INVALID_DEVICE
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t
-        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t
-        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
-    ) try {
-    auto pfnCreateExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnCreateExp;
-    if (nullptr == pfnCreateExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Increment the command-buffer object's reference count.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-    ) try {
-    auto pfnRetainExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnRetainExp;
-    if (nullptr == pfnRetainExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnRetainExp(hCommandBuffer);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Decrement the command-buffer object's reference count and delete the
-///        command-buffer object if the reference count becomes zero.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-    ) try {
-    auto pfnReleaseExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnReleaseExp;
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnReleaseExp(hCommandBuffer);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Stop recording on a command-buffer object such that no more commands
-///        can be appended and make it ready to enqueue.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-    ) try {
-    auto pfnFinalizeExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnFinalizeExp;
-    if (nullptr == pfnFinalizeExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnFinalizeExp(hCommandBuffer);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a kernel execution command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hKernel`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pGlobalWorkOffset`
-///         + `NULL == pGlobalWorkSize`
-///         + `NULL == pLocalWorkSize`
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL
-///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
-///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
-///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,         ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel, ///< [in] kernel to append
-    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
-    const size_t
-        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
-    const size_t *
-        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
-    const size_t
-        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    auto pfnAppendKernelExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendKernelExp;
-    if (nullptr == pfnAppendKernelExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnAppendKernelExp(hCommandBuffer, hKernel, WorkDim,
-                              pGlobalWorkOffset, pGlobalWorkSize,
-                              pLocalWorkSize, numSyncPointsInWaitList,
-                              pSyncPointWaitList, pSyncPoint);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a USM memcpy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDst`
-///         + `NULL == pSrc`
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    void *pDst,         ///< [in] Location the data will be copied to.
-    const void *pSrc,   ///< [in] The data to be copied.
-    size_t size,        ///< [in] The number of bytes to copy
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    auto pfnAppendMemcpyUSMExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
-    if (nullptr == pfnAppendMemcpyUSMExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
-                                 numSyncPointsInWaitList, pSyncPointWaitList,
-                                 pSyncPoint);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a memory copy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hSrcMem`
-///         + `NULL == hDstMem`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    size_t srcOffset,        ///< [in] Offset into the source memory.
-    size_t dstOffset,        ///< [in] Offset into the destination memory
-    size_t size,             ///< [in] The number of bytes to be copied.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    auto pfnAppendMembufferCopyExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
-    if (nullptr == pfnAppendMembufferCopyExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnAppendMembufferCopyExp(
-        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a rectangular memory copy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hSrcMem`
-///         + `NULL == hDstMem`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    ur_rect_offset_t
-        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t
-        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t
-        Region, ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-    ) try {
-    auto pfnAppendMembufferCopyRectExp =
-        ur_lib::context->urDdiTable.CommandBufferExp
-            .pfnAppendMembufferCopyRectExp;
-    if (nullptr == pfnAppendMembufferCopyRectExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnAppendMembufferCopyRectExp(
-        hCommandBuffer, hSrcMem, hDstMem, SrcOrigin, DstOrigin, Region,
-        SrcRowPitch, SrcSlicePitch, DstRowPitch, DstSlicePitch,
-        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Submit a command-buffer for execution on a queue.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_QUEUE
-///     - ::UR_RESULT_ERROR_INVALID_EVENT
-///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
-///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
-///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
-///         + If event objects in phEventWaitList are not valid events.
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t
-        hQueue, ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the command-buffer execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-    ///< events.
-    ur_event_handle_t *
-        phEvent ///< [out][optional] return an event object that identifies this particular
-                ///< command-buffer execution instance.
-    ) try {
-    auto pfnEnqueueExp =
-        ur_lib::context->urDdiTable.CommandBufferExp.pfnEnqueueExp;
-    if (nullptr == pfnEnqueueExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
-                         phEventWaitList, phEvent);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details
@@ -5644,6 +5266,374 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
     return pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
                             numEventsInWaitList, phEventWaitList, phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a Command-Buffer object
+///
+/// @details
+///     - Create a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+    ) try {
+    auto pfnCreateExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnCreateExp;
+    if (nullptr == pfnCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Increment the command-buffer object's reference count.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    auto pfnRetainExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnRetainExp;
+    if (nullptr == pfnRetainExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnRetainExp(hCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command-buffer object's reference count and delete the
+///        command-buffer object if the reference count becomes zero.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    auto pfnReleaseExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnReleaseExp(hCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop recording on a command-buffer object such that no more commands
+///        can be appended and make it ready to enqueue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+    ) try {
+    auto pfnFinalizeExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnFinalizeExp;
+    if (nullptr == pfnFinalizeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnFinalizeExp(hCommandBuffer);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a kernel execution command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == pLocalWorkSize`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL
+///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t workDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendKernelLaunchExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendKernelLaunchExp;
+    if (nullptr == pfnAppendKernelLaunchExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendKernelLaunchExp(hCommandBuffer, hKernel, workDim,
+                                    pGlobalWorkOffset, pGlobalWorkSize,
+                                    pLocalWorkSize, numSyncPointsInWaitList,
+                                    pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a USM memcpy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `size == 0`
+///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    const void *pSrc,   ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMemcpyUSMExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMemcpyUSMExp;
+    if (nullptr == pfnAppendMemcpyUSMExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMemcpyUSMExp(hCommandBuffer, pDst, pSrc, size,
+                                 numSyncPointsInWaitList, pSyncPointWaitList,
+                                 pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMembufferCopyExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMembufferCopyExp;
+    if (nullptr == pfnAppendMembufferCopyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMembufferCopyExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        srcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        dstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        region, ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMembufferCopyRectExp =
+        ur_lib::context->urDdiTable.CommandBufferExp
+            .pfnAppendMembufferCopyRectExp;
+    if (nullptr == pfnAppendMembufferCopyRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMembufferCopyRectExp(
+        hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
+        srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Submit a command-buffer for execution on a queue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_EVENT
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
+///         + If event objects in phEventWaitList are not valid events.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+    ) try {
+    auto pfnEnqueueExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnEnqueueExp;
+    if (nullptr == pfnEnqueueExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
+                         phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -814,7 +814,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName`
+///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -194,7 +194,7 @@ ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
-    void *pSrc,         ///< [in] The data to be copied.
+    const void *pSrc,   ///< [in] The data to be copied.
     size_t size,        ///< [in] The number of bytes to copy
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
@@ -316,9 +316,12 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///         + `NULL == hQueue`
 ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -335,8 +338,8 @@ ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnEnqueueExp(hCommandBuffer, numEventsInWaitList, phEventWaitList,
-                         phEvent);
+    return pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
+                         phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -26,6 +26,11 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
+        result = urGetCommandBufferExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &urDdiTable.CommandBufferExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
         result = urGetContextProcAddrTable(UR_API_VERSION_CURRENT,
                                            &urDdiTable.Context);
     }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -13,309 +13,6 @@
 #include "ur_api.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Create a Command-Buffer object
-///
-/// @details
-///     - Create a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///         + `NULL == hDevice`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_INVALID_DEVICE
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferCreateExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    const ur_exp_command_buffer_desc_t
-        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
-    ur_exp_command_buffer_handle_t
-        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Increment the command-buffer object's reference count.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urCommandBufferRetainExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Decrement the command-buffer object's reference count and delete the
-///        command-buffer object if the reference count becomes zero.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-ur_result_t UR_APICALL urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Stop recording on a command-buffer object such that no more commands
-///        can be appended and make it ready to enqueue.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferFinalizeExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in] handle of the command-buffer object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a kernel execution command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hKernel`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pGlobalWorkOffset`
-///         + `NULL == pGlobalWorkSize`
-///         + `NULL == pLocalWorkSize`
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL
-///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
-///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
-///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,         ///< [in] handle of the command-buffer object
-    ur_kernel_handle_t hKernel, ///< [in] kernel to append
-    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
-    const size_t
-        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
-    const size_t *
-        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
-    const size_t
-        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a USM memcpy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDst`
-///         + `NULL == pSrc`
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    void *pDst,         ///< [in] Location the data will be copied to.
-    const void *pSrc,   ///< [in] The data to be copied.
-    size_t size,        ///< [in] The number of bytes to copy
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a memory copy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hSrcMem`
-///         + `NULL == hDstMem`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    size_t srcOffset,        ///< [in] Offset into the source memory.
-    size_t dstOffset,        ///< [in] Offset into the destination memory
-    size_t size,             ///< [in] The number of bytes to be copied.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Append a rectangular memory copy command to a command-buffer object
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hSrcMem`
-///         + `NULL == hDstMem`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pSyncPointWaitList`
-///         + `NULL == pSyncPoint`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
-///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer,      ///< [in] handle of the command-buffer object.
-    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
-    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
-    ur_rect_offset_t
-        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
-    ur_rect_offset_t
-        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
-    ur_rect_region_t
-        Region, ///< [in] The extents describing the region to be copied.
-    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
-    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
-    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
-    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
-    uint32_t
-        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
-    const ur_exp_command_buffer_sync_point_t *
-        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
-    ur_exp_command_buffer_sync_point_t
-        *pSyncPoint ///< [out] sync point associated with this command
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Submit a command-buffer for execution on a queue.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hCommandBuffer`
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
-///     - ::UR_RESULT_ERROR_INVALID_QUEUE
-///     - ::UR_RESULT_ERROR_INVALID_EVENT
-///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
-///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
-///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
-///         + If event objects in phEventWaitList are not valid events.
-///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
-ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t
-        hCommandBuffer, ///< [in] handle of the command-buffer object.
-    ur_queue_handle_t
-        hQueue, ///< [in] the queue to submit this command-buffer for execution.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the command-buffer execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
-    ///< events.
-    ur_event_handle_t *
-        phEvent ///< [out][optional] return an event object that identifies this particular
-                ///< command-buffer execution instance.
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details
@@ -4741,6 +4438,299 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_event_handle_t *
         phEvent ///< [out] returns an event object that identifies this write command
     ///< and can be used to query or queue a wait for this command to complete.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a Command-Buffer object
+///
+/// @details
+///     - Create a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Increment the command-buffer object's reference count.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command-buffer object's reference count and delete the
+///        command-buffer object if the reference count becomes zero.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop recording on a command-buffer object such that no more commands
+///        can be appended and make it ready to enqueue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a kernel execution command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == pLocalWorkSize`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL
+///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t workDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a USM memcpy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `size == 0`
+///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    const void *pSrc,   ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        srcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        dstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        region, ///< [in] The extents describing the region to be copied.
+    size_t srcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Submit a command-buffer for execution on a queue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_EVENT
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
+///         + If event objects in phEventWaitList are not valid events.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -154,7 +154,7 @@ ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
-    void *pSrc,         ///< [in] The data to be copied.
+    const void *pSrc,   ///< [in] The data to be copied.
     size_t size,        ///< [in] The number of bytes to copy
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
@@ -249,9 +249,12 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///         + `NULL == hQueue`
 ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    ur_queue_handle_t
+        hQueue, ///< [in] the queue to submit this command-buffer for execution.
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -663,7 +663,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName`
+///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -13,6 +13,260 @@
 #include "ur_api.h"
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a Command-Buffer object
+///
+/// @details
+///     - Create a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phCommandBuffer`
+ur_result_t UR_APICALL urCommandBufferCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_exp_command_buffer_desc_t
+        *pCommandBufferDesc, ///< [in][optional] CommandBuffer descriptor
+    ur_exp_command_buffer_handle_t
+        *phCommandBuffer ///< [out] pointer to Command-Buffer handle
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Increment the command-buffer object's reference count.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferRetainExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Decrement the command-buffer object's reference count and delete the
+///        command-buffer object if the reference count becomes zero.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferReleaseExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Stop recording on a command-buffer object such that no more commands
+///        can be appended and make it ready to enqueue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer ///< [in] handle of the command-buffer object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a kernel execution command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hKernel`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalWorkOffset`
+///         + `NULL == pGlobalWorkSize`
+///         + `NULL == pLocalWorkSize`
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,         ///< [in] handle of the command-buffer object
+    ur_kernel_handle_t hKernel, ///< [in] kernel to append
+    uint32_t WorkDim,           ///< [in] dimension of the kernel execution
+    const size_t
+        *pGlobalWorkOffset, ///< [in] Offset to use when executing kernel.
+    const size_t *
+        pGlobalWorkSize, ///< [in] Global work size to use when executing kernel.
+    const size_t
+        *pLocalWorkSize, ///< [in] Local work size to use when executing kernel.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a USM memcpy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer, ///< [in] handle of the command-buffer object.
+    void *pDst,         ///< [in] Location the data will be copied to.
+    void *pSrc,         ///< [in] The data to be copied.
+    size_t size,        ///< [in] The number of bytes to copy
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    size_t srcOffset,        ///< [in] Offset into the source memory.
+    size_t dstOffset,        ///< [in] Offset into the destination memory
+    size_t size,             ///< [in] The number of bytes to be copied.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory copy command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hSrcMem`
+///         + `NULL == hDstMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDependencies`
+///         + `NULL == pSyncPoint`
+ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
+    ur_mem_handle_t hDstMem, ///< [in] The location the data will be copied to.
+    ur_rect_offset_t
+        SrcOrigin, ///< [in] Origin for the region of data to be copied from the source.
+    ur_rect_offset_t
+        DstOrigin, ///< [in] Origin for the region of data to be copied to in the destination.
+    ur_rect_region_t
+        Region, ///< [in] The extents describing the region to be copied.
+    size_t SrcRowPitch,   ///< [in] Row pitch of the source memory.
+    size_t SrcSlicePitch, ///< [in] Slice pitch of the source memory.
+    size_t DstRowPitch,   ///< [in] Row pitch of the destination memory.
+    size_t DstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pDependencies, ///< [in] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Submit a command-buffer for execution on a queue.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,           ///< [in] handle of the command-buffer object.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the command-buffer execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating no wait
+    ///< events.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command-buffer execution instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details
@@ -360,7 +614,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP < propName`
+///         + `::UR_DEVICE_INFO_EXP_COMMAND_BUFFER_SUPPORT < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -4556,7 +4556,9 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
@@ -4599,7 +4601,9 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 ///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
@@ -4632,7 +4636,9 @@ ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -4668,7 +4674,9 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
-///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -27,6 +27,10 @@
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -48,6 +52,7 @@ ur_result_t UR_APICALL urCommandBufferCreateExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urCommandBufferRetainExp(
@@ -68,6 +73,7 @@ ur_result_t UR_APICALL urCommandBufferRetainExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urCommandBufferReleaseExp(
@@ -88,8 +94,9 @@ ur_result_t UR_APICALL urCommandBufferReleaseExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
-///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in] handle of the command-buffer object
@@ -112,8 +119,17 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 ///         + `NULL == pGlobalWorkOffset`
 ///         + `NULL == pGlobalWorkSize`
 ///         + `NULL == pLocalWorkSize`
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL
+///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
+///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] handle of the command-buffer object
@@ -128,7 +144,7 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -148,9 +164,18 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
-ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `size == 0`
+///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -159,7 +184,7 @@ ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -179,9 +204,15 @@ ur_result_t UR_APICALL urCommandBufferMemcpyUSMExp(
 ///         + `NULL == hSrcMem`
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
-ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -192,7 +223,7 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -212,9 +243,15 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyExp(
 ///         + `NULL == hSrcMem`
 ///         + `NULL == hDstMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDependencies`
+///         + `NULL == pSyncPointWaitList`
 ///         + `NULL == pSyncPoint`
-ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`" - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -232,7 +269,7 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *
-        pDependencies, ///< [in] A list of sync points that this command depends on.
+        pSyncPointWaitList, ///< [in] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t
         *pSyncPoint ///< [out] sync point associated with this command
 ) {
@@ -250,6 +287,15 @@ ur_result_t UR_APICALL urCommandBufferMembufferCopyRectExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
 ///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_EVENT
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
+///         + If event objects in phEventWaitList are not valid events.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object.


### PR DESCRIPTION
- Adds support for command-buffers experimental feature
- Add command-buffer desc type to common.yml
- Add device info query for command-buffer support

Porting the PI command-buffer extension added in https://github.com/intel/llvm/pull/9375 which is currently under review. The functions implemented do not cover all possible command types, only those that have actually been implemented in the linked PR.

Notes:
- As there's no way to extend existing enums from the command-buffer YAML file I've modified those directly where necessary.