### PR TITLE
[ur] Sort experimental feature toctree order

### DIFF
--- a/scripts/templates/exp-features.rst.mako
+++ b/scripts/templates/exp-features.rst.mako
@@ -5,7 +5,7 @@ import glob
 expdocs = []
 for section in sections:
     foundDocs = glob.glob(section + "/EXP-*.rst")
-    for found in foundDocs:
+    for found in sorted(foundDocs):
         expdocs.append(found)
 %>
 =====================


### PR DESCRIPTION
Change the order of experimental features in the reStructuredText
`.. toctree::` to be alphabetically sorted. This align the order
experimental features are displayed in the *Experimental Features*
section with the *API Documentation* section.
