### PR TITLE
[UR] Fix code-block documentation rendering

### DIFF
--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -140,10 +140,11 @@ def _generate_valid_rst(fin, fout, namespace, tags, ver, rev, meta):
                         # If function is split across multiple lines
                         # then join lines until a ';' is encountered.
                         try:
-                            line = line.strip()
+                            line = line.rstrip()
                             while not line.endswith(';'):
                                 _, n_line = next(iter)
                                 line = line + n_line.strip()
+                            line += '\n'
                         except StopIteration:
                             print(f"Function {line[:100]} was not terminated by a ';' character.")
                             error = True


### PR DESCRIPTION
In Summary:
* the code was stripping all the white-space around the line including the preceding `tab` characters which moved statement outside of the `code_block`.

# Docs now appear as below
![image](https://github.com/oneapi-src/unified-runtime/assets/22935437/915b469a-e3dc-49f8-964b-c36d5995332a)


Fixes #665 