### PR TITLE
Add definitions in support of USM Import/Release functions.

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1817,6 +1817,8 @@ class ur_function_v(IntEnum):
     USM_POOL_RETAIN = 118                           ## Enumerator for ::urUSMPoolRetain
     USM_POOL_RELEASE = 119                          ## Enumerator for ::urUSMPoolRelease
     USM_POOL_GET_INFO = 120                         ## Enumerator for ::urUSMPoolGetInfo
+    USM_POOL_GET_INFO = 121                         ## Enumerator for ::urUSMImport
+    USM_POOL_GET_INFO = 122                         ## Enumerator for ::urUSMRelease
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -2788,6 +2790,20 @@ if __use_win_types:
     _urUSMPoolGetInfo_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
 else:
     _urUSMPoolGetInfo_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+    
+###############################################################################
+## @brief Function-pointer for urUSMImport
+if __use_win_types:
+    _urUSMImport_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
+else:
+    _urUSMImport_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for urUSMRelease
+if __use_win_types:
+    _urUSMRelease_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+else:
+    _urUSMRelease_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
 
 
 ###############################################################################
@@ -2803,6 +2819,8 @@ class ur_usm_dditable_t(Structure):
         ("pfnPoolRetain", c_void_p),                                    ## _urUSMPoolRetain_t
         ("pfnPoolRelease", c_void_p),                                   ## _urUSMPoolRelease_t
         ("pfnPoolGetInfo", c_void_p)                                    ## _urUSMPoolGetInfo_t
+        ("pfnImport", c_void_p)                                         ## _urUSMImport_t
+        ("pfnRelease", c_void_p)                                        ## _urUSMRelease_t
     ]
 
 ###############################################################################
@@ -3125,6 +3143,8 @@ class UR_DDI:
         self.urUSMPoolRetain = _urUSMPoolRetain_t(self.__dditable.USM.pfnPoolRetain)
         self.urUSMPoolRelease = _urUSMPoolRelease_t(self.__dditable.USM.pfnPoolRelease)
         self.urUSMPoolGetInfo = _urUSMPoolGetInfo_t(self.__dditable.USM.pfnPoolGetInfo)
+        self.urUSMImport = _urUSMImport_t(self.__dditable.USM.pfnImport)
+        self.urUSMRelease = _urUSMRelease_t(self.__dditable.USM.pfnRelease)
 
         # call driver to get function pointers
         Device = ur_device_dditable_t()

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2768,6 +2768,45 @@ urUSMFree(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMImport(
+  ur_context_handle_t hContext, ///< [in] handle of the context object
+  void* pMem                    ///< [in] pointer to host memory object
+  size_t size                   ///< [in] size in bytes of the host memory object to be imported
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMRelease(
+  ur_context_handle_t hContext, ///< [in] handle of the context object
+  void* pMem                    ///< [in] pointer to USM memory object
+);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Get USM memory object allocation information
 ///
 /// @returns
@@ -4769,6 +4808,8 @@ typedef enum ur_function_t {
     UR_FUNCTION_USM_POOL_RETAIN = 118,                      ///< Enumerator for ::urUSMPoolRetain
     UR_FUNCTION_USM_POOL_RELEASE = 119,                     ///< Enumerator for ::urUSMPoolRelease
     UR_FUNCTION_USM_POOL_GET_INFO = 120,                    ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_USM_IMPORT = 121,                           ///< Enumerator for ::urUSMImport
+    UR_FUNCTION_USM_RELEASE = 122,                          ///< Enumerator for ::urUSMRelease
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7191,6 +7232,25 @@ typedef struct ur_usm_shared_alloc_params_t {
 typedef struct ur_usm_free_params_t {
     ur_context_handle_t *phContext;
     void **ppMem;
+} ur_usm_free_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMImport
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_import_params_t {
+  ur_context_handle_t* phContext;
+  void* pMem;
+  size_t* psize;
+} ur_usm_free_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMRelease
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_release_params_t {
+  ur_context_handle_t* phContext;
+  void* pMem;
 } ur_usm_free_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change adds the definitions necessary for two new functions: USMImport and USMRelease.

USMImport converts host system memory into something akin to USM host memory.
USMRelease undoes the effect of a previous USMImport.

This functionality is used by SYCL to import/release host memory to speed up host <-> device data transfers.