### PR TITLE
[ur] Add NONE to virtual mem access flags

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -1324,8 +1324,9 @@ class ur_virtual_mem_granularity_info_t(c_int):
 ###############################################################################
 ## @brief Virtual memory access mode flags.
 class ur_virtual_mem_access_flags_v(IntEnum):
-    READ_WRITE = UR_BIT(0)                          ## Virtual memory both read and write accessible
-    READ_ONLY = UR_BIT(1)                           ## 
+    NONE = UR_BIT(0)                                ## Virtual memory has no access.
+    READ_WRITE = UR_BIT(1)                          ## Virtual memory has both read and write access.
+    READ_ONLY = UR_BIT(2)                           ## Virtual memory has read only access.
 
 class ur_virtual_mem_access_flags_t(c_int):
     def __str__(self):

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3055,15 +3055,16 @@ urVirtualMemFree(
 /// @brief Virtual memory access mode flags.
 typedef uint32_t ur_virtual_mem_access_flags_t;
 typedef enum ur_virtual_mem_access_flag_t {
-    UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE = UR_BIT(0), ///< Virtual memory both read and write accessible
-    UR_VIRTUAL_MEM_ACCESS_FLAG_READ_ONLY = UR_BIT(1),  ///<
+    UR_VIRTUAL_MEM_ACCESS_FLAG_NONE = UR_BIT(0),       ///< Virtual memory has no access.
+    UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE = UR_BIT(1), ///< Virtual memory has both read and write access.
+    UR_VIRTUAL_MEM_ACCESS_FLAG_READ_ONLY = UR_BIT(2),  ///< Virtual memory has read only access.
     /// @cond
     UR_VIRTUAL_MEM_ACCESS_FLAG_FORCE_UINT32 = 0x7fffffff
     /// @endcond
 
 } ur_virtual_mem_access_flag_t;
 /// @brief Bit Mask for validating ur_virtual_mem_access_flags_t
-#define UR_VIRTUAL_MEM_ACCESS_FLAGS_MASK 0xfffffffc
+#define UR_VIRTUAL_MEM_ACCESS_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Map a virtual memory range to a physical memory handle.

--- a/scripts/core/virtual_memory.yml
+++ b/scripts/core/virtual_memory.yml
@@ -106,12 +106,15 @@ desc: "Virtual memory access mode flags."
 class: $xVirtualMem
 name: $x_virtual_mem_access_flags_t
 etors:
-    - name: READ_WRITE
+    - name: NONE
       value: $X_BIT(0)
-      desc: "Virtual memory both read and write accessible"
-    - name: READ_ONLY
+      desc: "Virtual memory has no access."
+    - name: READ_WRITE
       value: $X_BIT(1)
-      desc: ""
+      desc: "Virtual memory has both read and write access."
+    - name: READ_ONLY
+      value: $X_BIT(2)
+      desc: "Virtual memory has read only access."
 
 --- #--------------------------------------------------------------------------
 type: function

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -6437,6 +6437,10 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_virtual_mem_access_flag_t value) {
     switch (value) {
 
+    case UR_VIRTUAL_MEM_ACCESS_FLAG_NONE:
+        os << "UR_VIRTUAL_MEM_ACCESS_FLAG_NONE";
+        break;
+
     case UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE:
         os << "UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE";
         break;
@@ -6457,6 +6461,17 @@ inline void serializeFlag<ur_virtual_mem_access_flag_t>(std::ostream &os,
                                                         uint32_t flag) {
     uint32_t val = flag;
     bool first = true;
+
+    if ((val & UR_VIRTUAL_MEM_ACCESS_FLAG_NONE) ==
+        (uint32_t)UR_VIRTUAL_MEM_ACCESS_FLAG_NONE) {
+        val ^= (uint32_t)UR_VIRTUAL_MEM_ACCESS_FLAG_NONE;
+        if (!first) {
+            os << " | ";
+        } else {
+            first = false;
+        }
+        os << UR_VIRTUAL_MEM_ACCESS_FLAG_NONE;
+    }
 
     if ((val & UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE) ==
         (uint32_t)UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE) {


### PR DESCRIPTION
Address [feedback](https://github.com/oneapi-src/unified-runtime/pull/525#discussion_r1234803903) and add `UR_VIRTUAL_MEM_ACCESS_FLAG_NONE` to allow specifying a no access.
