### PR TITLE
[uma] Replace list of providers with explicit data and metadata providers.

### DIFF
--- a/source/common/uma_helpers.hpp
+++ b/source/common/uma_helpers.hpp
@@ -92,7 +92,7 @@ auto memoryProviderMakeUnique(Args &&...args) {
     UMA_ASSIGN_OP(ops, T, get_min_page_size, UMA_RESULT_ERROR_UNKNOWN);
     UMA_ASSIGN_OP(ops, T, purge_lazy, UMA_RESULT_ERROR_UNKNOWN);
     UMA_ASSIGN_OP(ops, T, purge_force, UMA_RESULT_ERROR_UNKNOWN);
-    UMA_ASSIGN_OP_NORETURN(ops, T, get_name);
+    UMA_ASSIGN_OP(ops, T, get_name, "");
 
     uma_memory_provider_handle_t hProvider = nullptr;
     auto ret = umaMemoryProviderCreate(&ops, &argsTuple, &hProvider);

--- a/source/common/uma_pools/disjoint_pool.cpp
+++ b/source/common/uma_pools/disjoint_pool.cpp
@@ -840,14 +840,12 @@ void DisjointPool::AllocImpl::printStats(bool &TitlePrinted,
     }
 }
 
-uma_result_t DisjointPool::initialize(uma_memory_provider_handle_t *providers,
-                                      size_t numProviders,
-                                      DisjointPoolConfig parameters) {
-    if (numProviders != 1 || !providers[0]) {
-        return UMA_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    impl = std::make_unique<AllocImpl>(providers[0], parameters);
+uma_result_t
+DisjointPool::initialize(uma_memory_provider_handle_t data_provider,
+                         uma_memory_provider_handle_t metadata_provider,
+                         DisjointPoolConfig parameters) {
+    (void)metadata_provider;
+    impl = std::make_unique<AllocImpl>(data_provider, parameters);
     return UMA_RESULT_SUCCESS;
 }
 
@@ -918,6 +916,14 @@ enum uma_result_t DisjointPool::get_last_result(const char **ppMessage) {
     // TODO: implement and return last error, we probably need something like
     // https://github.com/oneapi-src/unified-runtime/issues/500 in UMA
     return UMA_RESULT_ERROR_UNKNOWN;
+}
+
+uma_memory_provider_handle_t DisjointPool::get_data_memory_provider() {
+    return impl->getMemHandle();
+}
+
+uma_memory_provider_handle_t DisjointPool::get_metadata_memory_provider() {
+    return nullptr;
 }
 
 DisjointPool::DisjointPool() {}

--- a/source/common/uma_pools/disjoint_pool.hpp
+++ b/source/common/uma_pools/disjoint_pool.hpp
@@ -60,8 +60,9 @@ class DisjointPool {
     class AllocImpl;
     using Config = DisjointPoolConfig;
 
-    uma_result_t initialize(uma_memory_provider_handle_t *providers,
-                            size_t numProviders, DisjointPoolConfig parameters);
+    uma_result_t initialize(uma_memory_provider_handle_t data_provider,
+                            uma_memory_provider_handle_t metadata_provider,
+                            DisjointPoolConfig parameters);
     void *malloc(size_t size);
     void *calloc(size_t, size_t);
     void *realloc(void *, size_t);
@@ -69,6 +70,8 @@ class DisjointPool {
     size_t malloc_usable_size(void *);
     void free(void *ptr);
     enum uma_result_t get_last_result(const char **ppMessage);
+    uma_memory_provider_handle_t get_data_memory_provider();
+    uma_memory_provider_handle_t get_metadata_memory_provider();
 
     DisjointPool();
     ~DisjointPool();

--- a/source/common/unified_memory_allocation/include/uma/base.h
+++ b/source/common/unified_memory_allocation/include/uma/base.h
@@ -39,13 +39,16 @@ enum uma_result_t {
     UMA_RESULT_ERROR_POOL_SPECIFIC =
         2, ///< A pool specific warning/error has been reported and can be
            ///< Retrieved via the umaPoolGetLastResult entry point.
-    UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC =
-        3, ///< A provider specific warning/error has been reported and can be
+    UMA_RESULT_ERROR_METADATA_MEMORY_PROVIDER_SPECIFIC =
+        3, ///< A metadata provider specific warning/error has been reported and can be
            ///< Retrieved via the umaMemoryProviderGetLastResult entry point.
+    UMA_RESULT_ERROR_DATA_MEMORY_PROVIDER_SPECIFIC =
+        4, ///< A data provider specific warning/error has been reported and can be
+    ///< Retrieved via the umaMemoryProviderGetLastNativeError entry point.
     UMA_RESULT_ERROR_INVALID_ARGUMENT =
-        4, ///< Generic error code for invalid arguments
-    UMA_RESULT_ERROR_INVALID_ALIGNMENT = 5, /// Invalid alignment of an argument
-    UMA_RESULT_ERROR_NOT_SUPPORTED = 6,     /// Operation not supported
+        5, ///< Generic error code for invalid arguments
+    UMA_RESULT_ERROR_INVALID_ALIGNMENT = 6, /// Invalid alignment of an argument
+    UMA_RESULT_ERROR_NOT_SUPPORTED = 7,     /// Operation not supported
 
     UMA_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
 };

--- a/source/common/unified_memory_allocation/include/uma/memory_pool.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool.h
@@ -25,17 +25,16 @@ struct uma_memory_pool_ops_t;
 ///
 /// \brief Creates new memory pool.
 /// \param ops instance of uma_memory_pool_ops_t
-/// \param providers array of memory providers that will be used for coarse-grain allocations.
-///        Should contain at least one memory provider.
-/// \param numProvider number of elements in the providers array
+/// \param data_provider memory provider that should be used for coarse-grain data allocation
+/// \param metadata_provider [optional] memory provider that should be used for metadata allocations
 /// \param params pointer to pool-specific parameters
 /// \param hPool [out] handle to the newly created memory pool
 /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
 ///
 enum uma_result_t umaPoolCreate(struct uma_memory_pool_ops_t *ops,
-                                uma_memory_provider_handle_t *providers,
-                                size_t numProviders, void *params,
-                                uma_memory_pool_handle_t *hPool);
+                                uma_memory_provider_handle_t data_provider,
+                                uma_memory_provider_handle_t metadata_provider,
+                                void *params, uma_memory_pool_handle_t *hPool);
 
 ///
 /// \brief Destroys memory pool.
@@ -134,17 +133,18 @@ enum uma_result_t umaPoolGetLastResult(uma_memory_pool_handle_t hPool,
 uma_memory_pool_handle_t umaPoolByPtr(const void *ptr);
 
 ///
-/// \brief Retrieve memory providers associated with a given pool.
+/// \brief Retrieve metadata memory provider associated with a given pool.
 /// \param hPool specified memory pool
-/// \param hProviders [out] pointer to an array of memory providers. If numProviders is not equal to or
-///        greater than the real number of providers, UMA_RESULT_ERROR_INVALID_ARGUMENT is returned.
-/// \param numProviders [in] number of memory providers to return
-/// \param numProvidersRet pointer to the actual number of memory providers
-/// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
-enum uma_result_t
-umaPoolGetMemoryProviders(uma_memory_pool_handle_t hPool, size_t numProviders,
-                          uma_memory_provider_handle_t *hProviders,
-                          size_t *numProvidersRet);
+/// \return handle to the metadata memory provider
+uma_memory_provider_handle_t
+umaPoolGetMetadataMemoryProvider(uma_memory_pool_handle_t hPool);
+
+///
+/// \brief Retrieve data memory provider associated with a given pool.
+/// \param hPool specified memory pool
+/// \return handle to the data memory provider
+uma_memory_provider_handle_t
+umaPoolGetDataMemoryProvider(uma_memory_pool_handle_t hPool);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_pool_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_pool_ops.h
@@ -27,15 +27,15 @@ struct uma_memory_pool_ops_t {
 
     ///
     /// \brief Intializes memory pool.
-    /// \param providers array of memory providers that will be used for coarse-grain allocations.
-    ///        Should contain at least one memory provider.
-    /// \param numProvider number of elements in the providers array
+    /// \param data_provider memory provider that should be used for coarse-grain data allocation
+    /// \param metadata_provider [optional] memory provider that should be used for metadata allocations
     /// \param params pool-specific params
     /// \param pool [out] returns pointer to the pool
     /// \return UMA_RESULT_SUCCESS on success or appropriate error code on failure.
-    enum uma_result_t (*initialize)(uma_memory_provider_handle_t *providers,
-                                    size_t numProviders, void *params,
-                                    void **pool);
+    enum uma_result_t (*initialize)(
+        uma_memory_provider_handle_t data_provider,
+        uma_memory_provider_handle_t metadata_provider, void *params,
+        void **pool);
 
     ///
     /// \brief Finalizes memory pool
@@ -50,6 +50,8 @@ struct uma_memory_pool_ops_t {
     size_t (*malloc_usable_size)(void *pool, void *ptr);
     void (*free)(void *pool, void *);
     enum uma_result_t (*get_last_result)(void *pool, const char **ppMessage);
+    uma_memory_provider_handle_t (*get_data_memory_provider)(void *pool);
+    uma_memory_provider_handle_t (*get_metadata_memory_provider)(void *pool);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -136,8 +136,7 @@ umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
 /// \brief Retrive name of a given memory provider.
 /// \param hProvider handle to the memory provider
 /// \param ppName [out] pointer to a string containing name of the provider
-void umaMemoryProviderGetName(uma_memory_provider_handle_t hProvider,
-                              const char **ppName);
+const char *umaMemoryProviderGetName(uma_memory_provider_handle_t hProvider);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_memory_allocation/include/uma/memory_provider.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider.h
@@ -63,7 +63,8 @@ enum uma_result_t umaMemoryProviderFree(uma_memory_provider_handle_t hProvider,
 ///
 /// \brief Retrieve string representation of the underlying provider specific
 ///        result reported by the last API that returned
-///        UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC. Allows for a provider
+///        UMA_RESULT_ERROR_METADATA_MEMORY_PROVIDER_SPECIFIC or
+///        UMA_RESULT_ERROR_DATA_MEMORY_PROVIDER_SPECIFIC. Allows for a provider
 ///        independent way to return a provider specific result.
 ///
 /// \details

--- a/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
+++ b/source/common/unified_memory_allocation/include/uma/memory_provider_ops.h
@@ -49,7 +49,7 @@ struct uma_memory_provider_ops_t {
                                            size_t *pageSize);
     enum uma_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);
     enum uma_result_t (*purge_force)(void *provider, void *ptr, size_t size);
-    void (*get_name)(void *provider, const char **ppName);
+    const char *(*get_name)(void *provider);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_memory_allocation/src/memory_provider.c
+++ b/source/common/unified_memory_allocation/src/memory_provider.c
@@ -98,7 +98,6 @@ umaMemoryProviderPurgeForce(uma_memory_provider_handle_t hProvider, void *ptr,
     return hProvider->ops.purge_force(hProvider->provider_priv, ptr, size);
 }
 
-void umaMemoryProviderGetName(uma_memory_provider_handle_t hProvider,
-                              const char **ppName) {
-    hProvider->ops.get_name(hProvider->provider_priv, ppName);
+const char *umaMemoryProviderGetName(uma_memory_provider_handle_t hProvider) {
+    return hProvider->ops.get_name(hProvider->provider_priv);
 }

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -235,13 +235,4 @@ enum uma_result_t umaTrackingMemoryProviderCreate(
     return umaMemoryProviderCreate(&trackingMemoryProviderOps, &params,
                                    hTrackingProvider);
 }
-
-void umaTrackingMemoryProviderGetUpstreamProvider(
-    uma_memory_provider_handle_t hTrackingProvider,
-    uma_memory_provider_handle_t *hUpstream) {
-    assert(hUpstream);
-    uma_tracking_memory_provider_t *p =
-        (uma_tracking_memory_provider_t *)hTrackingProvider;
-    *hUpstream = p->hUpstream;
-}
 }

--- a/source/common/unified_memory_allocation/src/memory_tracker.cpp
+++ b/source/common/unified_memory_allocation/src/memory_tracker.cpp
@@ -204,10 +204,10 @@ static enum uma_result_t trackingPurgeForce(void *provider, void *ptr,
     return umaMemoryProviderPurgeForce(p->hUpstream, ptr, size);
 }
 
-static void trackingName(void *provider, const char **ppName) {
+static const char *trackingName(void *provider) {
     uma_tracking_memory_provider_t *p =
         (uma_tracking_memory_provider_t *)provider;
-    return umaMemoryProviderGetName(p->hUpstream, ppName);
+    return umaMemoryProviderGetName(p->hUpstream);
 }
 
 enum uma_result_t umaTrackingMemoryProviderCreate(

--- a/source/common/unified_memory_allocation/src/memory_tracker.h
+++ b/source/common/unified_memory_allocation/src/memory_tracker.h
@@ -31,10 +31,6 @@ enum uma_result_t umaTrackingMemoryProviderCreate(
     uma_memory_provider_handle_t hUpstream, uma_memory_pool_handle_t hPool,
     uma_memory_provider_handle_t *hTrackingProvider);
 
-void umaTrackingMemoryProviderGetUpstreamProvider(
-    uma_memory_provider_handle_t hTrackingProvider,
-    uma_memory_provider_handle_t *hUpstream);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/unified_memory_allocation/common/pool.h
+++ b/test/unified_memory_allocation/common/pool.h
@@ -13,10 +13,8 @@ extern "C" {
 #endif
 
 uma_memory_pool_handle_t nullPoolCreate(void);
-uma_memory_pool_handle_t
-tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,
-                uma_memory_provider_handle_t providerDesc,
-                void (*trace)(const char *));
+uma_memory_pool_handle_t tracePoolCreate(uma_memory_pool_handle_t hUpstreamPool,
+                                         void (*trace)(const char *));
 
 #if defined(__cplusplus)
 }

--- a/test/unified_memory_allocation/common/provider.c
+++ b/test/unified_memory_allocation/common/provider.c
@@ -72,9 +72,9 @@ static enum uma_result_t nullPurgeForce(void *provider, void *ptr,
     return UMA_RESULT_SUCCESS;
 }
 
-static void nullName(void *provider, const char **ppName) {
+static const char *nullName(void *provider) {
     (void)provider;
-    *ppName = "null";
+    return "null";
 }
 
 uma_memory_provider_handle_t nullProviderCreate(void) {
@@ -177,11 +177,11 @@ static enum uma_result_t tracePurgeForce(void *provider, void *ptr,
                                        size);
 }
 
-static void traceName(void *provider, const char **ppName) {
+static const char *traceName(void *provider) {
     struct traceParams *traceProvider = (struct traceParams *)provider;
 
     traceProvider->trace("name");
-    umaMemoryProviderGetName(traceProvider->hUpstreamProvider, ppName);
+    return umaMemoryProviderGetName(traceProvider->hUpstreamProvider);
 }
 
 uma_memory_provider_handle_t

--- a/test/unified_memory_allocation/common/provider.hpp
+++ b/test/unified_memory_allocation/common/provider.hpp
@@ -49,7 +49,7 @@ struct provider_base {
     enum uma_result_t purge_force(void *ptr, size_t size) noexcept {
         return UMA_RESULT_ERROR_UNKNOWN;
     }
-    void get_name(const char **ppName) noexcept { *ppName = "base"; }
+    const char *get_name() noexcept { return "base"; }
 };
 
 struct provider_malloc : public provider_base {
@@ -75,7 +75,7 @@ struct provider_malloc : public provider_base {
 #endif
         return UMA_RESULT_SUCCESS;
     }
-    void get_name(const char **ppName) noexcept { *ppName = "malloc"; }
+    const char *get_name() noexcept { return "malloc"; }
 };
 
 } // namespace uma_test

--- a/test/unified_memory_allocation/memoryPoolAPI.cpp
+++ b/test/unified_memory_allocation/memoryPoolAPI.cpp
@@ -185,8 +185,9 @@ INSTANTIATE_TEST_SUITE_P(
     poolInitializeTest, poolInitializeTest,
     ::testing::Values(UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY,
                       UMA_RESULT_ERROR_POOL_SPECIFIC,
-                      UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC,
                       UMA_RESULT_ERROR_INVALID_ARGUMENT,
+                      UMA_RESULT_ERROR_METADATA_MEMORY_PROVIDER_SPECIFIC,
+                      UMA_RESULT_ERROR_DATA_MEMORY_PROVIDER_SPECIFIC,
                       UMA_RESULT_ERROR_UNKNOWN));
 
 TEST_P(poolInitializeTest, errorPropagation) {

--- a/test/unified_memory_allocation/memoryPoolAPI.cpp
+++ b/test/unified_memory_allocation/memoryPoolAPI.cpp
@@ -30,12 +30,11 @@ TEST_F(test, memoryPoolTrace) {
     auto provider = tracingProvider.get();
 
     auto [ret, proxyPool] =
-        uma::poolMakeUnique<uma_test::proxy_pool>(&provider, 1);
+        uma::poolMakeUnique<uma_test::proxy_pool>(provider, nullptr);
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
 
-    uma_memory_provider_handle_t providerDesc = nullProviderCreate();
-    auto tracingPool = uma_test::wrapPoolUnique(
-        tracePoolCreate(proxyPool.get(), providerDesc, tracePool));
+    auto tracingPool =
+        uma_test::wrapPoolUnique(tracePoolCreate(proxyPool.get(), tracePool));
 
     size_t pool_call_count = 0;
     size_t provider_call_count = 0;
@@ -89,51 +88,50 @@ TEST_F(test, memoryPoolTrace) {
     ASSERT_EQ(providerCalls["get_last_result"], 1);
     ASSERT_EQ(providerCalls.size(), ++provider_call_count);
 
-    umaMemoryProviderDestroy(providerDesc);
-}
+    auto p = umaPoolGetDataMemoryProvider(tracingPool.get());
+    ASSERT_NE(p, nullptr);
+    ASSERT_EQ(poolCalls["get_data_memory_provider"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
-TEST_F(test, memoryPoolWithCustomProviders) {
-    uma_memory_provider_handle_t providers[] = {nullProviderCreate(),
-                                                nullProviderCreate()};
-
-    struct pool : public uma_test::pool_base {
-        uma_result_t initialize(uma_memory_provider_handle_t *providers,
-                                size_t numProviders) noexcept {
-            EXPECT_NE_NOEXCEPT(providers, nullptr);
-            EXPECT_EQ_NOEXCEPT(numProviders, 2);
-            return UMA_RESULT_SUCCESS;
-        }
-    };
-
-    auto ret = uma::poolMakeUnique<pool>(providers, 2);
-    ASSERT_EQ(ret.first, UMA_RESULT_SUCCESS);
-    ASSERT_NE(ret.second, nullptr);
-
-    for (auto &provider : providers) {
-        umaMemoryProviderDestroy(provider);
-    }
+    p = umaPoolGetMetadataMemoryProvider(tracingPool.get());
+    ASSERT_EQ(poolCalls["get_metadata_memory_provider"], 1);
+    ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 }
 
 TEST_F(test, retrieveMemoryProviders) {
-    static constexpr size_t numProviders = 4;
-    std::array<uma_memory_provider_handle_t, numProviders> providers = {
-        (uma_memory_provider_handle_t)0x1, (uma_memory_provider_handle_t)0x2,
-        (uma_memory_provider_handle_t)0x3, (uma_memory_provider_handle_t)0x4};
+    struct memory_provider : uma_test::provider_base {
+        const char *name;
+        uma_result_t initialize(const char *name) {
+            this->name = name;
+            return UMA_RESULT_SUCCESS;
+        }
+        const char *get_name() noexcept { return name; }
+    };
+
+    auto [ret1, data_provider] =
+        uma::memoryProviderMakeUnique<memory_provider>("data_provider");
+    auto [ret2, metadata_provider] =
+        uma::memoryProviderMakeUnique<memory_provider>("metadata_provider");
+
+    ASSERT_EQ(ret1, UMA_RESULT_SUCCESS);
+    ASSERT_EQ(ret2, UMA_RESULT_SUCCESS);
 
     auto [ret, pool] = uma::poolMakeUnique<uma_test::proxy_pool>(
-        providers.data(), numProviders);
+        data_provider.get(), metadata_provider.get());
 
-    std::array<uma_memory_provider_handle_t, numProviders> retProviders;
-    size_t numProvidersRet = 0;
-
-    ret = umaPoolGetMemoryProviders(pool.get(), 0, nullptr, &numProvidersRet);
     ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
-    ASSERT_EQ(numProvidersRet, numProviders);
 
-    ret = umaPoolGetMemoryProviders(pool.get(), numProviders,
-                                    retProviders.data(), nullptr);
-    ASSERT_EQ(ret, UMA_RESULT_SUCCESS);
-    ASSERT_EQ(retProviders, providers);
+    uma_memory_provider_handle_t ret_data_provider =
+        umaPoolGetDataMemoryProvider(pool.get());
+    uma_memory_provider_handle_t ret_metadata_provider =
+        umaPoolGetMetadataMemoryProvider(pool.get());
+
+    // comapre names of the providers: handles might point to a different object if providers are wrapped by memory tracking-provider
+    ASSERT_EQ(std::string_view(umaMemoryProviderGetName(data_provider.get())),
+              std::string_view(umaMemoryProviderGetName(ret_data_provider)));
+    ASSERT_EQ(
+        std::string_view(umaMemoryProviderGetName(metadata_provider.get())),
+        std::string_view(umaMemoryProviderGetName(ret_metadata_provider)));
 }
 
 template <typename Pool>
@@ -141,7 +139,7 @@ static auto
 makePool(std::function<uma::provider_unique_handle_t()> makeProvider) {
     auto providerUnique = makeProvider();
     uma_memory_provider_handle_t provider = providerUnique.get();
-    auto pool = uma::poolMakeUnique<Pool>(&provider, 1).second;
+    auto pool = uma::poolMakeUnique<Pool>(provider, nullptr).second;
     auto dtor = [provider =
                      providerUnique.release()](uma_memory_pool_handle_t hPool) {
         umaPoolDestroy(hPool);
@@ -176,15 +174,7 @@ INSTANTIATE_TEST_SUITE_P(
 ////////////////// Negative test cases /////////////////
 
 TEST_F(test, memoryPoolInvalidProvidersNullptr) {
-    auto ret = uma::poolMakeUnique<uma_test::pool_base>(nullptr, 1);
-    ASSERT_EQ(ret.first, UMA_RESULT_ERROR_INVALID_ARGUMENT);
-}
-
-TEST_F(test, memoryPoolInvalidProvidersNum) {
-    auto nullProvider = uma_test::wrapProviderUnique(nullProviderCreate());
-    uma_memory_provider_handle_t providers[] = {nullProvider.get()};
-
-    auto ret = uma::poolMakeUnique<uma_test::pool_base>(providers, 0);
+    auto ret = uma::poolMakeUnique<uma_test::pool_base>(nullptr, nullptr);
     ASSERT_EQ(ret.first, UMA_RESULT_ERROR_INVALID_ARGUMENT);
 }
 
@@ -201,29 +191,15 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(poolInitializeTest, errorPropagation) {
     auto nullProvider = uma_test::wrapProviderUnique(nullProviderCreate());
-    uma_memory_provider_handle_t providers[] = {nullProvider.get()};
-
     struct pool : public uma_test::pool_base {
-        uma_result_t initialize(uma_memory_provider_handle_t *providers,
-                                size_t numProviders,
+        uma_result_t initialize(uma_memory_provider_handle_t data_provider,
+                                uma_memory_provider_handle_t metadata_provider,
                                 uma_result_t errorToReturn) noexcept {
             return errorToReturn;
         }
     };
-    auto ret = uma::poolMakeUnique<pool>(providers, 1, this->GetParam());
+    auto ret = uma::poolMakeUnique<pool>(nullProvider.get(), nullptr,
+                                         this->GetParam());
     ASSERT_EQ(ret.first, this->GetParam());
     ASSERT_EQ(ret.second, nullptr);
-}
-
-TEST_F(test, retrieveMemoryProvidersError) {
-    static constexpr size_t numProviders = 4;
-    std::array<uma_memory_provider_handle_t, numProviders> providers = {
-        (uma_memory_provider_handle_t)0x1, (uma_memory_provider_handle_t)0x2,
-        (uma_memory_provider_handle_t)0x3, (uma_memory_provider_handle_t)0x4};
-
-    auto [ret, pool] = uma::poolMakeUnique<uma_test::proxy_pool>(
-        providers.data(), numProviders);
-
-    ret = umaPoolGetMemoryProviders(pool.get(), 1, providers.data(), nullptr);
-    ASSERT_EQ(ret, UMA_RESULT_ERROR_INVALID_ARGUMENT);
 }

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -60,8 +60,7 @@ TEST_F(test, memoryProviderTrace) {
     ASSERT_EQ(calls["purge_force"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
 
-    const char *pName;
-    umaMemoryProviderGetName(tracingProvider.get(), &pName);
+    const char *pName = umaMemoryProviderGetName(tracingProvider.get());
     ASSERT_EQ(calls["name"], 1);
     ASSERT_EQ(calls.size(), ++call_count);
     ASSERT_EQ(std::string(pName), std::string("null"));

--- a/test/unified_memory_allocation/memoryProviderAPI.cpp
+++ b/test/unified_memory_allocation/memoryProviderAPI.cpp
@@ -76,7 +76,8 @@ INSTANTIATE_TEST_SUITE_P(
     providerInitializeTest, providerInitializeTest,
     ::testing::Values(UMA_RESULT_ERROR_OUT_OF_HOST_MEMORY,
                       UMA_RESULT_ERROR_POOL_SPECIFIC,
-                      UMA_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC,
+                      UMA_RESULT_ERROR_METADATA_MEMORY_PROVIDER_SPECIFIC,
+                      UMA_RESULT_ERROR_DATA_MEMORY_PROVIDER_SPECIFIC,
                       UMA_RESULT_ERROR_INVALID_ARGUMENT,
                       UMA_RESULT_ERROR_UNKNOWN));
 

--- a/test/unified_memory_allocation/uma_pools/disjoint_pool.cpp
+++ b/test/unified_memory_allocation/uma_pools/disjoint_pool.cpp
@@ -29,7 +29,7 @@ static auto makePool() {
     EXPECT_EQ(ret, UMA_RESULT_SUCCESS);
     auto provider = providerUnique.release();
     auto [retp, pool] =
-        uma::poolMakeUnique<usm::DisjointPool>(&provider, 1, poolConfig());
+        uma::poolMakeUnique<usm::DisjointPool>(provider, nullptr, poolConfig());
     EXPECT_EQ(retp, UMA_RESULT_SUCCESS);
     auto dtor = [provider = provider](uma_memory_pool_handle_t hPool) {
         umaPoolDestroy(hPool);


### PR DESCRIPTION
Existing API exposes list of memory provider but does not specify type/purpose of those providers. This makes it challenging to connect a memory allocation from memory pool with a memory provider (in case, someone wants to query properties of that memory provider or needs to get a provider-specific error message, as here: https://github.com/oneapi-src/unified-runtime/pull/640).

There was a discussion on https://github.com/oneapi-src/unified-runtime/pull/315 about passing some extra information along providers to initialize() (e.g. type) but I don't think we have a use case for that right now - passing data and metadata providers seems simpler. In future, if we'll need to pass more then 1 metadata and 1 data provider (e.g. to let pool choose) we might revert the change for initialize(). However, for querying - I think we should always return only 1 data and 1 metadata provider (those that are actually used).