### PR TITLE
[Exp] Add Import/Release USM APIs using .yml.

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1810,7 +1810,6 @@ class ur_function_v(IntEnum):
     USM_FREE = 110                                  ## Enumerator for ::urUSMFree
     USM_GET_MEM_ALLOC_INFO = 111                    ## Enumerator for ::urUSMGetMemAllocInfo
     USM_POOL_CREATE = 112                           ## Enumerator for ::urUSMPoolCreate
-    USM_IMPORT = 113                                ## Enumerator for ::urUSMImport
     PLATFORM_GET_BACKEND_OPTION = 114               ## Enumerator for ::urPlatformGetBackendOption
     MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115      ## Enumerator for ::urMemBufferCreateWithNativeHandle
     MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116       ## Enumerator for ::urMemImageCreateWithNativeHandle
@@ -1818,7 +1817,8 @@ class ur_function_v(IntEnum):
     USM_POOL_RETAIN = 118                           ## Enumerator for ::urUSMPoolRetain
     USM_POOL_RELEASE = 119                          ## Enumerator for ::urUSMPoolRelease
     USM_POOL_GET_INFO = 120                         ## Enumerator for ::urUSMPoolGetInfo
-    USM_RELEASE = 121                               ## Enumerator for ::urUSMRelease
+    USM_IMPORT_EXP = 122                            ## Enumerator for ::urUSMImportExp
+    USM_RELEASE_EXP = 123                           ## Enumerator for ::urUSMReleaseExp
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -2760,20 +2760,6 @@ if __use_win_types:
 else:
     _urUSMPoolGetInfo_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
 
-###############################################################################
-## @brief Function-pointer for urUSMImport
-if __use_win_types:
-    _urUSMImport_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
-else:
-    _urUSMImport_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
-
-###############################################################################
-## @brief Function-pointer for urUSMRelease
-if __use_win_types:
-    _urUSMRelease_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
-else:
-    _urUSMRelease_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
-
 
 ###############################################################################
 ## @brief Table of USM functions pointers
@@ -2787,9 +2773,30 @@ class ur_usm_dditable_t(Structure):
         ("pfnPoolCreate", c_void_p),                                    ## _urUSMPoolCreate_t
         ("pfnPoolRetain", c_void_p),                                    ## _urUSMPoolRetain_t
         ("pfnPoolRelease", c_void_p),                                   ## _urUSMPoolRelease_t
-        ("pfnPoolGetInfo", c_void_p),                                   ## _urUSMPoolGetInfo_t
-        ("pfnImport", c_void_p),                                        ## _urUSMImport_t
-        ("pfnRelease", c_void_p)                                        ## _urUSMRelease_t
+        ("pfnPoolGetInfo", c_void_p)                                    ## _urUSMPoolGetInfo_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urUSMImportExp
+if __use_win_types:
+    _urUSMImportExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
+else:
+    _urUSMImportExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for urUSMReleaseExp
+if __use_win_types:
+    _urUSMReleaseExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+else:
+    _urUSMReleaseExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+
+
+###############################################################################
+## @brief Table of USMExp functions pointers
+class ur_usm_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnImportExp", c_void_p),                                     ## _urUSMImportExp_t
+        ("pfnReleaseExp", c_void_p)                                     ## _urUSMReleaseExp_t
     ]
 
 ###############################################################################
@@ -2915,6 +2922,7 @@ class ur_dditable_t(Structure):
         ("Enqueue", ur_enqueue_dditable_t),
         ("Queue", ur_queue_dditable_t),
         ("USM", ur_usm_dditable_t),
+        ("USMExp", ur_usm_exp_dditable_t),
         ("Global", ur_global_dditable_t),
         ("Device", ur_device_dditable_t)
     ]
@@ -3131,8 +3139,17 @@ class UR_DDI:
         self.urUSMPoolRetain = _urUSMPoolRetain_t(self.__dditable.USM.pfnPoolRetain)
         self.urUSMPoolRelease = _urUSMPoolRelease_t(self.__dditable.USM.pfnPoolRelease)
         self.urUSMPoolGetInfo = _urUSMPoolGetInfo_t(self.__dditable.USM.pfnPoolGetInfo)
-        self.urUSMImport = _urUSMImport_t(self.__dditable.USM.pfnImport)
-        self.urUSMRelease = _urUSMRelease_t(self.__dditable.USM.pfnRelease)
+
+        # call driver to get function pointers
+        USMExp = ur_usm_exp_dditable_t()
+        r = ur_result_v(self.__dll.urGetUSMExpProcAddrTable(version, byref(USMExp)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.USMExp = USMExp
+
+        # attach function interface to function address
+        self.urUSMImportExp = _urUSMImportExp_t(self.__dditable.USMExp.pfnImportExp)
+        self.urUSMReleaseExp = _urUSMReleaseExp_t(self.__dditable.USMExp.pfnReleaseExp)
 
         # call driver to get function pointers
         Global = ur_global_dditable_t()

--- a/include/ur.py
+++ b/include/ur.py
@@ -1810,6 +1810,7 @@ class ur_function_v(IntEnum):
     USM_FREE = 110                                  ## Enumerator for ::urUSMFree
     USM_GET_MEM_ALLOC_INFO = 111                    ## Enumerator for ::urUSMGetMemAllocInfo
     USM_POOL_CREATE = 112                           ## Enumerator for ::urUSMPoolCreate
+    USM_IMPORT = 113                                ## Enumerator for ::urUSMImport
     PLATFORM_GET_BACKEND_OPTION = 114               ## Enumerator for ::urPlatformGetBackendOption
     MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115      ## Enumerator for ::urMemBufferCreateWithNativeHandle
     MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116       ## Enumerator for ::urMemImageCreateWithNativeHandle
@@ -1817,6 +1818,7 @@ class ur_function_v(IntEnum):
     USM_POOL_RETAIN = 118                           ## Enumerator for ::urUSMPoolRetain
     USM_POOL_RELEASE = 119                          ## Enumerator for ::urUSMPoolRelease
     USM_POOL_GET_INFO = 120                         ## Enumerator for ::urUSMPoolGetInfo
+    USM_RELEASE = 121                               ## Enumerator for ::urUSMRelease
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -2696,37 +2698,6 @@ class ur_queue_dditable_t(Structure):
     ]
 
 ###############################################################################
-## @brief Function-pointer for urInit
-if __use_win_types:
-    _urInit_t = WINFUNCTYPE( ur_result_t, ur_device_init_flags_t )
-else:
-    _urInit_t = CFUNCTYPE( ur_result_t, ur_device_init_flags_t )
-
-###############################################################################
-## @brief Function-pointer for urGetLastResult
-if __use_win_types:
-    _urGetLastResult_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
-else:
-    _urGetLastResult_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
-
-###############################################################################
-## @brief Function-pointer for urTearDown
-if __use_win_types:
-    _urTearDown_t = WINFUNCTYPE( ur_result_t, c_void_p )
-else:
-    _urTearDown_t = CFUNCTYPE( ur_result_t, c_void_p )
-
-
-###############################################################################
-## @brief Table of Global functions pointers
-class ur_global_dditable_t(Structure):
-    _fields_ = [
-        ("pfnInit", c_void_p),                                          ## _urInit_t
-        ("pfnGetLastResult", c_void_p),                                 ## _urGetLastResult_t
-        ("pfnTearDown", c_void_p)                                       ## _urTearDown_t
-    ]
-
-###############################################################################
 ## @brief Function-pointer for urUSMHostAlloc
 if __use_win_types:
     _urUSMHostAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
@@ -2789,6 +2760,20 @@ if __use_win_types:
 else:
     _urUSMPoolGetInfo_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
 
+###############################################################################
+## @brief Function-pointer for urUSMImport
+if __use_win_types:
+    _urUSMImport_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
+else:
+    _urUSMImport_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_size_t )
+
+###############################################################################
+## @brief Function-pointer for urUSMRelease
+if __use_win_types:
+    _urUSMRelease_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+else:
+    _urUSMRelease_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+
 
 ###############################################################################
 ## @brief Table of USM functions pointers
@@ -2802,7 +2787,40 @@ class ur_usm_dditable_t(Structure):
         ("pfnPoolCreate", c_void_p),                                    ## _urUSMPoolCreate_t
         ("pfnPoolRetain", c_void_p),                                    ## _urUSMPoolRetain_t
         ("pfnPoolRelease", c_void_p),                                   ## _urUSMPoolRelease_t
-        ("pfnPoolGetInfo", c_void_p)                                    ## _urUSMPoolGetInfo_t
+        ("pfnPoolGetInfo", c_void_p),                                   ## _urUSMPoolGetInfo_t
+        ("pfnImport", c_void_p),                                        ## _urUSMImport_t
+        ("pfnRelease", c_void_p)                                        ## _urUSMRelease_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urInit
+if __use_win_types:
+    _urInit_t = WINFUNCTYPE( ur_result_t, ur_device_init_flags_t )
+else:
+    _urInit_t = CFUNCTYPE( ur_result_t, ur_device_init_flags_t )
+
+###############################################################################
+## @brief Function-pointer for urGetLastResult
+if __use_win_types:
+    _urGetLastResult_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
+else:
+    _urGetLastResult_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
+
+###############################################################################
+## @brief Function-pointer for urTearDown
+if __use_win_types:
+    _urTearDown_t = WINFUNCTYPE( ur_result_t, c_void_p )
+else:
+    _urTearDown_t = CFUNCTYPE( ur_result_t, c_void_p )
+
+
+###############################################################################
+## @brief Table of Global functions pointers
+class ur_global_dditable_t(Structure):
+    _fields_ = [
+        ("pfnInit", c_void_p),                                          ## _urInit_t
+        ("pfnGetLastResult", c_void_p),                                 ## _urGetLastResult_t
+        ("pfnTearDown", c_void_p)                                       ## _urTearDown_t
     ]
 
 ###############################################################################
@@ -2896,8 +2914,8 @@ class ur_dditable_t(Structure):
         ("Mem", ur_mem_dditable_t),
         ("Enqueue", ur_enqueue_dditable_t),
         ("Queue", ur_queue_dditable_t),
-        ("Global", ur_global_dditable_t),
         ("USM", ur_usm_dditable_t),
+        ("Global", ur_global_dditable_t),
         ("Device", ur_device_dditable_t)
     ]
 
@@ -3097,18 +3115,6 @@ class UR_DDI:
         self.urQueueFlush = _urQueueFlush_t(self.__dditable.Queue.pfnFlush)
 
         # call driver to get function pointers
-        Global = ur_global_dditable_t()
-        r = ur_result_v(self.__dll.urGetGlobalProcAddrTable(version, byref(Global)))
-        if r != ur_result_v.SUCCESS:
-            raise Exception(r)
-        self.__dditable.Global = Global
-
-        # attach function interface to function address
-        self.urInit = _urInit_t(self.__dditable.Global.pfnInit)
-        self.urGetLastResult = _urGetLastResult_t(self.__dditable.Global.pfnGetLastResult)
-        self.urTearDown = _urTearDown_t(self.__dditable.Global.pfnTearDown)
-
-        # call driver to get function pointers
         USM = ur_usm_dditable_t()
         r = ur_result_v(self.__dll.urGetUSMProcAddrTable(version, byref(USM)))
         if r != ur_result_v.SUCCESS:
@@ -3125,6 +3131,20 @@ class UR_DDI:
         self.urUSMPoolRetain = _urUSMPoolRetain_t(self.__dditable.USM.pfnPoolRetain)
         self.urUSMPoolRelease = _urUSMPoolRelease_t(self.__dditable.USM.pfnPoolRelease)
         self.urUSMPoolGetInfo = _urUSMPoolGetInfo_t(self.__dditable.USM.pfnPoolGetInfo)
+        self.urUSMImport = _urUSMImport_t(self.__dditable.USM.pfnImport)
+        self.urUSMRelease = _urUSMRelease_t(self.__dditable.USM.pfnRelease)
+
+        # call driver to get function pointers
+        Global = ur_global_dditable_t()
+        r = ur_result_v(self.__dll.urGetGlobalProcAddrTable(version, byref(Global)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.Global = Global
+
+        # attach function interface to function address
+        self.urInit = _urInit_t(self.__dditable.Global.pfnInit)
+        self.urGetLastResult = _urGetLastResult_t(self.__dditable.Global.pfnGetLastResult)
+        self.urTearDown = _urTearDown_t(self.__dditable.Global.pfnTearDown)
 
         # call driver to get function pointers
         Device = ur_device_dditable_t()

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -295,6 +295,57 @@ typedef struct ur_rect_region_t {
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
+// Intel 'oneAPI' USM Import/Release Extension APIs
+#if !defined(__GNUC__)
+#pragma region usm import release(experimental)
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @details
+///     - Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMImport(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size                   ///< [in] size in bytes of the host memory object to be imported
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @details
+///     - Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMRelease(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+);
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
 // Intel 'oneAPI' Unified Runtime APIs for Runtime
 #if !defined(__GNUC__)
 #pragma region runtime
@@ -4762,6 +4813,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_USM_FREE = 110,                             ///< Enumerator for ::urUSMFree
     UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,               ///< Enumerator for ::urUSMGetMemAllocInfo
     UR_FUNCTION_USM_POOL_CREATE = 112,                      ///< Enumerator for ::urUSMPoolCreate
+    UR_FUNCTION_USM_IMPORT = 113,                           ///< Enumerator for ::urUSMImport
     UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,          ///< Enumerator for ::urPlatformGetBackendOption
     UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115, ///< Enumerator for ::urMemBufferCreateWithNativeHandle
     UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,  ///< Enumerator for ::urMemImageCreateWithNativeHandle
@@ -4769,6 +4821,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_USM_POOL_RETAIN = 118,                      ///< Enumerator for ::urUSMPoolRetain
     UR_FUNCTION_USM_POOL_RELEASE = 119,                     ///< Enumerator for ::urUSMPoolRelease
     UR_FUNCTION_USM_POOL_GET_INFO = 120,                    ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_USM_RELEASE = 121,                          ///< Enumerator for ::urUSMRelease
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7122,31 +7175,6 @@ typedef struct ur_queue_flush_params_t {
 } ur_queue_flush_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urInit
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_init_params_t {
-    ur_device_init_flags_t *pdevice_flags;
-} ur_init_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urGetLastResult
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_get_last_result_params_t {
-    ur_platform_handle_t *phPlatform;
-    const char ***pppMessage;
-} ur_get_last_result_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urTearDown
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_tear_down_params_t {
-    void **ppParams;
-} ur_tear_down_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urUSMHostAlloc
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -7243,6 +7271,50 @@ typedef struct ur_usm_pool_get_info_params_t {
     void **ppPropValue;
     size_t **ppPropSizeRet;
 } ur_usm_pool_get_info_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMImport
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_import_params_t {
+    ur_context_handle_t *phContext;
+    void **ppMem;
+    size_t *psize;
+} ur_usm_import_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMRelease
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_release_params_t {
+    ur_context_handle_t *phContext;
+    void **ppMem;
+} ur_usm_release_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urInit
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_init_params_t {
+    ur_device_init_flags_t *pdevice_flags;
+} ur_init_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urGetLastResult
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_get_last_result_params_t {
+    ur_platform_handle_t *phPlatform;
+    const char ***pppMessage;
+} ur_get_last_result_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urTearDown
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_tear_down_params_t {
+    void **ppParams;
+} ur_tear_down_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urDeviceGet

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -316,7 +316,7 @@ typedef struct ur_rect_region_t {
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMImport(
+urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size                   ///< [in] size in bytes of the host memory object to be imported
@@ -338,7 +338,7 @@ urUSMImport(
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 UR_APIEXPORT ur_result_t UR_APICALL
-urUSMRelease(
+urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
 );
@@ -4813,7 +4813,6 @@ typedef enum ur_function_t {
     UR_FUNCTION_USM_FREE = 110,                             ///< Enumerator for ::urUSMFree
     UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,               ///< Enumerator for ::urUSMGetMemAllocInfo
     UR_FUNCTION_USM_POOL_CREATE = 112,                      ///< Enumerator for ::urUSMPoolCreate
-    UR_FUNCTION_USM_IMPORT = 113,                           ///< Enumerator for ::urUSMImport
     UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,          ///< Enumerator for ::urPlatformGetBackendOption
     UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115, ///< Enumerator for ::urMemBufferCreateWithNativeHandle
     UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,  ///< Enumerator for ::urMemImageCreateWithNativeHandle
@@ -4821,7 +4820,8 @@ typedef enum ur_function_t {
     UR_FUNCTION_USM_POOL_RETAIN = 118,                      ///< Enumerator for ::urUSMPoolRetain
     UR_FUNCTION_USM_POOL_RELEASE = 119,                     ///< Enumerator for ::urUSMPoolRelease
     UR_FUNCTION_USM_POOL_GET_INFO = 120,                    ///< Enumerator for ::urUSMPoolGetInfo
-    UR_FUNCTION_USM_RELEASE = 121,                          ///< Enumerator for ::urUSMRelease
+    UR_FUNCTION_USM_IMPORT_EXP = 122,                       ///< Enumerator for ::urUSMImportExp
+    UR_FUNCTION_USM_RELEASE_EXP = 123,                      ///< Enumerator for ::urUSMReleaseExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7273,23 +7273,23 @@ typedef struct ur_usm_pool_get_info_params_t {
 } ur_usm_pool_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMImport
+/// @brief Function parameters for urUSMImportExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_import_params_t {
+typedef struct ur_usm_import_exp_params_t {
     ur_context_handle_t *phContext;
     void **ppMem;
     size_t *psize;
-} ur_usm_import_params_t;
+} ur_usm_import_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMRelease
+/// @brief Function parameters for urUSMReleaseExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_release_params_t {
+typedef struct ur_usm_release_exp_params_t {
     ur_context_handle_t *phContext;
     void **ppMem;
-} ur_usm_release_params_t;
+} ur_usm_release_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urInit

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -295,57 +295,6 @@ typedef struct ur_rect_region_t {
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
-// Intel 'oneAPI' USM Import/Release Extension APIs
-#if !defined(__GNUC__)
-#pragma region usm import release(experimental)
-#endif
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Import memory into USM
-///
-/// @details
-///     - Import memory into USM
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pMem`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size                   ///< [in] size in bytes of the host memory object to be imported
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Release memory from USM
-///
-/// @details
-///     - Release memory from USM
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pMem`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-);
-
-#if !defined(__GNUC__)
-#pragma endregion
-#endif
 // Intel 'oneAPI' Unified Runtime APIs for Runtime
 #if !defined(__GNUC__)
 #pragma region runtime
@@ -6011,6 +5960,57 @@ urEnqueueWriteHostPipe(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait event.
     ur_event_handle_t *phEvent                ///< [out] returns an event object that identifies this write command
                                               ///< and can be used to query or queue a wait for this command to complete.
+);
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Intel 'oneAPI' USM Import/Release Extension APIs
+#if !defined(__GNUC__)
+#pragma region usm import release(experimental)
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @details
+///     - Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size                   ///< [in] size in bytes of the host memory object to be imported
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @details
+///     - Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
 );
 
 #if !defined(__GNUC__)

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1214,51 +1214,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
     ur_queue_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urInit
-typedef ur_result_t(UR_APICALL *ur_pfnInit_t)(
-    ur_device_init_flags_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetLastResult
-typedef ur_result_t(UR_APICALL *ur_pfnGetLastResult_t)(
-    ur_platform_handle_t,
-    const char **);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urTearDown
-typedef ur_result_t(UR_APICALL *ur_pfnTearDown_t)(
-    void *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Table of Global functions pointers
-typedef struct ur_global_dditable_t {
-    ur_pfnInit_t pfnInit;
-    ur_pfnGetLastResult_t pfnGetLastResult;
-    ur_pfnTearDown_t pfnTearDown;
-} ur_global_dditable_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Global table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetGlobalProcAddrTable(
-    ur_api_version_t version,       ///< [in] API version requested
-    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetGlobalProcAddrTable
-typedef ur_result_t(UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
-    ur_api_version_t,
-    ur_global_dditable_t *);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urUSMHostAlloc
 typedef ur_result_t(UR_APICALL *ur_pfnUSMHostAlloc_t)(
     ur_context_handle_t,
@@ -1330,6 +1285,19 @@ typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolGetInfo_t)(
     size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMImport
+typedef ur_result_t(UR_APICALL *ur_pfnUSMImport_t)(
+    ur_context_handle_t,
+    void *,
+    size_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMRelease
+typedef ur_result_t(UR_APICALL *ur_pfnUSMRelease_t)(
+    ur_context_handle_t,
+    void *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of USM functions pointers
 typedef struct ur_usm_dditable_t {
     ur_pfnUSMHostAlloc_t pfnHostAlloc;
@@ -1341,6 +1309,8 @@ typedef struct ur_usm_dditable_t {
     ur_pfnUSMPoolRetain_t pfnPoolRetain;
     ur_pfnUSMPoolRelease_t pfnPoolRelease;
     ur_pfnUSMPoolGetInfo_t pfnPoolGetInfo;
+    ur_pfnUSMImport_t pfnImport;
+    ur_pfnUSMRelease_t pfnRelease;
 } ur_usm_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1363,6 +1333,51 @@ urGetUSMProcAddrTable(
 typedef ur_result_t(UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
     ur_api_version_t,
     ur_usm_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urInit
+typedef ur_result_t(UR_APICALL *ur_pfnInit_t)(
+    ur_device_init_flags_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetLastResult
+typedef ur_result_t(UR_APICALL *ur_pfnGetLastResult_t)(
+    ur_platform_handle_t,
+    const char **);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urTearDown
+typedef ur_result_t(UR_APICALL *ur_pfnTearDown_t)(
+    void *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Global functions pointers
+typedef struct ur_global_dditable_t {
+    ur_pfnInit_t pfnInit;
+    ur_pfnGetLastResult_t pfnGetLastResult;
+    ur_pfnTearDown_t pfnTearDown;
+} ur_global_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Global table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetGlobalProcAddrTable(
+    ur_api_version_t version,       ///< [in] API version requested
+    ur_global_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetGlobalProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
+    ur_api_version_t,
+    ur_global_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urDeviceGet
@@ -1477,8 +1492,8 @@ typedef struct ur_dditable_t {
     ur_mem_dditable_t Mem;
     ur_enqueue_dditable_t Enqueue;
     ur_queue_dditable_t Queue;
-    ur_global_dditable_t Global;
     ur_usm_dditable_t USM;
+    ur_global_dditable_t Global;
     ur_device_dditable_t Device;
 } ur_dditable_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1285,19 +1285,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolGetInfo_t)(
     size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMImport
-typedef ur_result_t(UR_APICALL *ur_pfnUSMImport_t)(
-    ur_context_handle_t,
-    void *,
-    size_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMRelease
-typedef ur_result_t(UR_APICALL *ur_pfnUSMRelease_t)(
-    ur_context_handle_t,
-    void *);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of USM functions pointers
 typedef struct ur_usm_dditable_t {
     ur_pfnUSMHostAlloc_t pfnHostAlloc;
@@ -1309,8 +1296,6 @@ typedef struct ur_usm_dditable_t {
     ur_pfnUSMPoolRetain_t pfnPoolRetain;
     ur_pfnUSMPoolRelease_t pfnPoolRelease;
     ur_pfnUSMPoolGetInfo_t pfnPoolGetInfo;
-    ur_pfnUSMImport_t pfnImport;
-    ur_pfnUSMRelease_t pfnRelease;
 } ur_usm_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1333,6 +1318,47 @@ urGetUSMProcAddrTable(
 typedef ur_result_t(UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
     ur_api_version_t,
     ur_usm_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMImportExp
+typedef ur_result_t(UR_APICALL *ur_pfnUSMImportExp_t)(
+    ur_context_handle_t,
+    void *,
+    size_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMReleaseExp
+typedef ur_result_t(UR_APICALL *ur_pfnUSMReleaseExp_t)(
+    ur_context_handle_t,
+    void *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of USMExp functions pointers
+typedef struct ur_usm_exp_dditable_t {
+    ur_pfnUSMImportExp_t pfnImportExp;
+    ur_pfnUSMReleaseExp_t pfnReleaseExp;
+} ur_usm_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USMExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMExpProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_usm_exp_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetUSMExpProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetUSMExpProcAddrTable_t)(
+    ur_api_version_t,
+    ur_usm_exp_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urInit
@@ -1493,6 +1519,7 @@ typedef struct ur_dditable_t {
     ur_enqueue_dditable_t Enqueue;
     ur_queue_dditable_t Queue;
     ur_usm_dditable_t USM;
+    ur_usm_exp_dditable_t USMExp;
     ur_global_dditable_t Global;
     ur_device_dditable_t Device;
 } ur_dditable_t;

--- a/scripts/core/EXP-USM-IMPORT-RELEASE.rst
+++ b/scripts/core/EXP-USM-IMPORT-RELEASE.rst
@@ -1,0 +1,58 @@
+
+<%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+.. _experimental-usm-import-release:
+
+==================
+USM Import/Release
+==================
+
+.. warning::
+
+    Experimental features:
+
+    *   May be replaced, updated, or removed at any time.
+    *   Do not require maintaining API/ABI stability of their own additions over
+        time.
+    *   Do not require conformance testing of their own additions.
+
+
+Data transfer between Host and Device is most efficient when source and
+destination are both allocated in USM memory.
+In situations where host data will participate in host/device transfers
+and the host data allocation is under user control, USM functions
+such as malloc_host could be used to allocate USM memory instead of
+system memory.
+However, this is not always possible if the source code where the allocation
+is made is not available, or source code changes are prohibited for portability
+reasons.
+In these situations a mechanism to temporarily promote system memory to USM
+for the duration of the host/device data transfers is useful for maximizing
+data transfer rate.
+
+
+Import Host Memory into USM
+===========================
+
+Import a range of host memory into USM.
+
+.. parsed-literal::
+
+    // Import into USM
+    USMImport(hContext, hostPtr, size);
+            
+Release Host Memory Previously Imported into USM
+================================================
+
+Release from USM a range of memory that had been previously imported
+into USM.
+
+
+.. parsed-literal::
+
+    // Release from USM
+    USMRelease(hContext, hostPtr);
+

--- a/scripts/core/exp-usm-import-release.yml
+++ b/scripts/core/exp-usm-import-release.yml
@@ -1,0 +1,42 @@
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi USM Import/Release Extension APIs"
+ordinal: "0"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Import memory into USM"
+class: $xUSM
+name: Import
+details:
+    - "Import memory into USM"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: "void*"
+      name: pMem
+      desc: "[in] pointer to host memory object"
+    - type: "size_t"
+      name: size
+      desc: "[in] size in bytes of the host memory object to be imported"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER
+    - $X_RESULT_ERROR_INVALID_SIZE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Release memory from USM"
+class: $xUSM
+name: Release
+details:
+    - "Release memory from USM"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: "void*"
+      name: pMem
+      desc: "[in] pointer to host memory object"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER

--- a/scripts/core/exp-usm-import-release.yml
+++ b/scripts/core/exp-usm-import-release.yml
@@ -6,7 +6,7 @@ ordinal: "0"
 type: function
 desc: "Import memory into USM"
 class: $xUSM
-name: Import
+name: ImportExp
 details:
     - "Import memory into USM"
 params:
@@ -27,7 +27,7 @@ returns:
 type: function
 desc: "Release memory from USM"
 class: $xUSM
-name: Release
+name: ReleaseExp
 details:
     - "Release memory from USM"
 params:

--- a/scripts/core/exp-usm-import-release.yml
+++ b/scripts/core/exp-usm-import-release.yml
@@ -1,7 +1,7 @@
 --- #--------------------------------------------------------------------------
 type: header
 desc: "Intel $OneApi USM Import/Release Extension APIs"
-ordinal: "0"
+ordinal: "99"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Import memory into USM"
@@ -21,7 +21,6 @@ params:
       desc: "[in] size in bytes of the host memory object to be imported"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
-    - $X_RESULT_ERROR_INVALID_NULL_POINTER
     - $X_RESULT_ERROR_INVALID_SIZE
 --- #--------------------------------------------------------------------------
 type: function
@@ -39,4 +38,3 @@ params:
       desc: "[in] pointer to host memory object"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
-    - $X_RESULT_ERROR_INVALID_NULL_POINTER

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -343,9 +343,6 @@ etors:
 - name: USM_POOL_CREATE
   desc: Enumerator for $xUSMPoolCreate
   value: '112'
-- name: USM_IMPORT
-  desc: Enumerator for $xUSMImport
-  value: '113'
 - name: PLATFORM_GET_BACKEND_OPTION
   desc: Enumerator for $xPlatformGetBackendOption
   value: '114'
@@ -367,6 +364,9 @@ etors:
 - name: USM_POOL_GET_INFO
   desc: Enumerator for $xUSMPoolGetInfo
   value: '120'
-- name: USM_RELEASE
-  desc: Enumerator for $xUSMRelease
-  value: '121'
+- name: USM_IMPORT_EXP
+  desc: Enumerator for $xUSMImportExp
+  value: '122'
+- name: USM_RELEASE_EXP
+  desc: Enumerator for $xUSMReleaseExp
+  value: '123'

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -343,6 +343,9 @@ etors:
 - name: USM_POOL_CREATE
   desc: Enumerator for $xUSMPoolCreate
   value: '112'
+- name: USM_IMPORT
+  desc: Enumerator for $xUSMImport
+  value: '113'
 - name: PLATFORM_GET_BACKEND_OPTION
   desc: Enumerator for $xPlatformGetBackendOption
   value: '114'
@@ -364,3 +367,6 @@ etors:
 - name: USM_POOL_GET_INFO
   desc: Enumerator for $xUSMPoolGetInfo
   value: '120'
+- name: USM_RELEASE
+  desc: Enumerator for $xUSMRelease
+  value: '121'

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -13,49 +13,6 @@
 
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size ///< [in] size in bytes of the host memory object to be imported
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnImportExp = d_context.urDdiTable.USMExp.pfnImportExp;
-    if (nullptr != pfnImportExp) {
-        result = pfnImportExp(hContext, pMem, size);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnReleaseExp = d_context.urDdiTable.USMExp.pfnReleaseExp;
-    if (nullptr != pfnReleaseExp) {
-        result = pfnReleaseExp(hContext, pMem);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -3525,6 +3482,49 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     } else {
         // generic implementation
         *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMImportExp
+__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImportExp = d_context.urDdiTable.USMExp.pfnImportExp;
+    if (nullptr != pfnImportExp) {
+        result = pfnImportExp(hContext, pMem, size);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMReleaseExp
+__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnReleaseExp = d_context.urDdiTable.USMExp.pfnReleaseExp;
+    if (nullptr != pfnReleaseExp) {
+        result = pfnReleaseExp(hContext, pMem);
+    } else {
+        // generic implementation
     }
 
     return result;

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -13,6 +13,49 @@
 
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMImport
+__urdlllocal ur_result_t UR_APICALL urUSMImport(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImport = d_context.urDdiTable.USM.pfnImport;
+    if (nullptr != pfnImport) {
+        result = pfnImport(hContext, pMem, size);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMRelease
+__urdlllocal ur_result_t UR_APICALL urUSMRelease(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnRelease = d_context.urDdiTable.USM.pfnRelease;
+    if (nullptr != pfnRelease) {
+        result = pfnRelease(hContext, pMem);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -4031,6 +4074,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
     pDdiTable->pfnPoolRelease = driver::urUSMPoolRelease;
 
     pDdiTable->pfnPoolGetInfo = driver::urUSMPoolGetInfo;
+
+    pDdiTable->pfnImport = driver::urUSMImport;
+
+    pDdiTable->pfnRelease = driver::urUSMRelease;
 
     return result;
 } catch (...) {

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -8135,10 +8135,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_USM_POOL_CREATE";
         break;
 
-    case UR_FUNCTION_USM_IMPORT:
-        os << "UR_FUNCTION_USM_IMPORT";
-        break;
-
     case UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION:
         os << "UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION";
         break;
@@ -8167,8 +8163,12 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_USM_POOL_GET_INFO";
         break;
 
-    case UR_FUNCTION_USM_RELEASE:
-        os << "UR_FUNCTION_USM_RELEASE";
+    case UR_FUNCTION_USM_IMPORT_EXP:
+        os << "UR_FUNCTION_USM_IMPORT_EXP";
+        break;
+
+    case UR_FUNCTION_USM_RELEASE_EXP:
+        os << "UR_FUNCTION_USM_RELEASE_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -11681,8 +11681,8 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_import_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_usm_import_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -11701,8 +11701,8 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_release_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_usm_release_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -12303,11 +12303,11 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     case UR_FUNCTION_USM_POOL_GET_INFO: {
         os << (const struct ur_usm_pool_get_info_params_t *)params;
     } break;
-    case UR_FUNCTION_USM_IMPORT: {
-        os << (const struct ur_usm_import_params_t *)params;
+    case UR_FUNCTION_USM_IMPORT_EXP: {
+        os << (const struct ur_usm_import_exp_params_t *)params;
     } break;
-    case UR_FUNCTION_USM_RELEASE: {
-        os << (const struct ur_usm_release_params_t *)params;
+    case UR_FUNCTION_USM_RELEASE_EXP: {
+        os << (const struct ur_usm_release_exp_params_t *)params;
     } break;
     case UR_FUNCTION_DEVICE_GET: {
         os << (const struct ur_device_get_params_t *)params;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -8135,6 +8135,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_USM_POOL_CREATE";
         break;
 
+    case UR_FUNCTION_USM_IMPORT:
+        os << "UR_FUNCTION_USM_IMPORT";
+        break;
+
     case UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION:
         os << "UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION";
         break;
@@ -8161,6 +8165,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
 
     case UR_FUNCTION_USM_POOL_GET_INFO:
         os << "UR_FUNCTION_USM_POOL_GET_INFO";
+        break;
+
+    case UR_FUNCTION_USM_RELEASE:
+        os << "UR_FUNCTION_USM_RELEASE";
         break;
     default:
         os << "unknown enumerator";
@@ -11674,6 +11682,41 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_import_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pMem = ";
+
+    ur_params::serializePtr(os, *(params->ppMem));
+
+    os << ", ";
+    os << ".size = ";
+
+    os << *(params->psize);
+
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_usm_release_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pMem = ";
+
+    ur_params::serializePtr(os, *(params->ppMem));
+
+    return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_device_get_params_t *params) {
 
     os << ".hPlatform = ";
@@ -12259,6 +12302,12 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     } break;
     case UR_FUNCTION_USM_POOL_GET_INFO: {
         os << (const struct ur_usm_pool_get_info_params_t *)params;
+    } break;
+    case UR_FUNCTION_USM_IMPORT: {
+        os << (const struct ur_usm_import_params_t *)params;
+    } break;
+    case UR_FUNCTION_USM_RELEASE: {
+        os << (const struct ur_usm_release_params_t *)params;
     } break;
     case UR_FUNCTION_DEVICE_GET: {
         os << (const struct ur_device_get_params_t *)params;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -16,55 +16,6 @@
 
 namespace ur_tracing_layer {
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size ///< [in] size in bytes of the host memory object to be imported
-) {
-    auto pfnImportExp = context.urDdiTable.USMExp.pfnImportExp;
-
-    if (nullptr == pfnImportExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_usm_import_exp_params_t params = {&hContext, &pMem, &size};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_IMPORT_EXP,
-                                             "urUSMImportExp", &params);
-
-    ur_result_t result = pfnImportExp(hContext, pMem, size);
-
-    context.notify_end(UR_FUNCTION_USM_IMPORT_EXP, "urUSMImportExp", &params,
-                       &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-) {
-    auto pfnReleaseExp = context.urDdiTable.USMExp.pfnReleaseExp;
-
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_usm_release_exp_params_t params = {&hContext, &pMem};
-    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_RELEASE_EXP,
-                                             "urUSMReleaseExp", &params);
-
-    ur_result_t result = pfnReleaseExp(hContext, pMem);
-
-    context.notify_end(UR_FUNCTION_USM_RELEASE_EXP, "urUSMReleaseExp", &params,
-                       &result, instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -3997,6 +3948,55 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
     context.notify_end(UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE,
                        "urEnqueueWriteHostPipe", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMImportExp
+__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+) {
+    auto pfnImportExp = context.urDdiTable.USMExp.pfnImportExp;
+
+    if (nullptr == pfnImportExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_usm_import_exp_params_t params = {&hContext, &pMem, &size};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_IMPORT_EXP,
+                                             "urUSMImportExp", &params);
+
+    ur_result_t result = pfnImportExp(hContext, pMem, size);
+
+    context.notify_end(UR_FUNCTION_USM_IMPORT_EXP, "urUSMImportExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMReleaseExp
+__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+) {
+    auto pfnReleaseExp = context.urDdiTable.USMExp.pfnReleaseExp;
+
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_usm_release_exp_params_t params = {&hContext, &pMem};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_RELEASE_EXP,
+                                             "urUSMReleaseExp", &params);
+
+    ur_result_t result = pfnReleaseExp(hContext, pMem);
+
+    context.notify_end(UR_FUNCTION_USM_RELEASE_EXP, "urUSMReleaseExp", &params,
+                       &result, instance);
 
     return result;
 }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -15,65 +15,6 @@
 namespace ur_validation_layer {
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size ///< [in] size in bytes of the host memory object to be imported
-) {
-    auto pfnImportExp = context.urDdiTable.USMExp.pfnImportExp;
-
-    if (nullptr == pfnImportExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hContext) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == pMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-    }
-
-    ur_result_t result = pfnImportExp(hContext, pMem, size);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-) {
-    auto pfnReleaseExp = context.urDdiTable.USMExp.pfnReleaseExp;
-
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hContext) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == pMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-    }
-
-    ur_result_t result = pfnReleaseExp(hContext, pMem);
-
-    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
-        refCountContext.decrementRefCount(pMem);
-    }
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -5084,6 +5025,65 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_result_t result =
         pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
                          numEventsInWaitList, phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMImportExp
+__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+) {
+    auto pfnImportExp = context.urDdiTable.USMExp.pfnImportExp;
+
+    if (nullptr == pfnImportExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnImportExp(hContext, pMem, size);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMReleaseExp
+__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+) {
+    auto pfnReleaseExp = context.urDdiTable.USMExp.pfnReleaseExp;
+
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnReleaseExp(hContext, pMem);
+
+    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
+        refCountContext.decrementRefCount(pMem);
+    }
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -27,55 +27,6 @@ ur_mem_factory_t ur_mem_factory;
 ur_usm_pool_factory_t ur_usm_pool_factory;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size ///< [in] size in bytes of the host memory object to be imported
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnImportExp = dditable->ur.USMExp.pfnImportExp;
-    if (nullptr == pfnImportExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
-
-    // forward to device-platform
-    result = pfnImportExp(hContext, pMem, size);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnReleaseExp = dditable->ur.USMExp.pfnReleaseExp;
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
-
-    // forward to device-platform
-    result = pfnReleaseExp(hContext, pMem);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urInit
 __urdlllocal ur_result_t UR_APICALL urInit(
     ur_device_init_flags_t device_flags ///< [in] device initialization flags.
@@ -4909,6 +4860,55 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     } catch (std::bad_alloc &) {
         result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMImportExp
+__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnImportExp = dditable->ur.USMExp.pfnImportExp;
+    if (nullptr == pfnImportExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // forward to device-platform
+    result = pfnImportExp(hContext, pMem, size);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMReleaseExp
+__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnReleaseExp = dditable->ur.USMExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // forward to device-platform
+    result = pfnReleaseExp(hContext, pMem);
 
     return result;
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -16,6 +16,66 @@
 extern "C" {
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @details
+///     - Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+ur_result_t UR_APICALL urUSMImport(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+    ) try {
+    auto pfnImport = ur_lib::context->urDdiTable.USM.pfnImport;
+    if (nullptr == pfnImport) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImport(hContext, pMem, size);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @details
+///     - Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+ur_result_t UR_APICALL urUSMRelease(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+    ) try {
+    auto pfnRelease = ur_lib::context->urDdiTable.USM.pfnRelease;
+    if (nullptr == pfnRelease) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnRelease(hContext, pMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -16,66 +16,6 @@
 extern "C" {
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import memory into USM
-///
-/// @details
-///     - Import memory into USM
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pMem`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size ///< [in] size in bytes of the host memory object to be imported
-    ) try {
-    auto pfnImportExp = ur_lib::context->urDdiTable.USMExp.pfnImportExp;
-    if (nullptr == pfnImportExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnImportExp(hContext, pMem, size);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Release memory from USM
-///
-/// @details
-///     - Release memory from USM
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pMem`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-ur_result_t UR_APICALL urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-    ) try {
-    auto pfnReleaseExp = ur_lib::context->urDdiTable.USMExp.pfnReleaseExp;
-    if (nullptr == pfnReleaseExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnReleaseExp(hContext, pMem);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details
@@ -5326,6 +5266,66 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
     return pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
                             numEventsInWaitList, phEventWaitList, phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @details
+///     - Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+    ) try {
+    auto pfnImportExp = ur_lib::context->urDdiTable.USMExp.pfnImportExp;
+    if (nullptr == pfnImportExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImportExp(hContext, pMem, size);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @details
+///     - Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+ur_result_t UR_APICALL urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+    ) try {
+    auto pfnReleaseExp = ur_lib::context->urDdiTable.USMExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnReleaseExp(hContext, pMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -31,17 +31,17 @@ extern "C" {
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL urUSMImport(
+ur_result_t UR_APICALL urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size ///< [in] size in bytes of the host memory object to be imported
     ) try {
-    auto pfnImport = ur_lib::context->urDdiTable.USM.pfnImport;
-    if (nullptr == pfnImport) {
+    auto pfnImportExp = ur_lib::context->urDdiTable.USMExp.pfnImportExp;
+    if (nullptr == pfnImportExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImport(hContext, pMem, size);
+    return pfnImportExp(hContext, pMem, size);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -61,16 +61,16 @@ ur_result_t UR_APICALL urUSMImport(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-ur_result_t UR_APICALL urUSMRelease(
+ur_result_t UR_APICALL urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
     ) try {
-    auto pfnRelease = ur_lib::context->urDdiTable.USM.pfnRelease;
-    if (nullptr == pfnRelease) {
+    auto pfnReleaseExp = ur_lib::context->urDdiTable.USMExp.pfnReleaseExp;
+    if (nullptr == pfnReleaseExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnRelease(hContext, pMem);
+    return pfnReleaseExp(hContext, pMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -74,6 +74,11 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
+        result = urGetUSMExpProcAddrTable(UR_API_VERSION_CURRENT,
+                                          &urDdiTable.USMExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
         result = urGetDeviceProcAddrTable(UR_API_VERSION_CURRENT,
                                           &urDdiTable.Device);
     }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -13,6 +13,54 @@
 #include "ur_api.h"
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @details
+///     - Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+ur_result_t UR_APICALL urUSMImport(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @details
+///     - Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+ur_result_t UR_APICALL urUSMRelease(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -28,7 +28,7 @@
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL urUSMImport(
+ur_result_t UR_APICALL urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size ///< [in] size in bytes of the host memory object to be imported
@@ -52,7 +52,7 @@ ur_result_t UR_APICALL urUSMImport(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-ur_result_t UR_APICALL urUSMRelease(
+ur_result_t UR_APICALL urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
 ) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -13,54 +13,6 @@
 #include "ur_api.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import memory into USM
-///
-/// @details
-///     - Import memory into USM
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pMem`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-ur_result_t UR_APICALL urUSMImportExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem,                   ///< [in] pointer to host memory object
-    size_t size ///< [in] size in bytes of the host memory object to be imported
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Release memory from USM
-///
-/// @details
-///     - Release memory from USM
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hContext`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pMem`
-///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
-ur_result_t UR_APICALL urUSMReleaseExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    void *pMem                    ///< [in] pointer to host memory object
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' adapter(s)
 ///
 /// @details
@@ -4486,6 +4438,54 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_event_handle_t *
         phEvent ///< [out] returns an event object that identifies this write command
     ///< and can be used to query or queue a wait for this command to complete.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import memory into USM
+///
+/// @details
+///     - Import memory into USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+ur_result_t UR_APICALL urUSMImportExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem,                   ///< [in] pointer to host memory object
+    size_t size ///< [in] size in bytes of the host memory object to be imported
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Release memory from USM
+///
+/// @details
+///     - Release memory from USM
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+ur_result_t UR_APICALL urUSMReleaseExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pMem                    ///< [in] pointer to host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
This change adds the definitions necessary for two new functions: USMImport and USMRelease.

USMImport converts host system memory into something akin to USM host memory.
USMRelease undoes the effect of a previous USMImport.

This functionality is used by SYCL to import/release host memory to speed up host <-> device data transfers.