### PR TITLE
[uma] add a function to query name of a provider

### DIFF
--- a/source/common/uma_helpers.hpp
+++ b/source/common/uma_helpers.hpp
@@ -90,6 +90,10 @@ auto memoryProviderMakeUnique(Args &&...args) {
             noexcept(reinterpret_cast<T *>(obj)->purge_force(args...)));
         return reinterpret_cast<T *>(obj)->purge_force(args...);
     };
+    ops.get_name = [](void *obj, auto... args) {
+        static_assert(noexcept(reinterpret_cast<T *>(obj)->get_name(args...)));
+        return reinterpret_cast<T *>(obj)->get_name(args...);
+    };
 
     uma_memory_provider_handle_t hProvider = nullptr;
     auto ret = umaMemoryProviderCreate(&ops, &argsTuple, &hProvider);

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -132,6 +132,13 @@ enum uma_result_t
 umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
                             size_t size);
 
+///
+/// \brief Retrive name of a given memory provider.
+/// \param hProvider handle to the memory provider
+/// \param ppName [out] pointer to a string containing name of the provider
+void umaMemoryProviderGetName(uma_memory_provider_handle_t hProvider,
+                              const char **ppName);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -49,6 +49,7 @@ struct uma_memory_provider_ops_t {
                                            size_t *pageSize);
     enum uma_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);
     enum uma_result_t (*purge_force)(void *provider, void *ptr, size_t size);
+    void (*get_name)(void *provider, const char **ppName);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -97,3 +97,8 @@ umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
                             size_t size) {
     return hProvider->ops.purge_force(hProvider->provider_priv, ptr, size);
 }
+
+void umaMemoryProviderGetName(uma_memory_provider_handle_t hProvider,
+                              const char **ppName) {
+    hProvider->ops.get_name(hProvider->provider_priv, ppName);
+}

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -204,6 +204,12 @@ static enum uma_result_t trackingPurgeForce(void *provider, void *ptr,
     return umaMemoryProviderPurgeForce(p->hUpstream, ptr, size);
 }
 
+static void trackingName(void *provider, const char **ppName) {
+    uma_tracking_memory_provider_t *p =
+        (uma_tracking_memory_provider_t *)provider;
+    return umaMemoryProviderGetName(p->hUpstream, ppName);
+}
+
 enum uma_result_t umaTrackingMemoryProviderCreate(
     uma_memory_provider_handle_t hUpstream, uma_memory_pool_handle_t hPool,
     uma_memory_provider_handle_t *hTrackingProvider) {
@@ -224,6 +230,7 @@ enum uma_result_t umaTrackingMemoryProviderCreate(
         trackingGetRecommendedPageSize;
     trackingMemoryProviderOps.purge_force = trackingPurgeForce;
     trackingMemoryProviderOps.purge_lazy = trackingPurgeLazy;
+    trackingMemoryProviderOps.get_name = trackingName;
 
     return umaMemoryProviderCreate(&trackingMemoryProviderOps, &params,
                                    hTrackingProvider);

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -72,6 +72,11 @@ static enum uma_result_t nullPurgeForce(void *provider, void *ptr,
     return UMA_RESULT_SUCCESS;
 }
 
+static void nullName(void *provider, const char **ppName) {
+    (void)provider;
+    *ppName = "null";
+}
+
 uma_memory_provider_handle_t nullProviderCreate(void) {
     struct uma_memory_provider_ops_t ops = {
         .version = UMA_VERSION_CURRENT,
@@ -83,7 +88,8 @@ uma_memory_provider_handle_t nullProviderCreate(void) {
         .get_recommended_page_size = nullGetRecommendedPageSize,
         .get_min_page_size = nullGetPageSize,
         .purge_lazy = nullPurgeLazy,
-        .purge_force = nullPurgeForce};
+        .purge_force = nullPurgeForce,
+        .get_name = nullName};
 
     uma_memory_provider_handle_t hProvider;
     enum uma_result_t ret = umaMemoryProviderCreate(&ops, NULL, &hProvider);
@@ -171,6 +177,13 @@ static enum uma_result_t tracePurgeForce(void *provider, void *ptr,
                                        size);
 }
 
+static void traceName(void *provider, const char **ppName) {
+    struct traceParams *traceProvider = (struct traceParams *)provider;
+
+    traceProvider->trace("name");
+    umaMemoryProviderGetName(traceProvider->hUpstreamProvider, ppName);
+}
+
 uma_memory_provider_handle_t
 traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
                     void (*trace)(const char *)) {
@@ -184,7 +197,8 @@ traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
         .get_recommended_page_size = traceGetRecommendedPageSize,
         .get_min_page_size = traceGetPageSize,
         .purge_lazy = tracePurgeLazy,
-        .purge_force = tracePurgeForce};
+        .purge_force = tracePurgeForce,
+        .get_name = traceName};
 
     struct traceParams params = {.hUpstreamProvider = hUpstreamProvider,
                                  .trace = trace};

--- a/test/unified_memory_allocation/common/provider.h
+++ b/test/unified_memory_allocation/common/provider.h
@@ -16,7 +16,6 @@ uma_memory_provider_handle_t nullProviderCreate(void);
 uma_memory_provider_handle_t
 traceProviderCreate(uma_memory_provider_handle_t hUpstreamProvider,
                     void (*trace)(const char *));
-uma_memory_provider_handle_t mallocProviderCreate(void);
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -49,6 +49,7 @@ struct provider_base {
     enum uma_result_t purge_force(void *ptr, size_t size) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }
+    void get_name(const char **ppName) noexcept { *ppName = "base"; }
 };
 
 struct provider_malloc : public provider_base {
@@ -74,6 +75,7 @@ struct provider_malloc : public provider_base {
 #endif
         return UMA_RESULT_SUCCESS;
     }
+    void get_name(const char **ppName) noexcept { *ppName = "malloc"; }
 };
 
 } // namespace uma_test

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -59,6 +59,12 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
     ASSERT_EQ(calls["purge_force"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
+
+    const char *pName;
+    umaMemoryProviderGetName(tracingProvider.get(), &pName);
+    ASSERT_EQ(calls["name"], 1);
+    ASSERT_EQ(calls.size(), ++call_count);
+    ASSERT_EQ(std::string(pName), std::string("null"));
 }
 
 //////////////////////////// Negative test cases


### PR DESCRIPTION
To allow interacting with the underlying implementation directly. This will be needed to support returning native error codes (name can be used to figure out how to interpret those errors) and possibly to support provider-specific queries.