### PR TITLE
[ur] Improve reporting of adapter specific errors

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1817,7 +1817,6 @@ class ur_function_v(IntEnum):
     PLATFORM_GET_API_VERSION = 74                   ## Enumerator for ::urPlatformGetApiVersion
     PLATFORM_GET_NATIVE_HANDLE = 75                 ## Enumerator for ::urPlatformGetNativeHandle
     PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76         ## Enumerator for ::urPlatformCreateWithNativeHandle
-    GET_LAST_RESULT = 77                            ## Enumerator for ::urGetLastResult
     PROGRAM_CREATE_WITH_IL = 78                     ## Enumerator for ::urProgramCreateWithIL
     PROGRAM_CREATE_WITH_BINARY = 79                 ## Enumerator for ::urProgramCreateWithBinary
     PROGRAM_BUILD = 80                              ## Enumerator for ::urProgramBuild
@@ -1887,6 +1886,7 @@ class ur_function_v(IntEnum):
     BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147## Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
     BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148   ## Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
     BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149 ## Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
+    PLATFORM_GET_LAST_ERROR = 150                   ## Enumerator for ::urPlatformGetLastError
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -2023,6 +2023,13 @@ else:
     _urPlatformCreateWithNativeHandle_t = CFUNCTYPE( ur_result_t, ur_native_handle_t, POINTER(ur_platform_native_properties_t), POINTER(ur_platform_handle_t) )
 
 ###############################################################################
+## @brief Function-pointer for urPlatformGetLastError
+if __use_win_types:
+    _urPlatformGetLastError_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p), POINTER(c_long) )
+else:
+    _urPlatformGetLastError_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p), POINTER(c_long) )
+
+###############################################################################
 ## @brief Function-pointer for urPlatformGetApiVersion
 if __use_win_types:
     _urPlatformGetApiVersion_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(ur_api_version_t) )
@@ -2045,6 +2052,7 @@ class ur_platform_dditable_t(Structure):
         ("pfnGetInfo", c_void_p),                                       ## _urPlatformGetInfo_t
         ("pfnGetNativeHandle", c_void_p),                               ## _urPlatformGetNativeHandle_t
         ("pfnCreateWithNativeHandle", c_void_p),                        ## _urPlatformCreateWithNativeHandle_t
+        ("pfnGetLastError", c_void_p),                                  ## _urPlatformGetLastError_t
         ("pfnGetApiVersion", c_void_p),                                 ## _urPlatformGetApiVersion_t
         ("pfnGetBackendOption", c_void_p)                               ## _urPlatformGetBackendOption_t
     ]
@@ -3165,13 +3173,6 @@ else:
     _urInit_t = CFUNCTYPE( ur_result_t, ur_device_init_flags_t )
 
 ###############################################################################
-## @brief Function-pointer for urGetLastResult
-if __use_win_types:
-    _urGetLastResult_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
-else:
-    _urGetLastResult_t = CFUNCTYPE( ur_result_t, ur_platform_handle_t, POINTER(c_char_p) )
-
-###############################################################################
 ## @brief Function-pointer for urTearDown
 if __use_win_types:
     _urTearDown_t = WINFUNCTYPE( ur_result_t, c_void_p )
@@ -3184,7 +3185,6 @@ else:
 class ur_global_dditable_t(Structure):
     _fields_ = [
         ("pfnInit", c_void_p),                                          ## _urInit_t
-        ("pfnGetLastResult", c_void_p),                                 ## _urGetLastResult_t
         ("pfnTearDown", c_void_p)                                       ## _urTearDown_t
     ]
 
@@ -3315,6 +3315,7 @@ class UR_DDI:
         self.urPlatformGetInfo = _urPlatformGetInfo_t(self.__dditable.Platform.pfnGetInfo)
         self.urPlatformGetNativeHandle = _urPlatformGetNativeHandle_t(self.__dditable.Platform.pfnGetNativeHandle)
         self.urPlatformCreateWithNativeHandle = _urPlatformCreateWithNativeHandle_t(self.__dditable.Platform.pfnCreateWithNativeHandle)
+        self.urPlatformGetLastError = _urPlatformGetLastError_t(self.__dditable.Platform.pfnGetLastError)
         self.urPlatformGetApiVersion = _urPlatformGetApiVersion_t(self.__dditable.Platform.pfnGetApiVersion)
         self.urPlatformGetBackendOption = _urPlatformGetBackendOption_t(self.__dditable.Platform.pfnGetBackendOption)
 
@@ -3563,7 +3564,6 @@ class UR_DDI:
 
         # attach function interface to function address
         self.urInit = _urInit_t(self.__dditable.Global.pfnInit)
-        self.urGetLastResult = _urGetLastResult_t(self.__dditable.Global.pfnGetLastResult)
         self.urTearDown = _urTearDown_t(self.__dditable.Global.pfnTearDown)
 
         # call driver to get function pointers

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -598,22 +598,37 @@ urPlatformGetBackendOption(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Retrieve string representation of the underlying adapter specific
-///        result reported by the the last API that returned
-///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
-///        return an adapter specific result.
+/// @brief Get the last adapter specific error.
 ///
 /// @details
-///     - The string returned via the ppMessage is a NULL terminated C style
-///       string.
-///     - The string returned via the ppMessage is thread local.
-///     - The entry point will return UR_RESULT_SUCCESS if the result being
-///       reported is to be considered a warning. Any other result code returned
-///       indicates that the adapter specific result is an error.
-///     - The memory in the string returned via the ppMessage is owned by the
-///       adapter.
-///     - The application may call this function from simultaneous threads.
-///     - The implementation of this function should be lock-free.
+/// To be used after another entry-point has returned
+/// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
+/// the circumstances of the underlying driver error and the error code
+/// returned by the failed driver entry-point.
+///
+/// * Implementations *must* store the message and error code in thread-local
+///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
+///
+/// * The message and error code storage is will only be valid if a previously
+///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
+///
+/// * The memory pointed to by the C string returned in `ppMessage` is owned by
+///   the adapter and *must* be null terminated.
+///
+/// * The application *may* call this function from simultaneous threads.
+///
+/// * The implementation of this function *should* be lock-free.
+///
+/// Example usage:
+///
+/// ```cpp
+/// if (::urQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
+///         ::UR_RESULT_ERROR_ADAPTER_SPECIFIC) {
+///     const char* pMessage;
+///     int32_t error;
+///     ::urPlatformGetLastError(hPlatform, &pMessage, &error);
+/// }
+/// ```
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -623,11 +638,14 @@ urPlatformGetBackendOption(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
+///         + `NULL == pError`
 UR_APIEXPORT ur_result_t UR_APICALL
-urGetLastResult(
+urPlatformGetLastError(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **ppMessage          ///< [out] pointer to a string containing adapter specific result in string
-                                    ///< representation.
+    const char **ppMessage,         ///< [out] pointer to a C string where the adapter specific error message
+                                    ///< will be stored.
+    int32_t *pError                 ///< [out] pointer to an integer where the adapter specific error code will
+                                    ///< be stored.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4768,7 +4786,6 @@ typedef enum ur_function_t {
     UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                                 ///< Enumerator for ::urPlatformGetApiVersion
     UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,                               ///< Enumerator for ::urPlatformGetNativeHandle
     UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,                       ///< Enumerator for ::urPlatformCreateWithNativeHandle
-    UR_FUNCTION_GET_LAST_RESULT = 77,                                          ///< Enumerator for ::urGetLastResult
     UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                                   ///< Enumerator for ::urProgramCreateWithIL
     UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,                               ///< Enumerator for ::urProgramCreateWithBinary
     UR_FUNCTION_PROGRAM_BUILD = 80,                                            ///< Enumerator for ::urProgramBuild
@@ -4838,6 +4855,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147,          ///< Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
     UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148,             ///< Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
     UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149,           ///< Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
+    UR_FUNCTION_PLATFORM_GET_LAST_ERROR = 150,                                 ///< Enumerator for ::urPlatformGetLastError
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -6952,6 +6970,16 @@ typedef struct ur_platform_create_with_native_handle_params_t {
 } ur_platform_create_with_native_handle_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urPlatformGetLastError
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_platform_get_last_error_params_t {
+    ur_platform_handle_t *phPlatform;
+    const char ***pppMessage;
+    int32_t **ppError;
+} ur_platform_get_last_error_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urPlatformGetApiVersion
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -8485,15 +8513,6 @@ typedef struct ur_command_buffer_enqueue_exp_params_t {
 typedef struct ur_init_params_t {
     ur_device_init_flags_t *pdevice_flags;
 } ur_init_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urGetLastResult
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_get_last_result_params_t {
-    ur_platform_handle_t *phPlatform;
-    const char ***pppMessage;
-} ur_get_last_result_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urTearDown

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -51,6 +51,13 @@ typedef ur_result_t(UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
     ur_platform_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urPlatformGetLastError
+typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetLastError_t)(
+    ur_platform_handle_t,
+    const char **,
+    int32_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urPlatformGetApiVersion
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetApiVersion_t)(
     ur_platform_handle_t,
@@ -70,6 +77,7 @@ typedef struct ur_platform_dditable_t {
     ur_pfnPlatformGetInfo_t pfnGetInfo;
     ur_pfnPlatformGetNativeHandle_t pfnGetNativeHandle;
     ur_pfnPlatformCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnPlatformGetLastError_t pfnGetLastError;
     ur_pfnPlatformGetApiVersion_t pfnGetApiVersion;
     ur_pfnPlatformGetBackendOption_t pfnGetBackendOption;
 } ur_platform_dditable_t;
@@ -1665,12 +1673,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnInit_t)(
     ur_device_init_flags_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetLastResult
-typedef ur_result_t(UR_APICALL *ur_pfnGetLastResult_t)(
-    ur_platform_handle_t,
-    const char **);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urTearDown
 typedef ur_result_t(UR_APICALL *ur_pfnTearDown_t)(
     void *);
@@ -1679,7 +1681,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnTearDown_t)(
 /// @brief Table of Global functions pointers
 typedef struct ur_global_dditable_t {
     ur_pfnInit_t pfnInit;
-    ur_pfnGetLastResult_t pfnGetLastResult;
     ur_pfnTearDown_t pfnTearDown;
 } ur_global_dditable_t;
 

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -222,33 +222,54 @@ returns:
       - "If `pFrontendOption` is not a valid frontend option."
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Retrieve string representation of the underlying adapter specific result
-       reported by the the last API that returned UR_RESULT_ADAPTER_SPECIFIC.
-       Allows for an adapter independent way to return an adapter
-       specific result."
-class: $x
-name: GetLastResult
+desc: "Get the last adapter specific error."
+details: |
+    To be used after another entry-point has returned
+    $X_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
+    the circumstances of the underlying driver error and the error code
+    returned by the failed driver entry-point.
+
+    * Implementations *must* store the message and error code in thread-local
+      storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.
+
+    * The message and error code storage is will only be valid if a previously
+      called entry-point returned $X_RESULT_ERROR_ADAPTER_SPECIFIC.
+
+    * The memory pointed to by the C string returned in `ppMessage` is owned by
+      the adapter and *must* be null terminated.
+
+    * The application *may* call this function from simultaneous threads.
+
+    * The implementation of this function *should* be lock-free.
+
+    Example usage:
+
+    ```cpp
+    if ($xQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
+            $X_RESULT_ERROR_ADAPTER_SPECIFIC) {
+        const char* pMessage;
+        int32_t error;
+        $xPlatformGetLastError(hPlatform, &pMessage, &error);
+    }
+    ```
+class: $xPlatform
+name: GetLastError
 decl: static
 ordinal: "0"
-details:
-    - "The string returned via the ppMessage is a NULL terminated C style string."
-    - "The string returned via the ppMessage is thread local."
-    - "The entry point will return UR_RESULT_SUCCESS if the result being
-       reported is to be considered a warning. Any other result code returned
-       indicates that the adapter specific result is an error."
-    -  "The memory in the string returned via the ppMessage is owned by the
-       adapter."
-    - "The application may call this function from simultaneous
-       threads."
-    - "The implementation of this function should be lock-free."
 params:
     - type: $x_platform_handle_t
       name: hPlatform
       desc: "[in] handle of the platform instance"
     - type: const char**
       name: ppMessage
-      desc: "[out] pointer to a string containing adapter specific result
-             in string representation."
+      desc: >
+          [out] pointer to a C string where the adapter specific error message
+          will be stored.
+    - type: int32_t*
+      name: pError
+      desc: >
+          [out] pointer to an integer where the adapter specific error code
+          will be stored.
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Identifies native backend adapters"

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -235,9 +235,6 @@ etors:
 - name: PLATFORM_CREATE_WITH_NATIVE_HANDLE
   desc: Enumerator for $xPlatformCreateWithNativeHandle
   value: '76'
-- name: GET_LAST_RESULT
-  desc: Enumerator for $xGetLastResult
-  value: '77'
 - name: PROGRAM_CREATE_WITH_IL
   desc: Enumerator for $xProgramCreateWithIL
   value: '78'
@@ -445,3 +442,6 @@ etors:
 - name: BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP
   desc: Enumerator for $xBindlessImagesSignalExternalSemaphoreExp
   value: '149'
+- name: PLATFORM_GET_LAST_ERROR
+  desc: Enumerator for $xPlatformGetLastError
+  value: '150'

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -8352,10 +8352,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         os << "UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE";
         break;
 
-    case UR_FUNCTION_GET_LAST_RESULT:
-        os << "UR_FUNCTION_GET_LAST_RESULT";
-        break;
-
     case UR_FUNCTION_PROGRAM_CREATE_WITH_IL:
         os << "UR_FUNCTION_PROGRAM_CREATE_WITH_IL";
         break;
@@ -8632,6 +8628,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP";
         break;
+
+    case UR_FUNCTION_PLATFORM_GET_LAST_ERROR:
+        os << "UR_FUNCTION_PLATFORM_GET_LAST_ERROR";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -8876,21 +8876,6 @@ inline std::ostream &operator<<(std::ostream &os,
 
     ur_params::serializeFlag<ur_device_init_flag_t>(os,
                                                     *(params->pdevice_flags));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_get_last_result_params_t *params) {
-
-    os << ".hPlatform = ";
-
-    ur_params::serializePtr(os, *(params->phPlatform));
-
-    os << ", ";
-    os << ".ppMessage = ";
-
-    ur_params::serializePtr(os, *(params->pppMessage));
 
     return os;
 }
@@ -12203,6 +12188,27 @@ inline std::ostream &operator<<(
 
 inline std::ostream &
 operator<<(std::ostream &os,
+           const struct ur_platform_get_last_error_params_t *params) {
+
+    os << ".hPlatform = ";
+
+    ur_params::serializePtr(os, *(params->phPlatform));
+
+    os << ", ";
+    os << ".ppMessage = ";
+
+    ur_params::serializePtr(os, *(params->pppMessage));
+
+    os << ", ";
+    os << ".pError = ";
+
+    ur_params::serializePtr(os, *(params->ppError));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
            const struct ur_platform_get_api_version_params_t *params) {
 
     os << ".hPlatform = ";
@@ -13347,9 +13353,6 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     case UR_FUNCTION_INIT: {
         os << (const struct ur_init_params_t *)params;
     } break;
-    case UR_FUNCTION_GET_LAST_RESULT: {
-        os << (const struct ur_get_last_result_params_t *)params;
-    } break;
     case UR_FUNCTION_TEAR_DOWN: {
         os << (const struct ur_tear_down_params_t *)params;
     } break;
@@ -13672,6 +13675,9 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     case UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE: {
         os << (const struct ur_platform_create_with_native_handle_params_t *)
                 params;
+    } break;
+    case UR_FUNCTION_PLATFORM_GET_LAST_ERROR: {
+        os << (const struct ur_platform_get_last_error_params_t *)params;
     } break;
     case UR_FUNCTION_PLATFORM_GET_API_VERSION: {
         os << (const struct ur_platform_get_api_version_params_t *)params;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -325,22 +325,37 @@ ur_result_t UR_APICALL urPlatformGetBackendOption(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Retrieve string representation of the underlying adapter specific
-///        result reported by the the last API that returned
-///        UR_RESULT_ADAPTER_SPECIFIC. Allows for an adapter independent way to
-///        return an adapter specific result.
+/// @brief Get the last adapter specific error.
 ///
 /// @details
-///     - The string returned via the ppMessage is a NULL terminated C style
-///       string.
-///     - The string returned via the ppMessage is thread local.
-///     - The entry point will return UR_RESULT_SUCCESS if the result being
-///       reported is to be considered a warning. Any other result code returned
-///       indicates that the adapter specific result is an error.
-///     - The memory in the string returned via the ppMessage is owned by the
-///       adapter.
-///     - The application may call this function from simultaneous threads.
-///     - The implementation of this function should be lock-free.
+/// To be used after another entry-point has returned
+/// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
+/// the circumstances of the underlying driver error and the error code
+/// returned by the failed driver entry-point.
+///
+/// * Implementations *must* store the message and error code in thread-local
+///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
+///
+/// * The message and error code storage is will only be valid if a previously
+///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
+///
+/// * The memory pointed to by the C string returned in `ppMessage` is owned by
+///   the adapter and *must* be null terminated.
+///
+/// * The application *may* call this function from simultaneous threads.
+///
+/// * The implementation of this function *should* be lock-free.
+///
+/// Example usage:
+///
+/// ```cpp
+/// if (::urQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
+///         ::UR_RESULT_ERROR_ADAPTER_SPECIFIC) {
+///     const char* pMessage;
+///     int32_t error;
+///     ::urPlatformGetLastError(hPlatform, &pMessage, &error);
+/// }
+/// ```
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -350,18 +365,22 @@ ur_result_t UR_APICALL urPlatformGetBackendOption(
 ///         + `NULL == hPlatform`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
-ur_result_t UR_APICALL urGetLastResult(
+///         + `NULL == pError`
+ur_result_t UR_APICALL urPlatformGetLastError(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     const char **
-        ppMessage ///< [out] pointer to a string containing adapter specific result in string
-                  ///< representation.
+        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
+                   ///< will be stored.
+    int32_t *
+        pError ///< [out] pointer to an integer where the adapter specific error code will
+               ///< be stored.
     ) try {
-    auto pfnGetLastResult = ur_lib::context->urDdiTable.Global.pfnGetLastResult;
-    if (nullptr == pfnGetLastResult) {
+    auto pfnGetLastError = ur_lib::context->urDdiTable.Platform.pfnGetLastError;
+    if (nullptr == pfnGetLastError) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnGetLastResult(hPlatform, ppMessage);
+    return pfnGetLastError(hPlatform, ppMessage, pError);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }


### PR DESCRIPTION
Remove the `urGetLastResult()` entry-point and replace it with
`urPlatformGetLastError()`. This primary difference is the addition of
the `pError` out parameter which returns an error code emitted from a
failed driver entry-point which resulted in a Unified Runtime
entry-point returning `UR_RESULT_ERROR_ADAPTER_SPECIFIC`.

Fixes #500.
