### PR TITLE
Fix adapter registry test CMake

### DIFF
--- a/test/loader/adapter_registry/CMakeLists.txt
+++ b/test/loader/adapter_registry/CMakeLists.txt
@@ -12,10 +12,10 @@ function(add_adapter_reg_search_test name)
 
     if(WIN32)
         target_sources(${TEST_TARGET_NAME} PRIVATE
-            ${CMAKE_SOURCE_DIR}/source/loader/windows/adapter_search.cpp)
+            ${PROJECT_SOURCE_DIR}/source/loader/windows/adapter_search.cpp)
     else()
         target_sources(${TEST_TARGET_NAME} PRIVATE
-            ${CMAKE_SOURCE_DIR}/source/loader/linux/adapter_search.cpp)
+            ${PROJECT_SOURCE_DIR}/source/loader/linux/adapter_search.cpp)
     endif()
 
     target_link_libraries(${TEST_TARGET_NAME}
@@ -25,7 +25,7 @@ function(add_adapter_reg_search_test name)
         GTest::gtest_main)
 
     target_include_directories(${TEST_TARGET_NAME} PRIVATE
-        ${CMAKE_SOURCE_DIR}/source/loader)
+        ${PROJECT_SOURCE_DIR}/source/loader)
 
     add_test(NAME adapter-reg-${name}
         COMMAND ${TEST_TARGET_NAME}
@@ -35,7 +35,7 @@ function(add_adapter_reg_search_test name)
         ENVIRONMENT "UR_ADAPTERS_SEARCH_PATH=\"${TEST_SEARCH_PATH}\"" ${TEST_ENVS})
 endfunction()
 
-set(TEST_SEARCH_PATH ${CMAKE_SOURCE_DIR})
+set(TEST_SEARCH_PATH ${PROJECT_SOURCE_DIR})
 set(TEST_BIN_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 add_adapter_reg_search_test(search-with-env
     SEARCH_PATH ${TEST_SEARCH_PATH}


### PR DESCRIPTION
Using `PROJECT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR` is more resilient as it will still resolve to the base of the unified runtime repository even if used as a sub-project.

I've ran into this issue in my DPC++ build, it's possible my configuration of cache is causing me to hit this when others may not, but it's sensible to replace the CMake variable used here.