### PR TITLE
[Exp][Bindless Images] Experimental Bindless Images

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -232,6 +232,7 @@ class ur_structure_type_v(IntEnum):
     QUEUE_NATIVE_DESC = 25                          ## ::ur_queue_native_desc_t
     DEVICE_PARTITION_PROPERTIES = 26                ## ::ur_device_partition_properties_t
     EXP_COMMAND_BUFFER_DESC = 27                    ## ::ur_exp_command_buffer_desc_t
+    EXP_SAMPLER_MIP_PROPERTIES = 28                 ## ::ur_exp_sampler_mip_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -572,6 +573,38 @@ class ur_device_info_v(IntEnum):
     IP_VERSION = 113                                ## [uint32_t] The device IP version. The meaning of the device IP version
                                                     ## is implementation-defined, but newer devices should have a higher
                                                     ## version than older devices.
+    BINDLESS_IMAGES_SUPPORT_EXP = 0x2000            ## [::ur_bool_t] returns true if the device supports the creation of
+                                                    ## bindless images
+    BINDLESS_IMAGES_1D_USM_SUPPORT_EXP = 0x2001     ## [::ur_bool_t] returns true if the device supports the creation of 1D
+                                                    ## bindless images backed by USM
+    BINDLESS_IMAGES_2D_USM_SUPPORT_EXP = 0x2002     ## [::ur_bool_t] returns true if the device supports the creation of 2D
+                                                    ## bindless images backed by USM
+    BINDLESS_IMAGES_3D_USM_SUPPORT_EXP = 0x2003     ## [::ur_bool_t] returns true if the device supports the creation of 3D
+                                                    ## bindless images backed by USM
+    IMAGE_PITCH_ALIGN_EXP = 0x2004                  ## [uint32_t] returns the required alignment of the pitch between two
+                                                    ## rows of an image in bytes
+    MAX_IMAGE_LINEAR_WIDTH_EXP = 0x2005             ## [size_t] returns the maximum linear width allowed for images allocated
+                                                    ## using USM
+    MAX_IMAGE_LINEAR_HEIGHT_EXP = 0x2006            ## [size_t] returns the maximum linear height allowed for images
+                                                    ## allocated using USM
+    MAX_IMAGE_LINEAR_PITCH_EXP = 0x2007             ## [size_t] returns the maximum linear pitch allowed for images allocated
+                                                    ## using USM
+    MIPMAP_SUPPORT_EXP = 0x2008                     ## [::ur_bool_t] returns true if the device supports allocating mipmap
+                                                    ## resources
+    MIPMAP_ANISOTROPY_SUPPORT_EXP = 0x2009          ## [::ur_bool_t] returns true if the device supports sampling mipmap
+                                                    ## images with anisotropic filtering
+    MIPMAP_MAX_ANISOTROPY_EXP = 0x200A              ## [uint32_t] returns the maximum anisotropic ratio supported by the
+                                                    ## device
+    MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP = 0x200B     ## [::ur_bool_t] returns true if the device supports using images created
+                                                    ## from individual mipmap levels
+    INTEROP_MEMORY_IMPORT_SUPPORT_EXP = 0x200C      ## [::ur_bool_t] returns true if the device supports importing external
+                                                    ## memory resources
+    INTEROP_MEMORY_EXPORT_SUPPORT_EXP = 0x200D      ## [::ur_bool_t] returns true if the device supports exporting internal
+                                                    ## memory resources
+    INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP = 0x200E   ## [::ur_bool_t] returns true if the device supports importing external
+                                                    ## semaphore resources
+    INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP = 0x200F   ## [::ur_bool_t] returns true if the device supports exporting internal
+                                                    ## event resources
 
 class ur_device_info_t(c_int):
     def __str__(self):
@@ -1613,6 +1646,8 @@ class ur_command_v(IntEnum):
     READ_HOST_PIPE = 25                             ## Event created by ::urEnqueueReadHostPipe
     WRITE_HOST_PIPE = 26                            ## Event created by ::urEnqueueWriteHostPipe
     COMMAND_BUFFER_ENQUEUE_EXP = 27                 ## Event created by ::urCommandBufferEnqueueExp
+    INTEROP_SEMAPHORE_WAIT_EXP = 0x2000             ## Event created by ::urBindlessImagesWaitExternalSemaphoreExp
+    INTEROP_SEMAPHORE_SIGNAL_EXP = 0x2001           ## Event created by ::urBindlessImagesSignalExternalSemaphoreExp
 
 class ur_command_t(c_int):
     def __str__(self):
@@ -1834,6 +1869,24 @@ class ur_function_v(IntEnum):
     COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129      ## Enumerator for ::urCommandBufferAppendMemcpyUSMExp
     COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130  ## Enumerator for ::urCommandBufferAppendMembufferCopyExp
     COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP = 131 ## Enumerator for ::urCommandBufferAppendMembufferCopyRectExp
+    USM_PITCHED_ALLOC_EXP = 132                     ## Enumerator for ::urUSMPitchedAllocExp
+    BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP = 133## Enumerator for ::urBindlessImagesUnsampledImageHandleDestroyExp
+    BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP = 134  ## Enumerator for ::urBindlessImagesSampledImageHandleDestroyExp
+    BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP = 135        ## Enumerator for ::urBindlessImagesImageAllocateExp
+    BINDLESS_IMAGES_IMAGE_FREE_EXP = 136            ## Enumerator for ::urBindlessImagesImageFreeExp
+    BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP = 137## Enumerator for ::urBindlessImagesUnsampledImageCreateExp
+    BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP = 138  ## Enumerator for ::urBindlessImagesSampledImageCreateExp
+    BINDLESS_IMAGES_IMAGE_COPY_EXP = 139            ## Enumerator for ::urBindlessImagesImageCopyExp
+    BINDLESS_IMAGES_IMAGE_GET_INFO_EXP = 140        ## Enumerator for ::urBindlessImagesImageGetInfoExp
+    BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP = 141      ## Enumerator for ::urBindlessImagesMipmapGetLevelExp
+    BINDLESS_IMAGES_MIPMAP_FREE_EXP = 142           ## Enumerator for ::urBindlessImagesMipmapFreeExp
+    BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP = 143      ## Enumerator for ::urBindlessImagesImportOpaqueFDExp
+    BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP = 144    ## Enumerator for ::urBindlessImagesMapExternalArrayExp
+    BINDLESS_IMAGES_RELEASE_INTEROP_EXP = 145       ## Enumerator for ::urBindlessImagesReleaseInteropExp
+    BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP = 146   ## Enumerator for ::urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+    BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147## Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
+    BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148   ## Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
+    BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149 ## Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -1861,6 +1914,57 @@ class ur_usm_migration_flags_t(c_int):
     def __str__(self):
         return hex(self.value)
 
+
+###############################################################################
+## @brief Handle of bindless image
+class ur_exp_image_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of bindless image memory
+class ur_exp_image_mem_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of interop memory
+class ur_exp_interop_mem_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Handle of interop semaphore
+class ur_exp_interop_semaphore_handle_t(c_void_p):
+    pass
+
+###############################################################################
+## @brief Dictates the type of memory copy.
+class ur_exp_image_copy_flags_v(IntEnum):
+    HOST_TO_DEVICE = UR_BIT(0)                      ## Host to device.
+    DEVICE_TO_HOST = UR_BIT(1)                      ## Device to host
+    DEVICE_TO_DEVICE = UR_BIT(2)                    ## Device to device
+
+class ur_exp_image_copy_flags_t(c_int):
+    def __str__(self):
+        return hex(self.value)
+
+
+###############################################################################
+## @brief Describes mipmap sampler properties
+## 
+## @details
+##     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
+##       as part of a `pNext` chain.
+class ur_exp_sampler_mip_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("minMipmapLevelClamp", c_float),                               ## [in] minimum mipmap level from which we can sample, minimum value
+                                                                        ## being 0
+        ("maxMipmapLevelClamp", c_float),                               ## [in] maximum mipmap level from which we can sample, maximum value
+                                                                        ## being the number of levels
+        ("maxAnistropy", c_float)                                       ## [in] anisotropic ratio used when samplling the mipmap with anisotropic
+                                                                        ## filtering
+    ]
 
 ###############################################################################
 ## @brief The extension string which defines support for command-buffers which
@@ -2738,6 +2842,243 @@ class ur_queue_dditable_t(Structure):
     ]
 
 ###############################################################################
+## @brief Function-pointer for urBindlessImagesUnsampledImageHandleDestroyExp
+if __use_win_types:
+    _urBindlessImagesUnsampledImageHandleDestroyExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_handle_t )
+else:
+    _urBindlessImagesUnsampledImageHandleDestroyExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesSampledImageHandleDestroyExp
+if __use_win_types:
+    _urBindlessImagesSampledImageHandleDestroyExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_handle_t )
+else:
+    _urBindlessImagesSampledImageHandleDestroyExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesImageAllocateExp
+if __use_win_types:
+    _urBindlessImagesImageAllocateExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), POINTER(ur_exp_image_mem_handle_t) )
+else:
+    _urBindlessImagesImageAllocateExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), POINTER(ur_exp_image_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesImageFreeExp
+if __use_win_types:
+    _urBindlessImagesImageFreeExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t )
+else:
+    _urBindlessImagesImageFreeExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesUnsampledImageCreateExp
+if __use_win_types:
+    _urBindlessImagesUnsampledImageCreateExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), POINTER(ur_mem_handle_t), POINTER(ur_exp_image_handle_t) )
+else:
+    _urBindlessImagesUnsampledImageCreateExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), POINTER(ur_mem_handle_t), POINTER(ur_exp_image_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesSampledImageCreateExp
+if __use_win_types:
+    _urBindlessImagesSampledImageCreateExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), ur_sampler_handle_t, POINTER(ur_mem_handle_t), POINTER(ur_exp_image_handle_t) )
+else:
+    _urBindlessImagesSampledImageCreateExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), ur_sampler_handle_t, POINTER(ur_mem_handle_t), POINTER(ur_exp_image_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesImageCopyExp
+if __use_win_types:
+    _urBindlessImagesImageCopyExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_void_p, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), ur_exp_image_copy_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urBindlessImagesImageCopyExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, c_void_p, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), ur_exp_image_copy_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesImageGetInfoExp
+if __use_win_types:
+    _urBindlessImagesImageGetInfoExp_t = WINFUNCTYPE( ur_result_t, ur_exp_image_mem_handle_t, ur_image_info_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urBindlessImagesImageGetInfoExp_t = CFUNCTYPE( ur_result_t, ur_exp_image_mem_handle_t, ur_image_info_t, c_void_p, POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesMipmapGetLevelExp
+if __use_win_types:
+    _urBindlessImagesMipmapGetLevelExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t, c_ulong, POINTER(ur_exp_image_mem_handle_t) )
+else:
+    _urBindlessImagesMipmapGetLevelExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t, c_ulong, POINTER(ur_exp_image_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesMipmapFreeExp
+if __use_win_types:
+    _urBindlessImagesMipmapFreeExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t )
+else:
+    _urBindlessImagesMipmapFreeExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_image_mem_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesImportOpaqueFDExp
+if __use_win_types:
+    _urBindlessImagesImportOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_size_t, c_ulong, POINTER(ur_exp_interop_mem_handle_t) )
+else:
+    _urBindlessImagesImportOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_size_t, c_ulong, POINTER(ur_exp_interop_mem_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesMapExternalArrayExp
+if __use_win_types:
+    _urBindlessImagesMapExternalArrayExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), ur_exp_interop_mem_handle_t, POINTER(ur_exp_image_handle_t) )
+else:
+    _urBindlessImagesMapExternalArrayExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_image_format_t), POINTER(ur_image_desc_t), ur_exp_interop_mem_handle_t, POINTER(ur_exp_image_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesReleaseInteropExp
+if __use_win_types:
+    _urBindlessImagesReleaseInteropExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_interop_mem_handle_t )
+else:
+    _urBindlessImagesReleaseInteropExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_interop_mem_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+if __use_win_types:
+    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_exp_interop_semaphore_handle_t) )
+else:
+    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_ulong, POINTER(ur_exp_interop_semaphore_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesDestroyExternalSemaphoreExp
+if __use_win_types:
+    _urBindlessImagesDestroyExternalSemaphoreExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_interop_semaphore_handle_t )
+else:
+    _urBindlessImagesDestroyExternalSemaphoreExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_exp_interop_semaphore_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesWaitExternalSemaphoreExp
+if __use_win_types:
+    _urBindlessImagesWaitExternalSemaphoreExp_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_exp_interop_semaphore_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urBindlessImagesWaitExternalSemaphoreExp_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_exp_interop_semaphore_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urBindlessImagesSignalExternalSemaphoreExp
+if __use_win_types:
+    _urBindlessImagesSignalExternalSemaphoreExp_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_exp_interop_semaphore_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+else:
+    _urBindlessImagesSignalExternalSemaphoreExp_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, ur_exp_interop_semaphore_handle_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
+
+
+###############################################################################
+## @brief Table of BindlessImagesExp functions pointers
+class ur_bindless_images_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnUnsampledImageHandleDestroyExp", c_void_p),                ## _urBindlessImagesUnsampledImageHandleDestroyExp_t
+        ("pfnSampledImageHandleDestroyExp", c_void_p),                  ## _urBindlessImagesSampledImageHandleDestroyExp_t
+        ("pfnImageAllocateExp", c_void_p),                              ## _urBindlessImagesImageAllocateExp_t
+        ("pfnImageFreeExp", c_void_p),                                  ## _urBindlessImagesImageFreeExp_t
+        ("pfnUnsampledImageCreateExp", c_void_p),                       ## _urBindlessImagesUnsampledImageCreateExp_t
+        ("pfnSampledImageCreateExp", c_void_p),                         ## _urBindlessImagesSampledImageCreateExp_t
+        ("pfnImageCopyExp", c_void_p),                                  ## _urBindlessImagesImageCopyExp_t
+        ("pfnImageGetInfoExp", c_void_p),                               ## _urBindlessImagesImageGetInfoExp_t
+        ("pfnMipmapGetLevelExp", c_void_p),                             ## _urBindlessImagesMipmapGetLevelExp_t
+        ("pfnMipmapFreeExp", c_void_p),                                 ## _urBindlessImagesMipmapFreeExp_t
+        ("pfnImportOpaqueFDExp", c_void_p),                             ## _urBindlessImagesImportOpaqueFDExp_t
+        ("pfnMapExternalArrayExp", c_void_p),                           ## _urBindlessImagesMapExternalArrayExp_t
+        ("pfnReleaseInteropExp", c_void_p),                             ## _urBindlessImagesReleaseInteropExp_t
+        ("pfnImportExternalSemaphoreOpaqueFDExp", c_void_p),            ## _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t
+        ("pfnDestroyExternalSemaphoreExp", c_void_p),                   ## _urBindlessImagesDestroyExternalSemaphoreExp_t
+        ("pfnWaitExternalSemaphoreExp", c_void_p),                      ## _urBindlessImagesWaitExternalSemaphoreExp_t
+        ("pfnSignalExternalSemaphoreExp", c_void_p)                     ## _urBindlessImagesSignalExternalSemaphoreExp_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urUSMHostAlloc
+if __use_win_types:
+    _urUSMHostAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
+else:
+    _urUSMHostAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urUSMDeviceAlloc
+if __use_win_types:
+    _urUSMDeviceAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
+else:
+    _urUSMDeviceAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urUSMSharedAlloc
+if __use_win_types:
+    _urUSMSharedAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
+else:
+    _urUSMSharedAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
+
+###############################################################################
+## @brief Function-pointer for urUSMFree
+if __use_win_types:
+    _urUSMFree_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+else:
+    _urUSMFree_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
+
+###############################################################################
+## @brief Function-pointer for urUSMGetMemAllocInfo
+if __use_win_types:
+    _urUSMGetMemAllocInfo_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_usm_alloc_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urUSMGetMemAllocInfo_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_usm_alloc_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+
+###############################################################################
+## @brief Function-pointer for urUSMPoolCreate
+if __use_win_types:
+    _urUSMPoolCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_pool_desc_t), POINTER(ur_usm_pool_handle_t) )
+else:
+    _urUSMPoolCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_pool_desc_t), POINTER(ur_usm_pool_handle_t) )
+
+###############################################################################
+## @brief Function-pointer for urUSMPoolRetain
+if __use_win_types:
+    _urUSMPoolRetain_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
+else:
+    _urUSMPoolRetain_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urUSMPoolRelease
+if __use_win_types:
+    _urUSMPoolRelease_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
+else:
+    _urUSMPoolRelease_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
+
+###############################################################################
+## @brief Function-pointer for urUSMPoolGetInfo
+if __use_win_types:
+    _urUSMPoolGetInfo_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+else:
+    _urUSMPoolGetInfo_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
+
+
+###############################################################################
+## @brief Table of USM functions pointers
+class ur_usm_dditable_t(Structure):
+    _fields_ = [
+        ("pfnHostAlloc", c_void_p),                                     ## _urUSMHostAlloc_t
+        ("pfnDeviceAlloc", c_void_p),                                   ## _urUSMDeviceAlloc_t
+        ("pfnSharedAlloc", c_void_p),                                   ## _urUSMSharedAlloc_t
+        ("pfnFree", c_void_p),                                          ## _urUSMFree_t
+        ("pfnGetMemAllocInfo", c_void_p),                               ## _urUSMGetMemAllocInfo_t
+        ("pfnPoolCreate", c_void_p),                                    ## _urUSMPoolCreate_t
+        ("pfnPoolRetain", c_void_p),                                    ## _urUSMPoolRetain_t
+        ("pfnPoolRelease", c_void_p),                                   ## _urUSMPoolRelease_t
+        ("pfnPoolGetInfo", c_void_p)                                    ## _urUSMPoolGetInfo_t
+    ]
+
+###############################################################################
+## @brief Function-pointer for urUSMPitchedAllocExp
+if __use_win_types:
+    _urUSMPitchedAllocExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, c_size_t, c_size_t, POINTER(c_void_p), POINTER(c_size_t) )
+else:
+    _urUSMPitchedAllocExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, c_size_t, c_size_t, POINTER(c_void_p), POINTER(c_size_t) )
+
+
+###############################################################################
+## @brief Table of USMExp functions pointers
+class ur_usm_exp_dditable_t(Structure):
+    _fields_ = [
+        ("pfnPitchedAllocExp", c_void_p)                                ## _urUSMPitchedAllocExp_t
+    ]
+
+###############################################################################
 ## @brief Function-pointer for urCommandBufferCreateExp
 if __use_win_types:
     _urCommandBufferCreateExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_exp_command_buffer_desc_t), POINTER(ur_exp_command_buffer_handle_t) )
@@ -2848,85 +3189,6 @@ class ur_global_dditable_t(Structure):
     ]
 
 ###############################################################################
-## @brief Function-pointer for urUSMHostAlloc
-if __use_win_types:
-    _urUSMHostAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
-else:
-    _urUSMHostAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
-
-###############################################################################
-## @brief Function-pointer for urUSMDeviceAlloc
-if __use_win_types:
-    _urUSMDeviceAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
-else:
-    _urUSMDeviceAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
-
-###############################################################################
-## @brief Function-pointer for urUSMSharedAlloc
-if __use_win_types:
-    _urUSMSharedAlloc_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
-else:
-    _urUSMSharedAlloc_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_usm_desc_t), ur_usm_pool_handle_t, c_size_t, POINTER(c_void_p) )
-
-###############################################################################
-## @brief Function-pointer for urUSMFree
-if __use_win_types:
-    _urUSMFree_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
-else:
-    _urUSMFree_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
-
-###############################################################################
-## @brief Function-pointer for urUSMGetMemAllocInfo
-if __use_win_types:
-    _urUSMGetMemAllocInfo_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_usm_alloc_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
-else:
-    _urUSMGetMemAllocInfo_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_usm_alloc_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
-
-###############################################################################
-## @brief Function-pointer for urUSMPoolCreate
-if __use_win_types:
-    _urUSMPoolCreate_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_pool_desc_t), POINTER(ur_usm_pool_handle_t) )
-else:
-    _urUSMPoolCreate_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, POINTER(ur_usm_pool_desc_t), POINTER(ur_usm_pool_handle_t) )
-
-###############################################################################
-## @brief Function-pointer for urUSMPoolRetain
-if __use_win_types:
-    _urUSMPoolRetain_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
-else:
-    _urUSMPoolRetain_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
-
-###############################################################################
-## @brief Function-pointer for urUSMPoolRelease
-if __use_win_types:
-    _urUSMPoolRelease_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
-else:
-    _urUSMPoolRelease_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t )
-
-###############################################################################
-## @brief Function-pointer for urUSMPoolGetInfo
-if __use_win_types:
-    _urUSMPoolGetInfo_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
-else:
-    _urUSMPoolGetInfo_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, ur_usm_pool_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
-
-
-###############################################################################
-## @brief Table of USM functions pointers
-class ur_usm_dditable_t(Structure):
-    _fields_ = [
-        ("pfnHostAlloc", c_void_p),                                     ## _urUSMHostAlloc_t
-        ("pfnDeviceAlloc", c_void_p),                                   ## _urUSMDeviceAlloc_t
-        ("pfnSharedAlloc", c_void_p),                                   ## _urUSMSharedAlloc_t
-        ("pfnFree", c_void_p),                                          ## _urUSMFree_t
-        ("pfnGetMemAllocInfo", c_void_p),                               ## _urUSMGetMemAllocInfo_t
-        ("pfnPoolCreate", c_void_p),                                    ## _urUSMPoolCreate_t
-        ("pfnPoolRetain", c_void_p),                                    ## _urUSMPoolRetain_t
-        ("pfnPoolRelease", c_void_p),                                   ## _urUSMPoolRelease_t
-        ("pfnPoolGetInfo", c_void_p)                                    ## _urUSMPoolGetInfo_t
-    ]
-
-###############################################################################
 ## @brief Function-pointer for urDeviceGet
 if __use_win_types:
     _urDeviceGet_t = WINFUNCTYPE( ur_result_t, ur_platform_handle_t, ur_device_type_t, c_ulong, POINTER(ur_device_handle_t), POINTER(c_ulong) )
@@ -3017,9 +3279,11 @@ class ur_dditable_t(Structure):
         ("Mem", ur_mem_dditable_t),
         ("Enqueue", ur_enqueue_dditable_t),
         ("Queue", ur_queue_dditable_t),
+        ("BindlessImagesExp", ur_bindless_images_exp_dditable_t),
+        ("USM", ur_usm_dditable_t),
+        ("USMExp", ur_usm_exp_dditable_t),
         ("CommandBufferExp", ur_command_buffer_exp_dditable_t),
         ("Global", ur_global_dditable_t),
-        ("USM", ur_usm_dditable_t),
         ("Device", ur_device_dditable_t)
     ]
 
@@ -3219,6 +3483,60 @@ class UR_DDI:
         self.urQueueFlush = _urQueueFlush_t(self.__dditable.Queue.pfnFlush)
 
         # call driver to get function pointers
+        BindlessImagesExp = ur_bindless_images_exp_dditable_t()
+        r = ur_result_v(self.__dll.urGetBindlessImagesExpProcAddrTable(version, byref(BindlessImagesExp)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.BindlessImagesExp = BindlessImagesExp
+
+        # attach function interface to function address
+        self.urBindlessImagesUnsampledImageHandleDestroyExp = _urBindlessImagesUnsampledImageHandleDestroyExp_t(self.__dditable.BindlessImagesExp.pfnUnsampledImageHandleDestroyExp)
+        self.urBindlessImagesSampledImageHandleDestroyExp = _urBindlessImagesSampledImageHandleDestroyExp_t(self.__dditable.BindlessImagesExp.pfnSampledImageHandleDestroyExp)
+        self.urBindlessImagesImageAllocateExp = _urBindlessImagesImageAllocateExp_t(self.__dditable.BindlessImagesExp.pfnImageAllocateExp)
+        self.urBindlessImagesImageFreeExp = _urBindlessImagesImageFreeExp_t(self.__dditable.BindlessImagesExp.pfnImageFreeExp)
+        self.urBindlessImagesUnsampledImageCreateExp = _urBindlessImagesUnsampledImageCreateExp_t(self.__dditable.BindlessImagesExp.pfnUnsampledImageCreateExp)
+        self.urBindlessImagesSampledImageCreateExp = _urBindlessImagesSampledImageCreateExp_t(self.__dditable.BindlessImagesExp.pfnSampledImageCreateExp)
+        self.urBindlessImagesImageCopyExp = _urBindlessImagesImageCopyExp_t(self.__dditable.BindlessImagesExp.pfnImageCopyExp)
+        self.urBindlessImagesImageGetInfoExp = _urBindlessImagesImageGetInfoExp_t(self.__dditable.BindlessImagesExp.pfnImageGetInfoExp)
+        self.urBindlessImagesMipmapGetLevelExp = _urBindlessImagesMipmapGetLevelExp_t(self.__dditable.BindlessImagesExp.pfnMipmapGetLevelExp)
+        self.urBindlessImagesMipmapFreeExp = _urBindlessImagesMipmapFreeExp_t(self.__dditable.BindlessImagesExp.pfnMipmapFreeExp)
+        self.urBindlessImagesImportOpaqueFDExp = _urBindlessImagesImportOpaqueFDExp_t(self.__dditable.BindlessImagesExp.pfnImportOpaqueFDExp)
+        self.urBindlessImagesMapExternalArrayExp = _urBindlessImagesMapExternalArrayExp_t(self.__dditable.BindlessImagesExp.pfnMapExternalArrayExp)
+        self.urBindlessImagesReleaseInteropExp = _urBindlessImagesReleaseInteropExp_t(self.__dditable.BindlessImagesExp.pfnReleaseInteropExp)
+        self.urBindlessImagesImportExternalSemaphoreOpaqueFDExp = _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t(self.__dditable.BindlessImagesExp.pfnImportExternalSemaphoreOpaqueFDExp)
+        self.urBindlessImagesDestroyExternalSemaphoreExp = _urBindlessImagesDestroyExternalSemaphoreExp_t(self.__dditable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp)
+        self.urBindlessImagesWaitExternalSemaphoreExp = _urBindlessImagesWaitExternalSemaphoreExp_t(self.__dditable.BindlessImagesExp.pfnWaitExternalSemaphoreExp)
+        self.urBindlessImagesSignalExternalSemaphoreExp = _urBindlessImagesSignalExternalSemaphoreExp_t(self.__dditable.BindlessImagesExp.pfnSignalExternalSemaphoreExp)
+
+        # call driver to get function pointers
+        USM = ur_usm_dditable_t()
+        r = ur_result_v(self.__dll.urGetUSMProcAddrTable(version, byref(USM)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.USM = USM
+
+        # attach function interface to function address
+        self.urUSMHostAlloc = _urUSMHostAlloc_t(self.__dditable.USM.pfnHostAlloc)
+        self.urUSMDeviceAlloc = _urUSMDeviceAlloc_t(self.__dditable.USM.pfnDeviceAlloc)
+        self.urUSMSharedAlloc = _urUSMSharedAlloc_t(self.__dditable.USM.pfnSharedAlloc)
+        self.urUSMFree = _urUSMFree_t(self.__dditable.USM.pfnFree)
+        self.urUSMGetMemAllocInfo = _urUSMGetMemAllocInfo_t(self.__dditable.USM.pfnGetMemAllocInfo)
+        self.urUSMPoolCreate = _urUSMPoolCreate_t(self.__dditable.USM.pfnPoolCreate)
+        self.urUSMPoolRetain = _urUSMPoolRetain_t(self.__dditable.USM.pfnPoolRetain)
+        self.urUSMPoolRelease = _urUSMPoolRelease_t(self.__dditable.USM.pfnPoolRelease)
+        self.urUSMPoolGetInfo = _urUSMPoolGetInfo_t(self.__dditable.USM.pfnPoolGetInfo)
+
+        # call driver to get function pointers
+        USMExp = ur_usm_exp_dditable_t()
+        r = ur_result_v(self.__dll.urGetUSMExpProcAddrTable(version, byref(USMExp)))
+        if r != ur_result_v.SUCCESS:
+            raise Exception(r)
+        self.__dditable.USMExp = USMExp
+
+        # attach function interface to function address
+        self.urUSMPitchedAllocExp = _urUSMPitchedAllocExp_t(self.__dditable.USMExp.pfnPitchedAllocExp)
+
+        # call driver to get function pointers
         CommandBufferExp = ur_command_buffer_exp_dditable_t()
         r = ur_result_v(self.__dll.urGetCommandBufferExpProcAddrTable(version, byref(CommandBufferExp)))
         if r != ur_result_v.SUCCESS:
@@ -3247,24 +3565,6 @@ class UR_DDI:
         self.urInit = _urInit_t(self.__dditable.Global.pfnInit)
         self.urGetLastResult = _urGetLastResult_t(self.__dditable.Global.pfnGetLastResult)
         self.urTearDown = _urTearDown_t(self.__dditable.Global.pfnTearDown)
-
-        # call driver to get function pointers
-        USM = ur_usm_dditable_t()
-        r = ur_result_v(self.__dll.urGetUSMProcAddrTable(version, byref(USM)))
-        if r != ur_result_v.SUCCESS:
-            raise Exception(r)
-        self.__dditable.USM = USM
-
-        # attach function interface to function address
-        self.urUSMHostAlloc = _urUSMHostAlloc_t(self.__dditable.USM.pfnHostAlloc)
-        self.urUSMDeviceAlloc = _urUSMDeviceAlloc_t(self.__dditable.USM.pfnDeviceAlloc)
-        self.urUSMSharedAlloc = _urUSMSharedAlloc_t(self.__dditable.USM.pfnSharedAlloc)
-        self.urUSMFree = _urUSMFree_t(self.__dditable.USM.pfnFree)
-        self.urUSMGetMemAllocInfo = _urUSMGetMemAllocInfo_t(self.__dditable.USM.pfnGetMemAllocInfo)
-        self.urUSMPoolCreate = _urUSMPoolCreate_t(self.__dditable.USM.pfnPoolCreate)
-        self.urUSMPoolRetain = _urUSMPoolRetain_t(self.__dditable.USM.pfnPoolRetain)
-        self.urUSMPoolRelease = _urUSMPoolRelease_t(self.__dditable.USM.pfnPoolRelease)
-        self.urUSMPoolGetInfo = _urUSMPoolGetInfo_t(self.__dditable.USM.pfnPoolGetInfo)
 
         # call driver to get function pointers
         Device = ur_device_dditable_t()

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -256,6 +256,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC = 25,               ///< ::ur_queue_native_desc_t
     UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES = 26,     ///< ::ur_device_partition_properties_t
     UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC = 27,         ///< ::ur_exp_command_buffer_desc_t
+    UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES = 28,      ///< ::ur_exp_sampler_mip_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -782,156 +783,188 @@ urDeviceGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported device info
 typedef enum ur_device_info_t {
-    UR_DEVICE_INFO_TYPE = 0,                                    ///< [::ur_device_type_t] type of the device
-    UR_DEVICE_INFO_VENDOR_ID = 1,                               ///< [uint32_t] vendor Id of the device
-    UR_DEVICE_INFO_DEVICE_ID = 2,                               ///< [uint32_t] Id of the device
-    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,                       ///< [uint32_t] the number of compute units
-    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                ///< [uint32_t] max work item dimensions
-    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                     ///< [size_t[]] return an array of max work item sizes
-    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                     ///< [size_t] max work group size
-    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                        ///< [::ur_device_fp_capability_flags_t] single precision floating point
-                                                                ///< capability
-    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                          ///< [::ur_device_fp_capability_flags_t] half precision floating point
-                                                                ///< capability
-    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                        ///< [::ur_device_fp_capability_flags_t] double precision floating point
-                                                                ///< capability
-    UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,                       ///< [::ur_queue_flags_t] command queue properties supported by the device
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,            ///< [uint32_t] preferred vector width for char
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 12,           ///< [uint32_t] preferred vector width for short
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 13,             ///< [uint32_t] preferred vector width for int
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 14,            ///< [uint32_t] preferred vector width for long
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 15,           ///< [uint32_t] preferred vector width for float
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 16,          ///< [uint32_t] preferred vector width for double
-    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 17,            ///< [uint32_t] preferred vector width for half float
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 18,               ///< [uint32_t] native vector width for char
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 19,              ///< [uint32_t] native vector width for short
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 20,                ///< [uint32_t] native vector width for int
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 21,               ///< [uint32_t] native vector width for long
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 22,              ///< [uint32_t] native vector width for float
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 23,             ///< [uint32_t] native vector width for double
-    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 24,               ///< [uint32_t] native vector width for half float
-    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 25,                    ///< [uint32_t] max clock frequency in MHz
-    UR_DEVICE_INFO_MEMORY_CLOCK_RATE = 26,                      ///< [uint32_t] memory clock frequency in MHz
-    UR_DEVICE_INFO_ADDRESS_BITS = 27,                           ///< [uint32_t] address bits
-    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 28,                     ///< [uint64_t] max memory allocation size
-    UR_DEVICE_INFO_IMAGE_SUPPORTED = 29,                        ///< [::ur_bool_t] images are supported
-    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 30,                    ///< [uint32_t] max number of image objects arguments of a kernel declared
-                                                                ///< with the read_only qualifier
-    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 31,                   ///< [uint32_t] max number of image objects arguments of a kernel declared
-                                                                ///< with the write_only qualifier
-    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 32,              ///< [uint32_t] max number of image objects arguments of a kernel declared
-                                                                ///< with the read_write qualifier
-    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 33,                      ///< [size_t] max width of Image2D object
-    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 34,                     ///< [size_t] max heigh of Image2D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 35,                      ///< [size_t] max width of Image3D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 36,                     ///< [size_t] max height of Image3D object
-    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 37,                      ///< [size_t] max depth of Image3D object
-    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 38,                  ///< [size_t] max image buffer size
-    UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE = 39,                   ///< [size_t] max image array size
-    UR_DEVICE_INFO_MAX_SAMPLERS = 40,                           ///< [uint32_t] max number of samplers that can be used in a kernel
-    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 41,                     ///< [size_t] max size in bytes of all arguments passed to a kernel
-    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 42,                    ///< [uint32_t] memory base address alignment
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 43,                  ///< [::ur_device_mem_cache_type_t] global memory cache type
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 44,              ///< [uint32_t] global memory cache line size in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 45,                  ///< [uint64_t] size of global memory cache in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 46,                        ///< [uint64_t] size of global memory in bytes
-    UR_DEVICE_INFO_GLOBAL_MEM_FREE = 47,                        ///< [uint64_t] size of global memory which is free in bytes
-    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 48,               ///< [uint64_t] max constant buffer size in bytes
-    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,                      ///< [uint32_t] max number of __const declared arguments in a kernel
-    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,                         ///< [::ur_device_local_mem_type_t] local memory type
-    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,                         ///< [uint64_t] local memory size in bytes
-    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,               ///< [::ur_bool_t] support error correction to global and local memory
-    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                    ///< [::ur_bool_t] unified host device memory
-    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54,             ///< [size_t] profiling timer resolution in nanoseconds
-    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                          ///< [::ur_bool_t] little endian byte order
-    UR_DEVICE_INFO_AVAILABLE = 56,                              ///< [::ur_bool_t] device is available
-    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                     ///< [::ur_bool_t] device compiler is available
-    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                       ///< [::ur_bool_t] device linker is available
-    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,                 ///< [::ur_device_exec_capability_flags_t] device kernel execution
-                                                                ///< capability bit-field
-    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,             ///< [::ur_queue_flags_t] device command queue property bit-field
-    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,               ///< [::ur_queue_flags_t] host queue property bit-field
-    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                       ///< [char[]] a semi-colon separated list of built-in kernels
-    UR_DEVICE_INFO_PLATFORM = 63,                               ///< [::ur_platform_handle_t] the platform associated with the device
-    UR_DEVICE_INFO_REFERENCE_COUNT = 64,                        ///< [uint32_t] Reference count of the device object.
-                                                                ///< The reference count returned should be considered immediately stale.
-                                                                ///< It is unsuitable for general use in applications. This feature is
-                                                                ///< provided for identifying memory leaks.
-    UR_DEVICE_INFO_IL_VERSION = 65,                             ///< [char[]] IL version
-    UR_DEVICE_INFO_NAME = 66,                                   ///< [char[]] Device name
-    UR_DEVICE_INFO_VENDOR = 67,                                 ///< [char[]] Device vendor
-    UR_DEVICE_INFO_DRIVER_VERSION = 68,                         ///< [char[]] Driver version
-    UR_DEVICE_INFO_PROFILE = 69,                                ///< [char[]] Device profile
-    UR_DEVICE_INFO_VERSION = 70,                                ///< [char[]] Device version
-    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                ///< [char[]] Version of backend runtime
-    UR_DEVICE_INFO_EXTENSIONS = 72,                             ///< [char[]] Return a space separated list of extension names
-    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,                     ///< [size_t] Maximum size in bytes of internal printf buffer
-    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,            ///< [::ur_bool_t] prefer user synchronization when sharing object with
-                                                                ///< other API
-    UR_DEVICE_INFO_PARENT_DEVICE = 75,                          ///< [::ur_device_handle_t] return parent device handle
-    UR_DEVICE_INFO_SUPPORTED_PARTITIONS = 76,                   ///< [::ur_device_partition_t[]] Returns an array of partition types
-                                                                ///< supported by the device
-    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,              ///< [uint32_t] maximum number of sub-devices when the device is
-                                                                ///< partitioned
-    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,              ///< [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
-                                                                ///< supported affinity domains for partitioning.
-                                                                ///< If the device does not support any affinity domains, then 0 will be returned.
-    UR_DEVICE_INFO_PARTITION_TYPE = 79,                         ///< [::ur_device_partition_property_t[]] return an array of
-                                                                ///< ::ur_device_partition_property_t for properties specified in
-                                                                ///< ::urDevicePartition
-    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                     ///< [uint32_t] max number of sub groups
-    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81, ///< [::ur_bool_t] support sub group independent forward progress
-    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                  ///< [uint32_t[]] return an array of sub group sizes supported on Intel
-                                                                ///< device
-    UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                       ///< [::ur_device_usm_access_capability_flags_t] support USM host memory
-                                                                ///< access
-    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                     ///< [::ur_device_usm_access_capability_flags_t] support USM device memory
-                                                                ///< access
-    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,              ///< [::ur_device_usm_access_capability_flags_t] support USM single device
-                                                                ///< shared memory access
-    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,               ///< [::ur_device_usm_access_capability_flags_t] support USM cross device
-                                                                ///< shared memory access
-    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,              ///< [::ur_device_usm_access_capability_flags_t] support USM system wide
-                                                                ///< shared memory access
-    UR_DEVICE_INFO_UUID = 88,                                   ///< [char[]] return device UUID
-    UR_DEVICE_INFO_PCI_ADDRESS = 89,                            ///< [char[]] return device PCI address
-    UR_DEVICE_INFO_GPU_EU_COUNT = 90,                           ///< [uint32_t] return Intel GPU EU count
-    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                      ///< [uint32_t] return Intel GPU EU SIMD width
-    UR_DEVICE_INFO_GPU_EU_SLICES = 92,                          ///< [uint32_t] return Intel GPU number of slices
-    UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE = 93,              ///< [uint32_t] return Intel GPU EU count per subslice
-    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 94,                ///< [uint32_t] return Intel GPU number of subslices per slice
-    UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU = 95,                  ///< [uint32_t] return Intel GPU number of threads per EU
-    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 96,                   ///< [uint32_t] return max memory bandwidth in Mb/s
-    UR_DEVICE_INFO_IMAGE_SRGB = 97,                             ///< [::ur_bool_t] device supports sRGB images
-    UR_DEVICE_INFO_BUILD_ON_SUBDEVICE = 98,                     ///< [::ur_bool_t] Return true if sub-device should do its own program
-                                                                ///< build
-    UR_DEVICE_INFO_ATOMIC_64 = 99,                              ///< [::ur_bool_t] support 64 bit atomics
-    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 100,      ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
-                                                                ///< memory order capabilities
-    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 101,      ///< [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
-                                                                ///< memory scope capabilities
-    UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES = 102,       ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
-                                                                ///< memory fence order capabilities
-    UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES = 103,       ///< [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
-                                                                ///< memory fence scope capabilities
-    UR_DEVICE_INFO_BFLOAT16 = 104,                              ///< [::ur_bool_t] support for bfloat16
-    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 105,             ///< [uint32_t] Returns 1 if the device doesn't have a notion of a
-                                                                ///< queue index. Otherwise, returns the number of queue indices that are
-                                                                ///< available for this device.
-    UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS = 106,   ///< [::ur_bool_t] support the ::urKernelSetSpecializationConstants entry
-                                                                ///< point
-    UR_DEVICE_INFO_MEMORY_BUS_WIDTH = 107,                      ///< [::ur_bool_t] Return 1 if the device doesn't have a notion of a "queue
-                                                                ///< index". Otherwise,
-                                                                ///< return the number of queue indices that are available for this device.
-    UR_DEVICE_INFO_MAX_WORK_GROUPS_3D = 108,                    ///< [size_t[3]] return max 3D work groups
-    UR_DEVICE_INFO_ASYNC_BARRIER = 109,                         ///< [::ur_bool_t] return true if Async Barrier is supported
-    UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT = 110,                   ///< [::ur_bool_t] return true if specifying memory channels is supported
-    UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED = 111,        ///< [::ur_bool_t] Return true if the device supports enqueing commands to
-                                                                ///< read and write pipes from the host.
-    UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP = 112,          ///< [uint32_t] The maximum number of registers available per block.
-    UR_DEVICE_INFO_IP_VERSION = 113,                            ///< [uint32_t] The device IP version. The meaning of the device IP version
-                                                                ///< is implementation-defined, but newer devices should have a higher
-                                                                ///< version than older devices.
+    UR_DEVICE_INFO_TYPE = 0,                                      ///< [::ur_device_type_t] type of the device
+    UR_DEVICE_INFO_VENDOR_ID = 1,                                 ///< [uint32_t] vendor Id of the device
+    UR_DEVICE_INFO_DEVICE_ID = 2,                                 ///< [uint32_t] Id of the device
+    UR_DEVICE_INFO_MAX_COMPUTE_UNITS = 3,                         ///< [uint32_t] the number of compute units
+    UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS = 4,                  ///< [uint32_t] max work item dimensions
+    UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES = 5,                       ///< [size_t[]] return an array of max work item sizes
+    UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE = 6,                       ///< [size_t] max work group size
+    UR_DEVICE_INFO_SINGLE_FP_CONFIG = 7,                          ///< [::ur_device_fp_capability_flags_t] single precision floating point
+                                                                  ///< capability
+    UR_DEVICE_INFO_HALF_FP_CONFIG = 8,                            ///< [::ur_device_fp_capability_flags_t] half precision floating point
+                                                                  ///< capability
+    UR_DEVICE_INFO_DOUBLE_FP_CONFIG = 9,                          ///< [::ur_device_fp_capability_flags_t] double precision floating point
+                                                                  ///< capability
+    UR_DEVICE_INFO_QUEUE_PROPERTIES = 10,                         ///< [::ur_queue_flags_t] command queue properties supported by the device
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR = 11,              ///< [uint32_t] preferred vector width for char
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT = 12,             ///< [uint32_t] preferred vector width for short
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT = 13,               ///< [uint32_t] preferred vector width for int
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG = 14,              ///< [uint32_t] preferred vector width for long
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT = 15,             ///< [uint32_t] preferred vector width for float
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE = 16,            ///< [uint32_t] preferred vector width for double
+    UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF = 17,              ///< [uint32_t] preferred vector width for half float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR = 18,                 ///< [uint32_t] native vector width for char
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT = 19,                ///< [uint32_t] native vector width for short
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT = 20,                  ///< [uint32_t] native vector width for int
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG = 21,                 ///< [uint32_t] native vector width for long
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT = 22,                ///< [uint32_t] native vector width for float
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE = 23,               ///< [uint32_t] native vector width for double
+    UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF = 24,                 ///< [uint32_t] native vector width for half float
+    UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY = 25,                      ///< [uint32_t] max clock frequency in MHz
+    UR_DEVICE_INFO_MEMORY_CLOCK_RATE = 26,                        ///< [uint32_t] memory clock frequency in MHz
+    UR_DEVICE_INFO_ADDRESS_BITS = 27,                             ///< [uint32_t] address bits
+    UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE = 28,                       ///< [uint64_t] max memory allocation size
+    UR_DEVICE_INFO_IMAGE_SUPPORTED = 29,                          ///< [::ur_bool_t] images are supported
+    UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS = 30,                      ///< [uint32_t] max number of image objects arguments of a kernel declared
+                                                                  ///< with the read_only qualifier
+    UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS = 31,                     ///< [uint32_t] max number of image objects arguments of a kernel declared
+                                                                  ///< with the write_only qualifier
+    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS = 32,                ///< [uint32_t] max number of image objects arguments of a kernel declared
+                                                                  ///< with the read_write qualifier
+    UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH = 33,                        ///< [size_t] max width of Image2D object
+    UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT = 34,                       ///< [size_t] max heigh of Image2D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH = 35,                        ///< [size_t] max width of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT = 36,                       ///< [size_t] max height of Image3D object
+    UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH = 37,                        ///< [size_t] max depth of Image3D object
+    UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE = 38,                    ///< [size_t] max image buffer size
+    UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE = 39,                     ///< [size_t] max image array size
+    UR_DEVICE_INFO_MAX_SAMPLERS = 40,                             ///< [uint32_t] max number of samplers that can be used in a kernel
+    UR_DEVICE_INFO_MAX_PARAMETER_SIZE = 41,                       ///< [size_t] max size in bytes of all arguments passed to a kernel
+    UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN = 42,                      ///< [uint32_t] memory base address alignment
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE = 43,                    ///< [::ur_device_mem_cache_type_t] global memory cache type
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE = 44,                ///< [uint32_t] global memory cache line size in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE = 45,                    ///< [uint64_t] size of global memory cache in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_SIZE = 46,                          ///< [uint64_t] size of global memory in bytes
+    UR_DEVICE_INFO_GLOBAL_MEM_FREE = 47,                          ///< [uint64_t] size of global memory which is free in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE = 48,                 ///< [uint64_t] max constant buffer size in bytes
+    UR_DEVICE_INFO_MAX_CONSTANT_ARGS = 49,                        ///< [uint32_t] max number of __const declared arguments in a kernel
+    UR_DEVICE_INFO_LOCAL_MEM_TYPE = 50,                           ///< [::ur_device_local_mem_type_t] local memory type
+    UR_DEVICE_INFO_LOCAL_MEM_SIZE = 51,                           ///< [uint64_t] local memory size in bytes
+    UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT = 52,                 ///< [::ur_bool_t] support error correction to global and local memory
+    UR_DEVICE_INFO_HOST_UNIFIED_MEMORY = 53,                      ///< [::ur_bool_t] unified host device memory
+    UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION = 54,               ///< [size_t] profiling timer resolution in nanoseconds
+    UR_DEVICE_INFO_ENDIAN_LITTLE = 55,                            ///< [::ur_bool_t] little endian byte order
+    UR_DEVICE_INFO_AVAILABLE = 56,                                ///< [::ur_bool_t] device is available
+    UR_DEVICE_INFO_COMPILER_AVAILABLE = 57,                       ///< [::ur_bool_t] device compiler is available
+    UR_DEVICE_INFO_LINKER_AVAILABLE = 58,                         ///< [::ur_bool_t] device linker is available
+    UR_DEVICE_INFO_EXECUTION_CAPABILITIES = 59,                   ///< [::ur_device_exec_capability_flags_t] device kernel execution
+                                                                  ///< capability bit-field
+    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,               ///< [::ur_queue_flags_t] device command queue property bit-field
+    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,                 ///< [::ur_queue_flags_t] host queue property bit-field
+    UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,                         ///< [char[]] a semi-colon separated list of built-in kernels
+    UR_DEVICE_INFO_PLATFORM = 63,                                 ///< [::ur_platform_handle_t] the platform associated with the device
+    UR_DEVICE_INFO_REFERENCE_COUNT = 64,                          ///< [uint32_t] Reference count of the device object.
+                                                                  ///< The reference count returned should be considered immediately stale.
+                                                                  ///< It is unsuitable for general use in applications. This feature is
+                                                                  ///< provided for identifying memory leaks.
+    UR_DEVICE_INFO_IL_VERSION = 65,                               ///< [char[]] IL version
+    UR_DEVICE_INFO_NAME = 66,                                     ///< [char[]] Device name
+    UR_DEVICE_INFO_VENDOR = 67,                                   ///< [char[]] Device vendor
+    UR_DEVICE_INFO_DRIVER_VERSION = 68,                           ///< [char[]] Driver version
+    UR_DEVICE_INFO_PROFILE = 69,                                  ///< [char[]] Device profile
+    UR_DEVICE_INFO_VERSION = 70,                                  ///< [char[]] Device version
+    UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,                  ///< [char[]] Version of backend runtime
+    UR_DEVICE_INFO_EXTENSIONS = 72,                               ///< [char[]] Return a space separated list of extension names
+    UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,                       ///< [size_t] Maximum size in bytes of internal printf buffer
+    UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC = 74,              ///< [::ur_bool_t] prefer user synchronization when sharing object with
+                                                                  ///< other API
+    UR_DEVICE_INFO_PARENT_DEVICE = 75,                            ///< [::ur_device_handle_t] return parent device handle
+    UR_DEVICE_INFO_SUPPORTED_PARTITIONS = 76,                     ///< [::ur_device_partition_t[]] Returns an array of partition types
+                                                                  ///< supported by the device
+    UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES = 77,                ///< [uint32_t] maximum number of sub-devices when the device is
+                                                                  ///< partitioned
+    UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,                ///< [::ur_device_affinity_domain_flags_t] Returns a bit-field of the
+                                                                  ///< supported affinity domains for partitioning.
+                                                                  ///< If the device does not support any affinity domains, then 0 will be returned.
+    UR_DEVICE_INFO_PARTITION_TYPE = 79,                           ///< [::ur_device_partition_property_t[]] return an array of
+                                                                  ///< ::ur_device_partition_property_t for properties specified in
+                                                                  ///< ::urDevicePartition
+    UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                       ///< [uint32_t] max number of sub groups
+    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81,   ///< [::ur_bool_t] support sub group independent forward progress
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                    ///< [uint32_t[]] return an array of sub group sizes supported on Intel
+                                                                  ///< device
+    UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                         ///< [::ur_device_usm_access_capability_flags_t] support USM host memory
+                                                                  ///< access
+    UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                       ///< [::ur_device_usm_access_capability_flags_t] support USM device memory
+                                                                  ///< access
+    UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT = 85,                ///< [::ur_device_usm_access_capability_flags_t] support USM single device
+                                                                  ///< shared memory access
+    UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT = 86,                 ///< [::ur_device_usm_access_capability_flags_t] support USM cross device
+                                                                  ///< shared memory access
+    UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,                ///< [::ur_device_usm_access_capability_flags_t] support USM system wide
+                                                                  ///< shared memory access
+    UR_DEVICE_INFO_UUID = 88,                                     ///< [char[]] return device UUID
+    UR_DEVICE_INFO_PCI_ADDRESS = 89,                              ///< [char[]] return device PCI address
+    UR_DEVICE_INFO_GPU_EU_COUNT = 90,                             ///< [uint32_t] return Intel GPU EU count
+    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                        ///< [uint32_t] return Intel GPU EU SIMD width
+    UR_DEVICE_INFO_GPU_EU_SLICES = 92,                            ///< [uint32_t] return Intel GPU number of slices
+    UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE = 93,                ///< [uint32_t] return Intel GPU EU count per subslice
+    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 94,                  ///< [uint32_t] return Intel GPU number of subslices per slice
+    UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU = 95,                    ///< [uint32_t] return Intel GPU number of threads per EU
+    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 96,                     ///< [uint32_t] return max memory bandwidth in Mb/s
+    UR_DEVICE_INFO_IMAGE_SRGB = 97,                               ///< [::ur_bool_t] device supports sRGB images
+    UR_DEVICE_INFO_BUILD_ON_SUBDEVICE = 98,                       ///< [::ur_bool_t] Return true if sub-device should do its own program
+                                                                  ///< build
+    UR_DEVICE_INFO_ATOMIC_64 = 99,                                ///< [::ur_bool_t] support 64 bit atomics
+    UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES = 100,        ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
+                                                                  ///< memory order capabilities
+    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES = 101,        ///< [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
+                                                                  ///< memory scope capabilities
+    UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES = 102,         ///< [::ur_memory_order_capability_flags_t] return a bit-field of atomic
+                                                                  ///< memory fence order capabilities
+    UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES = 103,         ///< [::ur_memory_scope_capability_flags_t] return a bit-field of atomic
+                                                                  ///< memory fence scope capabilities
+    UR_DEVICE_INFO_BFLOAT16 = 104,                                ///< [::ur_bool_t] support for bfloat16
+    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES = 105,               ///< [uint32_t] Returns 1 if the device doesn't have a notion of a
+                                                                  ///< queue index. Otherwise, returns the number of queue indices that are
+                                                                  ///< available for this device.
+    UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS = 106,     ///< [::ur_bool_t] support the ::urKernelSetSpecializationConstants entry
+                                                                  ///< point
+    UR_DEVICE_INFO_MEMORY_BUS_WIDTH = 107,                        ///< [::ur_bool_t] Return 1 if the device doesn't have a notion of a "queue
+                                                                  ///< index". Otherwise,
+                                                                  ///< return the number of queue indices that are available for this device.
+    UR_DEVICE_INFO_MAX_WORK_GROUPS_3D = 108,                      ///< [size_t[3]] return max 3D work groups
+    UR_DEVICE_INFO_ASYNC_BARRIER = 109,                           ///< [::ur_bool_t] return true if Async Barrier is supported
+    UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT = 110,                     ///< [::ur_bool_t] return true if specifying memory channels is supported
+    UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED = 111,          ///< [::ur_bool_t] Return true if the device supports enqueing commands to
+                                                                  ///< read and write pipes from the host.
+    UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP = 112,            ///< [uint32_t] The maximum number of registers available per block.
+    UR_DEVICE_INFO_IP_VERSION = 113,                              ///< [uint32_t] The device IP version. The meaning of the device IP version
+                                                                  ///< is implementation-defined, but newer devices should have a higher
+                                                                  ///< version than older devices.
+    UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP = 0x2000,          ///< [::ur_bool_t] returns true if the device supports the creation of
+                                                                  ///< bindless images
+    UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP = 0x2001,   ///< [::ur_bool_t] returns true if the device supports the creation of 1D
+                                                                  ///< bindless images backed by USM
+    UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP = 0x2002,   ///< [::ur_bool_t] returns true if the device supports the creation of 2D
+                                                                  ///< bindless images backed by USM
+    UR_DEVICE_INFO_BINDLESS_IMAGES_3D_USM_SUPPORT_EXP = 0x2003,   ///< [::ur_bool_t] returns true if the device supports the creation of 3D
+                                                                  ///< bindless images backed by USM
+    UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP = 0x2004,                ///< [uint32_t] returns the required alignment of the pitch between two
+                                                                  ///< rows of an image in bytes
+    UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP = 0x2005,           ///< [size_t] returns the maximum linear width allowed for images allocated
+                                                                  ///< using USM
+    UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP = 0x2006,          ///< [size_t] returns the maximum linear height allowed for images
+                                                                  ///< allocated using USM
+    UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP = 0x2007,           ///< [size_t] returns the maximum linear pitch allowed for images allocated
+                                                                  ///< using USM
+    UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP = 0x2008,                   ///< [::ur_bool_t] returns true if the device supports allocating mipmap
+                                                                  ///< resources
+    UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP = 0x2009,        ///< [::ur_bool_t] returns true if the device supports sampling mipmap
+                                                                  ///< images with anisotropic filtering
+    UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP = 0x200A,            ///< [uint32_t] returns the maximum anisotropic ratio supported by the
+                                                                  ///< device
+    UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP = 0x200B,   ///< [::ur_bool_t] returns true if the device supports using images created
+                                                                  ///< from individual mipmap levels
+    UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP = 0x200C,    ///< [::ur_bool_t] returns true if the device supports importing external
+                                                                  ///< memory resources
+    UR_DEVICE_INFO_INTEROP_MEMORY_EXPORT_SUPPORT_EXP = 0x200D,    ///< [::ur_bool_t] returns true if the device supports exporting internal
+                                                                  ///< memory resources
+    UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP = 0x200E, ///< [::ur_bool_t] returns true if the device supports importing external
+                                                                  ///< semaphore resources
+    UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP = 0x200F, ///< [::ur_bool_t] returns true if the device supports exporting internal
+                                                                  ///< event resources
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -956,7 +989,7 @@ typedef enum ur_device_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_IP_VERSION < propName`
+///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -4312,32 +4345,34 @@ urQueueFlush(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Command type
 typedef enum ur_command_t {
-    UR_COMMAND_KERNEL_LAUNCH = 0,                 ///< Event created by ::urEnqueueKernelLaunch
-    UR_COMMAND_EVENTS_WAIT = 1,                   ///< Event created by ::urEnqueueEventsWait
-    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,      ///< Event created by ::urEnqueueEventsWaitWithBarrier
-    UR_COMMAND_MEM_BUFFER_READ = 3,               ///< Event created by ::urEnqueueMemBufferRead
-    UR_COMMAND_MEM_BUFFER_WRITE = 4,              ///< Event created by ::urEnqueueMemBufferWrite
-    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,          ///< Event created by ::urEnqueueMemBufferReadRect
-    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,         ///< Event created by ::urEnqueueMemBufferWriteRect
-    UR_COMMAND_MEM_BUFFER_COPY = 7,               ///< Event created by ::urEnqueueMemBufferCopy
-    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,          ///< Event created by ::urEnqueueMemBufferCopyRect
-    UR_COMMAND_MEM_BUFFER_FILL = 9,               ///< Event created by ::urEnqueueMemBufferFill
-    UR_COMMAND_MEM_IMAGE_READ = 10,               ///< Event created by ::urEnqueueMemImageRead
-    UR_COMMAND_MEM_IMAGE_WRITE = 11,              ///< Event created by ::urEnqueueMemImageWrite
-    UR_COMMAND_MEM_IMAGE_COPY = 12,               ///< Event created by ::urEnqueueMemImageCopy
-    UR_COMMAND_MEM_BUFFER_MAP = 14,               ///< Event created by ::urEnqueueMemBufferMap
-    UR_COMMAND_MEM_UNMAP = 16,                    ///< Event created by ::urEnqueueMemUnmap
-    UR_COMMAND_USM_FILL = 17,                     ///< Event created by ::urEnqueueUSMFill
-    UR_COMMAND_USM_MEMCPY = 18,                   ///< Event created by ::urEnqueueUSMMemcpy
-    UR_COMMAND_USM_PREFETCH = 19,                 ///< Event created by ::urEnqueueUSMPrefetch
-    UR_COMMAND_USM_ADVISE = 20,                   ///< Event created by ::urEnqueueUSMAdvise
-    UR_COMMAND_USM_FILL_2D = 21,                  ///< Event created by ::urEnqueueUSMFill2D
-    UR_COMMAND_USM_MEMCPY_2D = 22,                ///< Event created by ::urEnqueueUSMMemcpy2D
-    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 23, ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
-    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 24,  ///< Event created by ::urEnqueueDeviceGlobalVariableRead
-    UR_COMMAND_READ_HOST_PIPE = 25,               ///< Event created by ::urEnqueueReadHostPipe
-    UR_COMMAND_WRITE_HOST_PIPE = 26,              ///< Event created by ::urEnqueueWriteHostPipe
-    UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP = 27,   ///< Event created by ::urCommandBufferEnqueueExp
+    UR_COMMAND_KERNEL_LAUNCH = 0,                     ///< Event created by ::urEnqueueKernelLaunch
+    UR_COMMAND_EVENTS_WAIT = 1,                       ///< Event created by ::urEnqueueEventsWait
+    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,          ///< Event created by ::urEnqueueEventsWaitWithBarrier
+    UR_COMMAND_MEM_BUFFER_READ = 3,                   ///< Event created by ::urEnqueueMemBufferRead
+    UR_COMMAND_MEM_BUFFER_WRITE = 4,                  ///< Event created by ::urEnqueueMemBufferWrite
+    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,              ///< Event created by ::urEnqueueMemBufferReadRect
+    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,             ///< Event created by ::urEnqueueMemBufferWriteRect
+    UR_COMMAND_MEM_BUFFER_COPY = 7,                   ///< Event created by ::urEnqueueMemBufferCopy
+    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,              ///< Event created by ::urEnqueueMemBufferCopyRect
+    UR_COMMAND_MEM_BUFFER_FILL = 9,                   ///< Event created by ::urEnqueueMemBufferFill
+    UR_COMMAND_MEM_IMAGE_READ = 10,                   ///< Event created by ::urEnqueueMemImageRead
+    UR_COMMAND_MEM_IMAGE_WRITE = 11,                  ///< Event created by ::urEnqueueMemImageWrite
+    UR_COMMAND_MEM_IMAGE_COPY = 12,                   ///< Event created by ::urEnqueueMemImageCopy
+    UR_COMMAND_MEM_BUFFER_MAP = 14,                   ///< Event created by ::urEnqueueMemBufferMap
+    UR_COMMAND_MEM_UNMAP = 16,                        ///< Event created by ::urEnqueueMemUnmap
+    UR_COMMAND_USM_FILL = 17,                         ///< Event created by ::urEnqueueUSMFill
+    UR_COMMAND_USM_MEMCPY = 18,                       ///< Event created by ::urEnqueueUSMMemcpy
+    UR_COMMAND_USM_PREFETCH = 19,                     ///< Event created by ::urEnqueueUSMPrefetch
+    UR_COMMAND_USM_ADVISE = 20,                       ///< Event created by ::urEnqueueUSMAdvise
+    UR_COMMAND_USM_FILL_2D = 21,                      ///< Event created by ::urEnqueueUSMFill2D
+    UR_COMMAND_USM_MEMCPY_2D = 22,                    ///< Event created by ::urEnqueueUSMMemcpy2D
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 23,     ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 24,      ///< Event created by ::urEnqueueDeviceGlobalVariableRead
+    UR_COMMAND_READ_HOST_PIPE = 25,                   ///< Event created by ::urEnqueueReadHostPipe
+    UR_COMMAND_WRITE_HOST_PIPE = 26,                  ///< Event created by ::urEnqueueWriteHostPipe
+    UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP = 27,       ///< Event created by ::urCommandBufferEnqueueExp
+    UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP = 0x2000,   ///< Event created by ::urBindlessImagesWaitExternalSemaphoreExp
+    UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP = 0x2001, ///< Event created by ::urBindlessImagesSignalExternalSemaphoreExp
     /// @cond
     UR_COMMAND_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -4658,134 +4693,152 @@ urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines unique stable identifiers for all functions
 typedef enum ur_function_t {
-    UR_FUNCTION_CONTEXT_CREATE = 1,                                  ///< Enumerator for ::urContextCreate
-    UR_FUNCTION_CONTEXT_RETAIN = 2,                                  ///< Enumerator for ::urContextRetain
-    UR_FUNCTION_CONTEXT_RELEASE = 3,                                 ///< Enumerator for ::urContextRelease
-    UR_FUNCTION_CONTEXT_GET_INFO = 4,                                ///< Enumerator for ::urContextGetInfo
-    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                       ///< Enumerator for ::urContextGetNativeHandle
-    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,               ///< Enumerator for ::urContextCreateWithNativeHandle
-    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,                    ///< Enumerator for ::urContextSetExtendedDeleter
-    UR_FUNCTION_DEVICE_GET = 8,                                      ///< Enumerator for ::urDeviceGet
-    UR_FUNCTION_DEVICE_GET_INFO = 9,                                 ///< Enumerator for ::urDeviceGetInfo
-    UR_FUNCTION_DEVICE_RETAIN = 10,                                  ///< Enumerator for ::urDeviceRetain
-    UR_FUNCTION_DEVICE_RELEASE = 11,                                 ///< Enumerator for ::urDeviceRelease
-    UR_FUNCTION_DEVICE_PARTITION = 12,                               ///< Enumerator for ::urDevicePartition
-    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                           ///< Enumerator for ::urDeviceSelectBinary
-    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                       ///< Enumerator for ::urDeviceGetNativeHandle
-    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,               ///< Enumerator for ::urDeviceCreateWithNativeHandle
-    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,                   ///< Enumerator for ::urDeviceGetGlobalTimestamps
-    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                          ///< Enumerator for ::urEnqueueKernelLaunch
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                            ///< Enumerator for ::urEnqueueEventsWait
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,               ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                        ///< Enumerator for ::urEnqueueMemBufferRead
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                       ///< Enumerator for ::urEnqueueMemBufferWrite
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,                   ///< Enumerator for ::urEnqueueMemBufferReadRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,                  ///< Enumerator for ::urEnqueueMemBufferWriteRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                        ///< Enumerator for ::urEnqueueMemBufferCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,                   ///< Enumerator for ::urEnqueueMemBufferCopyRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                        ///< Enumerator for ::urEnqueueMemBufferFill
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                         ///< Enumerator for ::urEnqueueMemImageRead
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                        ///< Enumerator for ::urEnqueueMemImageWrite
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                         ///< Enumerator for ::urEnqueueMemImageCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                         ///< Enumerator for ::urEnqueueMemBufferMap
-    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                              ///< Enumerator for ::urEnqueueMemUnmap
-    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                               ///< Enumerator for ::urEnqueueUSMFill
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                             ///< Enumerator for ::urEnqueueUSMMemcpy
-    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                           ///< Enumerator for ::urEnqueueUSMPrefetch
-    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                             ///< Enumerator for ::urEnqueueUSMAdvise
-    UR_FUNCTION_ENQUEUE_USM_FILL2_D = 36,                            ///< Enumerator for ::urEnqueueUSMFill2D
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D = 37,                          ///< Enumerator for ::urEnqueueUSMMemcpy2D
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,           ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,            ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
-    UR_FUNCTION_EVENT_GET_INFO = 40,                                 ///< Enumerator for ::urEventGetInfo
-    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                       ///< Enumerator for ::urEventGetProfilingInfo
-    UR_FUNCTION_EVENT_WAIT = 42,                                     ///< Enumerator for ::urEventWait
-    UR_FUNCTION_EVENT_RETAIN = 43,                                   ///< Enumerator for ::urEventRetain
-    UR_FUNCTION_EVENT_RELEASE = 44,                                  ///< Enumerator for ::urEventRelease
-    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                        ///< Enumerator for ::urEventGetNativeHandle
-    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,                ///< Enumerator for ::urEventCreateWithNativeHandle
-    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                             ///< Enumerator for ::urEventSetCallback
-    UR_FUNCTION_KERNEL_CREATE = 48,                                  ///< Enumerator for ::urKernelCreate
-    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                           ///< Enumerator for ::urKernelSetArgValue
-    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                           ///< Enumerator for ::urKernelSetArgLocal
-    UR_FUNCTION_KERNEL_GET_INFO = 51,                                ///< Enumerator for ::urKernelGetInfo
-    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                          ///< Enumerator for ::urKernelGetGroupInfo
-    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,                      ///< Enumerator for ::urKernelGetSubGroupInfo
-    UR_FUNCTION_KERNEL_RETAIN = 54,                                  ///< Enumerator for ::urKernelRetain
-    UR_FUNCTION_KERNEL_RELEASE = 55,                                 ///< Enumerator for ::urKernelRelease
-    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                         ///< Enumerator for ::urKernelSetArgPointer
-    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                           ///< Enumerator for ::urKernelSetExecInfo
-    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                         ///< Enumerator for ::urKernelSetArgSampler
-    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                         ///< Enumerator for ::urKernelSetArgMemObj
-    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,            ///< Enumerator for ::urKernelSetSpecializationConstants
-    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                       ///< Enumerator for ::urKernelGetNativeHandle
-    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,               ///< Enumerator for ::urKernelCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                               ///< Enumerator for ::urMemImageCreate
-    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                              ///< Enumerator for ::urMemBufferCreate
-    UR_FUNCTION_MEM_RETAIN = 65,                                     ///< Enumerator for ::urMemRetain
-    UR_FUNCTION_MEM_RELEASE = 66,                                    ///< Enumerator for ::urMemRelease
-    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                           ///< Enumerator for ::urMemBufferPartition
-    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                          ///< Enumerator for ::urMemGetNativeHandle
-    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                         ///< Enumerator for ::urEnqueueReadHostPipe
-    UR_FUNCTION_MEM_GET_INFO = 70,                                   ///< Enumerator for ::urMemGetInfo
-    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                             ///< Enumerator for ::urMemImageGetInfo
-    UR_FUNCTION_PLATFORM_GET = 72,                                   ///< Enumerator for ::urPlatformGet
-    UR_FUNCTION_PLATFORM_GET_INFO = 73,                              ///< Enumerator for ::urPlatformGetInfo
-    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                       ///< Enumerator for ::urPlatformGetApiVersion
-    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,                     ///< Enumerator for ::urPlatformGetNativeHandle
-    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,             ///< Enumerator for ::urPlatformCreateWithNativeHandle
-    UR_FUNCTION_GET_LAST_RESULT = 77,                                ///< Enumerator for ::urGetLastResult
-    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                         ///< Enumerator for ::urProgramCreateWithIL
-    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,                     ///< Enumerator for ::urProgramCreateWithBinary
-    UR_FUNCTION_PROGRAM_BUILD = 80,                                  ///< Enumerator for ::urProgramBuild
-    UR_FUNCTION_PROGRAM_COMPILE = 81,                                ///< Enumerator for ::urProgramCompile
-    UR_FUNCTION_PROGRAM_LINK = 82,                                   ///< Enumerator for ::urProgramLink
-    UR_FUNCTION_PROGRAM_RETAIN = 83,                                 ///< Enumerator for ::urProgramRetain
-    UR_FUNCTION_PROGRAM_RELEASE = 84,                                ///< Enumerator for ::urProgramRelease
-    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,                   ///< Enumerator for ::urProgramGetFunctionPointer
-    UR_FUNCTION_PROGRAM_GET_INFO = 86,                               ///< Enumerator for ::urProgramGetInfo
-    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                         ///< Enumerator for ::urProgramGetBuildInfo
-    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,           ///< Enumerator for ::urProgramSetSpecializationConstants
-    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,                      ///< Enumerator for ::urProgramGetNativeHandle
-    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,              ///< Enumerator for ::urProgramCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_GET_INFO = 91,                                 ///< Enumerator for ::urQueueGetInfo
-    UR_FUNCTION_QUEUE_CREATE = 92,                                   ///< Enumerator for ::urQueueCreate
-    UR_FUNCTION_QUEUE_RETAIN = 93,                                   ///< Enumerator for ::urQueueRetain
-    UR_FUNCTION_QUEUE_RELEASE = 94,                                  ///< Enumerator for ::urQueueRelease
-    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                        ///< Enumerator for ::urQueueGetNativeHandle
-    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,                ///< Enumerator for ::urQueueCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_FINISH = 97,                                   ///< Enumerator for ::urQueueFinish
-    UR_FUNCTION_QUEUE_FLUSH = 98,                                    ///< Enumerator for ::urQueueFlush
-    UR_FUNCTION_INIT = 99,                                           ///< Enumerator for ::urInit
-    UR_FUNCTION_TEAR_DOWN = 100,                                     ///< Enumerator for ::urTearDown
-    UR_FUNCTION_SAMPLER_CREATE = 101,                                ///< Enumerator for ::urSamplerCreate
-    UR_FUNCTION_SAMPLER_RETAIN = 102,                                ///< Enumerator for ::urSamplerRetain
-    UR_FUNCTION_SAMPLER_RELEASE = 103,                               ///< Enumerator for ::urSamplerRelease
-    UR_FUNCTION_SAMPLER_GET_INFO = 104,                              ///< Enumerator for ::urSamplerGetInfo
-    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,                     ///< Enumerator for ::urSamplerGetNativeHandle
-    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,             ///< Enumerator for ::urSamplerCreateWithNativeHandle
-    UR_FUNCTION_USM_HOST_ALLOC = 107,                                ///< Enumerator for ::urUSMHostAlloc
-    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                              ///< Enumerator for ::urUSMDeviceAlloc
-    UR_FUNCTION_USM_SHARED_ALLOC = 109,                              ///< Enumerator for ::urUSMSharedAlloc
-    UR_FUNCTION_USM_FREE = 110,                                      ///< Enumerator for ::urUSMFree
-    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                        ///< Enumerator for ::urUSMGetMemAllocInfo
-    UR_FUNCTION_USM_POOL_CREATE = 112,                               ///< Enumerator for ::urUSMPoolCreate
-    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,                     ///< Enumerator for ::urCommandBufferCreateExp
-    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,                   ///< Enumerator for ::urPlatformGetBackendOption
-    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,          ///< Enumerator for ::urMemBufferCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,           ///< Enumerator for ::urMemImageCreateWithNativeHandle
-    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                       ///< Enumerator for ::urEnqueueWriteHostPipe
-    UR_FUNCTION_USM_POOL_RETAIN = 118,                               ///< Enumerator for ::urUSMPoolRetain
-    UR_FUNCTION_USM_POOL_RELEASE = 119,                              ///< Enumerator for ::urUSMPoolRelease
-    UR_FUNCTION_USM_POOL_GET_INFO = 120,                             ///< Enumerator for ::urUSMPoolGetInfo
-    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,                     ///< Enumerator for ::urCommandBufferRetainExp
-    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,                    ///< Enumerator for ::urCommandBufferReleaseExp
-    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,                   ///< Enumerator for ::urCommandBufferFinalizeExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP = 125,       ///< Enumerator for ::urCommandBufferAppendKernelLaunchExp
-    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,                    ///< Enumerator for ::urCommandBufferEnqueueExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129,          ///< Enumerator for ::urCommandBufferAppendMemcpyUSMExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130,      ///< Enumerator for ::urCommandBufferAppendMembufferCopyExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP = 131, ///< Enumerator for ::urCommandBufferAppendMembufferCopyRectExp
+    UR_FUNCTION_CONTEXT_CREATE = 1,                                            ///< Enumerator for ::urContextCreate
+    UR_FUNCTION_CONTEXT_RETAIN = 2,                                            ///< Enumerator for ::urContextRetain
+    UR_FUNCTION_CONTEXT_RELEASE = 3,                                           ///< Enumerator for ::urContextRelease
+    UR_FUNCTION_CONTEXT_GET_INFO = 4,                                          ///< Enumerator for ::urContextGetInfo
+    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                                 ///< Enumerator for ::urContextGetNativeHandle
+    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,                         ///< Enumerator for ::urContextCreateWithNativeHandle
+    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,                              ///< Enumerator for ::urContextSetExtendedDeleter
+    UR_FUNCTION_DEVICE_GET = 8,                                                ///< Enumerator for ::urDeviceGet
+    UR_FUNCTION_DEVICE_GET_INFO = 9,                                           ///< Enumerator for ::urDeviceGetInfo
+    UR_FUNCTION_DEVICE_RETAIN = 10,                                            ///< Enumerator for ::urDeviceRetain
+    UR_FUNCTION_DEVICE_RELEASE = 11,                                           ///< Enumerator for ::urDeviceRelease
+    UR_FUNCTION_DEVICE_PARTITION = 12,                                         ///< Enumerator for ::urDevicePartition
+    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                                     ///< Enumerator for ::urDeviceSelectBinary
+    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                                 ///< Enumerator for ::urDeviceGetNativeHandle
+    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,                         ///< Enumerator for ::urDeviceCreateWithNativeHandle
+    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,                             ///< Enumerator for ::urDeviceGetGlobalTimestamps
+    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                                    ///< Enumerator for ::urEnqueueKernelLaunch
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                                      ///< Enumerator for ::urEnqueueEventsWait
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,                         ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                                  ///< Enumerator for ::urEnqueueMemBufferRead
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                                 ///< Enumerator for ::urEnqueueMemBufferWrite
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,                             ///< Enumerator for ::urEnqueueMemBufferReadRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,                            ///< Enumerator for ::urEnqueueMemBufferWriteRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                                  ///< Enumerator for ::urEnqueueMemBufferCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,                             ///< Enumerator for ::urEnqueueMemBufferCopyRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                                  ///< Enumerator for ::urEnqueueMemBufferFill
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                                   ///< Enumerator for ::urEnqueueMemImageRead
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                                  ///< Enumerator for ::urEnqueueMemImageWrite
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                                   ///< Enumerator for ::urEnqueueMemImageCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                                   ///< Enumerator for ::urEnqueueMemBufferMap
+    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                                        ///< Enumerator for ::urEnqueueMemUnmap
+    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                                         ///< Enumerator for ::urEnqueueUSMFill
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                                       ///< Enumerator for ::urEnqueueUSMMemcpy
+    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                                     ///< Enumerator for ::urEnqueueUSMPrefetch
+    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                                       ///< Enumerator for ::urEnqueueUSMAdvise
+    UR_FUNCTION_ENQUEUE_USM_FILL2_D = 36,                                      ///< Enumerator for ::urEnqueueUSMFill2D
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY2_D = 37,                                    ///< Enumerator for ::urEnqueueUSMMemcpy2D
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,                     ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,                      ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
+    UR_FUNCTION_EVENT_GET_INFO = 40,                                           ///< Enumerator for ::urEventGetInfo
+    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                                 ///< Enumerator for ::urEventGetProfilingInfo
+    UR_FUNCTION_EVENT_WAIT = 42,                                               ///< Enumerator for ::urEventWait
+    UR_FUNCTION_EVENT_RETAIN = 43,                                             ///< Enumerator for ::urEventRetain
+    UR_FUNCTION_EVENT_RELEASE = 44,                                            ///< Enumerator for ::urEventRelease
+    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                                  ///< Enumerator for ::urEventGetNativeHandle
+    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,                          ///< Enumerator for ::urEventCreateWithNativeHandle
+    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                                       ///< Enumerator for ::urEventSetCallback
+    UR_FUNCTION_KERNEL_CREATE = 48,                                            ///< Enumerator for ::urKernelCreate
+    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                                     ///< Enumerator for ::urKernelSetArgValue
+    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                                     ///< Enumerator for ::urKernelSetArgLocal
+    UR_FUNCTION_KERNEL_GET_INFO = 51,                                          ///< Enumerator for ::urKernelGetInfo
+    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                                    ///< Enumerator for ::urKernelGetGroupInfo
+    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,                                ///< Enumerator for ::urKernelGetSubGroupInfo
+    UR_FUNCTION_KERNEL_RETAIN = 54,                                            ///< Enumerator for ::urKernelRetain
+    UR_FUNCTION_KERNEL_RELEASE = 55,                                           ///< Enumerator for ::urKernelRelease
+    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                                   ///< Enumerator for ::urKernelSetArgPointer
+    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                                     ///< Enumerator for ::urKernelSetExecInfo
+    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                                   ///< Enumerator for ::urKernelSetArgSampler
+    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                                   ///< Enumerator for ::urKernelSetArgMemObj
+    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,                      ///< Enumerator for ::urKernelSetSpecializationConstants
+    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                                 ///< Enumerator for ::urKernelGetNativeHandle
+    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,                         ///< Enumerator for ::urKernelCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                                         ///< Enumerator for ::urMemImageCreate
+    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                                        ///< Enumerator for ::urMemBufferCreate
+    UR_FUNCTION_MEM_RETAIN = 65,                                               ///< Enumerator for ::urMemRetain
+    UR_FUNCTION_MEM_RELEASE = 66,                                              ///< Enumerator for ::urMemRelease
+    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                                     ///< Enumerator for ::urMemBufferPartition
+    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                                    ///< Enumerator for ::urMemGetNativeHandle
+    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                                   ///< Enumerator for ::urEnqueueReadHostPipe
+    UR_FUNCTION_MEM_GET_INFO = 70,                                             ///< Enumerator for ::urMemGetInfo
+    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                                       ///< Enumerator for ::urMemImageGetInfo
+    UR_FUNCTION_PLATFORM_GET = 72,                                             ///< Enumerator for ::urPlatformGet
+    UR_FUNCTION_PLATFORM_GET_INFO = 73,                                        ///< Enumerator for ::urPlatformGetInfo
+    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                                 ///< Enumerator for ::urPlatformGetApiVersion
+    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,                               ///< Enumerator for ::urPlatformGetNativeHandle
+    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,                       ///< Enumerator for ::urPlatformCreateWithNativeHandle
+    UR_FUNCTION_GET_LAST_RESULT = 77,                                          ///< Enumerator for ::urGetLastResult
+    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                                   ///< Enumerator for ::urProgramCreateWithIL
+    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,                               ///< Enumerator for ::urProgramCreateWithBinary
+    UR_FUNCTION_PROGRAM_BUILD = 80,                                            ///< Enumerator for ::urProgramBuild
+    UR_FUNCTION_PROGRAM_COMPILE = 81,                                          ///< Enumerator for ::urProgramCompile
+    UR_FUNCTION_PROGRAM_LINK = 82,                                             ///< Enumerator for ::urProgramLink
+    UR_FUNCTION_PROGRAM_RETAIN = 83,                                           ///< Enumerator for ::urProgramRetain
+    UR_FUNCTION_PROGRAM_RELEASE = 84,                                          ///< Enumerator for ::urProgramRelease
+    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,                             ///< Enumerator for ::urProgramGetFunctionPointer
+    UR_FUNCTION_PROGRAM_GET_INFO = 86,                                         ///< Enumerator for ::urProgramGetInfo
+    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                                   ///< Enumerator for ::urProgramGetBuildInfo
+    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,                     ///< Enumerator for ::urProgramSetSpecializationConstants
+    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,                                ///< Enumerator for ::urProgramGetNativeHandle
+    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,                        ///< Enumerator for ::urProgramCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_GET_INFO = 91,                                           ///< Enumerator for ::urQueueGetInfo
+    UR_FUNCTION_QUEUE_CREATE = 92,                                             ///< Enumerator for ::urQueueCreate
+    UR_FUNCTION_QUEUE_RETAIN = 93,                                             ///< Enumerator for ::urQueueRetain
+    UR_FUNCTION_QUEUE_RELEASE = 94,                                            ///< Enumerator for ::urQueueRelease
+    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                                  ///< Enumerator for ::urQueueGetNativeHandle
+    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,                          ///< Enumerator for ::urQueueCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_FINISH = 97,                                             ///< Enumerator for ::urQueueFinish
+    UR_FUNCTION_QUEUE_FLUSH = 98,                                              ///< Enumerator for ::urQueueFlush
+    UR_FUNCTION_INIT = 99,                                                     ///< Enumerator for ::urInit
+    UR_FUNCTION_TEAR_DOWN = 100,                                               ///< Enumerator for ::urTearDown
+    UR_FUNCTION_SAMPLER_CREATE = 101,                                          ///< Enumerator for ::urSamplerCreate
+    UR_FUNCTION_SAMPLER_RETAIN = 102,                                          ///< Enumerator for ::urSamplerRetain
+    UR_FUNCTION_SAMPLER_RELEASE = 103,                                         ///< Enumerator for ::urSamplerRelease
+    UR_FUNCTION_SAMPLER_GET_INFO = 104,                                        ///< Enumerator for ::urSamplerGetInfo
+    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,                               ///< Enumerator for ::urSamplerGetNativeHandle
+    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,                       ///< Enumerator for ::urSamplerCreateWithNativeHandle
+    UR_FUNCTION_USM_HOST_ALLOC = 107,                                          ///< Enumerator for ::urUSMHostAlloc
+    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                                        ///< Enumerator for ::urUSMDeviceAlloc
+    UR_FUNCTION_USM_SHARED_ALLOC = 109,                                        ///< Enumerator for ::urUSMSharedAlloc
+    UR_FUNCTION_USM_FREE = 110,                                                ///< Enumerator for ::urUSMFree
+    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                                  ///< Enumerator for ::urUSMGetMemAllocInfo
+    UR_FUNCTION_USM_POOL_CREATE = 112,                                         ///< Enumerator for ::urUSMPoolCreate
+    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,                               ///< Enumerator for ::urCommandBufferCreateExp
+    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,                             ///< Enumerator for ::urPlatformGetBackendOption
+    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,                    ///< Enumerator for ::urMemBufferCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,                     ///< Enumerator for ::urMemImageCreateWithNativeHandle
+    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                                 ///< Enumerator for ::urEnqueueWriteHostPipe
+    UR_FUNCTION_USM_POOL_RETAIN = 118,                                         ///< Enumerator for ::urUSMPoolRetain
+    UR_FUNCTION_USM_POOL_RELEASE = 119,                                        ///< Enumerator for ::urUSMPoolRelease
+    UR_FUNCTION_USM_POOL_GET_INFO = 120,                                       ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,                               ///< Enumerator for ::urCommandBufferRetainExp
+    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,                              ///< Enumerator for ::urCommandBufferReleaseExp
+    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,                             ///< Enumerator for ::urCommandBufferFinalizeExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP = 125,                 ///< Enumerator for ::urCommandBufferAppendKernelLaunchExp
+    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,                              ///< Enumerator for ::urCommandBufferEnqueueExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP = 129,                    ///< Enumerator for ::urCommandBufferAppendMemcpyUSMExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP = 130,                ///< Enumerator for ::urCommandBufferAppendMembufferCopyExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP = 131,           ///< Enumerator for ::urCommandBufferAppendMembufferCopyRectExp
+    UR_FUNCTION_USM_PITCHED_ALLOC_EXP = 132,                                   ///< Enumerator for ::urUSMPitchedAllocExp
+    UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP = 133,      ///< Enumerator for ::urBindlessImagesUnsampledImageHandleDestroyExp
+    UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP = 134,        ///< Enumerator for ::urBindlessImagesSampledImageHandleDestroyExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP = 135,                      ///< Enumerator for ::urBindlessImagesImageAllocateExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP = 136,                          ///< Enumerator for ::urBindlessImagesImageFreeExp
+    UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP = 137,              ///< Enumerator for ::urBindlessImagesUnsampledImageCreateExp
+    UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP = 138,                ///< Enumerator for ::urBindlessImagesSampledImageCreateExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP = 139,                          ///< Enumerator for ::urBindlessImagesImageCopyExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP = 140,                      ///< Enumerator for ::urBindlessImagesImageGetInfoExp
+    UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP = 141,                    ///< Enumerator for ::urBindlessImagesMipmapGetLevelExp
+    UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP = 142,                         ///< Enumerator for ::urBindlessImagesMipmapFreeExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP = 143,                    ///< Enumerator for ::urBindlessImagesImportOpaqueFDExp
+    UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP = 144,                  ///< Enumerator for ::urBindlessImagesMapExternalArrayExp
+    UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP = 145,                     ///< Enumerator for ::urBindlessImagesReleaseInteropExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP = 146, ///< Enumerator for ::urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+    UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147,          ///< Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
+    UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148,             ///< Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
+    UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149,           ///< Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -5975,6 +6028,597 @@ urEnqueueWriteHostPipe(
                                               ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait event.
     ur_event_handle_t *phEvent                ///< [out] returns an event object that identifies this write command
                                               ///< and can be used to query or queue a wait for this command to complete.
+);
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
+// Bindless Images Extension APIs
+#if !defined(__GNUC__)
+#pragma region bindless images(experimental)
+#endif
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of bindless image
+typedef struct ur_exp_image_handle_t_ *ur_exp_image_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of bindless image memory
+typedef struct ur_exp_image_mem_handle_t_ *ur_exp_image_mem_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of interop memory
+typedef struct ur_exp_interop_mem_handle_t_ *ur_exp_interop_mem_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of interop semaphore
+typedef struct ur_exp_interop_semaphore_handle_t_ *ur_exp_interop_semaphore_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Dictates the type of memory copy.
+typedef uint32_t ur_exp_image_copy_flags_t;
+typedef enum ur_exp_image_copy_flag_t {
+    UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE = UR_BIT(0),   ///< Host to device.
+    UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST = UR_BIT(1),   ///< Device to host
+    UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE = UR_BIT(2), ///< Device to device
+    /// @cond
+    UR_EXP_IMAGE_COPY_FLAG_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_image_copy_flag_t;
+/// @brief Bit Mask for validating ur_exp_image_copy_flags_t
+#define UR_EXP_IMAGE_COPY_FLAGS_MASK 0xfffffff8
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Describes mipmap sampler properties
+///
+/// @details
+///     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
+///       as part of a `pNext` chain.
+typedef struct ur_exp_sampler_mip_properties_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES
+    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    float minMipmapLevelClamp; ///< [in] minimum mipmap level from which we can sample, minimum value
+                               ///< being 0
+    float maxMipmapLevelClamp; ///< [in] maximum mipmap level from which we can sample, maximum value
+                               ///< being the number of levels
+    float maxAnistropy;        ///< [in] anisotropic ratio used when samplling the mipmap with anisotropic
+                               ///< filtering
+
+} ur_exp_sampler_mip_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocate pitched memory
+///
+/// @details
+///     - This function must support memory pooling.
+///     - If pUSMDesc is not NULL and pUSMDesc->pool is not NULL the allocation
+///       will be served from a specified memory pool.
+///     - Otherwise, the behavior is implementation-defined.
+///     - Allocations served from different memory pools must be isolated and
+///       must not reside on the same page.
+///     - Any flags/hints passed through pUSMDesc only affect the single
+///       allocation.
+///     - See also ::ur_usm_host_desc_t.
+///     - See also ::ur_usm_device_desc_t.
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMemAllocPitch**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMem`
+///         + `NULL == pResultPitch`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`
+///         + If `align` is greater that the size of the largest data type supported by `hDevice`.
+///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
+///         + `widthInBytes == 0`
+///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+///         + If `UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT` and `UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT` are both false.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMPitchedAllocExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_device_handle_t hDevice,    ///< [in] handle of the device object
+    const ur_usm_desc_t *pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t pool,     ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t widthInBytes,           ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height,                 ///< [in] height of the USM memory object to be allocated
+    size_t elementSizeBytes,       ///< [in] size in bytes of an element in the allocation
+    void **ppMem,                  ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch           ///< [out] pitch of the allocation
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy bindless unsampled image handles
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSurfObjectDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t hImage  ///< [in] pointer to handle of image object to destroy
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy bindless sampled image handles
+///
+/// @remarks
+///   _Analogues_
+///     - **cuTexObjectDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t hImage  ///< [in] pointer to handle of image object to destroy
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocate memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuArray3DCreate**
+///     - **cuMipmappedArrayCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t *phImageMem  ///< [out] pointer to handle of image memory allocated
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuArrayDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext,       ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hImageMem ///< [in] handle of image memory to be freed
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a bindless unsampled image handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSurfObjectCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phMem`
+///         + `NULL == phImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hImageMem,   ///< [in] handle to memory from which to create the image
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    ur_mem_handle_t *phMem,                ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t *phImage         ///< [out] pointer to handle of image object created
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a bindless sampled image handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuTexObjectCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phMem`
+///         + `NULL == phImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext,          ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hImageMem,   ///< [in] handle to memory from which to create the image
+    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,          ///< [in] sampler to be used
+    ur_mem_handle_t *phMem,                ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t *phImage         ///< [out] pointer to handle of image object created
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copy image data Host to Device or Device to Host
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMemcpyHtoAAsync**
+///     - **cuMemcpyAtoHAsync**
+///     - **cuMemcpy2DAsync**
+///     - **cuMemcpy3DAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext,             ///< [in] handle of the context object
+    void *pDst,                               ///< [in] location the data will be copied to
+    void *pSrc,                               ///< [in] location the data will be copied from
+    const ur_image_format_t *pImageFormat,    ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,        ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                              ///< previously enqueued commands
+                                              ///< must be complete.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query an image memory handle for specific properties
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+///         + `NULL == pPropSizeRet`
+///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
+///         + If `propName` is not supported by the adapter.
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `propSize` is less than the real number of bytes needed to return the info.
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve individual image from mipmap
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMipmappedArrayGetLevel**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext,         ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hImageMem,  ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel,                 ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t *phImageMem ///< [out] returning memory handle to the individual image
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free mipmap memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMipmappedArrayDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import external memory in the form of a file descriptor
+///
+/// @remarks
+///   _Analogues_
+///     - **cuImportExternalMemory**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext,             ///< [in] handle of the context object
+    size_t size,                              ///< [in] size of the external memory
+    uint32_t fileDescriptor,                  ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t *phInteropMem ///< [out] interop memory handle to the external memory
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Map an interop memory handle to an image memory handle
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext,            ///< [in] handle of the context object
+    const ur_image_format_t *pImageFormat,   ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,       ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *phImageMem        ///< [out] image memory handle to the externally allocated memory
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy interop memory
+///
+/// @remarks
+///   _Analogues_
+///     - **cuDestroyExternalMemory**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext,           ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t hInteropMem ///< [in] handle of interop memory to be freed
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import an external semaphore in the form of a file descriptor
+///
+/// @remarks
+///   _Analogues_
+///     - **cuImportExternalSemaphore**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phInteropSemaphoreHandle`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext,                               ///< [in] handle of the context object
+    uint32_t fileDescriptor,                                    ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy the external semaphore handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuDestroyExternalSemaphore**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext,                       ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Instruct the queue with a non-blocking wait on an external semaphore
+///
+/// @remarks
+///   _Analogues_
+///     - **cuWaitExternalSemaphoresAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue,                     ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t hSemaphore, ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList,                 ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList,     ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                  ///< events that must be complete before this command can be executed.
+                                                  ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                  ///< previously enqueued commands
+                                                  ///< must be complete.
+    ur_event_handle_t *phEvent                    ///< [out][optional] return an event object that identifies this particular
+                                                  ///< command instance.
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Instruct the queue to signal the external semaphore handle once all
+///        previous commands have completed execution
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSignalExternalSemaphoresAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+UR_APIEXPORT ur_result_t UR_APICALL
+urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue,                     ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t hSemaphore, ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList,                 ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList,     ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                  ///< events that must be complete before this command can be executed.
+                                                  ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                  ///< previously enqueued commands
+                                                  ///< must be complete.
+    ur_event_handle_t *phEvent                    ///< [out][optional] return an event object that identifies this particular
+                                                  ///< command instance.
 );
 
 #if !defined(__GNUC__)
@@ -7423,6 +8067,307 @@ typedef struct ur_queue_flush_params_t {
 } ur_queue_flush_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesUnsampledImageHandleDestroyExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_handle_t *phImage;
+} ur_bindless_images_unsampled_image_handle_destroy_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesSampledImageHandleDestroyExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_sampled_image_handle_destroy_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_handle_t *phImage;
+} ur_bindless_images_sampled_image_handle_destroy_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesImageAllocateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_image_allocate_exp_params_t {
+    ur_context_handle_t *phContext;
+    const ur_image_format_t **ppImageFormat;
+    const ur_image_desc_t **ppImageDesc;
+    ur_exp_image_mem_handle_t **pphImageMem;
+} ur_bindless_images_image_allocate_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesImageFreeExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_image_free_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_mem_handle_t *phImageMem;
+} ur_bindless_images_image_free_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesUnsampledImageCreateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_unsampled_image_create_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_mem_handle_t *phImageMem;
+    const ur_image_format_t **ppImageFormat;
+    const ur_image_desc_t **ppImageDesc;
+    ur_mem_handle_t **pphMem;
+    ur_exp_image_handle_t **pphImage;
+} ur_bindless_images_unsampled_image_create_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesSampledImageCreateExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_sampled_image_create_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_mem_handle_t *phImageMem;
+    const ur_image_format_t **ppImageFormat;
+    const ur_image_desc_t **ppImageDesc;
+    ur_sampler_handle_t *phSampler;
+    ur_mem_handle_t **pphMem;
+    ur_exp_image_handle_t **pphImage;
+} ur_bindless_images_sampled_image_create_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesImageCopyExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_image_copy_exp_params_t {
+    ur_context_handle_t *phContext;
+    void **ppDst;
+    void **ppSrc;
+    const ur_image_format_t **ppImageFormat;
+    const ur_image_desc_t **ppImageDesc;
+    ur_exp_image_copy_flags_t *pimageCopyFlags;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
+} ur_bindless_images_image_copy_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesImageGetInfoExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_image_get_info_exp_params_t {
+    ur_exp_image_mem_handle_t *phImageMem;
+    ur_image_info_t *ppropName;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
+} ur_bindless_images_image_get_info_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesMipmapGetLevelExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_mipmap_get_level_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_mem_handle_t *phImageMem;
+    uint32_t *pmipmapLevel;
+    ur_exp_image_mem_handle_t **pphImageMem;
+} ur_bindless_images_mipmap_get_level_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesMipmapFreeExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_mipmap_free_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_image_mem_handle_t *phMem;
+} ur_bindless_images_mipmap_free_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesImportOpaqueFDExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_import_opaque_fd_exp_params_t {
+    ur_context_handle_t *phContext;
+    size_t *psize;
+    uint32_t *pfileDescriptor;
+    ur_exp_interop_mem_handle_t **pphInteropMem;
+} ur_bindless_images_import_opaque_fd_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesMapExternalArrayExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_map_external_array_exp_params_t {
+    ur_context_handle_t *phContext;
+    const ur_image_format_t **ppImageFormat;
+    const ur_image_desc_t **ppImageDesc;
+    ur_exp_interop_mem_handle_t *phInteropMem;
+    ur_exp_image_handle_t **pphImageMem;
+} ur_bindless_images_map_external_array_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesReleaseInteropExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_release_interop_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_interop_mem_handle_t *phInteropMem;
+} ur_bindless_images_release_interop_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t {
+    ur_context_handle_t *phContext;
+    uint32_t *pfileDescriptor;
+    ur_exp_interop_semaphore_handle_t **pphInteropSemaphoreHandle;
+} ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesDestroyExternalSemaphoreExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_destroy_external_semaphore_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_exp_interop_semaphore_handle_t *phInteropSemaphore;
+} ur_bindless_images_destroy_external_semaphore_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesWaitExternalSemaphoreExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_wait_external_semaphore_exp_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_exp_interop_semaphore_handle_t *phSemaphore;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
+} ur_bindless_images_wait_external_semaphore_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urBindlessImagesSignalExternalSemaphoreExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_bindless_images_signal_external_semaphore_exp_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_exp_interop_semaphore_handle_t *phSemaphore;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
+} ur_bindless_images_signal_external_semaphore_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMHostAlloc
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_host_alloc_params_t {
+    ur_context_handle_t *phContext;
+    const ur_usm_desc_t **ppUSMDesc;
+    ur_usm_pool_handle_t *ppool;
+    size_t *psize;
+    void ***pppMem;
+} ur_usm_host_alloc_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMDeviceAlloc
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_device_alloc_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_usm_desc_t **ppUSMDesc;
+    ur_usm_pool_handle_t *ppool;
+    size_t *psize;
+    void ***pppMem;
+} ur_usm_device_alloc_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMSharedAlloc
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_shared_alloc_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_usm_desc_t **ppUSMDesc;
+    ur_usm_pool_handle_t *ppool;
+    size_t *psize;
+    void ***pppMem;
+} ur_usm_shared_alloc_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMFree
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_free_params_t {
+    ur_context_handle_t *phContext;
+    void **ppMem;
+} ur_usm_free_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMGetMemAllocInfo
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_get_mem_alloc_info_params_t {
+    ur_context_handle_t *phContext;
+    const void **ppMem;
+    ur_usm_alloc_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
+} ur_usm_get_mem_alloc_info_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMPoolCreate
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_pool_create_params_t {
+    ur_context_handle_t *phContext;
+    ur_usm_pool_desc_t **ppPoolDesc;
+    ur_usm_pool_handle_t **pppPool;
+} ur_usm_pool_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMPoolRetain
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_pool_retain_params_t {
+    ur_usm_pool_handle_t *ppPool;
+} ur_usm_pool_retain_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMPoolRelease
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_pool_release_params_t {
+    ur_usm_pool_handle_t *ppPool;
+} ur_usm_pool_release_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMPoolGetInfo
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_pool_get_info_params_t {
+    ur_usm_pool_handle_t *phPool;
+    ur_usm_pool_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
+} ur_usm_pool_get_info_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMPitchedAllocExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_pitched_alloc_exp_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_usm_desc_t **ppUSMDesc;
+    ur_usm_pool_handle_t *ppool;
+    size_t *pwidthInBytes;
+    size_t *pheight;
+    size_t *pelementSizeBytes;
+    void ***pppMem;
+    size_t **ppResultPitch;
+} ur_usm_pitched_alloc_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urCommandBufferCreateExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -7559,104 +8504,6 @@ typedef struct ur_get_last_result_params_t {
 typedef struct ur_tear_down_params_t {
     void **ppParams;
 } ur_tear_down_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMHostAlloc
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_host_alloc_params_t {
-    ur_context_handle_t *phContext;
-    const ur_usm_desc_t **ppUSMDesc;
-    ur_usm_pool_handle_t *ppool;
-    size_t *psize;
-    void ***pppMem;
-} ur_usm_host_alloc_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMDeviceAlloc
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_device_alloc_params_t {
-    ur_context_handle_t *phContext;
-    ur_device_handle_t *phDevice;
-    const ur_usm_desc_t **ppUSMDesc;
-    ur_usm_pool_handle_t *ppool;
-    size_t *psize;
-    void ***pppMem;
-} ur_usm_device_alloc_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMSharedAlloc
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_shared_alloc_params_t {
-    ur_context_handle_t *phContext;
-    ur_device_handle_t *phDevice;
-    const ur_usm_desc_t **ppUSMDesc;
-    ur_usm_pool_handle_t *ppool;
-    size_t *psize;
-    void ***pppMem;
-} ur_usm_shared_alloc_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMFree
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_free_params_t {
-    ur_context_handle_t *phContext;
-    void **ppMem;
-} ur_usm_free_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMGetMemAllocInfo
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_get_mem_alloc_info_params_t {
-    ur_context_handle_t *phContext;
-    const void **ppMem;
-    ur_usm_alloc_info_t *ppropName;
-    size_t *ppropSize;
-    void **ppPropValue;
-    size_t **ppPropSizeRet;
-} ur_usm_get_mem_alloc_info_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMPoolCreate
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_pool_create_params_t {
-    ur_context_handle_t *phContext;
-    ur_usm_pool_desc_t **ppPoolDesc;
-    ur_usm_pool_handle_t **pppPool;
-} ur_usm_pool_create_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMPoolRetain
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_pool_retain_params_t {
-    ur_usm_pool_handle_t *ppPool;
-} ur_usm_pool_retain_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMPoolRelease
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_pool_release_params_t {
-    ur_usm_pool_handle_t *ppPool;
-} ur_usm_pool_release_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urUSMPoolGetInfo
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_usm_pool_get_info_params_t {
-    ur_usm_pool_handle_t *phPool;
-    ur_usm_pool_info_t *ppropName;
-    size_t *ppropSize;
-    void **ppPropValue;
-    size_t **ppPropSizeRet;
-} ur_usm_pool_get_info_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urDeviceGet

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1214,6 +1214,331 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
     ur_queue_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesUnsampledImageHandleDestroyExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesUnsampledImageHandleDestroyExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesSampledImageHandleDestroyExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSampledImageHandleDestroyExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesImageAllocateExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageAllocateExp_t)(
+    ur_context_handle_t,
+    const ur_image_format_t *,
+    const ur_image_desc_t *,
+    ur_exp_image_mem_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesImageFreeExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageFreeExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_mem_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesUnsampledImageCreateExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesUnsampledImageCreateExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_mem_handle_t,
+    const ur_image_format_t *,
+    const ur_image_desc_t *,
+    ur_mem_handle_t *,
+    ur_exp_image_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesSampledImageCreateExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSampledImageCreateExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_mem_handle_t,
+    const ur_image_format_t *,
+    const ur_image_desc_t *,
+    ur_sampler_handle_t,
+    ur_mem_handle_t *,
+    ur_exp_image_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesImageCopyExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageCopyExp_t)(
+    ur_context_handle_t,
+    void *,
+    void *,
+    const ur_image_format_t *,
+    const ur_image_desc_t *,
+    ur_exp_image_copy_flags_t,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesImageGetInfoExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageGetInfoExp_t)(
+    ur_exp_image_mem_handle_t,
+    ur_image_info_t,
+    void *,
+    size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesMipmapGetLevelExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMipmapGetLevelExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_mem_handle_t,
+    uint32_t,
+    ur_exp_image_mem_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesMipmapFreeExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMipmapFreeExp_t)(
+    ur_context_handle_t,
+    ur_exp_image_mem_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesImportOpaqueFDExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportOpaqueFDExp_t)(
+    ur_context_handle_t,
+    size_t,
+    uint32_t,
+    ur_exp_interop_mem_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesMapExternalArrayExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMapExternalArrayExp_t)(
+    ur_context_handle_t,
+    const ur_image_format_t *,
+    const ur_image_desc_t *,
+    ur_exp_interop_mem_handle_t,
+    ur_exp_image_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesReleaseInteropExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseInteropExp_t)(
+    ur_context_handle_t,
+    ur_exp_interop_mem_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreOpaqueFDExp_t)(
+    ur_context_handle_t,
+    uint32_t,
+    ur_exp_interop_semaphore_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesDestroyExternalSemaphoreExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesDestroyExternalSemaphoreExp_t)(
+    ur_context_handle_t,
+    ur_exp_interop_semaphore_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesWaitExternalSemaphoreExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesWaitExternalSemaphoreExp_t)(
+    ur_queue_handle_t,
+    ur_exp_interop_semaphore_handle_t,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urBindlessImagesSignalExternalSemaphoreExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSignalExternalSemaphoreExp_t)(
+    ur_queue_handle_t,
+    ur_exp_interop_semaphore_handle_t,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of BindlessImagesExp functions pointers
+typedef struct ur_bindless_images_exp_dditable_t {
+    ur_pfnBindlessImagesUnsampledImageHandleDestroyExp_t pfnUnsampledImageHandleDestroyExp;
+    ur_pfnBindlessImagesSampledImageHandleDestroyExp_t pfnSampledImageHandleDestroyExp;
+    ur_pfnBindlessImagesImageAllocateExp_t pfnImageAllocateExp;
+    ur_pfnBindlessImagesImageFreeExp_t pfnImageFreeExp;
+    ur_pfnBindlessImagesUnsampledImageCreateExp_t pfnUnsampledImageCreateExp;
+    ur_pfnBindlessImagesSampledImageCreateExp_t pfnSampledImageCreateExp;
+    ur_pfnBindlessImagesImageCopyExp_t pfnImageCopyExp;
+    ur_pfnBindlessImagesImageGetInfoExp_t pfnImageGetInfoExp;
+    ur_pfnBindlessImagesMipmapGetLevelExp_t pfnMipmapGetLevelExp;
+    ur_pfnBindlessImagesMipmapFreeExp_t pfnMipmapFreeExp;
+    ur_pfnBindlessImagesImportOpaqueFDExp_t pfnImportOpaqueFDExp;
+    ur_pfnBindlessImagesMapExternalArrayExp_t pfnMapExternalArrayExp;
+    ur_pfnBindlessImagesReleaseInteropExp_t pfnReleaseInteropExp;
+    ur_pfnBindlessImagesImportExternalSemaphoreOpaqueFDExp_t pfnImportExternalSemaphoreOpaqueFDExp;
+    ur_pfnBindlessImagesDestroyExternalSemaphoreExp_t pfnDestroyExternalSemaphoreExp;
+    ur_pfnBindlessImagesWaitExternalSemaphoreExp_t pfnWaitExternalSemaphoreExp;
+    ur_pfnBindlessImagesSignalExternalSemaphoreExp_t pfnSignalExternalSemaphoreExp;
+} ur_bindless_images_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's BindlessImagesExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetBindlessImagesExpProcAddrTable(
+    ur_api_version_t version,                    ///< [in] API version requested
+    ur_bindless_images_exp_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetBindlessImagesExpProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetBindlessImagesExpProcAddrTable_t)(
+    ur_api_version_t,
+    ur_bindless_images_exp_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMHostAlloc
+typedef ur_result_t(UR_APICALL *ur_pfnUSMHostAlloc_t)(
+    ur_context_handle_t,
+    const ur_usm_desc_t *,
+    ur_usm_pool_handle_t,
+    size_t,
+    void **);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMDeviceAlloc
+typedef ur_result_t(UR_APICALL *ur_pfnUSMDeviceAlloc_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    const ur_usm_desc_t *,
+    ur_usm_pool_handle_t,
+    size_t,
+    void **);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMSharedAlloc
+typedef ur_result_t(UR_APICALL *ur_pfnUSMSharedAlloc_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    const ur_usm_desc_t *,
+    ur_usm_pool_handle_t,
+    size_t,
+    void **);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMFree
+typedef ur_result_t(UR_APICALL *ur_pfnUSMFree_t)(
+    ur_context_handle_t,
+    void *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMGetMemAllocInfo
+typedef ur_result_t(UR_APICALL *ur_pfnUSMGetMemAllocInfo_t)(
+    ur_context_handle_t,
+    const void *,
+    ur_usm_alloc_info_t,
+    size_t,
+    void *,
+    size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMPoolCreate
+typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolCreate_t)(
+    ur_context_handle_t,
+    ur_usm_pool_desc_t *,
+    ur_usm_pool_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMPoolRetain
+typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolRetain_t)(
+    ur_usm_pool_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMPoolRelease
+typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolRelease_t)(
+    ur_usm_pool_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMPoolGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolGetInfo_t)(
+    ur_usm_pool_handle_t,
+    ur_usm_pool_info_t,
+    size_t,
+    void *,
+    size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of USM functions pointers
+typedef struct ur_usm_dditable_t {
+    ur_pfnUSMHostAlloc_t pfnHostAlloc;
+    ur_pfnUSMDeviceAlloc_t pfnDeviceAlloc;
+    ur_pfnUSMSharedAlloc_t pfnSharedAlloc;
+    ur_pfnUSMFree_t pfnFree;
+    ur_pfnUSMGetMemAllocInfo_t pfnGetMemAllocInfo;
+    ur_pfnUSMPoolCreate_t pfnPoolCreate;
+    ur_pfnUSMPoolRetain_t pfnPoolRetain;
+    ur_pfnUSMPoolRelease_t pfnPoolRelease;
+    ur_pfnUSMPoolGetInfo_t pfnPoolGetInfo;
+} ur_usm_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USM table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(
+    ur_api_version_t version,    ///< [in] API version requested
+    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetUSMProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
+    ur_api_version_t,
+    ur_usm_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMPitchedAllocExp
+typedef ur_result_t(UR_APICALL *ur_pfnUSMPitchedAllocExp_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    const ur_usm_desc_t *,
+    ur_usm_pool_handle_t,
+    size_t,
+    size_t,
+    size_t,
+    void **,
+    size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of USMExp functions pointers
+typedef struct ur_usm_exp_dditable_t {
+    ur_pfnUSMPitchedAllocExp_t pfnPitchedAllocExp;
+} ur_usm_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USMExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMExpProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_usm_exp_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetUSMExpProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetUSMExpProcAddrTable_t)(
+    ur_api_version_t,
+    ur_usm_exp_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urCommandBufferCreateExp
 typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferCreateExp_t)(
     ur_context_handle_t,
@@ -1380,112 +1705,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetGlobalProcAddrTable_t)(
     ur_global_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMHostAlloc
-typedef ur_result_t(UR_APICALL *ur_pfnUSMHostAlloc_t)(
-    ur_context_handle_t,
-    const ur_usm_desc_t *,
-    ur_usm_pool_handle_t,
-    size_t,
-    void **);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMDeviceAlloc
-typedef ur_result_t(UR_APICALL *ur_pfnUSMDeviceAlloc_t)(
-    ur_context_handle_t,
-    ur_device_handle_t,
-    const ur_usm_desc_t *,
-    ur_usm_pool_handle_t,
-    size_t,
-    void **);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMSharedAlloc
-typedef ur_result_t(UR_APICALL *ur_pfnUSMSharedAlloc_t)(
-    ur_context_handle_t,
-    ur_device_handle_t,
-    const ur_usm_desc_t *,
-    ur_usm_pool_handle_t,
-    size_t,
-    void **);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMFree
-typedef ur_result_t(UR_APICALL *ur_pfnUSMFree_t)(
-    ur_context_handle_t,
-    void *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMGetMemAllocInfo
-typedef ur_result_t(UR_APICALL *ur_pfnUSMGetMemAllocInfo_t)(
-    ur_context_handle_t,
-    const void *,
-    ur_usm_alloc_info_t,
-    size_t,
-    void *,
-    size_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMPoolCreate
-typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolCreate_t)(
-    ur_context_handle_t,
-    ur_usm_pool_desc_t *,
-    ur_usm_pool_handle_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMPoolRetain
-typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolRetain_t)(
-    ur_usm_pool_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMPoolRelease
-typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolRelease_t)(
-    ur_usm_pool_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urUSMPoolGetInfo
-typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolGetInfo_t)(
-    ur_usm_pool_handle_t,
-    ur_usm_pool_info_t,
-    size_t,
-    void *,
-    size_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Table of USM functions pointers
-typedef struct ur_usm_dditable_t {
-    ur_pfnUSMHostAlloc_t pfnHostAlloc;
-    ur_pfnUSMDeviceAlloc_t pfnDeviceAlloc;
-    ur_pfnUSMSharedAlloc_t pfnSharedAlloc;
-    ur_pfnUSMFree_t pfnFree;
-    ur_pfnUSMGetMemAllocInfo_t pfnGetMemAllocInfo;
-    ur_pfnUSMPoolCreate_t pfnPoolCreate;
-    ur_pfnUSMPoolRetain_t pfnPoolRetain;
-    ur_pfnUSMPoolRelease_t pfnPoolRelease;
-    ur_pfnUSMPoolGetInfo_t pfnPoolGetInfo;
-} ur_usm_dditable_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's USM table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetUSMProcAddrTable(
-    ur_api_version_t version,    ///< [in] API version requested
-    ur_usm_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetUSMProcAddrTable
-typedef ur_result_t(UR_APICALL *ur_pfnGetUSMProcAddrTable_t)(
-    ur_api_version_t,
-    ur_usm_dditable_t *);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urDeviceGet
 typedef ur_result_t(UR_APICALL *ur_pfnDeviceGet_t)(
     ur_platform_handle_t,
@@ -1598,9 +1817,11 @@ typedef struct ur_dditable_t {
     ur_mem_dditable_t Mem;
     ur_enqueue_dditable_t Enqueue;
     ur_queue_dditable_t Queue;
+    ur_bindless_images_exp_dditable_t BindlessImagesExp;
+    ur_usm_dditable_t USM;
+    ur_usm_exp_dditable_t USMExp;
     ur_command_buffer_exp_dditable_t CommandBufferExp;
     ur_global_dditable_t Global;
-    ur_usm_dditable_t USM;
     ur_device_dditable_t Device;
 } ur_dditable_t;
 

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -1,0 +1,136 @@
+
+<%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+
+.. _exp-bindless-images:
+
+================================================================================
+Bindless Images
+================================================================================
+
+.. warning::
+
+    Experimental features:
+
+    *   May be replaced, updated, or removed at any time.
+    *   Do not require maintaining API/ABI stability of their own additions over
+        time.
+    *   Do not require conformance testing of their own additions.
+
+================================================================================
+Terminology
+================================================================================
+For the purposes of this document, a bindless image is one which provides
+access to the underlying data via image reference handles. At the application
+level, this allows the user to implement programs where the number of images
+is not known at compile-time, and store all handles to images -- irrespective
+of varying formats and layouts -- in some container, e.g. a dynamic array.
+
+================================================================================
+Motivation
+================================================================================
+The `DPC++ bindless images extension <https://github.com/intel/llvm/pull/8307>`_
+has sought to provide the flexibility of bindless images at the SYCL
+application level. This extension has been implemented using the CUDA backend of
+the DPC++ PI. With the movement to migrate from PI to the Unified Runtime in
+DPC++, as seen in `Port CUDA plugin to Unified Runtime
+<https://github.com/intel/llvm/pull/9512/>`_, the Unified Runtime's support for
+this experimental feature would enable the DPC++ bindless images extension to be
+migrated to UR without issue.
+
+================================================================================
+Overview
+================================================================================
+
+In this document, we propose the following experimental additions to the Unified
+Runtime:
+
+* Bindless images support
+
+  * Sampled images
+  * Unsampled images
+  * Mipmaps
+  * USM backed images
+
+* Interoperability support
+
+  * External memory
+  * Semaphores
+
+================================================================================
+API
+================================================================================
+
+--------------------------------------------------------------------------------
+Definitions
+--------------------------------------------------------------------------------
+
+* ${x}_exp_sampler_mip_properties_t
+
+The following definitions will be implementation-dependent
+
+* ${x}_exp_image_handle_t
+* ${x}_exp_image_mem_handle_t
+* ${x}_exp_interop_mem_handle_t
+* ${x}_exp_interop_semaphore_handle_t
+
+--------------------------------------------------------------------------------
+Enums
+--------------------------------------------------------------------------------
+
+* ${x}_device_info_t
+* ${x}_command_t
+* ${x}_exp_image_copy_flags_t
+
+--------------------------------------------------------------------------------
+Interface
+--------------------------------------------------------------------------------
+
+* USM
+   * ${x}USMPitchedAllocExp
+
+* Bindless Images
+   * ${x}BindlessImagesUnsampledImageHandleDestroyExp
+   * ${x}BindlessImagesSampledImageHandleDestroyExp
+   * ${x}BindlessImagesImageAllocateExp
+   * ${x}BindlessImagesImageFreeExp
+   * ${x}BindlessImagesUnsampledImageCreateExp
+   * ${x}BindlessImagesSampledImageCreateExp
+   * ${x}BindlessImagesImageCopyExp
+   * ${x}BindlessImagesImageGetInfoExp
+   * ${x}BindlessImagesMipmapGetLevelExp
+   * ${x}BindlessImagesMipmapFreeExp
+
+* Interop
+   * ${x}BindlessImagesImportOpaqueFDExp
+   * ${x}BindlessImagesMapExternalArrayExp
+   * ${x}BindlessImagesReleaseInteropExp
+   * ${x}BindlessImagesImportExternalSemaphoreOpaqueFDExp
+   * ${x}BindlessImagesDestroyExternalSemaphoreExp
+   * ${x}BindlessImagesWaitExternalSemaphoreExp
+   * ${x}BindlessImagesSignalExternalSemaphoreExp
+
+
+================================================================================
+Changelog
+================================================================================
+
++-----------+------------------------+
+| Revision  | Changes                |
++===========+========================+
+| 1         | Intial Draft           |
++-----------+------------------------+
+
+================================================================================
+Contributors
+================================================================================
+
+* Isaac Ault `isaac.ault@codeplay.com <isaac.ault@codeplay.com>`_
+* Duncan Brawley `duncan.brawley@codeplay.com <duncan.brawley@codeplay.com>`_
+* Przemek Malon `przemek.malon@codeplay.com <przemek.malon@codeplay.com>`_
+* Chedy Najjar `chedy.najjar@codeplay.com <chedy.najjar@codeplay.com>`_
+* Sean Stirling `sean.stirling@codeplay.com <sean.stirling@codeplay.com>`_
+* Peter Zuzek `peter@codeplay.com peter@codeplay.com <peter@codeplay.com>`_

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -329,6 +329,8 @@ etors:
       desc: $x_device_partition_properties_t
     - name: EXP_COMMAND_BUFFER_DESC
       desc: $x_exp_command_buffer_desc_t
+    - name: EXP_SAMPLER_MIP_PROPERTIES
+      desc: $x_exp_sampler_mip_properties_t
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -385,6 +385,54 @@ etors:
       desc: "[uint32_t] The maximum number of registers available per block."
     - name: IP_VERSION
       desc: "[uint32_t] The device IP version. The meaning of the device IP version is implementation-defined, but newer devices should have a higher version than older devices."
+    - name: BINDLESS_IMAGES_SUPPORT_EXP
+      value: "0x2000"
+      desc: "[$x_bool_t] returns true if the device supports the creation of bindless images"
+    - name: BINDLESS_IMAGES_1D_USM_SUPPORT_EXP
+      value: "0x2001"
+      desc: "[$x_bool_t] returns true if the device supports the creation of 1D bindless images backed by USM"
+    - name: BINDLESS_IMAGES_2D_USM_SUPPORT_EXP
+      value: "0x2002"
+      desc: "[$x_bool_t] returns true if the device supports the creation of 2D bindless images backed by USM"
+    - name: BINDLESS_IMAGES_3D_USM_SUPPORT_EXP
+      value: "0x2003"
+      desc: "[$x_bool_t] returns true if the device supports the creation of 3D bindless images backed by USM"
+    - name: IMAGE_PITCH_ALIGN_EXP
+      value: "0x2004"
+      desc: "[uint32_t] returns the required alignment of the pitch between two rows of an image in bytes"
+    - name: MAX_IMAGE_LINEAR_WIDTH_EXP
+      value: "0x2005"
+      desc: "[size_t] returns the maximum linear width allowed for images allocated using USM"
+    - name: MAX_IMAGE_LINEAR_HEIGHT_EXP
+      value: "0x2006"
+      desc: "[size_t] returns the maximum linear height allowed for images allocated using USM"
+    - name: MAX_IMAGE_LINEAR_PITCH_EXP
+      value: "0x2007"
+      desc: "[size_t] returns the maximum linear pitch allowed for images allocated using USM"
+    - name: MIPMAP_SUPPORT_EXP
+      value: "0x2008"
+      desc: "[$x_bool_t] returns true if the device supports allocating mipmap resources"
+    - name: MIPMAP_ANISOTROPY_SUPPORT_EXP
+      value: "0x2009"
+      desc: "[$x_bool_t] returns true if the device supports sampling mipmap images with anisotropic filtering"
+    - name: MIPMAP_MAX_ANISOTROPY_EXP
+      value: "0x200A"
+      desc: "[uint32_t] returns the maximum anisotropic ratio supported by the device"
+    - name: MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP
+      value: "0x200B"
+      desc: "[$x_bool_t] returns true if the device supports using images created from individual mipmap levels"
+    - name: INTEROP_MEMORY_IMPORT_SUPPORT_EXP
+      value: "0x200C"
+      desc: "[$x_bool_t] returns true if the device supports importing external memory resources"
+    - name: INTEROP_MEMORY_EXPORT_SUPPORT_EXP
+      value: "0x200D"
+      desc: "[$x_bool_t] returns true if the device supports exporting internal memory resources"
+    - name: INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP
+      value: "0x200E"
+      desc: "[$x_bool_t] returns true if the device supports importing external semaphore resources"
+    - name: INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP
+      value: "0x200F"
+      desc: "[$x_bool_t] returns true if the device supports exporting internal event resources"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -75,6 +75,12 @@ etors:
       desc: Event created by $xEnqueueWriteHostPipe
     - name: COMMAND_BUFFER_ENQUEUE_EXP
       desc: Event created by $xCommandBufferEnqueueExp
+    - name: INTEROP_SEMAPHORE_WAIT_EXP
+      value: "0x2000"
+      desc: Event created by $xBindlessImagesWaitExternalSemaphoreExp
+    - name: INTEROP_SEMAPHORE_SIGNAL_EXP
+      value: "0x2001"
+      desc: Event created by $xBindlessImagesSignalExternalSemaphoreExp
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Event Status"

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -1,0 +1,561 @@
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Bindless Images Extension APIs"
+ordinal: "99"
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of bindless image"
+class: $xBindlessImages
+name: "$x_exp_image_handle_t"
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of bindless image memory"
+class: $xBindlessImages
+name: "$x_exp_image_mem_handle_t"
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of interop memory"
+class: $xBindlessImages
+name: "$x_exp_interop_mem_handle_t"
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of interop semaphore"
+class: $xBindlessImages
+name: "$x_exp_interop_semaphore_handle_t"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Dictates the type of memory copy."
+class: $xBindlessImages
+name: $x_exp_image_copy_flags_t
+etors:
+  - name: HOST_TO_DEVICE
+    desc: "Host to device."
+  - name: DEVICE_TO_HOST
+    desc: "Device to host"
+  - name: DEVICE_TO_DEVICE
+    desc: "Device to device"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Describes mipmap sampler properties"
+details:
+    - Specify these properties in $xSamplerCreate via $x_sampler_desc_t as part
+      of a `pNext` chain.
+class: $xBindlessImages
+name: $x_exp_sampler_mip_properties_t
+base: $x_base_properties_t
+members:
+    - type: float
+      name: minMipmapLevelClamp
+      desc: "[in] minimum mipmap level from which we can sample, minimum value being 0"
+    - type: float
+      name: maxMipmapLevelClamp
+      desc: "[in] maximum mipmap level from which we can sample, maximum value being the number of levels"
+    - type: float
+      name: maxAnistropy
+      desc: "[in] anisotropic ratio used when samplling the mipmap with anisotropic filtering"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "USM allocate pitched memory"
+class: $xUSM
+name: PitchedAllocExp
+ordinal: "0"
+analogue:
+    - "**cuMemAllocPitch**"
+details:
+  - "This function must support memory pooling."
+  - "If pUSMDesc is not NULL and pUSMDesc->pool is not NULL the allocation will be served from a specified memory pool."
+  - "Otherwise, the behavior is implementation-defined."
+  - "Allocations served from different memory pools must be isolated and must not reside on the same page."
+  - "Any flags/hints passed through pUSMDesc only affect the single allocation."
+  - "See also $x_usm_host_desc_t."
+  - "See also $x_usm_device_desc_t."
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_device_handle_t
+      name: hDevice
+      desc: "[in] handle of the device object"
+    - type: const $x_usm_desc_t*
+      name: pUSMDesc
+      desc: "[in][optional] Pointer to USM memory allocation descriptor."
+    - type: $x_usm_pool_handle_t
+      name: pool
+      desc: "[in][optional] Pointer to a pool created using urUSMPoolCreate"
+    - type: "size_t"
+      name: widthInBytes
+      desc: "[in] width in bytes of the USM memory object to be allocated"
+    - type: "size_t"
+      name: height
+      desc: "[in] height of the USM memory object to be allocated"
+    - type: "size_t"
+      name: elementSizeBytes
+      desc: "[in] size in bytes of an element in the allocation"
+    - type: void**
+      name: ppMem
+      desc: "[out] pointer to USM shared memory object"
+    - type: size_t*
+      name: pResultPitch
+      desc: "[out] pitch of the allocation"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE:
+      - "`pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`" # alignment must be power of two
+      - "If `align` is greater that the size of the largest data type supported by `hDevice`."
+    - $X_RESULT_ERROR_INVALID_USM_SIZE:
+      - "`widthInBytes == 0`"
+      - "`size` is greater than $X_DEVICE_INFO_MAX_MEM_ALLOC_SIZE."
+    - $X_RESULT_ERROR_INVALID_OPERATION:
+      - "If `UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT` and `UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT` are both false."
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Destroy bindless unsampled image handles"
+class: $xBindlessImages
+name: UnsampledImageHandleDestroyExp
+ordinal: "0"
+analogue:
+    - "**cuSurfObjectDestroy**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_handle_t
+      name: hImage
+      desc: "[in] pointer to handle of image object to destroy"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Destroy bindless sampled image handles"
+class: $xBindlessImages
+name: SampledImageHandleDestroyExp
+ordinal: "0"
+analogue:
+    - "**cuTexObjectDestroy**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_handle_t
+      name: hImage
+      desc: "[in] pointer to handle of image object to destroy"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Allocate memory for bindless images"
+class: $xBindlessImages
+name: ImageAllocateExp
+ordinal: "0"
+analogue:
+    - "**cuArray3DCreate**"
+    - "**cuMipmappedArrayCreate**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: "const $x_image_format_t*"
+      name: pImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "const $x_image_desc_t*"
+      name: pImageDesc
+      desc: "[in] pointer to image description"
+    - type: $x_exp_image_mem_handle_t*
+      name: phImageMem
+      desc: "[out] pointer to handle of image memory allocated"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`"
+    - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
+    - $X_RESULT_ERROR_INVALID_OPERATION
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Free memory for bindless images"
+class: $xBindlessImages
+name: ImageFreeExp
+ordinal: "0"
+analogue:
+    - "**cuArrayDestroy**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_mem_handle_t
+      name: hImageMem
+      desc: "[in] handle of image memory to be freed"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Create a bindless unsampled image handle"
+class: $xBindlessImages
+name: UnsampledImageCreateExp
+ordinal: "0"
+analogue:
+    - "**cuSurfObjectCreate**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_mem_handle_t
+      name: hImageMem
+      desc: "[in] handle to memory from which to create the image"
+    - type: "const $x_image_format_t*"
+      name: pImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "const $x_image_desc_t*"
+      name: pImageDesc
+      desc: "[in] pointer to image description"
+    - type: $x_mem_handle_t*
+      name: phMem
+      desc: "[out] pointer to handle of image object created"
+    - type: $x_exp_image_handle_t*
+      name: phImage
+      desc: "[out] pointer to handle of image object created"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`"
+    - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
+    - $X_RESULT_ERROR_INVALID_OPERATION
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Create a bindless sampled image handle"
+class: $xBindlessImages
+name: SampledImageCreateExp
+ordinal: "0"
+analogue:
+    - "**cuTexObjectCreate**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_mem_handle_t
+      name: hImageMem
+      desc: "[in] handle to memory from which to create the image"
+    - type: "const $x_image_format_t*"
+      name: pImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "const $x_image_desc_t*"
+      name: pImageDesc
+      desc: "[in] pointer to image description"
+    - type: $x_sampler_handle_t
+      name: hSampler
+      desc: "[in] sampler to be used"
+    - type: $x_mem_handle_t*
+      name: phMem
+      desc: "[out] pointer to handle of image object created"
+    - type: $x_exp_image_handle_t*
+      name: phImage
+      desc: "[out] pointer to handle of image object created"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`"
+    - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
+    - $X_RESULT_ERROR_INVALID_SAMPLER
+    - $X_RESULT_ERROR_INVALID_OPERATION
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Copy image data Host to Device or Device to Host"
+class: $xBindlessImages
+name: ImageCopyExp
+ordinal: "0"
+analogue:
+    - "**cuMemcpyHtoAAsync**"
+    - "**cuMemcpyAtoHAsync**"
+    - "**cuMemcpy2DAsync**"
+    - "**cuMemcpy3DAsync**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: void*
+      name: pDst
+      desc: "[in] location the data will be copied to"
+    - type: void*
+      name: pSrc
+      desc: "[in] location the data will be copied from"
+    - type: "const $x_image_format_t*"
+      name: pImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "const $x_image_desc_t*"
+      name: pImageDesc
+      desc: "[in] pointer to image description"
+    - type: $x_exp_image_copy_flags_t
+      name: imageCopyFlags
+      desc: "[in] flags describing copy direction e.g. H2D or D2H"
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before this command can be executed.
+            If nullptr, the numEventsInWaitList must be 0, indicating that all previously enqueued commands
+            must be complete.
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [out][optional] return an event object that identifies this particular command instance.
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`"
+    - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
+    - $X_RESULT_ERROR_INVALID_OPERATION
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Query an image memory handle for specific properties"
+class: $xBindlessImages
+name: ImageGetInfoExp
+ordinal: "0"
+params:
+    - type: $x_exp_image_mem_handle_t
+      name: hImageMem
+      desc: "[in] handle to the image memory"
+    - type: $x_image_info_t
+      name: propName
+      desc: "[in] queried info name"
+    - type: void*
+      name: pPropValue
+      desc: "[out] returned query value"
+    - type: "size_t*"
+      name: pPropSizeRet
+      desc: "[out] returned query value size"
+returns:
+    - $X_RESULT_ERROR_UNSUPPORTED_ENUMERATION:
+        - "If `propName` is not supported by the adapter."
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "If `propSize` is less than the real number of bytes needed to return the info."
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER:
+        - "`pPropValue == NULL && pPropSizeRet == NULL`"
+    - $X_RESULT_ERROR_INVALID_DEVICE
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieve individual image from mipmap"
+class: $xBindlessImages
+name: MipmapGetLevelExp
+ordinal: "0"
+analogue:
+    - "**cuMipmappedArrayGetLevel**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_mem_handle_t
+      name: hImageMem
+      desc: "[in] memory handle to the mipmap image"
+    - type: uint32_t
+      name: mipmapLevel
+      desc: "[in] requested level of the mipmap"
+    - type: "$x_exp_image_mem_handle_t*"
+      name: phImageMem
+      desc: "[out] returning memory handle to the individual image"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Free mipmap memory for bindless images"
+class: $xBindlessImages
+name: MipmapFreeExp
+ordinal: "0"
+analogue:
+    - "**cuMipmappedArrayDestroy**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_mem_handle_t
+      name: hMem
+      desc: "[in] handle of image memory to be freed"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Import external memory in the form of a file descriptor"
+class: $xBindlessImages
+name: ImportOpaqueFDExp
+ordinal: "0"
+analogue:
+    - "**cuImportExternalMemory**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: size_t
+      name: size
+      desc: "[in] size of the external memory"
+    - type: uint32_t
+      name: fileDescriptor
+      desc: "[in] the file descriptor"
+    - type: $x_exp_interop_mem_handle_t*
+      name: phInteropMem
+      desc: "[out] interop memory handle to the external memory"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Map an interop memory handle to an image memory handle"
+class: $xBindlessImages
+name: MapExternalArrayExp
+ordinal: "0"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: "const $x_image_format_t*"
+      name: pImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "const $x_image_desc_t*"
+      name: pImageDesc
+      desc: "[in] pointer to image description"
+    - type: $x_exp_interop_mem_handle_t
+      name: hInteropMem
+      desc: "[in] interop memory handle to the external memory"
+    - type: $x_exp_image_handle_t*
+      name: phImageMem
+      desc: "[out] image memory handle to the externally allocated memory"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+    - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`"
+    - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
+    - $X_RESULT_ERROR_INVALID_OPERATION
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Destroy interop memory"
+class: $xBindlessImages
+name: ReleaseInteropExp
+ordinal: "0"
+analogue:
+    - "**cuDestroyExternalMemory**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_interop_mem_handle_t
+      name: hInteropMem
+      desc: "[in] handle of interop memory to be freed"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Import an external semaphore in the form of a file descriptor"
+class: $xBindlessImages
+name: ImportExternalSemaphoreOpaqueFDExp
+ordinal: "0"
+analogue:
+    - "**cuImportExternalSemaphore**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: uint32_t
+      name: fileDescriptor
+      desc: "[in] the file descriptor"
+    - type: $x_exp_interop_semaphore_handle_t*
+      name: phInteropSemaphoreHandle
+      desc: "[out] interop semaphore handle to the external semaphore"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Destroy the external semaphore handle"
+class: $xBindlessImages
+name: DestroyExternalSemaphoreExp
+ordinal: "0"
+analogue:
+    - "**cuDestroyExternalSemaphore**"
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_interop_semaphore_handle_t
+      name: hInteropSemaphore
+      desc: "[in] handle of interop semaphore to be destroyed"
+returns:
+    - $X_RESULT_ERROR_INVALID_CONTEXT
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Instruct the queue with a non-blocking wait on an external semaphore"
+class: $xBindlessImages
+name: WaitExternalSemaphoreExp
+ordinal: "0"
+analogue:
+    - "**cuWaitExternalSemaphoresAsync**"
+params:
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] handle of the queue object"
+    - type: $x_exp_interop_semaphore_handle_t
+      name: hSemaphore
+      desc: "[in] interop semaphore handle"
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before this command can be executed.
+            If nullptr, the numEventsInWaitList must be 0, indicating that all previously enqueued commands
+            must be complete.
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [out][optional] return an event object that identifies this particular command instance.
+returns:
+    - $X_RESULT_ERROR_INVALID_QUEUE
+    - $X_RESULT_ERROR_INVALID_VALUE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Instruct the queue to signal the external semaphore handle once all previous commands have completed execution"
+class: $xBindlessImages
+name: SignalExternalSemaphoreExp
+ordinal: "0"
+analogue:
+    - "**cuSignalExternalSemaphoresAsync**"
+params:
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] handle of the queue object"
+    - type: $x_exp_interop_semaphore_handle_t
+      name: hSemaphore
+      desc: "[in] interop semaphore handle"
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before this command can be executed.
+            If nullptr, the numEventsInWaitList must be 0, indicating that all previously enqueued commands
+            must be complete.
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [out][optional] return an event object that identifies this particular command instance.
+returns:
+    - $X_RESULT_ERROR_INVALID_QUEUE
+    - $X_RESULT_ERROR_INVALID_VALUE

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -391,3 +391,57 @@ etors:
 - name: COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP
   desc: Enumerator for $xCommandBufferAppendMembufferCopyRectExp
   value: '131'
+- name: USM_PITCHED_ALLOC_EXP
+  desc: Enumerator for $xUSMPitchedAllocExp
+  value: '132'
+- name: BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP
+  desc: Enumerator for $xBindlessImagesUnsampledImageHandleDestroyExp
+  value: '133'
+- name: BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP
+  desc: Enumerator for $xBindlessImagesSampledImageHandleDestroyExp
+  value: '134'
+- name: BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP
+  desc: Enumerator for $xBindlessImagesImageAllocateExp
+  value: '135'
+- name: BINDLESS_IMAGES_IMAGE_FREE_EXP
+  desc: Enumerator for $xBindlessImagesImageFreeExp
+  value: '136'
+- name: BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP
+  desc: Enumerator for $xBindlessImagesUnsampledImageCreateExp
+  value: '137'
+- name: BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP
+  desc: Enumerator for $xBindlessImagesSampledImageCreateExp
+  value: '138'
+- name: BINDLESS_IMAGES_IMAGE_COPY_EXP
+  desc: Enumerator for $xBindlessImagesImageCopyExp
+  value: '139'
+- name: BINDLESS_IMAGES_IMAGE_GET_INFO_EXP
+  desc: Enumerator for $xBindlessImagesImageGetInfoExp
+  value: '140'
+- name: BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP
+  desc: Enumerator for $xBindlessImagesMipmapGetLevelExp
+  value: '141'
+- name: BINDLESS_IMAGES_MIPMAP_FREE_EXP
+  desc: Enumerator for $xBindlessImagesMipmapFreeExp
+  value: '142'
+- name: BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP
+  desc: Enumerator for $xBindlessImagesImportOpaqueFDExp
+  value: '143'
+- name: BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP
+  desc: Enumerator for $xBindlessImagesMapExternalArrayExp
+  value: '144'
+- name: BINDLESS_IMAGES_RELEASE_INTEROP_EXP
+  desc: Enumerator for $xBindlessImagesReleaseInteropExp
+  value: '145'
+- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP
+  desc: Enumerator for $xBindlessImagesImportExternalSemaphoreOpaqueFDExp
+  value: '146'
+- name: BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP
+  desc: Enumerator for $xBindlessImagesDestroyExternalSemaphoreExp
+  value: '147'
+- name: BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP
+  desc: Enumerator for $xBindlessImagesWaitExternalSemaphoreExp
+  value: '148'
+- name: BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP
+  desc: Enumerator for $xBindlessImagesSignalExternalSemaphoreExp
+  value: '149'

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -3490,6 +3490,535 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMPitchedAllocExp
+__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_usm_desc_t *
+        pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        widthInBytes, ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height, ///< [in] height of the USM memory object to be allocated
+    size_t
+        elementSizeBytes, ///< [in] size in bytes of an element in the allocation
+    void **ppMem,         ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch  ///< [out] pitch of the allocation
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnPitchedAllocExp = d_context.urDdiTable.USMExp.pfnPitchedAllocExp;
+    if (nullptr != pfnPitchedAllocExp) {
+        result =
+            pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
+                               height, elementSizeBytes, ppMem, pResultPitch);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnUnsampledImageHandleDestroyExp =
+        d_context.urDdiTable.BindlessImagesExp
+            .pfnUnsampledImageHandleDestroyExp;
+    if (nullptr != pfnUnsampledImageHandleDestroyExp) {
+        result = pfnUnsampledImageHandleDestroyExp(hContext, hImage);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnSampledImageHandleDestroyExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnSampledImageHandleDestroyExp;
+    if (nullptr != pfnSampledImageHandleDestroyExp) {
+        result = pfnSampledImageHandleDestroyExp(hContext, hImage);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageAllocateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] pointer to handle of image memory allocated
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImageAllocateExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
+    if (nullptr != pfnImageAllocateExp) {
+        result =
+            pfnImageAllocateExp(hContext, pImageFormat, pImageDesc, phImageMem);
+    } else {
+        // generic implementation
+        *phImageMem =
+            reinterpret_cast<ur_exp_image_mem_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem ///< [in] handle of image memory to be freed
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImageFreeExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImageFreeExp;
+    if (nullptr != pfnImageFreeExp) {
+        result = pfnImageFreeExp(hContext, hImageMem);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnUnsampledImageCreateExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnUnsampledImageCreateExp;
+    if (nullptr != pfnUnsampledImageCreateExp) {
+        result = pfnUnsampledImageCreateExp(hContext, hImageMem, pImageFormat,
+                                            pImageDesc, phMem, phImage);
+    } else {
+        // generic implementation
+        *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());
+
+        *phImage = reinterpret_cast<ur_exp_image_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnSampledImageCreateExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnSampledImageCreateExp;
+    if (nullptr != pfnSampledImageCreateExp) {
+        result = pfnSampledImageCreateExp(hContext, hImageMem, pImageFormat,
+                                          pImageDesc, hSampler, phMem, phImage);
+    } else {
+        // generic implementation
+        *phMem = reinterpret_cast<ur_mem_handle_t>(d_context.get());
+
+        *phImage = reinterpret_cast<ur_exp_image_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageCopyExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pDst,                   ///< [in] location the data will be copied to
+    void *pSrc, ///< [in] location the data will be copied from
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t
+        imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImageCopyExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImageCopyExp;
+    if (nullptr != pfnImageCopyExp) {
+        result = pfnImageCopyExp(hContext, pDst, pSrc, pImageFormat, pImageDesc,
+                                 imageCopyFlags, numEventsInWaitList,
+                                 phEventWaitList, phEvent);
+    } else {
+        // generic implementation
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
+        }
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageGetInfoExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImageGetInfoExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
+    if (nullptr != pfnImageGetInfoExp) {
+        result =
+            pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem,        ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel, ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] returning memory handle to the individual image
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnMipmapGetLevelExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnMipmapGetLevelExp;
+    if (nullptr != pfnMipmapGetLevelExp) {
+        result =
+            pfnMipmapGetLevelExp(hContext, hImageMem, mipmapLevel, phImageMem);
+    } else {
+        // generic implementation
+        *phImageMem =
+            reinterpret_cast<ur_exp_image_mem_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnMipmapFreeExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnMipmapFreeExp;
+    if (nullptr != pfnMipmapFreeExp) {
+        result = pfnMipmapFreeExp(hContext, hMem);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    size_t size,                  ///< [in] size of the external memory
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t
+        *phInteropMem ///< [out] interop memory handle to the external memory
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImportOpaqueFDExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
+    if (nullptr != pfnImportOpaqueFDExp) {
+        result =
+            pfnImportOpaqueFDExp(hContext, size, fileDescriptor, phInteropMem);
+    } else {
+        // generic implementation
+        *phInteropMem =
+            reinterpret_cast<ur_exp_interop_mem_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMapExternalArrayExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t
+        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *
+        phImageMem ///< [out] image memory handle to the externally allocated memory
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnMapExternalArrayExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnMapExternalArrayExp;
+    if (nullptr != pfnMapExternalArrayExp) {
+        result = pfnMapExternalArrayExp(hContext, pImageFormat, pImageDesc,
+                                        hInteropMem, phImageMem);
+    } else {
+        // generic implementation
+        *phImageMem = reinterpret_cast<ur_exp_image_handle_t>(d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesReleaseInteropExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t
+        hInteropMem ///< [in] handle of interop memory to be freed
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnReleaseInteropExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
+    if (nullptr != pfnReleaseInteropExp) {
+        result = pfnReleaseInteropExp(hContext, hInteropMem);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *
+        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnImportExternalSemaphoreOpaqueFDExp =
+        d_context.urDdiTable.BindlessImagesExp
+            .pfnImportExternalSemaphoreOpaqueFDExp;
+    if (nullptr != pfnImportExternalSemaphoreOpaqueFDExp) {
+        result = pfnImportExternalSemaphoreOpaqueFDExp(
+            hContext, fileDescriptor, phInteropSemaphoreHandle);
+    } else {
+        // generic implementation
+        *phInteropSemaphoreHandle =
+            reinterpret_cast<ur_exp_interop_semaphore_handle_t>(
+                d_context.get());
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t
+        hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnDestroyExternalSemaphoreExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
+    if (nullptr != pfnDestroyExternalSemaphoreExp) {
+        result = pfnDestroyExternalSemaphoreExp(hContext, hInteropSemaphore);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnWaitExternalSemaphoreExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
+    if (nullptr != pfnWaitExternalSemaphoreExp) {
+        result = pfnWaitExternalSemaphoreExp(
+            hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+    } else {
+        // generic implementation
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
+        }
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnSignalExternalSemaphoreExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
+    if (nullptr != pfnSignalExternalSemaphoreExp) {
+        result = pfnSignalExternalSemaphoreExp(
+            hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+    } else {
+        // generic implementation
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
+        }
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -3800,6 +4329,77 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     pDdiTable->pfnGetLastResult = driver::urGetLastResult;
 
     pDdiTable->pfnTearDown = driver::urTearDown;
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's BindlessImagesExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_bindless_images_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+    ) try {
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (driver::d_context.version < version) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    pDdiTable->pfnUnsampledImageHandleDestroyExp =
+        driver::urBindlessImagesUnsampledImageHandleDestroyExp;
+
+    pDdiTable->pfnSampledImageHandleDestroyExp =
+        driver::urBindlessImagesSampledImageHandleDestroyExp;
+
+    pDdiTable->pfnImageAllocateExp = driver::urBindlessImagesImageAllocateExp;
+
+    pDdiTable->pfnImageFreeExp = driver::urBindlessImagesImageFreeExp;
+
+    pDdiTable->pfnUnsampledImageCreateExp =
+        driver::urBindlessImagesUnsampledImageCreateExp;
+
+    pDdiTable->pfnSampledImageCreateExp =
+        driver::urBindlessImagesSampledImageCreateExp;
+
+    pDdiTable->pfnImageCopyExp = driver::urBindlessImagesImageCopyExp;
+
+    pDdiTable->pfnImageGetInfoExp = driver::urBindlessImagesImageGetInfoExp;
+
+    pDdiTable->pfnMipmapGetLevelExp = driver::urBindlessImagesMipmapGetLevelExp;
+
+    pDdiTable->pfnMipmapFreeExp = driver::urBindlessImagesMipmapFreeExp;
+
+    pDdiTable->pfnImportOpaqueFDExp = driver::urBindlessImagesImportOpaqueFDExp;
+
+    pDdiTable->pfnMapExternalArrayExp =
+        driver::urBindlessImagesMapExternalArrayExp;
+
+    pDdiTable->pfnReleaseInteropExp = driver::urBindlessImagesReleaseInteropExp;
+
+    pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
+        driver::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+
+    pDdiTable->pfnDestroyExternalSemaphoreExp =
+        driver::urBindlessImagesDestroyExternalSemaphoreExp;
+
+    pDdiTable->pfnWaitExternalSemaphoreExp =
+        driver::urBindlessImagesWaitExternalSemaphoreExp;
+
+    pDdiTable->pfnSignalExternalSemaphoreExp =
+        driver::urBindlessImagesSignalExternalSemaphoreExp;
 
     return result;
 } catch (...) {
@@ -4358,6 +4958,36 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
     pDdiTable->pfnPoolRelease = driver::urUSMPoolRelease;
 
     pDdiTable->pfnPoolGetInfo = driver::urUSMPoolGetInfo;
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USMExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+    ) try {
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (driver::d_context.version < version) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    pDdiTable->pfnPitchedAllocExp = driver::urUSMPitchedAllocExp;
 
     return result;
 } catch (...) {

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -154,6 +154,10 @@ template <>
 inline void serializeFlag<ur_usm_migration_flag_t>(std::ostream &os,
                                                    uint32_t flag);
 
+template <>
+inline void serializeFlag<ur_exp_image_copy_flag_t>(std::ostream &os,
+                                                    uint32_t flag);
+
 } // namespace ur_params
 
 inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value);
@@ -330,6 +334,11 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_map_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_migration_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_exp_image_copy_flag_t value);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_exp_sampler_mip_properties_t params);
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 
@@ -744,6 +753,10 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC:
         os << "UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC";
         break;
+
+    case UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -917,6 +930,12 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC: {
         const ur_exp_command_buffer_desc_t *pstruct =
             (const ur_exp_command_buffer_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES: {
+        const ur_exp_sampler_mip_properties_t *pstruct =
+            (const ur_exp_sampler_mip_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -1759,6 +1778,70 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
 
     case UR_DEVICE_INFO_IP_VERSION:
         os << "UR_DEVICE_INFO_IP_VERSION";
+        break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_3D_USM_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_BINDLESS_IMAGES_3D_USM_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP:
+        os << "UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP:
+        os << "UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP:
+        os << "UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP:
+        os << "UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP:
+        os << "UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP";
+        break;
+
+    case UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_INTEROP_MEMORY_EXPORT_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_INTEROP_MEMORY_EXPORT_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP";
+        break;
+
+    case UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -3312,6 +3395,230 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
         if (sizeof(uint32_t) > size) {
             os << "invalid size (is: " << size
                << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_BINDLESS_IMAGES_3D_USM_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP: {
+        const size_t *tptr = (const size_t *)ptr;
+        if (sizeof(size_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(size_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_INTEROP_MEMORY_EXPORT_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";
@@ -7424,6 +7731,14 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value) {
     case UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP:
         os << "UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP";
         break;
+
+    case UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP:
+        os << "UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP";
+        break;
+
+    case UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP:
+        os << "UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -8244,6 +8559,79 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP";
         break;
+
+    case UR_FUNCTION_USM_PITCHED_ALLOC_EXP:
+        os << "UR_FUNCTION_USM_PITCHED_ALLOC_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_"
+              "EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP";
+        break;
+
+    case UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -8360,6 +8748,110 @@ inline void serializeFlag<ur_usm_migration_flag_t>(std::ostream &os,
     }
 }
 } // namespace ur_params
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_exp_image_copy_flag_t value) {
+    switch (value) {
+
+    case UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE:
+        os << "UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE";
+        break;
+
+    case UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST:
+        os << "UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST";
+        break;
+
+    case UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE:
+        os << "UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+namespace ur_params {
+
+template <>
+inline void serializeFlag<ur_exp_image_copy_flag_t>(std::ostream &os,
+                                                    uint32_t flag) {
+    uint32_t val = flag;
+    bool first = true;
+
+    if ((val & UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE) ==
+        (uint32_t)UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE) {
+        val ^= (uint32_t)UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE;
+    }
+
+    if ((val & UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST) ==
+        (uint32_t)UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST) {
+        val ^= (uint32_t)UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST;
+    }
+
+    if ((val & UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE) ==
+        (uint32_t)UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE) {
+        val ^= (uint32_t)UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE;
+    }
+    if (val != 0) {
+        std::bitset<32> bits(val);
+        if (!first) {
+            os << " | ";
+        }
+        os << "unknown bit flags " << bits;
+    } else if (first) {
+        os << "0";
+    }
+}
+} // namespace ur_params
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_exp_sampler_mip_properties_t params) {
+    os << "(struct ur_exp_sampler_mip_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".minMipmapLevelClamp = ";
+
+    os << (params.minMipmapLevelClamp);
+
+    os << ", ";
+    os << ".maxMipmapLevelClamp = ";
+
+    os << (params.maxMipmapLevelClamp);
+
+    os << ", ";
+    os << ".maxAnistropy = ";
+
+    os << (params.maxAnistropy);
+
+    os << "}";
+    return os;
+}
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
     os << "(struct ur_exp_command_buffer_desc_t){";
@@ -8409,6 +8901,480 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ".pParams = ";
 
     ur_params::serializePtr(os, *(params->ppParams));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t
+        *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hImage = ";
+
+    ur_params::serializePtr(os, *(params->phImage));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_sampled_image_handle_destroy_exp_params_t
+        *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hImage = ";
+
+    ur_params::serializePtr(os, *(params->phImage));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_image_allocate_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pImageFormat = ";
+
+    ur_params::serializePtr(os, *(params->ppImageFormat));
+
+    os << ", ";
+    os << ".pImageDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppImageDesc));
+
+    os << ", ";
+    os << ".phImageMem = ";
+
+    ur_params::serializePtr(os, *(params->pphImageMem));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_bindless_images_image_free_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hImageMem = ";
+
+    ur_params::serializePtr(os, *(params->phImageMem));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_bindless_images_unsampled_image_create_exp_params_t
+               *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hImageMem = ";
+
+    ur_params::serializePtr(os, *(params->phImageMem));
+
+    os << ", ";
+    os << ".pImageFormat = ";
+
+    ur_params::serializePtr(os, *(params->ppImageFormat));
+
+    os << ", ";
+    os << ".pImageDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppImageDesc));
+
+    os << ", ";
+    os << ".phMem = ";
+
+    ur_params::serializePtr(os, *(params->pphMem));
+
+    os << ", ";
+    os << ".phImage = ";
+
+    ur_params::serializePtr(os, *(params->pphImage));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_sampled_image_create_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hImageMem = ";
+
+    ur_params::serializePtr(os, *(params->phImageMem));
+
+    os << ", ";
+    os << ".pImageFormat = ";
+
+    ur_params::serializePtr(os, *(params->ppImageFormat));
+
+    os << ", ";
+    os << ".pImageDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppImageDesc));
+
+    os << ", ";
+    os << ".hSampler = ";
+
+    ur_params::serializePtr(os, *(params->phSampler));
+
+    os << ", ";
+    os << ".phMem = ";
+
+    ur_params::serializePtr(os, *(params->pphMem));
+
+    os << ", ";
+    os << ".phImage = ";
+
+    ur_params::serializePtr(os, *(params->pphImage));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_bindless_images_image_copy_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pDst = ";
+
+    ur_params::serializePtr(os, *(params->ppDst));
+
+    os << ", ";
+    os << ".pSrc = ";
+
+    ur_params::serializePtr(os, *(params->ppSrc));
+
+    os << ", ";
+    os << ".pImageFormat = ";
+
+    ur_params::serializePtr(os, *(params->ppImageFormat));
+
+    os << ", ";
+    os << ".pImageDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppImageDesc));
+
+    os << ", ";
+    os << ".imageCopyFlags = ";
+
+    ur_params::serializeFlag<ur_exp_image_copy_flag_t>(
+        os, *(params->pimageCopyFlags));
+
+    os << ", ";
+    os << ".numEventsInWaitList = ";
+
+    os << *(params->pnumEventsInWaitList);
+
+    os << ", ";
+    os << ".phEventWaitList = {";
+    for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
+                       i < *params->pnumEventsInWaitList;
+         ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur_params::serializePtr(os, (*(params->pphEventWaitList))[i]);
+    }
+    os << "}";
+
+    os << ", ";
+    os << ".phEvent = ";
+
+    ur_params::serializePtr(os, *(params->pphEvent));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_image_get_info_exp_params_t *params) {
+
+    os << ".hImageMem = ";
+
+    ur_params::serializePtr(os, *(params->phImageMem));
+
+    os << ", ";
+    os << ".propName = ";
+
+    os << *(params->ppropName);
+
+    os << ", ";
+    os << ".pPropValue = ";
+
+    ur_params::serializePtr(os, *(params->ppPropValue));
+
+    os << ", ";
+    os << ".pPropSizeRet = ";
+
+    ur_params::serializePtr(os, *(params->ppPropSizeRet));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_mipmap_get_level_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hImageMem = ";
+
+    ur_params::serializePtr(os, *(params->phImageMem));
+
+    os << ", ";
+    os << ".mipmapLevel = ";
+
+    os << *(params->pmipmapLevel);
+
+    os << ", ";
+    os << ".phImageMem = ";
+
+    ur_params::serializePtr(os, *(params->pphImageMem));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_bindless_images_mipmap_free_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hMem = ";
+
+    ur_params::serializePtr(os, *(params->phMem));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_import_opaque_fd_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".size = ";
+
+    os << *(params->psize);
+
+    os << ", ";
+    os << ".fileDescriptor = ";
+
+    os << *(params->pfileDescriptor);
+
+    os << ", ";
+    os << ".phInteropMem = ";
+
+    ur_params::serializePtr(os, *(params->pphInteropMem));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_map_external_array_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".pImageFormat = ";
+
+    ur_params::serializePtr(os, *(params->ppImageFormat));
+
+    os << ", ";
+    os << ".pImageDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppImageDesc));
+
+    os << ", ";
+    os << ".hInteropMem = ";
+
+    ur_params::serializePtr(os, *(params->phInteropMem));
+
+    os << ", ";
+    os << ".phImageMem = ";
+
+    ur_params::serializePtr(os, *(params->pphImageMem));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_release_interop_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hInteropMem = ";
+
+    ur_params::serializePtr(os, *(params->phInteropMem));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os, const struct
+           ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t
+               *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".fileDescriptor = ";
+
+    os << *(params->pfileDescriptor);
+
+    os << ", ";
+    os << ".phInteropSemaphoreHandle = ";
+
+    ur_params::serializePtr(os, *(params->pphInteropSemaphoreHandle));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_destroy_external_semaphore_exp_params_t
+        *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hInteropSemaphore = ";
+
+    ur_params::serializePtr(os, *(params->phInteropSemaphore));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_bindless_images_wait_external_semaphore_exp_params_t
+               *params) {
+
+    os << ".hQueue = ";
+
+    ur_params::serializePtr(os, *(params->phQueue));
+
+    os << ", ";
+    os << ".hSemaphore = ";
+
+    ur_params::serializePtr(os, *(params->phSemaphore));
+
+    os << ", ";
+    os << ".numEventsInWaitList = ";
+
+    os << *(params->pnumEventsInWaitList);
+
+    os << ", ";
+    os << ".phEventWaitList = {";
+    for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
+                       i < *params->pnumEventsInWaitList;
+         ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur_params::serializePtr(os, (*(params->pphEventWaitList))[i]);
+    }
+    os << "}";
+
+    os << ", ";
+    os << ".phEvent = ";
+
+    ur_params::serializePtr(os, *(params->pphEvent));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_bindless_images_signal_external_semaphore_exp_params_t
+        *params) {
+
+    os << ".hQueue = ";
+
+    ur_params::serializePtr(os, *(params->phQueue));
+
+    os << ", ";
+    os << ".hSemaphore = ";
+
+    ur_params::serializePtr(os, *(params->phSemaphore));
+
+    os << ", ";
+    os << ".numEventsInWaitList = ";
+
+    os << *(params->pnumEventsInWaitList);
+
+    os << ", ";
+    os << ".phEventWaitList = {";
+    for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
+                       i < *params->pnumEventsInWaitList;
+         ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur_params::serializePtr(os, (*(params->pphEventWaitList))[i]);
+    }
+    os << "}";
+
+    os << ", ";
+    os << ".phEvent = ";
+
+    ur_params::serializePtr(os, *(params->pphEvent));
 
     return os;
 }
@@ -12084,6 +13050,57 @@ operator<<(std::ostream &os,
     return os;
 }
 
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_usm_pitched_alloc_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur_params::serializePtr(os, *(params->phDevice));
+
+    os << ", ";
+    os << ".pUSMDesc = ";
+
+    ur_params::serializePtr(os, *(params->ppUSMDesc));
+
+    os << ", ";
+    os << ".pool = ";
+
+    ur_params::serializePtr(os, *(params->ppool));
+
+    os << ", ";
+    os << ".widthInBytes = ";
+
+    os << *(params->pwidthInBytes);
+
+    os << ", ";
+    os << ".height = ";
+
+    os << *(params->pheight);
+
+    os << ", ";
+    os << ".elementSizeBytes = ";
+
+    os << *(params->pelementSizeBytes);
+
+    os << ", ";
+    os << ".ppMem = ";
+
+    ur_params::serializePtr(os, *(params->pppMem));
+
+    os << ", ";
+    os << ".pResultPitch = ";
+
+    ur_params::serializePtr(os, *(params->ppResultPitch));
+
+    return os;
+}
+
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_device_get_params_t *params) {
 
@@ -12335,6 +13352,77 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     } break;
     case UR_FUNCTION_TEAR_DOWN: {
         os << (const struct ur_tear_down_params_t *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP: {
+        os << (const struct
+               ur_bindless_images_unsampled_image_handle_destroy_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP: {
+        os << (const struct
+               ur_bindless_images_sampled_image_handle_destroy_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP: {
+        os << (const struct ur_bindless_images_image_allocate_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP: {
+        os << (const struct ur_bindless_images_image_free_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP: {
+        os << (const struct
+               ur_bindless_images_unsampled_image_create_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP: {
+        os << (const struct ur_bindless_images_sampled_image_create_exp_params_t
+                   *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP: {
+        os << (const struct ur_bindless_images_image_copy_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP: {
+        os << (const struct ur_bindless_images_image_get_info_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP: {
+        os << (const struct ur_bindless_images_mipmap_get_level_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP: {
+        os << (const struct ur_bindless_images_mipmap_free_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP: {
+        os << (const struct ur_bindless_images_import_opaque_fd_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP: {
+        os << (const struct ur_bindless_images_map_external_array_exp_params_t
+                   *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP: {
+        os << (const struct ur_bindless_images_release_interop_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP: {
+        os << (const struct
+               ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t
+                   *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP: {
+        os << (const struct
+               ur_bindless_images_destroy_external_semaphore_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP: {
+        os << (const struct
+               ur_bindless_images_wait_external_semaphore_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP: {
+        os << (const struct
+               ur_bindless_images_signal_external_semaphore_exp_params_t *)
+                params;
     } break;
     case UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP: {
         os << (const struct ur_command_buffer_create_exp_params_t *)params;
@@ -12702,6 +13790,9 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     } break;
     case UR_FUNCTION_USM_POOL_GET_INFO: {
         os << (const struct ur_usm_pool_get_info_params_t *)params;
+    } break;
+    case UR_FUNCTION_USM_PITCHED_ALLOC_EXP: {
+        os << (const struct ur_usm_pitched_alloc_exp_params_t *)params;
     } break;
     case UR_FUNCTION_DEVICE_GET: {
         os << (const struct ur_device_get_params_t *)params;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -3953,6 +3953,627 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMPitchedAllocExp
+__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_usm_desc_t *
+        pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        widthInBytes, ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height, ///< [in] height of the USM memory object to be allocated
+    size_t
+        elementSizeBytes, ///< [in] size in bytes of an element in the allocation
+    void **ppMem,         ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch  ///< [out] pitch of the allocation
+) {
+    auto pfnPitchedAllocExp = context.urDdiTable.USMExp.pfnPitchedAllocExp;
+
+    if (nullptr == pfnPitchedAllocExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_usm_pitched_alloc_exp_params_t params = {
+        &hContext, &hDevice,          &pUSMDesc, &pool,        &widthInBytes,
+        &height,   &elementSizeBytes, &ppMem,    &pResultPitch};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
+                                             "urUSMPitchedAllocExp", &params);
+
+    ur_result_t result =
+        pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
+                           height, elementSizeBytes, ppMem, pResultPitch);
+
+    context.notify_end(UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
+                       "urUSMPitchedAllocExp", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    auto pfnUnsampledImageHandleDestroyExp =
+        context.urDdiTable.BindlessImagesExp.pfnUnsampledImageHandleDestroyExp;
+
+    if (nullptr == pfnUnsampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_unsampled_image_handle_destroy_exp_params_t params = {
+        &hContext, &hImage};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP,
+        "urBindlessImagesUnsampledImageHandleDestroyExp", &params);
+
+    ur_result_t result = pfnUnsampledImageHandleDestroyExp(hContext, hImage);
+
+    context.notify_end(
+        UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP,
+        "urBindlessImagesUnsampledImageHandleDestroyExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    auto pfnSampledImageHandleDestroyExp =
+        context.urDdiTable.BindlessImagesExp.pfnSampledImageHandleDestroyExp;
+
+    if (nullptr == pfnSampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_sampled_image_handle_destroy_exp_params_t params = {
+        &hContext, &hImage};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP,
+        "urBindlessImagesSampledImageHandleDestroyExp", &params);
+
+    ur_result_t result = pfnSampledImageHandleDestroyExp(hContext, hImage);
+
+    context.notify_end(
+        UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP,
+        "urBindlessImagesSampledImageHandleDestroyExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageAllocateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] pointer to handle of image memory allocated
+) {
+    auto pfnImageAllocateExp =
+        context.urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
+
+    if (nullptr == pfnImageAllocateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_image_allocate_exp_params_t params = {
+        &hContext, &pImageFormat, &pImageDesc, &phImageMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP,
+                             "urBindlessImagesImageAllocateExp", &params);
+
+    ur_result_t result =
+        pfnImageAllocateExp(hContext, pImageFormat, pImageDesc, phImageMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP,
+                       "urBindlessImagesImageAllocateExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem ///< [in] handle of image memory to be freed
+) {
+    auto pfnImageFreeExp = context.urDdiTable.BindlessImagesExp.pfnImageFreeExp;
+
+    if (nullptr == pfnImageFreeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_image_free_exp_params_t params = {&hContext, &hImageMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP,
+                             "urBindlessImagesImageFreeExp", &params);
+
+    ur_result_t result = pfnImageFreeExp(hContext, hImageMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP,
+                       "urBindlessImagesImageFreeExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    auto pfnUnsampledImageCreateExp =
+        context.urDdiTable.BindlessImagesExp.pfnUnsampledImageCreateExp;
+
+    if (nullptr == pfnUnsampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_unsampled_image_create_exp_params_t params = {
+        &hContext, &hImageMem, &pImageFormat, &pImageDesc, &phMem, &phImage};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
+        "urBindlessImagesUnsampledImageCreateExp", &params);
+
+    ur_result_t result = pfnUnsampledImageCreateExp(
+        hContext, hImageMem, pImageFormat, pImageDesc, phMem, phImage);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
+                       "urBindlessImagesUnsampledImageCreateExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    auto pfnSampledImageCreateExp =
+        context.urDdiTable.BindlessImagesExp.pfnSampledImageCreateExp;
+
+    if (nullptr == pfnSampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_sampled_image_create_exp_params_t params = {
+        &hContext, &hImageMem, &pImageFormat, &pImageDesc,
+        &hSampler, &phMem,     &phImage};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP,
+        "urBindlessImagesSampledImageCreateExp", &params);
+
+    ur_result_t result =
+        pfnSampledImageCreateExp(hContext, hImageMem, pImageFormat, pImageDesc,
+                                 hSampler, phMem, phImage);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP,
+                       "urBindlessImagesSampledImageCreateExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageCopyExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pDst,                   ///< [in] location the data will be copied to
+    void *pSrc, ///< [in] location the data will be copied from
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t
+        imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    auto pfnImageCopyExp = context.urDdiTable.BindlessImagesExp.pfnImageCopyExp;
+
+    if (nullptr == pfnImageCopyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_image_copy_exp_params_t params = {&hContext,
+                                                         &pDst,
+                                                         &pSrc,
+                                                         &pImageFormat,
+                                                         &pImageDesc,
+                                                         &imageCopyFlags,
+                                                         &numEventsInWaitList,
+                                                         &phEventWaitList,
+                                                         &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP,
+                             "urBindlessImagesImageCopyExp", &params);
+
+    ur_result_t result = pfnImageCopyExp(
+        hContext, pDst, pSrc, pImageFormat, pImageDesc, imageCopyFlags,
+        numEventsInWaitList, phEventWaitList, phEvent);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP,
+                       "urBindlessImagesImageCopyExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageGetInfoExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+) {
+    auto pfnImageGetInfoExp =
+        context.urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
+
+    if (nullptr == pfnImageGetInfoExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_image_get_info_exp_params_t params = {
+        &hImageMem, &propName, &pPropValue, &pPropSizeRet};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP,
+                             "urBindlessImagesImageGetInfoExp", &params);
+
+    ur_result_t result =
+        pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP,
+                       "urBindlessImagesImageGetInfoExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem,        ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel, ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] returning memory handle to the individual image
+) {
+    auto pfnMipmapGetLevelExp =
+        context.urDdiTable.BindlessImagesExp.pfnMipmapGetLevelExp;
+
+    if (nullptr == pfnMipmapGetLevelExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_mipmap_get_level_exp_params_t params = {
+        &hContext, &hImageMem, &mipmapLevel, &phImageMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP,
+                             "urBindlessImagesMipmapGetLevelExp", &params);
+
+    ur_result_t result =
+        pfnMipmapGetLevelExp(hContext, hImageMem, mipmapLevel, phImageMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP,
+                       "urBindlessImagesMipmapGetLevelExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+) {
+    auto pfnMipmapFreeExp =
+        context.urDdiTable.BindlessImagesExp.pfnMipmapFreeExp;
+
+    if (nullptr == pfnMipmapFreeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_mipmap_free_exp_params_t params = {&hContext, &hMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP,
+                             "urBindlessImagesMipmapFreeExp", &params);
+
+    ur_result_t result = pfnMipmapFreeExp(hContext, hMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP,
+                       "urBindlessImagesMipmapFreeExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    size_t size,                  ///< [in] size of the external memory
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t
+        *phInteropMem ///< [out] interop memory handle to the external memory
+) {
+    auto pfnImportOpaqueFDExp =
+        context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
+
+    if (nullptr == pfnImportOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_import_opaque_fd_exp_params_t params = {
+        &hContext, &size, &fileDescriptor, &phInteropMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
+                             "urBindlessImagesImportOpaqueFDExp", &params);
+
+    ur_result_t result =
+        pfnImportOpaqueFDExp(hContext, size, fileDescriptor, phInteropMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
+                       "urBindlessImagesImportOpaqueFDExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMapExternalArrayExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t
+        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *
+        phImageMem ///< [out] image memory handle to the externally allocated memory
+) {
+    auto pfnMapExternalArrayExp =
+        context.urDdiTable.BindlessImagesExp.pfnMapExternalArrayExp;
+
+    if (nullptr == pfnMapExternalArrayExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_map_external_array_exp_params_t params = {
+        &hContext, &pImageFormat, &pImageDesc, &hInteropMem, &phImageMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP,
+                             "urBindlessImagesMapExternalArrayExp", &params);
+
+    ur_result_t result = pfnMapExternalArrayExp(
+        hContext, pImageFormat, pImageDesc, hInteropMem, phImageMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP,
+                       "urBindlessImagesMapExternalArrayExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesReleaseInteropExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t
+        hInteropMem ///< [in] handle of interop memory to be freed
+) {
+    auto pfnReleaseInteropExp =
+        context.urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
+
+    if (nullptr == pfnReleaseInteropExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_release_interop_exp_params_t params = {&hContext,
+                                                              &hInteropMem};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP,
+                             "urBindlessImagesReleaseInteropExp", &params);
+
+    ur_result_t result = pfnReleaseInteropExp(hContext, hInteropMem);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP,
+                       "urBindlessImagesReleaseInteropExp", &params, &result,
+                       instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *
+        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+) {
+    auto pfnImportExternalSemaphoreOpaqueFDExp =
+        context.urDdiTable.BindlessImagesExp
+            .pfnImportExternalSemaphoreOpaqueFDExp;
+
+    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t params =
+        {&hContext, &fileDescriptor, &phInteropSemaphoreHandle};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
+        "urBindlessImagesImportExternalSemaphoreOpaqueFDExp", &params);
+
+    ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
+        hContext, fileDescriptor, phInteropSemaphoreHandle);
+
+    context.notify_end(
+        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
+        "urBindlessImagesImportExternalSemaphoreOpaqueFDExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t
+        hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+) {
+    auto pfnDestroyExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
+
+    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_destroy_external_semaphore_exp_params_t params = {
+        &hContext, &hInteropSemaphore};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesDestroyExternalSemaphoreExp", &params);
+
+    ur_result_t result =
+        pfnDestroyExternalSemaphoreExp(hContext, hInteropSemaphore);
+
+    context.notify_end(
+        UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesDestroyExternalSemaphoreExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    auto pfnWaitExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
+
+    if (nullptr == pfnWaitExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_wait_external_semaphore_exp_params_t params = {
+        &hQueue, &hSemaphore, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesWaitExternalSemaphoreExp", &params);
+
+    ur_result_t result = pfnWaitExternalSemaphoreExp(
+        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
+                       "urBindlessImagesWaitExternalSemaphoreExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    auto pfnSignalExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
+
+    if (nullptr == pfnSignalExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_bindless_images_signal_external_semaphore_exp_params_t params = {
+        &hQueue, &hSemaphore, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesSignalExternalSemaphoreExp", &params);
+
+    ur_result_t result = pfnSignalExternalSemaphoreExp(
+        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+
+    context.notify_end(
+        UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesSignalExternalSemaphoreExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4338,6 +4959,108 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 
     dditable.pfnTearDown = pDdiTable->pfnTearDown;
     pDdiTable->pfnTearDown = ur_tracing_layer::urTearDown;
+
+    return result;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's BindlessImagesExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+__urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_bindless_images_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_tracing_layer::context.urDdiTable.BindlessImagesExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnUnsampledImageHandleDestroyExp =
+        pDdiTable->pfnUnsampledImageHandleDestroyExp;
+    pDdiTable->pfnUnsampledImageHandleDestroyExp =
+        ur_tracing_layer::urBindlessImagesUnsampledImageHandleDestroyExp;
+
+    dditable.pfnSampledImageHandleDestroyExp =
+        pDdiTable->pfnSampledImageHandleDestroyExp;
+    pDdiTable->pfnSampledImageHandleDestroyExp =
+        ur_tracing_layer::urBindlessImagesSampledImageHandleDestroyExp;
+
+    dditable.pfnImageAllocateExp = pDdiTable->pfnImageAllocateExp;
+    pDdiTable->pfnImageAllocateExp =
+        ur_tracing_layer::urBindlessImagesImageAllocateExp;
+
+    dditable.pfnImageFreeExp = pDdiTable->pfnImageFreeExp;
+    pDdiTable->pfnImageFreeExp = ur_tracing_layer::urBindlessImagesImageFreeExp;
+
+    dditable.pfnUnsampledImageCreateExp = pDdiTable->pfnUnsampledImageCreateExp;
+    pDdiTable->pfnUnsampledImageCreateExp =
+        ur_tracing_layer::urBindlessImagesUnsampledImageCreateExp;
+
+    dditable.pfnSampledImageCreateExp = pDdiTable->pfnSampledImageCreateExp;
+    pDdiTable->pfnSampledImageCreateExp =
+        ur_tracing_layer::urBindlessImagesSampledImageCreateExp;
+
+    dditable.pfnImageCopyExp = pDdiTable->pfnImageCopyExp;
+    pDdiTable->pfnImageCopyExp = ur_tracing_layer::urBindlessImagesImageCopyExp;
+
+    dditable.pfnImageGetInfoExp = pDdiTable->pfnImageGetInfoExp;
+    pDdiTable->pfnImageGetInfoExp =
+        ur_tracing_layer::urBindlessImagesImageGetInfoExp;
+
+    dditable.pfnMipmapGetLevelExp = pDdiTable->pfnMipmapGetLevelExp;
+    pDdiTable->pfnMipmapGetLevelExp =
+        ur_tracing_layer::urBindlessImagesMipmapGetLevelExp;
+
+    dditable.pfnMipmapFreeExp = pDdiTable->pfnMipmapFreeExp;
+    pDdiTable->pfnMipmapFreeExp =
+        ur_tracing_layer::urBindlessImagesMipmapFreeExp;
+
+    dditable.pfnImportOpaqueFDExp = pDdiTable->pfnImportOpaqueFDExp;
+    pDdiTable->pfnImportOpaqueFDExp =
+        ur_tracing_layer::urBindlessImagesImportOpaqueFDExp;
+
+    dditable.pfnMapExternalArrayExp = pDdiTable->pfnMapExternalArrayExp;
+    pDdiTable->pfnMapExternalArrayExp =
+        ur_tracing_layer::urBindlessImagesMapExternalArrayExp;
+
+    dditable.pfnReleaseInteropExp = pDdiTable->pfnReleaseInteropExp;
+    pDdiTable->pfnReleaseInteropExp =
+        ur_tracing_layer::urBindlessImagesReleaseInteropExp;
+
+    dditable.pfnImportExternalSemaphoreOpaqueFDExp =
+        pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp;
+    pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
+        ur_tracing_layer::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+
+    dditable.pfnDestroyExternalSemaphoreExp =
+        pDdiTable->pfnDestroyExternalSemaphoreExp;
+    pDdiTable->pfnDestroyExternalSemaphoreExp =
+        ur_tracing_layer::urBindlessImagesDestroyExternalSemaphoreExp;
+
+    dditable.pfnWaitExternalSemaphoreExp =
+        pDdiTable->pfnWaitExternalSemaphoreExp;
+    pDdiTable->pfnWaitExternalSemaphoreExp =
+        ur_tracing_layer::urBindlessImagesWaitExternalSemaphoreExp;
+
+    dditable.pfnSignalExternalSemaphoreExp =
+        pDdiTable->pfnSignalExternalSemaphoreExp;
+    pDdiTable->pfnSignalExternalSemaphoreExp =
+        ur_tracing_layer::urBindlessImagesSignalExternalSemaphoreExp;
 
     return result;
 }
@@ -5052,6 +5775,39 @@ __urdlllocal ur_result_t UR_APICALL urGetUSMProcAddrTable(
     return result;
 }
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USMExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+__urdlllocal ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_tracing_layer::context.urDdiTable.USMExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_tracing_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_tracing_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnPitchedAllocExp = pDdiTable->pfnPitchedAllocExp;
+    pDdiTable->pfnPitchedAllocExp = ur_tracing_layer::urUSMPitchedAllocExp;
+
+    return result;
+}
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Device table
 ///        with current process' addresses
 ///
@@ -5120,6 +5876,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     }
 
     if (UR_RESULT_SUCCESS == result) {
+        result = ur_tracing_layer::urGetBindlessImagesExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->BindlessImagesExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
         result = ur_tracing_layer::urGetCommandBufferExpProcAddrTable(
             UR_API_VERSION_CURRENT, &dditable->CommandBufferExp);
     }
@@ -5172,6 +5933,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     if (UR_RESULT_SUCCESS == result) {
         result = ur_tracing_layer::urGetUSMProcAddrTable(UR_API_VERSION_CURRENT,
                                                          &dditable->USM);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        result = ur_tracing_layer::urGetUSMExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->USMExp);
     }
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -369,7 +369,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_DEVICE_INFO_IP_VERSION < propName) {
+        if (UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -5030,6 +5030,746 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMPitchedAllocExp
+__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_usm_desc_t *
+        pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        widthInBytes, ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height, ///< [in] height of the USM memory object to be allocated
+    size_t
+        elementSizeBytes, ///< [in] size in bytes of an element in the allocation
+    void **ppMem,         ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch  ///< [out] pitch of the allocation
+) {
+    auto pfnPitchedAllocExp = context.urDdiTable.USMExp.pfnPitchedAllocExp;
+
+    if (nullptr == pfnPitchedAllocExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDevice) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == ppMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pResultPitch) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pUSMDesc && pUSMDesc->align != 0 &&
+            ((pUSMDesc->align & (pUSMDesc->align - 1)) != 0)) {
+            return UR_RESULT_ERROR_INVALID_VALUE;
+        }
+
+        if (widthInBytes == 0) {
+            return UR_RESULT_ERROR_INVALID_USM_SIZE;
+        }
+    }
+
+    ur_result_t result =
+        pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
+                           height, elementSizeBytes, ppMem, pResultPitch);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    auto pfnUnsampledImageHandleDestroyExp =
+        context.urDdiTable.BindlessImagesExp.pfnUnsampledImageHandleDestroyExp;
+
+    if (nullptr == pfnUnsampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hImage) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnUnsampledImageHandleDestroyExp(hContext, hImage);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    auto pfnSampledImageHandleDestroyExp =
+        context.urDdiTable.BindlessImagesExp.pfnSampledImageHandleDestroyExp;
+
+    if (nullptr == pfnSampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hImage) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnSampledImageHandleDestroyExp(hContext, hImage);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageAllocateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] pointer to handle of image memory allocated
+) {
+    auto pfnImageAllocateExp =
+        context.urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
+
+    if (nullptr == pfnImageAllocateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+    }
+
+    ur_result_t result =
+        pfnImageAllocateExp(hContext, pImageFormat, pImageDesc, phImageMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem ///< [in] handle of image memory to be freed
+) {
+    auto pfnImageFreeExp = context.urDdiTable.BindlessImagesExp.pfnImageFreeExp;
+
+    if (nullptr == pfnImageFreeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnImageFreeExp(hContext, hImageMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    auto pfnUnsampledImageCreateExp =
+        context.urDdiTable.BindlessImagesExp.pfnUnsampledImageCreateExp;
+
+    if (nullptr == pfnUnsampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phImage) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+    }
+
+    ur_result_t result = pfnUnsampledImageCreateExp(
+        hContext, hImageMem, pImageFormat, pImageDesc, phMem, phImage);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    auto pfnSampledImageCreateExp =
+        context.urDdiTable.BindlessImagesExp.pfnSampledImageCreateExp;
+
+    if (nullptr == pfnSampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSampler) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phImage) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+    }
+
+    ur_result_t result =
+        pfnSampledImageCreateExp(hContext, hImageMem, pImageFormat, pImageDesc,
+                                 hSampler, phMem, phImage);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageCopyExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pDst,                   ///< [in] location the data will be copied to
+    void *pSrc, ///< [in] location the data will be copied from
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t
+        imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    auto pfnImageCopyExp = context.urDdiTable.BindlessImagesExp.pfnImageCopyExp;
+
+    if (nullptr == pfnImageCopyExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDst) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSrc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
+
+        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+    }
+
+    ur_result_t result = pfnImageCopyExp(
+        hContext, pDst, pSrc, pImageFormat, pImageDesc, imageCopyFlags,
+        numEventsInWaitList, phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageGetInfoExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+) {
+    auto pfnImageGetInfoExp =
+        context.urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
+
+    if (nullptr == pfnImageGetInfoExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pPropValue) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pPropSizeRet) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pPropValue == NULL && pPropSizeRet == NULL) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (UR_IMAGE_INFO_DEPTH < propName) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
+    }
+
+    ur_result_t result =
+        pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem,        ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel, ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] returning memory handle to the individual image
+) {
+    auto pfnMipmapGetLevelExp =
+        context.urDdiTable.BindlessImagesExp.pfnMipmapGetLevelExp;
+
+    if (nullptr == pfnMipmapGetLevelExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result =
+        pfnMipmapGetLevelExp(hContext, hImageMem, mipmapLevel, phImageMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+) {
+    auto pfnMipmapFreeExp =
+        context.urDdiTable.BindlessImagesExp.pfnMipmapFreeExp;
+
+    if (nullptr == pfnMipmapFreeExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnMipmapFreeExp(hContext, hMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    size_t size,                  ///< [in] size of the external memory
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t
+        *phInteropMem ///< [out] interop memory handle to the external memory
+) {
+    auto pfnImportOpaqueFDExp =
+        context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
+
+    if (nullptr == pfnImportOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phInteropMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result =
+        pfnImportOpaqueFDExp(hContext, size, fileDescriptor, phInteropMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMapExternalArrayExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t
+        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *
+        phImageMem ///< [out] image memory handle to the externally allocated memory
+) {
+    auto pfnMapExternalArrayExp =
+        context.urDdiTable.BindlessImagesExp.pfnMapExternalArrayExp;
+
+    if (nullptr == pfnMapExternalArrayExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hInteropMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phImageMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+    }
+
+    ur_result_t result = pfnMapExternalArrayExp(
+        hContext, pImageFormat, pImageDesc, hInteropMem, phImageMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesReleaseInteropExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t
+        hInteropMem ///< [in] handle of interop memory to be freed
+) {
+    auto pfnReleaseInteropExp =
+        context.urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
+
+    if (nullptr == pfnReleaseInteropExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hInteropMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnReleaseInteropExp(hContext, hInteropMem);
+
+    if (context.enableLeakChecking && result == UR_RESULT_SUCCESS) {
+        refCountContext.decrementRefCount(hInteropMem);
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *
+        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+) {
+    auto pfnImportExternalSemaphoreOpaqueFDExp =
+        context.urDdiTable.BindlessImagesExp
+            .pfnImportExternalSemaphoreOpaqueFDExp;
+
+    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phInteropSemaphoreHandle) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
+        hContext, fileDescriptor, phInteropSemaphoreHandle);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t
+        hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+) {
+    auto pfnDestroyExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
+
+    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hContext) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hInteropSemaphore) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result =
+        pfnDestroyExternalSemaphoreExp(hContext, hInteropSemaphore);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    auto pfnWaitExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
+
+    if (nullptr == pfnWaitExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hQueue) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSemaphore) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnWaitExternalSemaphoreExp(
+        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    auto pfnSignalExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
+
+    if (nullptr == pfnSignalExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hQueue) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hSemaphore) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+    }
+
+    ur_result_t result = pfnSignalExternalSemaphoreExp(
+        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -5459,6 +6199,111 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 
     dditable.pfnTearDown = pDdiTable->pfnTearDown;
     pDdiTable->pfnTearDown = ur_validation_layer::urTearDown;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's BindlessImagesExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_bindless_images_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_validation_layer::context.urDdiTable.BindlessImagesExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnUnsampledImageHandleDestroyExp =
+        pDdiTable->pfnUnsampledImageHandleDestroyExp;
+    pDdiTable->pfnUnsampledImageHandleDestroyExp =
+        ur_validation_layer::urBindlessImagesUnsampledImageHandleDestroyExp;
+
+    dditable.pfnSampledImageHandleDestroyExp =
+        pDdiTable->pfnSampledImageHandleDestroyExp;
+    pDdiTable->pfnSampledImageHandleDestroyExp =
+        ur_validation_layer::urBindlessImagesSampledImageHandleDestroyExp;
+
+    dditable.pfnImageAllocateExp = pDdiTable->pfnImageAllocateExp;
+    pDdiTable->pfnImageAllocateExp =
+        ur_validation_layer::urBindlessImagesImageAllocateExp;
+
+    dditable.pfnImageFreeExp = pDdiTable->pfnImageFreeExp;
+    pDdiTable->pfnImageFreeExp =
+        ur_validation_layer::urBindlessImagesImageFreeExp;
+
+    dditable.pfnUnsampledImageCreateExp = pDdiTable->pfnUnsampledImageCreateExp;
+    pDdiTable->pfnUnsampledImageCreateExp =
+        ur_validation_layer::urBindlessImagesUnsampledImageCreateExp;
+
+    dditable.pfnSampledImageCreateExp = pDdiTable->pfnSampledImageCreateExp;
+    pDdiTable->pfnSampledImageCreateExp =
+        ur_validation_layer::urBindlessImagesSampledImageCreateExp;
+
+    dditable.pfnImageCopyExp = pDdiTable->pfnImageCopyExp;
+    pDdiTable->pfnImageCopyExp =
+        ur_validation_layer::urBindlessImagesImageCopyExp;
+
+    dditable.pfnImageGetInfoExp = pDdiTable->pfnImageGetInfoExp;
+    pDdiTable->pfnImageGetInfoExp =
+        ur_validation_layer::urBindlessImagesImageGetInfoExp;
+
+    dditable.pfnMipmapGetLevelExp = pDdiTable->pfnMipmapGetLevelExp;
+    pDdiTable->pfnMipmapGetLevelExp =
+        ur_validation_layer::urBindlessImagesMipmapGetLevelExp;
+
+    dditable.pfnMipmapFreeExp = pDdiTable->pfnMipmapFreeExp;
+    pDdiTable->pfnMipmapFreeExp =
+        ur_validation_layer::urBindlessImagesMipmapFreeExp;
+
+    dditable.pfnImportOpaqueFDExp = pDdiTable->pfnImportOpaqueFDExp;
+    pDdiTable->pfnImportOpaqueFDExp =
+        ur_validation_layer::urBindlessImagesImportOpaqueFDExp;
+
+    dditable.pfnMapExternalArrayExp = pDdiTable->pfnMapExternalArrayExp;
+    pDdiTable->pfnMapExternalArrayExp =
+        ur_validation_layer::urBindlessImagesMapExternalArrayExp;
+
+    dditable.pfnReleaseInteropExp = pDdiTable->pfnReleaseInteropExp;
+    pDdiTable->pfnReleaseInteropExp =
+        ur_validation_layer::urBindlessImagesReleaseInteropExp;
+
+    dditable.pfnImportExternalSemaphoreOpaqueFDExp =
+        pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp;
+    pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
+        ur_validation_layer::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+
+    dditable.pfnDestroyExternalSemaphoreExp =
+        pDdiTable->pfnDestroyExternalSemaphoreExp;
+    pDdiTable->pfnDestroyExternalSemaphoreExp =
+        ur_validation_layer::urBindlessImagesDestroyExternalSemaphoreExp;
+
+    dditable.pfnWaitExternalSemaphoreExp =
+        pDdiTable->pfnWaitExternalSemaphoreExp;
+    pDdiTable->pfnWaitExternalSemaphoreExp =
+        ur_validation_layer::urBindlessImagesWaitExternalSemaphoreExp;
+
+    dditable.pfnSignalExternalSemaphoreExp =
+        pDdiTable->pfnSignalExternalSemaphoreExp;
+    pDdiTable->pfnSignalExternalSemaphoreExp =
+        ur_validation_layer::urBindlessImagesSignalExternalSemaphoreExp;
 
     return result;
 }
@@ -6192,6 +7037,40 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USMExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_validation_layer::context.urDdiTable.USMExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnPitchedAllocExp = pDdiTable->pfnPitchedAllocExp;
+    pDdiTable->pfnPitchedAllocExp = ur_validation_layer::urUSMPitchedAllocExp;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's Device table
 ///        with current process' addresses
 ///
@@ -6261,6 +7140,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     }
 
     if (UR_RESULT_SUCCESS == result) {
+        result = ur_validation_layer::urGetBindlessImagesExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->BindlessImagesExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
         result = ur_validation_layer::urGetCommandBufferExpProcAddrTable(
             UR_API_VERSION_CURRENT, &dditable->CommandBufferExp);
     }
@@ -6313,6 +7197,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable) {
     if (UR_RESULT_SUCCESS == result) {
         result = ur_validation_layer::urGetUSMProcAddrTable(
             UR_API_VERSION_CURRENT, &dditable->USM);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        result = ur_validation_layer::urGetUSMExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->USMExp);
     }
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -25,6 +25,10 @@ ur_native_factory_t ur_native_factory;
 ur_sampler_factory_t ur_sampler_factory;
 ur_mem_factory_t ur_mem_factory;
 ur_usm_pool_factory_t ur_usm_pool_factory;
+ur_exp_image_factory_t ur_exp_image_factory;
+ur_exp_image_mem_factory_t ur_exp_image_mem_factory;
+ur_exp_interop_mem_factory_t ur_exp_interop_mem_factory;
+ur_exp_interop_semaphore_factory_t ur_exp_interop_semaphore_factory;
 ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4869,6 +4873,784 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urUSMPitchedAllocExp
+__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_usm_desc_t *
+        pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        widthInBytes, ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height, ///< [in] height of the USM memory object to be allocated
+    size_t
+        elementSizeBytes, ///< [in] size in bytes of an element in the allocation
+    void **ppMem,         ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch  ///< [out] pitch of the allocation
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnPitchedAllocExp = dditable->ur.USMExp.pfnPitchedAllocExp;
+    if (nullptr == pfnPitchedAllocExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
+
+    // convert loader handle to platform handle
+    pool = (pool) ? reinterpret_cast<ur_usm_pool_object_t *>(pool)->handle
+                  : nullptr;
+
+    // forward to device-platform
+    result = pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
+                                height, elementSizeBytes, ppMem, pResultPitch);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnUnsampledImageHandleDestroyExp =
+        dditable->ur.BindlessImagesExp.pfnUnsampledImageHandleDestroyExp;
+    if (nullptr == pfnUnsampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hImage = reinterpret_cast<ur_exp_image_object_t *>(hImage)->handle;
+
+    // forward to device-platform
+    result = pfnUnsampledImageHandleDestroyExp(hContext, hImage);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnSampledImageHandleDestroyExp =
+        dditable->ur.BindlessImagesExp.pfnSampledImageHandleDestroyExp;
+    if (nullptr == pfnSampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hImage = reinterpret_cast<ur_exp_image_object_t *>(hImage)->handle;
+
+    // forward to device-platform
+    result = pfnSampledImageHandleDestroyExp(hContext, hImage);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageAllocateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] pointer to handle of image memory allocated
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnImageAllocateExp =
+        dditable->ur.BindlessImagesExp.pfnImageAllocateExp;
+    if (nullptr == pfnImageAllocateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // forward to device-platform
+    result =
+        pfnImageAllocateExp(hContext, pImageFormat, pImageDesc, phImageMem);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phImageMem = reinterpret_cast<ur_exp_image_mem_handle_t>(
+            ur_exp_image_mem_factory.getInstance(*phImageMem, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem ///< [in] handle of image memory to be freed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnImageFreeExp = dditable->ur.BindlessImagesExp.pfnImageFreeExp;
+    if (nullptr == pfnImageFreeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hImageMem =
+        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
+
+    // forward to device-platform
+    result = pfnImageFreeExp(hContext, hImageMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnUnsampledImageCreateExp =
+        dditable->ur.BindlessImagesExp.pfnUnsampledImageCreateExp;
+    if (nullptr == pfnUnsampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hImageMem =
+        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
+
+    // forward to device-platform
+    result = pfnUnsampledImageCreateExp(hContext, hImageMem, pImageFormat,
+                                        pImageDesc, phMem, phImage);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phMem = reinterpret_cast<ur_mem_handle_t>(
+            ur_mem_factory.getInstance(*phMem, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phImage = reinterpret_cast<ur_exp_image_handle_t>(
+            ur_exp_image_factory.getInstance(*phImage, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSampledImageCreateExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnSampledImageCreateExp =
+        dditable->ur.BindlessImagesExp.pfnSampledImageCreateExp;
+    if (nullptr == pfnSampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hImageMem =
+        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
+
+    // convert loader handle to platform handle
+    hSampler = reinterpret_cast<ur_sampler_object_t *>(hSampler)->handle;
+
+    // forward to device-platform
+    result = pfnSampledImageCreateExp(hContext, hImageMem, pImageFormat,
+                                      pImageDesc, hSampler, phMem, phImage);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phMem = reinterpret_cast<ur_mem_handle_t>(
+            ur_mem_factory.getInstance(*phMem, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phImage = reinterpret_cast<ur_exp_image_handle_t>(
+            ur_exp_image_factory.getInstance(*phImage, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageCopyExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pDst,                   ///< [in] location the data will be copied to
+    void *pSrc, ///< [in] location the data will be copied from
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t
+        imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnImageCopyExp = dditable->ur.BindlessImagesExp.pfnImageCopyExp;
+    if (nullptr == pfnImageCopyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal =
+        std::vector<ur_event_handle_t>(numEventsInWaitList);
+    for (size_t i = 0; i < numEventsInWaitList; ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result = pfnImageCopyExp(hContext, pDst, pSrc, pImageFormat, pImageDesc,
+                             imageCopyFlags, numEventsInWaitList,
+                             phEventWaitListLocal.data(), phEvent);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(
+                ur_event_factory.getInstance(*phEvent, dditable));
+        }
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImageGetInfoExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->dditable;
+    auto pfnImageGetInfoExp = dditable->ur.BindlessImagesExp.pfnImageGetInfoExp;
+    if (nullptr == pfnImageGetInfoExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hImageMem =
+        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
+
+    // forward to device-platform
+    result = pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem,        ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel, ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] returning memory handle to the individual image
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnMipmapGetLevelExp =
+        dditable->ur.BindlessImagesExp.pfnMipmapGetLevelExp;
+    if (nullptr == pfnMipmapGetLevelExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hImageMem =
+        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
+
+    // forward to device-platform
+    result = pfnMipmapGetLevelExp(hContext, hImageMem, mipmapLevel, phImageMem);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phImageMem = reinterpret_cast<ur_exp_image_mem_handle_t>(
+            ur_exp_image_mem_factory.getInstance(*phImageMem, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMipmapFreeExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnMipmapFreeExp = dditable->ur.BindlessImagesExp.pfnMipmapFreeExp;
+    if (nullptr == pfnMipmapFreeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hMem = reinterpret_cast<ur_exp_image_mem_object_t *>(hMem)->handle;
+
+    // forward to device-platform
+    result = pfnMipmapFreeExp(hContext, hMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    size_t size,                  ///< [in] size of the external memory
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t
+        *phInteropMem ///< [out] interop memory handle to the external memory
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnImportOpaqueFDExp =
+        dditable->ur.BindlessImagesExp.pfnImportOpaqueFDExp;
+    if (nullptr == pfnImportOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // forward to device-platform
+    result = pfnImportOpaqueFDExp(hContext, size, fileDescriptor, phInteropMem);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phInteropMem = reinterpret_cast<ur_exp_interop_mem_handle_t>(
+            ur_exp_interop_mem_factory.getInstance(*phInteropMem, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesMapExternalArrayExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t
+        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *
+        phImageMem ///< [out] image memory handle to the externally allocated memory
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnMapExternalArrayExp =
+        dditable->ur.BindlessImagesExp.pfnMapExternalArrayExp;
+    if (nullptr == pfnMapExternalArrayExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hInteropMem =
+        reinterpret_cast<ur_exp_interop_mem_object_t *>(hInteropMem)->handle;
+
+    // forward to device-platform
+    result = pfnMapExternalArrayExp(hContext, pImageFormat, pImageDesc,
+                                    hInteropMem, phImageMem);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phImageMem = reinterpret_cast<ur_exp_image_handle_t>(
+            ur_exp_image_factory.getInstance(*phImageMem, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesReleaseInteropExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t
+        hInteropMem ///< [in] handle of interop memory to be freed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnReleaseInteropExp =
+        dditable->ur.BindlessImagesExp.pfnReleaseInteropExp;
+    if (nullptr == pfnReleaseInteropExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hInteropMem =
+        reinterpret_cast<ur_exp_interop_mem_object_t *>(hInteropMem)->handle;
+
+    // forward to device-platform
+    result = pfnReleaseInteropExp(hContext, hInteropMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+__urdlllocal ur_result_t UR_APICALL
+urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *
+        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnImportExternalSemaphoreOpaqueFDExp =
+        dditable->ur.BindlessImagesExp.pfnImportExternalSemaphoreOpaqueFDExp;
+    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // forward to device-platform
+    result = pfnImportExternalSemaphoreOpaqueFDExp(hContext, fileDescriptor,
+                                                   phInteropSemaphoreHandle);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phInteropSemaphoreHandle =
+            reinterpret_cast<ur_exp_interop_semaphore_handle_t>(
+                ur_exp_interop_semaphore_factory.getInstance(
+                    *phInteropSemaphoreHandle, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t
+        hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
+    auto pfnDestroyExternalSemaphoreExp =
+        dditable->ur.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
+    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
+
+    // convert loader handle to platform handle
+    hInteropSemaphore =
+        reinterpret_cast<ur_exp_interop_semaphore_object_t *>(hInteropSemaphore)
+            ->handle;
+
+    // forward to device-platform
+    result = pfnDestroyExternalSemaphoreExp(hContext, hInteropSemaphore);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
+    auto pfnWaitExternalSemaphoreExp =
+        dditable->ur.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
+    if (nullptr == pfnWaitExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
+
+    // convert loader handle to platform handle
+    hSemaphore =
+        reinterpret_cast<ur_exp_interop_semaphore_object_t *>(hSemaphore)
+            ->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal =
+        std::vector<ur_event_handle_t>(numEventsInWaitList);
+    for (size_t i = 0; i < numEventsInWaitList; ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result =
+        pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, numEventsInWaitList,
+                                    phEventWaitListLocal.data(), phEvent);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(
+                ur_event_factory.getInstance(*phEvent, dditable));
+        }
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
+    auto pfnSignalExternalSemaphoreExp =
+        dditable->ur.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
+    if (nullptr == pfnSignalExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
+
+    // convert loader handle to platform handle
+    hSemaphore =
+        reinterpret_cast<ur_exp_interop_semaphore_object_t *>(hSemaphore)
+            ->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal =
+        std::vector<ur_event_handle_t>(numEventsInWaitList);
+    for (size_t i = 0; i < numEventsInWaitList; ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result =
+        pfnSignalExternalSemaphoreExp(hQueue, hSemaphore, numEventsInWaitList,
+                                      phEventWaitListLocal.data(), phEvent);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        if (nullptr != phEvent) {
+            *phEvent = reinterpret_cast<ur_event_handle_t>(
+                ur_event_factory.getInstance(*phEvent, dditable));
+        }
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -5310,6 +6092,95 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
             // return pointers directly to platform's DDIs
             *pDdiTable =
                 ur_loader::context->platforms.front().dditable.ur.Global;
+        }
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's BindlessImagesExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_bindless_images_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (ur_loader::context->version < version) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // Load the device-platform DDI tables
+    for (auto &platform : ur_loader::context->platforms) {
+        if (platform.initStatus != UR_RESULT_SUCCESS) {
+            continue;
+        }
+        auto getTable =
+            reinterpret_cast<ur_pfnGetBindlessImagesExpProcAddrTable_t>(
+                ur_loader::LibLoader::getFunctionPtr(
+                    platform.handle.get(),
+                    "urGetBindlessImagesExpProcAddrTable"));
+        if (!getTable) {
+            continue;
+        }
+        platform.initStatus =
+            getTable(version, &platform.dditable.ur.BindlessImagesExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        if (ur_loader::context->platforms.size() != 1 ||
+            ur_loader::context->forceIntercept) {
+            // return pointers to loader's DDIs
+            pDdiTable->pfnUnsampledImageHandleDestroyExp =
+                ur_loader::urBindlessImagesUnsampledImageHandleDestroyExp;
+            pDdiTable->pfnSampledImageHandleDestroyExp =
+                ur_loader::urBindlessImagesSampledImageHandleDestroyExp;
+            pDdiTable->pfnImageAllocateExp =
+                ur_loader::urBindlessImagesImageAllocateExp;
+            pDdiTable->pfnImageFreeExp =
+                ur_loader::urBindlessImagesImageFreeExp;
+            pDdiTable->pfnUnsampledImageCreateExp =
+                ur_loader::urBindlessImagesUnsampledImageCreateExp;
+            pDdiTable->pfnSampledImageCreateExp =
+                ur_loader::urBindlessImagesSampledImageCreateExp;
+            pDdiTable->pfnImageCopyExp =
+                ur_loader::urBindlessImagesImageCopyExp;
+            pDdiTable->pfnImageGetInfoExp =
+                ur_loader::urBindlessImagesImageGetInfoExp;
+            pDdiTable->pfnMipmapGetLevelExp =
+                ur_loader::urBindlessImagesMipmapGetLevelExp;
+            pDdiTable->pfnMipmapFreeExp =
+                ur_loader::urBindlessImagesMipmapFreeExp;
+            pDdiTable->pfnImportOpaqueFDExp =
+                ur_loader::urBindlessImagesImportOpaqueFDExp;
+            pDdiTable->pfnMapExternalArrayExp =
+                ur_loader::urBindlessImagesMapExternalArrayExp;
+            pDdiTable->pfnReleaseInteropExp =
+                ur_loader::urBindlessImagesReleaseInteropExp;
+            pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
+                ur_loader::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+            pDdiTable->pfnDestroyExternalSemaphoreExp =
+                ur_loader::urBindlessImagesDestroyExternalSemaphoreExp;
+            pDdiTable->pfnWaitExternalSemaphoreExp =
+                ur_loader::urBindlessImagesWaitExternalSemaphoreExp;
+            pDdiTable->pfnSignalExternalSemaphoreExp =
+                ur_loader::urBindlessImagesSignalExternalSemaphoreExp;
+        } else {
+            // return pointers directly to platform's DDIs
+            *pDdiTable = ur_loader::context->platforms.front()
+                             .dditable.ur.BindlessImagesExp;
         }
     }
 
@@ -6025,6 +6896,59 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMProcAddrTable(
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable = ur_loader::context->platforms.front().dditable.ur.USM;
+        }
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's USMExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_usm_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (ur_loader::context->version < version) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // Load the device-platform DDI tables
+    for (auto &platform : ur_loader::context->platforms) {
+        if (platform.initStatus != UR_RESULT_SUCCESS) {
+            continue;
+        }
+        auto getTable = reinterpret_cast<ur_pfnGetUSMExpProcAddrTable_t>(
+            ur_loader::LibLoader::getFunctionPtr(platform.handle.get(),
+                                                 "urGetUSMExpProcAddrTable"));
+        if (!getTable) {
+            continue;
+        }
+        platform.initStatus = getTable(version, &platform.dditable.ur.USMExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        if (ur_loader::context->platforms.size() != 1 ||
+            ur_loader::context->forceIntercept) {
+            // return pointers to loader's DDIs
+            pDdiTable->pfnPitchedAllocExp = ur_loader::urUSMPitchedAllocExp;
+        } else {
+            // return pointers directly to platform's DDIs
+            *pDdiTable =
+                ur_loader::context->platforms.front().dditable.ur.USMExp;
         }
     }
 

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -60,6 +60,25 @@ using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
 using ur_usm_pool_factory_t =
     singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
 
+using ur_exp_image_object_t = object_t<ur_exp_image_handle_t>;
+using ur_exp_image_factory_t =
+    singleton_factory_t<ur_exp_image_object_t, ur_exp_image_handle_t>;
+
+using ur_exp_image_mem_object_t = object_t<ur_exp_image_mem_handle_t>;
+using ur_exp_image_mem_factory_t =
+    singleton_factory_t<ur_exp_image_mem_object_t, ur_exp_image_mem_handle_t>;
+
+using ur_exp_interop_mem_object_t = object_t<ur_exp_interop_mem_handle_t>;
+using ur_exp_interop_mem_factory_t =
+    singleton_factory_t<ur_exp_interop_mem_object_t,
+                        ur_exp_interop_mem_handle_t>;
+
+using ur_exp_interop_semaphore_object_t =
+    object_t<ur_exp_interop_semaphore_handle_t>;
+using ur_exp_interop_semaphore_factory_t =
+    singleton_factory_t<ur_exp_interop_semaphore_object_t,
+                        ur_exp_interop_semaphore_handle_t>;
+
 using ur_exp_command_buffer_object_t = object_t<ur_exp_command_buffer_handle_t>;
 using ur_exp_command_buffer_factory_t =
     singleton_factory_t<ur_exp_command_buffer_object_t,

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -436,7 +436,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_IP_VERSION < propName`
+///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -5266,6 +5266,752 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
     return pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
                             numEventsInWaitList, phEventWaitList, phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocate pitched memory
+///
+/// @details
+///     - This function must support memory pooling.
+///     - If pUSMDesc is not NULL and pUSMDesc->pool is not NULL the allocation
+///       will be served from a specified memory pool.
+///     - Otherwise, the behavior is implementation-defined.
+///     - Allocations served from different memory pools must be isolated and
+///       must not reside on the same page.
+///     - Any flags/hints passed through pUSMDesc only affect the single
+///       allocation.
+///     - See also ::ur_usm_host_desc_t.
+///     - See also ::ur_usm_device_desc_t.
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMemAllocPitch**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMem`
+///         + `NULL == pResultPitch`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`
+///         + If `align` is greater that the size of the largest data type supported by `hDevice`.
+///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
+///         + `widthInBytes == 0`
+///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+///         + If `UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT` and `UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT` are both false.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urUSMPitchedAllocExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_usm_desc_t *
+        pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        widthInBytes, ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height, ///< [in] height of the USM memory object to be allocated
+    size_t
+        elementSizeBytes, ///< [in] size in bytes of an element in the allocation
+    void **ppMem,         ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch  ///< [out] pitch of the allocation
+    ) try {
+    auto pfnPitchedAllocExp =
+        ur_lib::context->urDdiTable.USMExp.pfnPitchedAllocExp;
+    if (nullptr == pfnPitchedAllocExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
+                              height, elementSizeBytes, ppMem, pResultPitch);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy bindless unsampled image handles
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSurfObjectDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+    ) try {
+    auto pfnUnsampledImageHandleDestroyExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnUnsampledImageHandleDestroyExp;
+    if (nullptr == pfnUnsampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnUnsampledImageHandleDestroyExp(hContext, hImage);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy bindless sampled image handles
+///
+/// @remarks
+///   _Analogues_
+///     - **cuTexObjectDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+    ) try {
+    auto pfnSampledImageHandleDestroyExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnSampledImageHandleDestroyExp;
+    if (nullptr == pfnSampledImageHandleDestroyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnSampledImageHandleDestroyExp(hContext, hImage);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocate memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuArray3DCreate**
+///     - **cuMipmappedArrayCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] pointer to handle of image memory allocated
+    ) try {
+    auto pfnImageAllocateExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
+    if (nullptr == pfnImageAllocateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImageAllocateExp(hContext, pImageFormat, pImageDesc, phImageMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuArrayDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem ///< [in] handle of image memory to be freed
+    ) try {
+    auto pfnImageFreeExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnImageFreeExp;
+    if (nullptr == pfnImageFreeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImageFreeExp(hContext, hImageMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a bindless unsampled image handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSurfObjectCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phMem`
+///         + `NULL == phImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+    ) try {
+    auto pfnUnsampledImageCreateExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnUnsampledImageCreateExp;
+    if (nullptr == pfnUnsampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnUnsampledImageCreateExp(hContext, hImageMem, pImageFormat,
+                                      pImageDesc, phMem, phImage);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a bindless sampled image handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuTexObjectCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phMem`
+///         + `NULL == phImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+    ) try {
+    auto pfnSampledImageCreateExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnSampledImageCreateExp;
+    if (nullptr == pfnSampledImageCreateExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnSampledImageCreateExp(hContext, hImageMem, pImageFormat,
+                                    pImageDesc, hSampler, phMem, phImage);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copy image data Host to Device or Device to Host
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMemcpyHtoAAsync**
+///     - **cuMemcpyAtoHAsync**
+///     - **cuMemcpy2DAsync**
+///     - **cuMemcpy3DAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pDst,                   ///< [in] location the data will be copied to
+    void *pSrc, ///< [in] location the data will be copied from
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t
+        imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+    ) try {
+    auto pfnImageCopyExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
+    if (nullptr == pfnImageCopyExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImageCopyExp(hContext, pDst, pSrc, pImageFormat, pImageDesc,
+                           imageCopyFlags, numEventsInWaitList, phEventWaitList,
+                           phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query an image memory handle for specific properties
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+///         + `NULL == pPropSizeRet`
+///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
+///         + If `propName` is not supported by the adapter.
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `propSize` is less than the real number of bytes needed to return the info.
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+    ) try {
+    auto pfnImageGetInfoExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
+    if (nullptr == pfnImageGetInfoExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve individual image from mipmap
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMipmappedArrayGetLevel**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem,        ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel, ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] returning memory handle to the individual image
+    ) try {
+    auto pfnMipmapGetLevelExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnMipmapGetLevelExp;
+    if (nullptr == pfnMipmapGetLevelExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnMipmapGetLevelExp(hContext, hImageMem, mipmapLevel, phImageMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free mipmap memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMipmappedArrayDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+    ) try {
+    auto pfnMipmapFreeExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnMipmapFreeExp;
+    if (nullptr == pfnMipmapFreeExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnMipmapFreeExp(hContext, hMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import external memory in the form of a file descriptor
+///
+/// @remarks
+///   _Analogues_
+///     - **cuImportExternalMemory**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    size_t size,                  ///< [in] size of the external memory
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t
+        *phInteropMem ///< [out] interop memory handle to the external memory
+    ) try {
+    auto pfnImportOpaqueFDExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
+    if (nullptr == pfnImportOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImportOpaqueFDExp(hContext, size, fileDescriptor, phInteropMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Map an interop memory handle to an image memory handle
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t
+        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *
+        phImageMem ///< [out] image memory handle to the externally allocated memory
+    ) try {
+    auto pfnMapExternalArrayExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnMapExternalArrayExp;
+    if (nullptr == pfnMapExternalArrayExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnMapExternalArrayExp(hContext, pImageFormat, pImageDesc,
+                                  hInteropMem, phImageMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy interop memory
+///
+/// @remarks
+///   _Analogues_
+///     - **cuDestroyExternalMemory**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t
+        hInteropMem ///< [in] handle of interop memory to be freed
+    ) try {
+    auto pfnReleaseInteropExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
+    if (nullptr == pfnReleaseInteropExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnReleaseInteropExp(hContext, hInteropMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import an external semaphore in the form of a file descriptor
+///
+/// @remarks
+///   _Analogues_
+///     - **cuImportExternalSemaphore**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phInteropSemaphoreHandle`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *
+        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+    ) try {
+    auto pfnImportExternalSemaphoreOpaqueFDExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnImportExternalSemaphoreOpaqueFDExp;
+    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnImportExternalSemaphoreOpaqueFDExp(hContext, fileDescriptor,
+                                                 phInteropSemaphoreHandle);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy the external semaphore handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuDestroyExternalSemaphore**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t
+        hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+    ) try {
+    auto pfnDestroyExternalSemaphoreExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnDestroyExternalSemaphoreExp;
+    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnDestroyExternalSemaphoreExp(hContext, hInteropSemaphore);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Instruct the queue with a non-blocking wait on an external semaphore
+///
+/// @remarks
+///   _Analogues_
+///     - **cuWaitExternalSemaphoresAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+    ) try {
+    auto pfnWaitExternalSemaphoreExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnWaitExternalSemaphoreExp;
+    if (nullptr == pfnWaitExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, numEventsInWaitList,
+                                       phEventWaitList, phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Instruct the queue to signal the external semaphore handle once all
+///        previous commands have completed execution
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSignalExternalSemaphoresAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+    ) try {
+    auto pfnSignalExternalSemaphoreExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnSignalExternalSemaphoreExp;
+    if (nullptr == pfnSignalExternalSemaphoreExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnSignalExternalSemaphoreExp(
+        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -26,6 +26,11 @@ __urdlllocal ur_result_t context_t::urInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
+        result = urGetBindlessImagesExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &urDdiTable.BindlessImagesExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
         result = urGetCommandBufferExpProcAddrTable(
             UR_API_VERSION_CURRENT, &urDdiTable.CommandBufferExp);
     }
@@ -76,6 +81,11 @@ __urdlllocal ur_result_t context_t::urInit() {
 
     if (UR_RESULT_SUCCESS == result) {
         result = urGetUSMProcAddrTable(UR_API_VERSION_CURRENT, &urDdiTable.USM);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        result = urGetUSMExpProcAddrTable(UR_API_VERSION_CURRENT,
+                                          &urDdiTable.USMExp);
     }
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -360,7 +360,7 @@ ur_result_t UR_APICALL urDeviceGet(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_IP_VERSION < propName`
+///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -4438,6 +4438,610 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_event_handle_t *
         phEvent ///< [out] returns an event object that identifies this write command
     ///< and can be used to query or queue a wait for this command to complete.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocate pitched memory
+///
+/// @details
+///     - This function must support memory pooling.
+///     - If pUSMDesc is not NULL and pUSMDesc->pool is not NULL the allocation
+///       will be served from a specified memory pool.
+///     - Otherwise, the behavior is implementation-defined.
+///     - Allocations served from different memory pools must be isolated and
+///       must not reside on the same page.
+///     - Any flags/hints passed through pUSMDesc only affect the single
+///       allocation.
+///     - See also ::ur_usm_host_desc_t.
+///     - See also ::ur_usm_device_desc_t.
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMemAllocPitch**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMem`
+///         + `NULL == pResultPitch`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`
+///         + If `align` is greater that the size of the largest data type supported by `hDevice`.
+///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
+///         + `widthInBytes == 0`
+///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+///         + If `UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT` and `UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT` are both false.
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urUSMPitchedAllocExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    const ur_usm_desc_t *
+        pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
+    ur_usm_pool_handle_t
+        pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
+    size_t
+        widthInBytes, ///< [in] width in bytes of the USM memory object to be allocated
+    size_t height, ///< [in] height of the USM memory object to be allocated
+    size_t
+        elementSizeBytes, ///< [in] size in bytes of an element in the allocation
+    void **ppMem,         ///< [out] pointer to USM shared memory object
+    size_t *pResultPitch  ///< [out] pitch of the allocation
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy bindless unsampled image handles
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSurfObjectDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy bindless sampled image handles
+///
+/// @remarks
+///   _Analogues_
+///     - **cuTexObjectDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_handle_t
+        hImage ///< [in] pointer to handle of image object to destroy
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Allocate memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuArray3DCreate**
+///     - **cuMipmappedArrayCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] pointer to handle of image memory allocated
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuArrayDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem ///< [in] handle of image memory to be freed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a bindless unsampled image handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSurfObjectCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phMem`
+///         + `NULL == phImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Create a bindless sampled image handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuTexObjectCreate**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///         + `NULL == hSampler`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phMem`
+///         + `NULL == phImage`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
+    ur_mem_handle_t *phMem, ///< [out] pointer to handle of image object created
+    ur_exp_image_handle_t
+        *phImage ///< [out] pointer to handle of image object created
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Copy image data Host to Device or Device to Host
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMemcpyHtoAAsync**
+///     - **cuMemcpyAtoHAsync**
+///     - **cuMemcpy2DAsync**
+///     - **cuMemcpy3DAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///         + `NULL == pSrc`
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    void *pDst,                   ///< [in] location the data will be copied to
+    void *pSrc, ///< [in] location the data will be copied from
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_image_copy_flags_t
+        imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Query an image memory handle for specific properties
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pPropValue`
+///         + `NULL == pPropSizeRet`
+///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
+///         + If `propName` is not supported by the adapter.
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + If `propSize` is less than the real number of bytes needed to return the info.
+///     - ::UR_RESULT_ERROR_INVALID_DEVICE
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,            ///< [in] queried info name
+    void *pPropValue,                    ///< [out] returned query value
+    size_t *pPropSizeRet                 ///< [out] returned query value size
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieve individual image from mipmap
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMipmappedArrayGetLevel**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t
+        hImageMem,        ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel, ///< [in] requested level of the mipmap
+    ur_exp_image_mem_handle_t
+        *phImageMem ///< [out] returning memory handle to the individual image
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free mipmap memory for bindless images
+///
+/// @remarks
+///   _Analogues_
+///     - **cuMipmappedArrayDestroy**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    ur_context_handle_t hContext,  ///< [in] handle of the context object
+    ur_exp_image_mem_handle_t hMem ///< [in] handle of image memory to be freed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import external memory in the form of a file descriptor
+///
+/// @remarks
+///   _Analogues_
+///     - **cuImportExternalMemory**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    size_t size,                  ///< [in] size of the external memory
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_mem_handle_t
+        *phInteropMem ///< [out] interop memory handle to the external memory
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Map an interop memory handle to an image memory handle
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pImageFormat`
+///         + `NULL == pImageDesc`
+///         + `NULL == phImageMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    const ur_image_format_t
+        *pImageFormat, ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t
+        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_image_handle_t *
+        phImageMem ///< [out] image memory handle to the externally allocated memory
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy interop memory
+///
+/// @remarks
+///   _Analogues_
+///     - **cuDestroyExternalMemory**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropMem`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_mem_handle_t
+        hInteropMem ///< [in] handle of interop memory to be freed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Import an external semaphore in the form of a file descriptor
+///
+/// @remarks
+///   _Analogues_
+///     - **cuImportExternalSemaphore**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phInteropSemaphoreHandle`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_handle_t *
+        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Destroy the external semaphore handle
+///
+/// @remarks
+///   _Analogues_
+///     - **cuDestroyExternalSemaphore**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hContext`
+///         + `NULL == hInteropSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_interop_semaphore_handle_t
+        hInteropSemaphore ///< [in] handle of interop semaphore to be destroyed
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Instruct the queue with a non-blocking wait on an external semaphore
+///
+/// @remarks
+///   _Analogues_
+///     - **cuWaitExternalSemaphoresAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Instruct the queue to signal the external semaphore handle once all
+///        previous commands have completed execution
+///
+/// @remarks
+///   _Analogues_
+///     - **cuSignalExternalSemaphoresAsync**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///         + `NULL == hSemaphore`
+///     - ::UR_RESULT_ERROR_INVALID_QUEUE
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    ur_exp_interop_semaphore_handle_t
+        hSemaphore,               ///< [in] interop semaphore handle
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+    ///< previously enqueued commands
+    ///< must be complete.
+    ur_event_handle_t *
+        phEvent ///< [out][optional] return an event object that identifies this particular
+                ///< command instance.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
Experimental support for bindless images in Unified Runtime.

This feature is to add support for the [experimental implementation of bindless images extension #9665](https://github.com/intel/llvm/pull/9665) in DPC++ after [Port CUDA plugin to Unified Runtime #9512](https://github.com/intel/llvm/pull/9512) is merged.