### PR TITLE
[umf] create/destroy memory tracker in lib ctor/dtor

### DIFF
--- a/source/common/unified_malloc_framework/CMakeLists.txt
+++ b/source/common/unified_malloc_framework/CMakeLists.txt
@@ -16,6 +16,7 @@ if(UMF_BUILD_SHARED_LIBRARY)
                      "Do not use the shared library in production software.")
     add_library(unified_malloc_framework SHARED
         ${UMF_SOURCES})
+    target_compile_definitions(unified_malloc_framework PUBLIC UMF_SHARED_LIBRARY)
 else()
     add_library(unified_malloc_framework STATIC
         ${UMF_SOURCES})


### PR DESCRIPTION
instead of using a static variable.

In C++ no guarantee is made for initialization order of static variables across translation units.

This is problematic when an application (e.g. SYCL) wants to do some cleanup in it's library destructor. Such application might want to specify priority for it's destructor (to make sure it's executed before any other library desturctor) but it doesn't seem to work for static variables.