### PR TITLE
[UR] Remove clang-format requirement for make generate-code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,14 +238,14 @@ install(
 
 set(API_JSON_FILE ${PROJECT_BINARY_DIR}/unified_runtime.json)
 
-if(UR_FORMAT_CPP_STYLE)
-    # Generate source from the specification
-    add_custom_target(generate-code USES_TERMINAL
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
-        COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE} --clang-format=${CLANG_FORMAT}
-        COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
-    )
+# Generate source from the specification
+add_custom_target(generate-code USES_TERMINAL
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts
+    COMMAND ${Python3_EXECUTABLE} run.py --api-json ${API_JSON_FILE}
+    COMMAND ${Python3_EXECUTABLE} json2src.py --api-json ${API_JSON_FILE} ${PROJECT_SOURCE_DIR}
+)
 
+if(UR_FORMAT_CPP_STYLE)
     # Generate and format source from the specification
     add_custom_target(generate USES_TERMINAL
         COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target generate-code

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2022 Intel Corporation
+ Copyright (C) 2022-2023 Intel Corporation
 
  Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  See LICENSE.TXT
@@ -119,7 +119,6 @@ def main():
     parser.add_argument("--ver", type=str, default=get_version_from_cmakelists(),
                         required=False, help="specification version to generate.")
     parser.add_argument("--api-json", type=str, default="unified_runtime.json", required=False, help="json output file for the spec")
-    parser.add_argument("--clang-format", type=str, default="clang-format", required=False, help="path to clang-format executable")
     args = vars(parser.parse_args())
     args['rev'] = revision()
 
@@ -166,13 +165,6 @@ def main():
             if args[config['name']]:
 
                 generate_code.generate_api(incpath, srcpath, config['namespace'], config['tags'], args['ver'], args['rev'], specs, input['meta'])
-
-                # clang-format ur_api.h
-                proc = subprocess.run([args['clang_format'], "--style=file", "-i" , "ur_api.h"], stderr=subprocess.PIPE, cwd=incpath)
-                if proc.returncode != 0:
-                    print("-- clang-format failed with non-zero return code. --")
-                    print(proc.stderr.decode())
-                    raise Exception("Failed to format ur_api.h")
 
                 if args['rst']:
                     generate_docs.generate_rst(docpath, config['name'], config['namespace'], config['tags'], args['ver'], args['rev'], specs, input['meta'])


### PR DESCRIPTION
'make generate-code' should not require clang-format to be installed. It required the removal of a doubled functionality from run.py (it is covered via 'make cppformat' target).