### PR TITLE
[uma] add a function to query type of a provider

### DIFF
--- a/source/common/uma_helpers.hpp
+++ b/source/common/uma_helpers.hpp
@@ -90,6 +90,10 @@ auto memoryProviderMakeUnique(Args &&...args) {
             noexcept(reinterpret_cast<T *>(obj)->purge_force(args...)));
         return reinterpret_cast<T *>(obj)->purge_force(args...);
     };
+    ops.type = [](void *obj) {
+        static_assert(noexcept(reinterpret_cast<T *>(obj)->type()));
+        return reinterpret_cast<T *>(obj)->type();
+    };
 
     uma_memory_provider_handle_t hProvider = nullptr;
     auto ret = umaMemoryProviderCreate(&ops, &argsTuple, &hProvider);

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -131,6 +131,12 @@ enum uma_result_t
 umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
                             size_t size);
 
+///
+/// \brief Retrive type of a given memory provider.
+/// \return type of the provider.
+enum uma_provider_type
+umaMemoryProviderType(uma_memory_provider_handle_t hProvider);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -17,6 +17,13 @@
 extern "C" {
 #endif
 
+enum uma_provider_type {
+    UMA_PROVIDER_UNKNOWN = 0,
+    UMA_PROVIDER_OS,
+    UMA_PROVIDER_USM,
+    UMA_PROVIDER_FORCE_UINT64 = UINT64_MAX
+};
+
 /// This structure comprises function pointers used by corresponding
 /// umaMemoryProvider* calls. Each memory provider implementation should
 /// initialize all function pointers.
@@ -49,6 +56,7 @@ struct uma_memory_provider_ops_t {
                                            size_t *pageSize);
     enum uma_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);
     enum uma_result_t (*purge_force)(void *provider, void *ptr, size_t size);
+    enum uma_provider_type (*type)(void *provider);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -97,3 +97,8 @@ umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
                             size_t size) {
     return hProvider->ops.purge_force(hProvider->provider_priv, ptr, size);
 }
+
+enum uma_provider_type
+umaMemoryProviderType(uma_memory_provider_handle_t hProvider) {
+    return hProvider->ops.type(hProvider->provider_priv);
+}

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -204,6 +204,12 @@ static enum uma_result_t trackingPurgeForce(void *provider, void *ptr,
     return umaMemoryProviderPurgeForce(p->hUpstream, ptr, size);
 }
 
+static enum uma_provider_type trackingType(void *provider) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderType(p->hUpstream);
+}
+
 enum uma_result_t umaTrackingMemoryProviderCreate(
     uma_memory_provider_handle_t hUpstream, uma_memory_pool_handle_t hPool,
     uma_memory_provider_handle_t *hTrackingProvider) {
@@ -224,6 +230,7 @@ enum uma_result_t umaTrackingMemoryProviderCreate(
         trackingGetRecommendedPageSize;
     trackingMemoryProviderOps.purge_force = trackingPurgeForce;
     trackingMemoryProviderOps.purge_lazy = trackingPurgeLazy;
+    trackingMemoryProviderOps.type = trackingType;
 
     return umaMemoryProviderCreate(&trackingMemoryProviderOps, &params,
                                    hTrackingProvider);

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -72,6 +72,11 @@ static enum uma_result_t nullPurgeForce(void *provider, void *ptr,
     return UMA_RESULT_SUCCESS;
 }
 
+static enum uma_provider_type nullType(void *provider) {
+    (void)provider;
+    return UMA_PROVIDER_UNKNOWN;
+}
+
 uma_memory_provider_handle_t nullProviderCreate(void) {
     struct uma_memory_provider_ops_t ops = {
         .version = UMA_VERSION_CURRENT,
@@ -83,7 +88,8 @@ uma_memory_provider_handle_t nullProviderCreate(void) {
         .get_recommended_page_size = nullGetRecommendedPageSize,
         .get_min_page_size = nullGetPageSize,
         .purge_lazy = nullPurgeLazy,
-        .purge_force = nullPurgeForce};
+        .purge_force = nullPurgeForce,
+        .type = nullType};
 
     uma_memory_provider_handle_t hProvider;
     enum uma_result_t ret = umaMemoryProviderCreate(&ops, NULL, &hProvider);
@@ -171,6 +177,13 @@ static enum uma_result_t tracePurgeForce(void *provider, void *ptr,
                                        size);
 }
 
+static enum uma_provider_type traceType(void *provider) {
+    struct traceParams *traceProvider = (struct traceParams *)provider;
+
+    traceProvider->trace("type");
+    return umaMemoryProviderType(traceProvider->hUpstreamProvider);
+}
+
 uma_memory_provider_handle_t
 traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
                     void (*trace)(const char *)) {
@@ -184,7 +197,8 @@ traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
         .get_recommended_page_size = traceGetRecommendedPageSize,
         .get_min_page_size = traceGetPageSize,
         .purge_lazy = tracePurgeLazy,
-        .purge_force = tracePurgeForce};
+        .purge_force = tracePurgeForce,
+        .type = traceType};
 
     struct traceParams params = {.hUpstreamProvider = hUpstreamProvider,
                                  .trace = trace};

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -49,6 +49,7 @@ struct provider_base {
     enum uma_result_t purge_force(void *ptr, size_t size) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }
+    enum uma_provider_type type() noexcept { return UMA_PROVIDER_UNKNOWN; }
 };
 
 struct provider_malloc : public provider_base {

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -59,6 +59,11 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
     ASSERT_EQ(calls["purge_force"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
+
+    auto typeId = umaMemoryProviderType(tracingProvider.get());
+    ASSERT_EQ(typeId, UMA_PROVIDER_UNKNOWN);
+    ASSERT_EQ(calls["type"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
 }
 
 //////////////////////////// Negative test cases


### PR DESCRIPTION
UMA should define types for memory providers that will be that will be shipped with UMA.