### PR TITLE
[ur] Make hArgValue optional again in urKernelSetMemObj

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3850,13 +3850,12 @@ urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex,          ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue   ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue   ///< [in][optional] handle of Memory object.
 );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -374,7 +374,7 @@ params:
       desc: "[in] argument index in range [0, num args - 1]"
     - type: "$x_mem_handle_t"
       name: hArgValue
-      desc: "[in] handle of Memory object."
+      desc: "[in][optional] handle of Memory object."
 returns:
     - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 --- #--------------------------------------------------------------------------

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -1951,7 +1951,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -2223,7 +2223,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = context.urDdiTable.Kernel.pfnSetArgMemObj;
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2725,7 +2725,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     auto pfnSetArgMemObj = context.urDdiTable.Kernel.pfnSetArgMemObj;
 
@@ -2735,10 +2735,6 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
     if (context.enableParameterValidation) {
         if (NULL == hKernel) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hArgValue) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2560,7 +2560,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2575,7 +2575,9 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     hKernel = reinterpret_cast<ur_kernel_object_t *>(hKernel)->handle;
 
     // convert loader handle to platform handle
-    hArgValue = reinterpret_cast<ur_mem_object_t *>(hArgValue)->handle;
+    hArgValue = (hArgValue)
+                    ? reinterpret_cast<ur_mem_object_t *>(hArgValue)->handle
+                    : nullptr;
 
     // forward to device-platform
     result = pfnSetArgMemObj(hKernel, argIndex, hArgValue);

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3016,12 +3016,11 @@ ur_result_t UR_APICALL urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
     ) try {
     auto pfnSetArgMemObj = ur_lib::context->urDdiTable.Kernel.pfnSetArgMemObj;
     if (nullptr == pfnSetArgMemObj) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2522,12 +2522,11 @@ ur_result_t UR_APICALL urKernelSetArgSampler(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
-///         + `NULL == hArgValue`
 ///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
 ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
-    ur_mem_handle_t hArgValue ///< [in] handle of Memory object.
+    ur_mem_handle_t hArgValue ///< [in][optional] handle of Memory object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/conformance/kernel/urKernelSetArgMemObj.cpp
+++ b/test/conformance/kernel/urKernelSetArgMemObj.cpp
@@ -42,8 +42,3 @@ TEST_P(urKernelSetArgMemObjTest, InvalidKernelArgumentIndex) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX,
                      urKernelSetArgMemObj(kernel, num_kernel_args + 1, buffer));
 }
-
-TEST_P(urKernelSetArgMemObjTest, InvalidNullPointer) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urKernelSetArgMemObj(kernel, 0, nullptr));
-}


### PR DESCRIPTION
This reverts #494

We need to support null argument values again because https://github.com/intel/llvm/pull/9634 implicitly allows them in PI