### PR TITLE
[UR] Fail build on spec generate

### DIFF
--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -430,7 +430,7 @@ def _validate_doc(f, d, tags, line_num):
         print("%s(%s): %s!"%(os.path.abspath(f), line_num, msg))
         print("-- Function Info --")
         print(d)
-        return False
+        raise
 
 """
     filters object by version

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -133,69 +133,76 @@ def main():
         'meta'   : {},
         'ref'    : {}
         }
+    
+    try:
 
-    for section in configParser.sections():
-        input['configs'].append({
-            'name'     : section,
-            'namespace': configParser.get(section,'namespace'),
-            'tags'     : {'$'+key : configParser.get(section,key) for key in configParser.get(section,'tags').split(",")},
-            })
+        for section in configParser.sections():
+            input['configs'].append({
+                'name'     : section,
+                'namespace': configParser.get(section,'namespace'),
+                'tags'     : {'$'+key : configParser.get(section,key) for key in configParser.get(section,'tags').split(",")},
+                })
 
-    # phase 2: parse specs
-    for config in input['configs']:
-        specs, input['meta'], input['ref'] = parse_specs.parse(config['name'], args['ver'], config['tags'], input['meta'], input['ref'])
-        input['specs'].append(specs)
+        # phase 2: parse specs
+        for config in input['configs']:
+            specs, input['meta'], input['ref'] = parse_specs.parse(config['name'], args['ver'], config['tags'], input['meta'], input['ref'])
+            input['specs'].append(specs)
 
-    util.jsonWrite(args['api_json'], input)
+        util.jsonWrite(args['api_json'], input)
 
-    # phase 3: generate files
-    if args['clean']:
-        clean()
+        # phase 3: generate files
+        if args['clean']:
+            clean()
 
-    incpath = os.path.join("../include/")
-    srcpath = os.path.join("../source/")
-    docpath = os.path.join("../docs/")
+        incpath = os.path.join("../include/")
+        srcpath = os.path.join("../source/")
+        docpath = os.path.join("../docs/")
 
-    generate_docs.prepare(docpath, args['rst'], args['html'], args['ver'])
-    generate_docs.generate_ref(docpath, input['ref'])
+        generate_docs.prepare(docpath, args['rst'], args['html'], args['ver'])
+        generate_docs.generate_ref(docpath, input['ref'])
 
-    for idx, specs in enumerate(input['specs']):
-        config = input['configs'][idx]
-        if args[config['name']]:
+        for idx, specs in enumerate(input['specs']):
+            config = input['configs'][idx]
+            if args[config['name']]:
 
-            generate_code.generate_api(incpath, srcpath, config['namespace'], config['tags'], args['ver'], args['rev'], specs, input['meta'])
+                generate_code.generate_api(incpath, srcpath, config['namespace'], config['tags'], args['ver'], args['rev'], specs, input['meta'])
 
-            if args['rst']:
-                generate_docs.generate_rst(docpath, config['name'], config['namespace'], config['tags'], args['ver'], args['rev'], specs, input['meta'])
+                if args['rst']:
+                    generate_docs.generate_rst(docpath, config['name'], config['namespace'], config['tags'], args['ver'], args['rev'], specs, input['meta'])
 
-        if util.makeErrorCount():
-            print("\n%s Errors found during generation, stopping execution!"%util.makeErrorCount())
-            return
+            if util.makeErrorCount():
+                print("\n%s Errors found during generation, stopping execution!"%util.makeErrorCount())
+                return
 
-    if args['debug']:
-        util.makoFileListWrite("generated.json")
+        if args['debug']:
+            util.makoFileListWrite("generated.json")
 
-    # phase 4: build code
-    if args['build']:
-        if not build():
-            print("\nBuild failed, stopping execution!")
-            return
+        # phase 4: build code
+        if args['build']:
+            if not build():
+                print("\nBuild failed, stopping execution!")
+                return
 
-    # phase 5: prep for publication of html or pdf
-    if args['html'] or args['pdf']:
-        generate_docs.generate_common(docpath, configParser.sections(), args['ver'], args['rev'])
+        # phase 5: prep for publication of html or pdf
+        if args['html'] or args['pdf']:
+            generate_docs.generate_common(docpath, configParser.sections(), args['ver'], args['rev'])
 
-    # phase 5: publish documentation
-    if args['html']:
-        generate_docs.generate_html(docpath)
+        # phase 5: publish documentation
+        if args['html']:
+            generate_docs.generate_html(docpath)
 
-    if args['pdf']:
-        generate_docs.generate_pdf(docpath)
+        if args['pdf']:
+            generate_docs.generate_pdf(docpath)
 
-    if args['update_spec']:
-        update_spec(args['update_spec'])
+        if args['update_spec']:
+            update_spec(args['update_spec'])
 
-    print("\nCompleted in %.1f seconds!"%(time.time() - start))
+        print("\nCompleted in %.1f seconds!"%(time.time() - start))
+
+    except:
+        print("Failed to generate specification.")
+        return sys.exit(1)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR:
* Re-throws exception from `__validate_params()` instead of swallowing the error
* Adds try/catch around spec generation to detect when failure occurs - return non-zero error to fail build

Closes #565 