### PR TITLE
[UR][CTS] Fix urKernelSetArgPointer tests

### DIFF
--- a/test/conformance/kernel/urKernelSetArgPointer.cpp
+++ b/test/conformance/kernel/urKernelSetArgPointer.cpp
@@ -43,7 +43,8 @@ TEST_P(urKernelSetArgPointerTest, SuccessHost) {
     ASSERT_NE(allocation, nullptr);
 
     ASSERT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, &allocation));
-    ASSERT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), &data));
+    ASSERT_SUCCESS(
+        urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
     Launch1DRange(array_size);
     ValidateAllocation(allocation);
 }
@@ -60,7 +61,8 @@ TEST_P(urKernelSetArgPointerTest, SuccessDevice) {
     ASSERT_NE(allocation, nullptr);
 
     ASSERT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, &allocation));
-    ASSERT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), &data));
+    ASSERT_SUCCESS(
+        urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
     Launch1DRange(array_size);
 
     // Copy the device allocation to a host one so we can validate the results.
@@ -86,7 +88,8 @@ TEST_P(urKernelSetArgPointerTest, SuccessShared) {
     ASSERT_NE(allocation, nullptr);
 
     ASSERT_SUCCESS(urKernelSetArgPointer(kernel, 0, nullptr, &allocation));
-    ASSERT_SUCCESS(urKernelSetArgValue(kernel, 1, sizeof(data), &data));
+    ASSERT_SUCCESS(
+        urKernelSetArgValue(kernel, 1, sizeof(data), nullptr, &data));
     Launch1DRange(array_size);
     ValidateAllocation(allocation);
 }


### PR DESCRIPTION
These tests weren't updated after the API change in https://github.com/oneapi-src/unified-runtime/commit/6da20017f64f48813b98b68068b4f730420ec939

These tests aren't built by CI so we didn't catch the regression, see https://github.com/oneapi-src/unified-runtime/issues/650