### PR TITLE
[UR] re-raise exception in makoWrite

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -168,7 +168,7 @@ def makoWrite(inpath, outpath, **args):
         line = "%s: %s" % (str(traceback.error.__class__.__name__), traceback.error)
         makoErrorList.append(line)
         print(line)
-        return 0
+        raise
 
 def makoFileListWrite(outpath):
     jsonWrite(outpath, makoFileList)


### PR DESCRIPTION
Re-raise the exception from writing mako templates. This will be caught by main() and fail the build