### PR TITLE
Add UR_DEVICE_INFO_DEVICE_IP_VERSION property

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -925,6 +925,9 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED = 111,        ///< [::ur_bool_t] Return true if the device supports enqueing commands to
                                                                 ///< read and write pipes from the host.
     UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP = 112,          ///< [uint32_t] The maximum number of registers available per block.
+    UR_DEVICE_INFO_DEVICE_IP_VERSION = 113,                     ///< [uint32_t] Device IP version. The meaning of the device IP version is
+                                                                ///< implementation-defined, but newer devices should have a higher version 
+                                                                ///< than older devices.
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond


### PR DESCRIPTION
This patch extends `ur_device_info_t` with the new property `UR_DEVICE_INFO_DEVICE_IP_VERSION`. 
This property is needed to query the device architecture ID value as described in the [Level Zero spec](https://github.com/oneapi-src/level-zero-spec/pull/23). 
The property will be used in the implementation of host API of [sycl_ext_oneapi_device_architecture](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc) extension