### PR TITLE
Add queue properties to support immediate and batched submissions.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4000,6 +4000,12 @@ typedef enum ur_queue_flag_t {
     UR_QUEUE_FLAG_DISCARD_EVENTS = UR_BIT(4),                ///< Events will be discarded
     UR_QUEUE_FLAG_PRIORITY_LOW = UR_BIT(5),                  ///< Low priority queue
     UR_QUEUE_FLAG_PRIORITY_HIGH = UR_BIT(6),                 ///< High priority queue
+    UR_QUEUE_FLAG_SUBMISSION_BATCHED = UR_BIT(7),            ///< Do not necessarily submit the operation as
+                                                             ///< soon as enqueue completes. Collect operations
+                                                             ///< and then submit at a later time in a batch.
+                                                             ///< Batch size will be determined automatically.
+    UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE = UR_BIT(8),          ///< Submit immediately after the enqueue operation
+                                                             ///< completes.
     /// @cond
     UR_QUEUE_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -7093,6 +7093,14 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_queue_flag_t value) {
     case UR_QUEUE_FLAG_PRIORITY_HIGH:
         os << "UR_QUEUE_FLAG_PRIORITY_HIGH";
         break;
+
+    case UR_QUEUE_FLAG_SUBMISSION_BATCHED:
+      os << "UR_QUEUE_FLAG_SUBMISSION_BATCHED";
+      break;
+
+    case UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE:
+      os << "UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE";
+      break;
     default:
         os << "unknown enumerator";
         break;
@@ -7106,81 +7114,28 @@ inline void serializeFlag<ur_queue_flag_t>(std::ostream &os, uint32_t flag) {
     uint32_t val = flag;
     bool first = true;
 
-    if ((val & UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE) ==
-        (uint32_t)UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+    auto showFlag = [&](ur_queue_flag_t flag) {
+      if ((val & flag) == (uint32_t)flag) {
+        val ^= (uint32_t)flag;
         if (!first) {
-            os << " | ";
+          os << " | ";
         } else {
-            first = false;
+          first = false;
         }
-        os << UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE;
-    }
+        os << flag;
+      }
+    };
 
-    if ((val & UR_QUEUE_FLAG_PROFILING_ENABLE) ==
-        (uint32_t)UR_QUEUE_FLAG_PROFILING_ENABLE) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_PROFILING_ENABLE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_QUEUE_FLAG_PROFILING_ENABLE;
-    }
+    showFlag(UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE);
+    showFlag(UR_QUEUE_FLAG_PROFILING_ENABLE);
+    showFlag(UR_QUEUE_FLAG_ON_DEVICE);
+    showFlag(UR_QUEUE_FLAG_ON_DEVICE_DEFAULT);
+    showFlag(UR_QUEUE_FLAG_DISCARD_EVENTS);
+    showFlag(UR_QUEUE_FLAG_PRIORITY_LOW);
+    showFlag(UR_QUEUE_FLAG_PRIORITY_HIGH);
+    showFlag(UR_QUEUE_FLAG_SUBMISSION_BATCHED);
+    showFlag(UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE);
 
-    if ((val & UR_QUEUE_FLAG_ON_DEVICE) == (uint32_t)UR_QUEUE_FLAG_ON_DEVICE) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_ON_DEVICE;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_QUEUE_FLAG_ON_DEVICE;
-    }
-
-    if ((val & UR_QUEUE_FLAG_ON_DEVICE_DEFAULT) ==
-        (uint32_t)UR_QUEUE_FLAG_ON_DEVICE_DEFAULT) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_ON_DEVICE_DEFAULT;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_QUEUE_FLAG_ON_DEVICE_DEFAULT;
-    }
-
-    if ((val & UR_QUEUE_FLAG_DISCARD_EVENTS) ==
-        (uint32_t)UR_QUEUE_FLAG_DISCARD_EVENTS) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_DISCARD_EVENTS;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_QUEUE_FLAG_DISCARD_EVENTS;
-    }
-
-    if ((val & UR_QUEUE_FLAG_PRIORITY_LOW) ==
-        (uint32_t)UR_QUEUE_FLAG_PRIORITY_LOW) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_PRIORITY_LOW;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_QUEUE_FLAG_PRIORITY_LOW;
-    }
-
-    if ((val & UR_QUEUE_FLAG_PRIORITY_HIGH) ==
-        (uint32_t)UR_QUEUE_FLAG_PRIORITY_HIGH) {
-        val ^= (uint32_t)UR_QUEUE_FLAG_PRIORITY_HIGH;
-        if (!first) {
-            os << " | ";
-        } else {
-            first = false;
-        }
-        os << UR_QUEUE_FLAG_PRIORITY_HIGH;
-    }
     if (val != 0) {
         std::bitset<32> bits(val);
         if (!first) {

--- a/test/conformance/queue/urQueueCreate.cpp
+++ b/test/conformance/queue/urQueueCreate.cpp
@@ -88,3 +88,17 @@ TEST_P(urQueueCreateTest, InvalidQueueProperties) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES,
                      urQueueCreate(context, device, &props, &queue));
 }
+
+TEST_P(urQueueCreateTest, InvalidQueueProperties) {
+  ur_queue_handle_t queue = nullptr;
+
+  // It should be an error to specify both batched and immediate submission
+  ur_queue_properties_t props = {
+      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
+      /*.pNext =*/nullptr,
+      /*.flags =*/UR_QUEUE_FLAG_SUBMISSION_BATCHED |
+          UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE,
+  };
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES,
+                   urQueueCreate(context, device, &props, &queue));
+}


### PR DESCRIPTION
This change adds two new queue properties which will be used to handle the corresponding SYCL queue properties for immediate and batched submissions. Short-running kernels are best collected into batches and submitted together.  Long-running kernels are better submitted immediately.

In batched mode, submission is separated from the actual start of execution on the GPU. Multiple submissions can be collected and then issued together.

In immediate mode submission of an operation and start of execution happen together.