### PR TITLE
[UR] Pointer to handle arguments require a range() check

### DIFF
--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -326,6 +326,10 @@ def _validate_doc(f, d, tags, line_num):
 
             if item['type'].endswith("flag_t"):
                 raise Exception(prefix+"'type' must not be '*_flag_t': %s"%item['type'])
+        
+            if type_traits.is_pointer(item['type']) and "_handle_t" in item['type'] and "[in]" in item['desc']:
+                if not param_traits.is_range(item):
+                    raise Exception(prefix+"handle type must include a range(start, end) as part of 'desc'")
 
             ver = __validate_version(item, prefix=prefix, base_version=d_ver)
             if ver < max_ver:

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -1148,6 +1148,9 @@ def get_loader_prologue(namespace, tags, obj, meta):
             fty_name = re.sub(r"(\w+)_handle_t", r"\1_factory", tname)
 
             if type_traits.is_pointer(item['type']):
+                if not param_traits.is_range(item):
+                    print(item)
+                    raise Exception("Pointer to a handle parameter requires a `[range(start, end)]` check as part of the description.")
                 range_start = param_traits.range_start(item)
                 range_end   = param_traits.range_end(item)
                 prologue.append({

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -1148,9 +1148,6 @@ def get_loader_prologue(namespace, tags, obj, meta):
             fty_name = re.sub(r"(\w+)_handle_t", r"\1_factory", tname)
 
             if type_traits.is_pointer(item['type']):
-                if not param_traits.is_range(item):
-                    print(item)
-                    raise Exception("Pointer to a handle parameter requires a `[range(start, end)]` check as part of the description.")
                 range_start = param_traits.range_start(item)
                 range_end   = param_traits.range_end(item)
                 prologue.append({


### PR DESCRIPTION
A pointer to handle argument requires that a `[range(start, end)]` check is included as part of it's description. This is required for the loader to do some local conversion of it's types. This also leads to some confusion as without this check the script generator will match a different part of the description resulting in other parts of the description being included into the generated files.