### PR TITLE
[UR] print unions correctly in ur_params

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -848,7 +848,7 @@ class ur_device_partition_value_t(Structure):
         ("count", c_ulong),                                             ## [in] Number of compute units in a sub-device when partitioning with
                                                                         ## ::UR_DEVICE_PARTITION_BY_COUNTS.
         ("affinity_domain", ur_device_affinity_domain_flags_t)          ## [in] The affinity domain to partition for when partitioning with
-                                                                        ## $UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN.
+                                                                        ## ::UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN.
     ]
 
 ###############################################################################
@@ -856,7 +856,7 @@ class ur_device_partition_value_t(Structure):
 class ur_device_partition_property_t(Structure):
     _fields_ = [
         ("type", ur_device_partition_t),                                ## [in] The partitioning type to be used.
-        ("value", ur_device_partition_value_t)                          ## [in] The partitioning value.
+        ("value", ur_device_partition_value_t)                          ## [in][tagged_by(type)] The partitioning value.
     ]
 
 ###############################################################################
@@ -1579,7 +1579,7 @@ class ur_program_metadata_t(Structure):
         ("type", ur_program_metadata_type_t),                           ## [in] the type of metadata value.
         ("size", c_size_t),                                             ## [in] size in bytes of the data pointed to by value.pData, or 0 when
                                                                         ## value size is less than 64-bits and is stored directly in value.data.
-        ("value", ur_program_metadata_value_t)                          ## [in] the metadata value storage.
+        ("value", ur_program_metadata_value_t)                          ## [in][tagged_by(type)] the metadata value storage.
     ]
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1348,7 +1348,7 @@ typedef union ur_device_partition_value_t {
     uint32_t count;                                    ///< [in] Number of compute units in a sub-device when partitioning with
                                                        ///< ::UR_DEVICE_PARTITION_BY_COUNTS.
     ur_device_affinity_domain_flags_t affinity_domain; ///< [in] The affinity domain to partition for when partitioning with
-                                                       ///< $UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN.
+                                                       ///< ::UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN.
 
 } ur_device_partition_value_t;
 
@@ -1356,7 +1356,7 @@ typedef union ur_device_partition_value_t {
 /// @brief Device partition property
 typedef struct ur_device_partition_property_t {
     ur_device_partition_t type;        ///< [in] The partitioning type to be used.
-    ur_device_partition_value_t value; ///< [in] The partitioning value.
+    ur_device_partition_value_t value; ///< [in][tagged_by(type)] The partitioning value.
 
 } ur_device_partition_property_t;
 
@@ -3553,11 +3553,11 @@ typedef union ur_program_metadata_value_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program metadata property.
 typedef struct ur_program_metadata_t {
-    char *pName;                       ///< [in] null-terminated metadata name.
+    const char *pName;                 ///< [in] null-terminated metadata name.
     ur_program_metadata_type_t type;   ///< [in] the type of metadata value.
     size_t size;                       ///< [in] size in bytes of the data pointed to by value.pData, or 0 when
                                        ///< value size is less than 64-bits and is stored directly in value.data.
-    ur_program_metadata_value_t value; ///< [in] the metadata value storage.
+    ur_program_metadata_value_t value; ///< [in][tagged_by(type)] the metadata value storage.
 
 } ur_program_metadata_t;
 

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -455,7 +455,7 @@ class ur_name_flags_v(IntEnum):
     + The special-case descriptor struct should always end with `_desc_t`
     + The special-case property struct should always end with `_properties_t`
 * A union requires the following 
-  - `tag` is a reference to a type which will be used to describe which field to access of the union.
+  - `tag` is a reference to an enum type that will be used to describe which field of the union to access.
 * A struct|union may take the following optional scalar fields: {`class`, `base`, `condition`, `ordinal`, `version`}
   - `class` will be used to scope the struct|union declaration within the specified C++ class
   - `base` will be used as the base type of the structure

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -454,6 +454,8 @@ class ur_name_flags_v(IntEnum):
   - `name` must be a unique ISO-C standard identifier, start with `$` tag, be snake_case and end with `_t`
     + The special-case descriptor struct should always end with `_desc_t`
     + The special-case property struct should always end with `_properties_t`
+* A union requires the following 
+  - `tag` is a reference to a type which will be used to describe which field to access of the union.
 * A struct|union may take the following optional scalar fields: {`class`, `base`, `condition`, `ordinal`, `version`}
   - `class` will be used to scope the struct|union declaration within the specified C++ class
   - `base` will be used as the base type of the structure
@@ -468,6 +470,8 @@ class ur_name_flags_v(IntEnum):
       - `out` is used for members that are write-only; if the member is a pointer, then the memory being pointed to is also write-only
       - `in,out` is used for members that are both read and write; typically this is used for pointers to other data structures that contain both read and write members
       - `nocheck` is used to specify that no additional validation checks will be generated.
+    + `desc` must also include the following annotation when describing a union: {`"tagged_by(param)"`}
+      - `tagged_by` is use to specify which parameter will be used as the tag for accessing the union.
     + `desc` may include one the following annotations: {`"[optional]"`, `"[typename(typeVarName, sizeVarName)]"`}
       - `optional` is used for members that are pointers where it is legal for the value to be `nullptr`
       - `typename` is used to denote the type enum for params that are opaque pointers to values of tagged data types.
@@ -477,6 +481,7 @@ class ur_name_flags_v(IntEnum):
     + `init` will be used to initialize the C++ struct|union member's value
     + `init` must be an ISO-C standard identifier or literal
     + `version` will be used to define the minimum API version in which the member will appear; `default="1.0"` This will also affect the order in which the member appears within the struct|union.
+    + `tag` applies only to unions and refers to a value for when this member can be accessed.
 * A struct|union may take the following optional field which can be a scalar, a sequence of scalars or scalars to sequences: {`details`}
   - `details` will be used as the struct|union's detailed comment
 

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -471,7 +471,7 @@ class ur_name_flags_v(IntEnum):
       - `in,out` is used for members that are both read and write; typically this is used for pointers to other data structures that contain both read and write members
       - `nocheck` is used to specify that no additional validation checks will be generated.
     + `desc` must also include the following annotation when describing a union: {`"tagged_by(param)"`}
-      - `tagged_by` is use to specify which parameter will be used as the tag for accessing the union.
+      - `tagged_by` is used to specify which parameter will be used as the tag for accessing the union.
     + `desc` may include one the following annotations: {`"[optional]"`, `"[typename(typeVarName, sizeVarName)]"`}
       - `optional` is used for members that are pointers where it is legal for the value to be `nullptr`
       - `typename` is used to denote the type enum for params that are opaque pointers to values of tagged data types.

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -518,16 +518,20 @@ type: union
 desc: "Device partition value."
 name: $x_device_partition_value_t
 class: $xDevice
+tag: $x_device_partition_t
 members:
     - type: uint32_t
       name: equally
       desc: "[in] Number of compute units per sub-device when partitioning with $X_DEVICE_PARTITION_EQUALLY."
+      tag: $X_DEVICE_PARTITION_EQUALLY
     - type: uint32_t
       name: count
       desc: "[in] Number of compute units in a sub-device when partitioning with $X_DEVICE_PARTITION_BY_COUNTS."
+      tag: $X_DEVICE_PARTITION_BY_COUNTS
     - type: $x_device_affinity_domain_flags_t
       name: affinity_domain
-      desc: "[in] The affinity domain to partition for when partitioning with $UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN."
+      desc: "[in] The affinity domain to partition for when partitioning with $X_DEVICE_PARTITION_BY_AFFINITY_DOMAIN."
+      tag: $X_DEVICE_PARTITION_BY_AFFINITY_DOMAIN
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Device partition property"
@@ -539,7 +543,7 @@ members:
       desc: "[in] The partitioning type to be used."
     - type: $x_device_partition_value_t
       name: value
-      desc: "[in] The partitioning value."
+      desc: "[in][tagged_by(type)] The partitioning value."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Device Partition Properties"

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -29,26 +29,31 @@ type: union
 desc: "Program metadata value union."
 class: $xProgram
 name: $x_program_metadata_value_t
+tag: $x_program_metadata_type_t
 members:
     - type: uint32_t
       name: data32
       desc: "[in] inline storage for the 32-bit data, type $X_PROGRAM_METADATA_TYPE_UINT32."
+      tag: $X_PROGRAM_METADATA_TYPE_UINT32
     - type: uint64_t
       name: data64
       desc: "[in] inline storage for the 64-bit data, type $X_PROGRAM_METADATA_TYPE_UINT64."
+      tag: $X_PROGRAM_METADATA_TYPE_UINT64
     - type: char*
       name: pString
       desc: "[in] pointer to null-terminated string data, type $X_PROGRAM_METADATA_TYPE_STRING."
+      tag: $X_PROGRAM_METADATA_TYPE_STRING
     - type: void*
       name: pData
       desc: "[in] pointer to binary data, type $X_PROGRAM_METADATA_TYPE_BYTE_ARRAY."
+      tag: $X_PROGRAM_METADATA_TYPE_BYTE_ARRAY
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Program metadata property."
 class: $xProgram
 name: $x_program_metadata_t
 members:
-    - type: char*
+    - type: const char*
       name: pName
       desc: "[in] null-terminated metadata name."
     - type: $x_program_metadata_type_t
@@ -59,7 +64,7 @@ members:
       desc: "[in] size in bytes of the data pointed to by value.pData, or 0 when value size is less than 64-bits and is stored directly in value.data."
     - type: $x_program_metadata_value_t
       name: value
-      desc: "[in] the metadata value storage."
+      desc: "[in][tagged_by(type)] the metadata value storage."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Program creation properties."

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -292,6 +292,9 @@ def _validate_doc(f, d, tags, line_num):
             if item['type'].endswith("flag_t"):
                 raise Exception(prefix+"'type' must not be '*_flag_t': %s"%item['type'])
 
+            if d['type'] == 'union'and item.get('tag') is None:
+                raise Exception(prefix + f"union member {item['name']} must include a 'tag' annotation")
+
             ver = __validate_version(item, prefix=prefix, base_version=d_ver)
             if ver < max_ver:
                 raise Exception(prefix+"'version' must be increasing: %s"%item['version'])
@@ -339,7 +342,11 @@ def _validate_doc(f, d, tags, line_num):
             if ver < max_ver:
                 raise Exception(prefix+"'version' must be increasing: %s"%item['version'])
             max_ver = ver
-
+    
+    def __validate_union_tag(d):
+        if d.get('tag') is None:
+            raise Exception(f"{d['name']} must include a 'tag' part of the union.")
+        
     try:
         if 'type' not in d:
             raise Exception("every document must have 'type'")
@@ -401,6 +408,8 @@ def _validate_doc(f, d, tags, line_num):
             if ('desc' not in d) or ('name' not in d):
                 raise Exception("'%s' requires the following scalar fields: {`desc`, `name`}"%d['type'])
 
+            if d['type'] == 'union':
+                __validate_union_tag(d)
             __validate_type(d, 'name', tags)
             __validate_base(d)
             __validate_members(d, tags)

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -319,6 +319,7 @@ class param_traits:
     RE_RANGE    = r".*\[range\((.+),\s*(.+)\)\][\S\s]*"
     RE_RELEASE  = r".*\[release\].*"
     RE_TYPENAME = r".*\[typename\((.+),\s(.+)\)\].*"
+    RE_TAGGED   = r".*\[tagged_by\((.+)\)].*"
 
     @classmethod
     def is_mbz(cls, item):
@@ -368,6 +369,20 @@ class param_traits:
             return True if re.match(cls.RE_RANGE, item['desc']) else False
         except:
             return False
+
+    @classmethod
+    def is_tagged(cls, item):
+        try:
+            return True if re.match(cls.RE_TAGGED, item['desc']) else False
+        except:
+            return False
+    
+    @classmethod
+    def tagged_member(cls, item):
+        try:
+            return re.sub(cls.RE_TAGGED, r"\1", item['desc'])
+        except:
+            return None
 
     @classmethod
     def range_start(cls, item):

--- a/scripts/templates/params.hpp.mako
+++ b/scripts/templates/params.hpp.mako
@@ -41,6 +41,12 @@ from templates import helper as th
     %endif
 </%def>
 
+<%
+def findUnionTag(union):
+    tag = [_obj for _s in specs for _obj in _s['objects'] if _obj['name'] == obj['tag']]
+    return tag[0] if len(tag) > 0 else None
+%>
+
 <%def name="line(item, n, params, params_dict)">
     <%
         iname = th._get_param_name(n, tags, item)
@@ -74,7 +80,7 @@ member_type = query[0] if len(query) > 0 else None%>
         os << "}";
     %elif member_type is not None and member_type['type'] == "union":
         os << ".${iname} = ";
-        ${x}_params::print_union(os, params.${item['name']}, params.${th.param_traits.tagged_member(item)});
+        ${x}_params::serializeUnion(os, ${deref}(params${access}${item['name']}), params${access}${th.param_traits.tagged_member(item)});
     %elif typename is not None:
         os << ".${iname} = ";
         ${x}_params::serializeTagged(os, ${deref}(params${access}${pname}), ${deref}(params${access}${prefix}${typename}), ${deref}(params${access}${prefix}${typename_size}));
@@ -104,7 +110,7 @@ template <typename T> inline void serializeTagged(std::ostream &os, const void *
 
 %if re.match(r"union", obj['type']) and obj['name']:
     <% tag = [_obj for _s in specs for _obj in _s['objects'] if _obj['name'] == obj['tag']][0] %>
-    inline void print_union(
+    inline void serializeUnion(
         std::ostream &os,
         const ${obj['type']} ${th.make_type_name(n, tags, obj)} params,
         const ${tag['type']} ${th.make_type_name(n, tags, tag)} tag
@@ -293,8 +299,8 @@ inline std::ostream &operator<<(std::ostream &os, const ${obj['type']} ${th.make
     return os;
 }
 %elif re.match(r"union", obj['type']) and obj['name']:
-<% tag = [_obj for _s in specs for _obj in _s['objects'] if _obj['name'] == obj['tag']][0] %>
-inline void ${x}_params::print_union(
+<% tag = findUnionTag(obj) %>
+inline void ${x}_params::serializeUnion(
     std::ostream &os,
     const ${obj['type']} ${th.make_type_name(n, tags, obj)} params,
     const ${tag['type']} ${th.make_type_name(n, tags, tag)} tag

--- a/scripts/templates/params.hpp.mako
+++ b/scripts/templates/params.hpp.mako
@@ -305,16 +305,26 @@ inline void ${x}_params::serializeUnion(
     const ${obj['type']} ${th.make_type_name(n, tags, obj)} params,
     const ${tag['type']} ${th.make_type_name(n, tags, tag)} tag
 ){
+    os << "(${obj['type']} ${th.make_type_name(n, tags, obj)}){";
+<%
+params_dict = dict()
+for item in obj['members']:
+    iname = th._get_param_name(n, tags, item)
+    itype = th._get_type_name(n, tags, obj, item)
+    params_dict[iname] = itype
+%>
     switch(tag){
 %for mem in obj['members']:
     case ${th.subt(n, tags, mem['tag'])}:
-        os << params.${mem['name']};
+        ## os << params.${mem['name']};
+        ${line(mem, 0, False, params_dict)}
         break;
 %endfor
     default:
         os << "<unknown>";
         break;
     }
+    os << "}";
 }
 %endif
 %endfor # obj in spec['objects']

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -1747,7 +1747,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -1764,7 +1763,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -1781,13 +1779,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.x);
 
     os << ", ";
-
     os << ".y = ";
 
     os << (params.y);
 
     os << ", ";
-
     os << ".z = ";
 
     os << (params.z);
@@ -1804,13 +1800,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.width);
 
     os << ", ";
-
     os << ".height = ";
 
     os << (params.height);
 
     os << ", ";
-
     os << ".depth = ";
 
     os << (params.depth);
@@ -2023,13 +2017,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -2075,13 +2067,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".pDeviceTargetSpec = ";
 
     ur_params::serializePtr(os, (params.pDeviceTargetSpec));
@@ -4625,7 +4615,6 @@ operator<<(std::ostream &os,
     os << (params.type);
 
     os << ", ";
-
     os << ".value = ";
     ur_params::serializeUnion(os, (params.value), params.type);
 
@@ -4642,19 +4631,16 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, (params.pProperties));
 
     os << ", ";
-
     os << ".PropCount = ";
 
     os << (params.PropCount);
@@ -4919,13 +4905,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -5277,13 +5261,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_context_flag_t>(os, (params.flags));
@@ -5497,13 +5479,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -6016,7 +5996,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.channelOrder);
 
     os << ", ";
-
     os << ".channelType = ";
 
     os << (params.channelType);
@@ -6033,61 +6012,51 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".type = ";
 
     os << (params.type);
 
     os << ", ";
-
     os << ".width = ";
 
     os << (params.width);
 
     os << ", ";
-
     os << ".height = ";
 
     os << (params.height);
 
     os << ", ";
-
     os << ".depth = ";
 
     os << (params.depth);
 
     os << ", ";
-
     os << ".arraySize = ";
 
     os << (params.arraySize);
 
     os << ", ";
-
     os << ".rowPitch = ";
 
     os << (params.rowPitch);
 
     os << ", ";
-
     os << ".slicePitch = ";
 
     os << (params.slicePitch);
 
     os << ", ";
-
     os << ".numMipLevel = ";
 
     os << (params.numMipLevel);
 
     os << ", ";
-
     os << ".numSamples = ";
 
     os << (params.numSamples);
@@ -6104,13 +6073,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".pHost = ";
 
     ur_params::serializePtr(os, (params.pHost));
@@ -6128,13 +6095,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".channel = ";
 
     os << (params.channel);
@@ -6152,13 +6117,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".location = ";
 
     os << (params.location);
@@ -6175,19 +6138,16 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".origin = ";
 
     os << (params.origin);
 
     os << ", ";
-
     os << ".size = ";
 
     os << (params.size);
@@ -6217,13 +6177,11 @@ operator<<(std::ostream &os, const struct ur_mem_native_properties_t params) {
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -6404,25 +6362,21 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".normalizedCoords = ";
 
     os << (params.normalizedCoords);
 
     os << ", ";
-
     os << ".addressingMode = ";
 
     os << (params.addressingMode);
 
     os << ", ";
-
     os << ".filterMode = ";
 
     os << (params.filterMode);
@@ -6440,13 +6394,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -7009,19 +6961,16 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".hints = ";
 
     ur_params::serializeFlag<ur_usm_advice_flag_t>(os, (params.hints));
 
     os << ", ";
-
     os << ".align = ";
 
     os << (params.align);
@@ -7038,13 +6987,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_host_mem_flag_t>(os, (params.flags));
@@ -7061,13 +7008,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_device_mem_flag_t>(os, (params.flags));
@@ -7084,13 +7029,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_pool_flag_t>(os, (params.flags));
@@ -7107,19 +7050,16 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".maxPoolableSize = ";
 
     os << (params.maxPoolableSize);
 
     os << ", ";
-
     os << ".minDriverAllocSize = ";
 
     os << (params.minDriverAllocSize);
@@ -7418,13 +7358,11 @@ operator<<(std::ostream &os, const struct ur_physical_mem_properties_t params) {
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_physical_mem_flag_t>(os, (params.flags));
@@ -7508,19 +7446,16 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, (params.pName));
 
     os << ", ";
-
     os << ".type = ";
 
     os << (params.type);
 
     os << ", ";
-
     os << ".size = ";
 
     os << (params.size);
 
     os << ", ";
-
     os << ".value = ";
     ur_params::serializeUnion(os, (params.value), params.type);
 
@@ -7536,19 +7471,16 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".count = ";
 
     os << (params.count);
 
     os << ", ";
-
     os << ".pMetadatas = {";
     for (size_t i = 0; (params.pMetadatas) != NULL && i < params.count; ++i) {
         if (i != 0) {
@@ -7870,13 +7802,11 @@ operator<<(std::ostream &os,
     os << (params.id);
 
     os << ", ";
-
     os << ".size = ";
 
     os << (params.size);
 
     os << ", ";
-
     os << ".pValue = ";
 
     ur_params::serializePtr(os, (params.pValue));
@@ -7894,13 +7824,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -7918,7 +7846,6 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -7936,7 +7863,6 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8422,7 +8348,6 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8440,7 +8365,6 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8458,7 +8382,6 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8476,13 +8399,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".memoryAccess = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, (params.memoryAccess));
@@ -8500,13 +8421,11 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -8862,13 +8781,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_queue_flag_t>(os, (params.flags));
@@ -8885,13 +8802,11 @@ operator<<(std::ostream &os, const struct ur_queue_index_properties_t params) {
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".computeIndex = ";
 
     os << (params.computeIndex);
@@ -8908,13 +8823,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".pNativeData = ";
 
     ur_params::serializePtr(os, (params.pNativeData));
@@ -8931,13 +8844,11 @@ operator<<(std::ostream &os, const struct ur_queue_native_properties_t params) {
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -9328,13 +9239,11 @@ operator<<(std::ostream &os, const struct ur_event_native_properties_t params) {
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -9559,31 +9468,26 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-
     os << ".minMipmapLevelClamp = ";
 
     os << (params.minMipmapLevelClamp);
 
     os << ", ";
-
     os << ".maxMipmapLevelClamp = ";
 
     os << (params.maxMipmapLevelClamp);
 
     os << ", ";
-
     os << ".maxAnisotropy = ";
 
     os << (params.maxAnisotropy);
 
     os << ", ";
-
     os << ".mipFilterMode = ";
 
     os << (params.mipFilterMode);
@@ -9600,7 +9504,6 @@ operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
     os << (params.stype);
 
     os << ", ";
-
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -9701,13 +9604,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
@@ -9725,13 +9626,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
@@ -9748,25 +9647,21 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".phImageMem = ";
 
     ur_params::serializePtr(os, *(params->pphImageMem));
@@ -9783,13 +9678,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
@@ -9807,37 +9700,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
 
     os << ", ";
-
     os << ".phImage = ";
 
     ur_params::serializePtr(os, *(params->pphImage));
@@ -9854,43 +9741,36 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".hSampler = ";
 
     ur_params::serializePtr(os, *(params->phSampler));
 
     os << ", ";
-
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
 
     os << ", ";
-
     os << ".phImage = ";
 
     ur_params::serializePtr(os, *(params->pphImage));
@@ -9907,68 +9787,57 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".imageCopyFlags = ";
 
     ur_params::serializeFlag<ur_exp_image_copy_flag_t>(
         os, *(params->pimageCopyFlags));
 
     os << ", ";
-
     os << ".srcOffset = ";
 
     os << *(params->psrcOffset);
 
     os << ", ";
-
     os << ".dstOffset = ";
 
     os << *(params->pdstOffset);
 
     os << ", ";
-
     os << ".copyExtent = ";
 
     os << *(params->pcopyExtent);
 
     os << ", ";
-
     os << ".hostExtent = ";
 
     os << *(params->phostExtent);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -9982,7 +9851,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -9999,19 +9867,16 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".pPropValue = ";
 
     ur_params::serializePtr(os, *(params->ppPropValue));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -10028,25 +9893,21 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
-
     os << ".mipmapLevel = ";
 
     os << *(params->pmipmapLevel);
 
     os << ", ";
-
     os << ".phImageMem = ";
 
     ur_params::serializePtr(os, *(params->pphImageMem));
@@ -10063,13 +9924,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hMem = ";
 
     ur_params::serializePtr(os, *(params->phMem));
@@ -10086,25 +9945,21 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".fileDescriptor = ";
 
     os << *(params->pfileDescriptor);
 
     os << ", ";
-
     os << ".phInteropMem = ";
 
     ur_params::serializePtr(os, *(params->pphInteropMem));
@@ -10121,31 +9976,26 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".hInteropMem = ";
 
     ur_params::serializePtr(os, *(params->phInteropMem));
 
     os << ", ";
-
     os << ".phImageMem = ";
 
     ur_params::serializePtr(os, *(params->pphImageMem));
@@ -10162,13 +10012,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hInteropMem = ";
 
     ur_params::serializePtr(os, *(params->phInteropMem));
@@ -10186,19 +10034,16 @@ operator<<(std::ostream &os, const struct
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".fileDescriptor = ";
 
     os << *(params->pfileDescriptor);
 
     os << ", ";
-
     os << ".phInteropSemaphoreHandle = ";
 
     ur_params::serializePtr(os, *(params->pphInteropSemaphoreHandle));
@@ -10216,13 +10061,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hInteropSemaphore = ";
 
     ur_params::serializePtr(os, *(params->phInteropSemaphore));
@@ -10240,19 +10083,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hSemaphore = ";
 
     ur_params::serializePtr(os, *(params->phSemaphore));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10266,7 +10106,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10284,19 +10123,16 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hSemaphore = ";
 
     ur_params::serializePtr(os, *(params->phSemaphore));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10310,7 +10146,6 @@ inline std::ostream &operator<<(
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10327,19 +10162,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pCommandBufferDesc = ";
 
     ur_params::serializePtr(os, *(params->ppCommandBufferDesc));
 
     os << ", ";
-
     os << ".phCommandBuffer = ";
 
     ur_params::serializePtr(os, *(params->pphCommandBuffer));
@@ -10389,49 +10221,41 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hKernel = ";
 
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".workDim = ";
 
     os << *(params->pworkDim);
 
     os << ", ";
-
     os << ".pGlobalWorkOffset = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkOffset));
 
     os << ", ";
-
     os << ".pGlobalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkSize));
 
     os << ", ";
-
     os << ".pLocalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppLocalWorkSize));
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10448,37 +10272,31 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10495,49 +10313,41 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hSrcMem = ";
 
     ur_params::serializePtr(os, *(params->phSrcMem));
 
     os << ", ";
-
     os << ".hDstMem = ";
 
     ur_params::serializePtr(os, *(params->phDstMem));
 
     os << ", ";
-
     os << ".srcOffset = ";
 
     os << *(params->psrcOffset);
 
     os << ", ";
-
     os << ".dstOffset = ";
 
     os << *(params->pdstOffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10555,43 +10365,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10608,43 +10411,36 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10662,73 +10458,61 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hSrcMem = ";
 
     ur_params::serializePtr(os, *(params->phSrcMem));
 
     os << ", ";
-
     os << ".hDstMem = ";
 
     ur_params::serializePtr(os, *(params->phDstMem));
 
     os << ", ";
-
     os << ".srcOrigin = ";
 
     os << *(params->psrcOrigin);
 
     os << ", ";
-
     os << ".dstOrigin = ";
 
     os << *(params->pdstOrigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".srcRowPitch = ";
 
     os << *(params->psrcRowPitch);
 
     os << ", ";
-
     os << ".srcSlicePitch = ";
 
     os << *(params->psrcSlicePitch);
 
     os << ", ";
-
     os << ".dstRowPitch = ";
 
     os << *(params->pdstRowPitch);
 
     os << ", ";
-
     os << ".dstSlicePitch = ";
 
     os << *(params->pdstSlicePitch);
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10746,73 +10530,61 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".bufferOffset = ";
 
     os << *(params->pbufferOffset);
 
     os << ", ";
-
     os << ".hostOffset = ";
 
     os << *(params->phostOffset);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
-
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
-
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
-
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10830,73 +10602,61 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".bufferOffset = ";
 
     os << *(params->pbufferOffset);
 
     os << ", ";
-
     os << ".hostOffset = ";
 
     os << *(params->phostOffset);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
-
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
-
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
-
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
-
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
-
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10913,19 +10673,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
-
     os << ".hQueue = ";
 
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10939,7 +10696,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10955,7 +10711,6 @@ operator<<(std::ostream &os, const struct ur_context_create_params_t *params) {
     os << *(params->pDeviceCount);
 
     os << ", ";
-
     os << ".phDevices = {";
     for (size_t i = 0;
          *(params->pphDevices) != NULL && i < *params->pDeviceCount; ++i) {
@@ -10968,13 +10723,11 @@ operator<<(std::ostream &os, const struct ur_context_create_params_t *params) {
     os << "}";
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phContext = ";
 
     ur_params::serializePtr(os, *(params->pphContext));
@@ -11011,25 +10764,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -11046,7 +10795,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".phNativeContext = ";
 
     ur_params::serializePtr(os, *(params->pphNativeContext));
@@ -11063,13 +10811,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeContext));
 
     os << ", ";
-
     os << ".numDevices = ";
 
     os << *(params->pnumDevices);
 
     os << ", ";
-
     os << ".phDevices = {";
     for (size_t i = 0;
          *(params->pphDevices) != NULL && i < *params->pnumDevices; ++i) {
@@ -11082,13 +10828,11 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phContext = ";
 
     ur_params::serializePtr(os, *(params->pphContext));
@@ -11105,13 +10849,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pfnDeleter = ";
 
     os << *(params->ppfnDeleter);
 
     os << ", ";
-
     os << ".pUserData = ";
 
     ur_params::serializePtr(os, *(params->ppUserData));
@@ -11128,43 +10870,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hKernel = ";
 
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".workDim = ";
 
     os << *(params->pworkDim);
 
     os << ", ";
-
     os << ".pGlobalWorkOffset = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkOffset));
 
     os << ", ";
-
     os << ".pGlobalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkSize));
 
     os << ", ";
-
     os << ".pLocalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppLocalWorkSize));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11178,7 +10913,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11195,13 +10929,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11215,7 +10947,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11232,13 +10963,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11252,7 +10981,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11269,43 +10997,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11319,7 +11040,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11336,43 +11056,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11386,7 +11099,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11403,73 +11115,61 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
-
     os << ".bufferOrigin = ";
 
     os << *(params->pbufferOrigin);
 
     os << ", ";
-
     os << ".hostOrigin = ";
 
     os << *(params->phostOrigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
-
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
-
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
-
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11483,7 +11183,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11500,73 +11199,61 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
-
     os << ".bufferOrigin = ";
 
     os << *(params->pbufferOrigin);
 
     os << ", ";
-
     os << ".hostOrigin = ";
 
     os << *(params->phostOrigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
-
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
-
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
-
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11580,7 +11267,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11597,43 +11283,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBufferSrc = ";
 
     ur_params::serializePtr(os, *(params->phBufferSrc));
 
     os << ", ";
-
     os << ".hBufferDst = ";
 
     ur_params::serializePtr(os, *(params->phBufferDst));
 
     os << ", ";
-
     os << ".srcOffset = ";
 
     os << *(params->psrcOffset);
 
     os << ", ";
-
     os << ".dstOffset = ";
 
     os << *(params->pdstOffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11647,7 +11326,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11664,67 +11342,56 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBufferSrc = ";
 
     ur_params::serializePtr(os, *(params->phBufferSrc));
 
     os << ", ";
-
     os << ".hBufferDst = ";
 
     ur_params::serializePtr(os, *(params->phBufferDst));
 
     os << ", ";
-
     os << ".srcOrigin = ";
 
     os << *(params->psrcOrigin);
 
     os << ", ";
-
     os << ".dstOrigin = ";
 
     os << *(params->pdstOrigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".srcRowPitch = ";
 
     os << *(params->psrcRowPitch);
 
     os << ", ";
-
     os << ".srcSlicePitch = ";
 
     os << *(params->psrcSlicePitch);
 
     os << ", ";
-
     os << ".dstRowPitch = ";
 
     os << *(params->pdstRowPitch);
 
     os << ", ";
-
     os << ".dstSlicePitch = ";
 
     os << *(params->pdstSlicePitch);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11738,7 +11405,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11755,43 +11421,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".pPattern = ";
 
     ur_params::serializePtr(os, *(params->ppPattern));
 
     os << ", ";
-
     os << ".patternSize = ";
 
     os << *(params->ppatternSize);
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11805,7 +11464,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11822,55 +11480,46 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
 
     os << ", ";
-
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
-
     os << ".origin = ";
 
     os << *(params->porigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".rowPitch = ";
 
     os << *(params->prowPitch);
 
     os << ", ";
-
     os << ".slicePitch = ";
 
     os << *(params->pslicePitch);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11884,7 +11533,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11901,55 +11549,46 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
 
     os << ", ";
-
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
-
     os << ".origin = ";
 
     os << *(params->porigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".rowPitch = ";
 
     os << *(params->prowPitch);
 
     os << ", ";
-
     os << ".slicePitch = ";
 
     os << *(params->pslicePitch);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11963,7 +11602,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11980,43 +11618,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hImageSrc = ";
 
     ur_params::serializePtr(os, *(params->phImageSrc));
 
     os << ", ";
-
     os << ".hImageDst = ";
 
     ur_params::serializePtr(os, *(params->phImageDst));
 
     os << ", ";
-
     os << ".srcOrigin = ";
 
     os << *(params->psrcOrigin);
 
     os << ", ";
-
     os << ".dstOrigin = ";
 
     os << *(params->pdstOrigin);
 
     os << ", ";
-
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12030,7 +11661,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12047,43 +11677,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".blockingMap = ";
 
     os << *(params->pblockingMap);
 
     os << ", ";
-
     os << ".mapFlags = ";
 
     ur_params::serializeFlag<ur_map_flag_t>(os, *(params->pmapFlags));
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12097,13 +11720,11 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
 
     os << ", ";
-
     os << ".ppRetMap = ";
 
     ur_params::serializePtr(os, *(params->pppRetMap));
@@ -12120,25 +11741,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hMem = ";
 
     ur_params::serializePtr(os, *(params->phMem));
 
     os << ", ";
-
     os << ".pMappedPtr = ";
 
     ur_params::serializePtr(os, *(params->ppMappedPtr));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12152,7 +11769,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12169,37 +11785,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".ptr = ";
 
     ur_params::serializePtr(os, *(params->pptr));
 
     os << ", ";
-
     os << ".patternSize = ";
 
     os << *(params->ppatternSize);
 
     os << ", ";
-
     os << ".pPattern = ";
 
     ur_params::serializePtr(os, *(params->ppPattern));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12213,7 +11823,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12230,37 +11839,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12274,7 +11877,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12291,31 +11893,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_migration_flag_t>(os, *(params->pflags));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12329,7 +11926,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12346,25 +11942,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".advice = ";
 
     ur_params::serializeFlag<ur_usm_advice_flag_t>(os, *(params->padvice));
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12381,49 +11973,41 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
-
     os << ".pitch = ";
 
     os << *(params->ppitch);
 
     os << ", ";
-
     os << ".patternSize = ";
 
     os << *(params->ppatternSize);
 
     os << ", ";
-
     os << ".pPattern = ";
 
     ur_params::serializePtr(os, *(params->ppPattern));
 
     os << ", ";
-
     os << ".width = ";
 
     os << *(params->pwidth);
 
     os << ", ";
-
     os << ".height = ";
 
     os << *(params->pheight);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12437,7 +12021,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12454,55 +12037,46 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".dstPitch = ";
 
     os << *(params->pdstPitch);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".srcPitch = ";
 
     os << *(params->psrcPitch);
 
     os << ", ";
-
     os << ".width = ";
 
     os << *(params->pwidth);
 
     os << ", ";
-
     os << ".height = ";
 
     os << *(params->pheight);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12516,7 +12090,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12533,49 +12106,41 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".name = ";
 
     ur_params::serializePtr(os, *(params->pname));
 
     os << ", ";
-
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
-
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12589,7 +12154,6 @@ inline std::ostream &operator<<(
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12606,49 +12170,41 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".name = ";
 
     ur_params::serializePtr(os, *(params->pname));
 
     os << ", ";
-
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
-
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12662,7 +12218,6 @@ inline std::ostream &operator<<(
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12679,43 +12234,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pipe_symbol = ";
 
     ur_params::serializePtr(os, *(params->ppipe_symbol));
 
     os << ", ";
-
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
-
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12729,7 +12277,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12746,43 +12293,36 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pipe_symbol = ";
 
     ur_params::serializePtr(os, *(params->ppipe_symbol));
 
     os << ", ";
-
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
-
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12796,7 +12336,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12812,25 +12351,21 @@ operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12847,25 +12382,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12881,7 +12412,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << *(params->pnumEvents);
 
     os << ", ";
-
     os << ".phEventWaitList = {";
     for (size_t i = 0;
          *(params->pphEventWaitList) != NULL && i < *params->pnumEvents; ++i) {
@@ -12925,7 +12455,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
-
     os << ".phNativeEvent = ";
 
     ur_params::serializePtr(os, *(params->pphNativeEvent));
@@ -12942,19 +12471,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeEvent));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12971,19 +12497,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
-
     os << ".execStatus = ";
 
     os << *(params->pexecStatus);
 
     os << ", ";
-
     os << ".pfnNotify = ";
 
     os << *(params->ppfnNotify);
 
     os << ", ";
-
     os << ".pUserData = ";
 
     ur_params::serializePtr(os, *(params->ppUserData));
@@ -12999,13 +12522,11 @@ operator<<(std::ostream &os, const struct ur_kernel_create_params_t *params) {
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pKernelName = ";
 
     ur_params::serializePtr(os, *(params->ppKernelName));
 
     os << ", ";
-
     os << ".phKernel = ";
 
     ur_params::serializePtr(os, *(params->pphKernel));
@@ -13021,25 +12542,21 @@ operator<<(std::ostream &os, const struct ur_kernel_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13056,31 +12573,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13097,31 +12609,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13158,7 +12665,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".phNativeKernel = ";
 
     ur_params::serializePtr(os, *(params->pphNativeKernel));
@@ -13175,25 +12681,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeKernel));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phKernel = ";
 
     ur_params::serializePtr(os, *(params->pphKernel));
@@ -13210,25 +12712,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
-
     os << ".argSize = ";
 
     os << *(params->pargSize);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".pArgValue = ";
 
     ur_params::serializePtr(os, *(params->ppArgValue));
@@ -13245,19 +12743,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
-
     os << ".argSize = ";
 
     os << *(params->pargSize);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
@@ -13274,19 +12769,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".pArgValue = ";
 
     ur_params::serializePtr(os, *(params->ppArgValue));
@@ -13303,25 +12795,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
@@ -13338,19 +12826,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".hArgValue = ";
 
     ur_params::serializePtr(os, *(params->phArgValue));
@@ -13367,19 +12852,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".hArgValue = ";
 
     ur_params::serializePtr(os, *(params->phArgValue));
@@ -13396,13 +12878,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
-
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
-
     os << ".pSpecConstants = ";
 
     ur_params::serializePtr(os, *(params->ppSpecConstants));
@@ -13419,31 +12899,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, *(params->pflags));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".pHost = ";
 
     ur_params::serializePtr(os, *(params->ppHost));
 
     os << ", ";
-
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -13460,25 +12935,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, *(params->pflags));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phBuffer = ";
 
     ur_params::serializePtr(os, *(params->pphBuffer));
@@ -13515,25 +12986,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, *(params->pflags));
 
     os << ", ";
-
     os << ".bufferCreateType = ";
 
     os << *(params->pbufferCreateType);
 
     os << ", ";
-
     os << ".pRegion = ";
 
     ur_params::serializePtr(os, *(params->ppRegion));
 
     os << ", ";
-
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -13550,7 +13017,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phMem));
 
     os << ", ";
-
     os << ".phNativeMem = ";
 
     ur_params::serializePtr(os, *(params->pphNativeMem));
@@ -13567,19 +13033,16 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phNativeMem));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -13596,31 +13059,26 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phNativeMem));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
-
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -13636,25 +13094,21 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phMemory));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13671,25 +13125,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phMemory));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13706,25 +13156,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phPhysicalMem = ";
 
     ur_params::serializePtr(os, *(params->pphPhysicalMem));
@@ -13762,7 +13208,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << *(params->pNumEntries);
 
     os << ", ";
-
     os << ".phPlatforms = {";
     for (size_t i = 0;
          *(params->pphPlatforms) != NULL && i < *params->pNumEntries; ++i) {
@@ -13775,7 +13220,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".pNumPlatforms = ";
 
     ur_params::serializePtr(os, *(params->ppNumPlatforms));
@@ -13792,25 +13236,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13827,7 +13267,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".phNativePlatform = ";
 
     ur_params::serializePtr(os, *(params->pphNativePlatform));
@@ -13844,13 +13283,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phNativePlatform));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phPlatform = ";
 
     ur_params::serializePtr(os, *(params->pphPlatform));
@@ -13867,13 +13304,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".ppMessage = ";
 
     ur_params::serializePtr(os, *(params->pppMessage));
 
     os << ", ";
-
     os << ".pError = ";
 
     ur_params::serializePtr(os, *(params->ppError));
@@ -13890,7 +13325,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".pVersion = ";
 
     ur_params::serializePtr(os, *(params->ppVersion));
@@ -13907,13 +13341,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".pFrontendOption = ";
 
     ur_params::serializePtr(os, *(params->ppFrontendOption));
 
     os << ", ";
-
     os << ".ppPlatformOption = ";
 
     ur_params::serializePtr(os, *(params->pppPlatformOption));
@@ -13930,25 +13362,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pIL = ";
 
     ur_params::serializePtr(os, *(params->ppIL));
 
     os << ", ";
-
     os << ".length = ";
 
     os << *(params->plength);
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -13965,31 +13393,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".pBinary = ";
 
     ur_params::serializePtr(os, *(params->ppBinary));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -14005,13 +13428,11 @@ operator<<(std::ostream &os, const struct ur_program_build_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pOptions = ";
 
     ur_params::serializePtr(os, *(params->ppOptions));
@@ -14027,13 +13448,11 @@ operator<<(std::ostream &os, const struct ur_program_compile_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pOptions = ";
 
     ur_params::serializePtr(os, *(params->ppOptions));
@@ -14049,13 +13468,11 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
-
     os << ".phPrograms = {";
     for (size_t i = 0; *(params->pphPrograms) != NULL && i < *params->pcount;
          ++i) {
@@ -14068,13 +13485,11 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".pOptions = ";
 
     ur_params::serializePtr(os, *(params->ppOptions));
 
     os << ", ";
-
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -14111,19 +13526,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".pFunctionName = ";
 
     ur_params::serializePtr(os, *(params->ppFunctionName));
 
     os << ", ";
-
     os << ".ppFunctionPointer = ";
 
     ur_params::serializePtr(os, *(params->pppFunctionPointer));
@@ -14140,25 +13552,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14175,31 +13583,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14216,13 +13619,11 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
-
     os << ".pSpecConstants = {";
     for (size_t i = 0;
          *(params->ppSpecConstants) != NULL && i < *params->pcount; ++i) {
@@ -14246,7 +13647,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
-
     os << ".phNativeProgram = ";
 
     ur_params::serializePtr(os, *(params->pphNativeProgram));
@@ -14263,19 +13663,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeProgram));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -14291,25 +13688,21 @@ operator<<(std::ostream &os, const struct ur_queue_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14325,19 +13718,16 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phQueue = ";
 
     ur_params::serializePtr(os, *(params->pphQueue));
@@ -14374,13 +13764,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
-
     os << ".pDesc = ";
 
     ur_params::serializePtr(os, *(params->ppDesc));
 
     os << ", ";
-
     os << ".phNativeQueue = ";
 
     ur_params::serializePtr(os, *(params->pphNativeQueue));
@@ -14397,25 +13785,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeQueue));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phQueue = ";
 
     ur_params::serializePtr(os, *(params->pphQueue));
@@ -14451,13 +13835,11 @@ operator<<(std::ostream &os, const struct ur_sampler_create_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pDesc = ";
 
     ur_params::serializePtr(os, *(params->ppDesc));
 
     os << ", ";
-
     os << ".phSampler = ";
 
     ur_params::serializePtr(os, *(params->pphSampler));
@@ -14494,25 +13876,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phSampler));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14529,7 +13907,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phSampler));
 
     os << ", ";
-
     os << ".phNativeSampler = ";
 
     ur_params::serializePtr(os, *(params->pphNativeSampler));
@@ -14546,19 +13923,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeSampler));
 
     os << ", ";
-
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phSampler = ";
 
     ur_params::serializePtr(os, *(params->pphSampler));
@@ -14574,25 +13948,21 @@ operator<<(std::ostream &os, const struct ur_usm_host_alloc_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
-
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
@@ -14609,31 +13979,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
-
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
@@ -14650,31 +14015,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
-
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
@@ -14690,7 +14050,6 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
@@ -14707,31 +14066,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14747,13 +14101,11 @@ operator<<(std::ostream &os, const struct ur_usm_pool_create_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pPoolDesc = ";
 
     ur_params::serializePtr(os, *(params->ppPoolDesc));
 
     os << ", ";
-
     os << ".ppPool = ";
 
     ur_params::serializePtr(os, *(params->pppPool));
@@ -14791,25 +14143,21 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPool));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14826,49 +14174,41 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
-
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
-
     os << ".widthInBytes = ";
 
     os << *(params->pwidthInBytes);
 
     os << ", ";
-
     os << ".height = ";
 
     os << *(params->pheight);
 
     os << ", ";
-
     os << ".elementSizeBytes = ";
 
     os << *(params->pelementSizeBytes);
 
     os << ", ";
-
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
 
     os << ", ";
-
     os << ".pResultPitch = ";
 
     ur_params::serializePtr(os, *(params->ppResultPitch));
@@ -14884,13 +14224,11 @@ operator<<(std::ostream &os, const struct ur_usm_import_exp_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
@@ -14906,7 +14244,6 @@ operator<<(std::ostream &os, const struct ur_usm_release_exp_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
@@ -14923,7 +14260,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->pcommandDevice));
 
     os << ", ";
-
     os << ".peerDevice = ";
 
     ur_params::serializePtr(os, *(params->ppeerDevice));
@@ -14940,7 +14276,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->pcommandDevice));
 
     os << ", ";
-
     os << ".peerDevice = ";
 
     ur_params::serializePtr(os, *(params->ppeerDevice));
@@ -14957,31 +14292,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->pcommandDevice));
 
     os << ", ";
-
     os << ".peerDevice = ";
 
     ur_params::serializePtr(os, *(params->ppeerDevice));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14998,31 +14328,26 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -15039,19 +14364,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".ppStart = ";
 
     ur_params::serializePtr(os, *(params->pppStart));
@@ -15068,13 +14390,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
@@ -15090,31 +14410,26 @@ operator<<(std::ostream &os, const struct ur_virtual_mem_map_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".hPhysicalMem = ";
 
     ur_params::serializePtr(os, *(params->phPhysicalMem));
 
     os << ", ";
-
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_virtual_mem_access_flag_t>(os,
@@ -15132,13 +14447,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
@@ -15155,19 +14468,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_virtual_mem_access_flag_t>(os,
@@ -15185,37 +14495,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
-
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
-
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -15231,19 +14535,16 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".DeviceType = ";
 
     os << *(params->pDeviceType);
 
     os << ", ";
-
     os << ".NumEntries = ";
 
     os << *(params->pNumEntries);
 
     os << ", ";
-
     os << ".phDevices = {";
     for (size_t i = 0;
          *(params->pphDevices) != NULL && i < *params->pNumEntries; ++i) {
@@ -15256,7 +14557,6 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".pNumDevices = ";
 
     ur_params::serializePtr(os, *(params->ppNumDevices));
@@ -15272,25 +14572,21 @@ operator<<(std::ostream &os, const struct ur_device_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
-
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
-
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
-
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -15327,19 +14623,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".NumDevices = ";
 
     os << *(params->pNumDevices);
 
     os << ", ";
-
     os << ".phSubDevices = {";
     for (size_t i = 0;
          *(params->pphSubDevices) != NULL && i < *params->pNumDevices; ++i) {
@@ -15352,7 +14645,6 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
-
     os << ".pNumDevicesRet = ";
 
     ur_params::serializePtr(os, *(params->ppNumDevicesRet));
@@ -15369,19 +14661,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pBinaries = ";
 
     ur_params::serializePtr(os, *(params->ppBinaries));
 
     os << ", ";
-
     os << ".NumBinaries = ";
 
     os << *(params->pNumBinaries);
 
     os << ", ";
-
     os << ".pSelectedBinary = ";
 
     ur_params::serializePtr(os, *(params->ppSelectedBinary));
@@ -15398,7 +14687,6 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".phNativeDevice = ";
 
     ur_params::serializePtr(os, *(params->pphNativeDevice));
@@ -15415,19 +14703,16 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeDevice));
 
     os << ", ";
-
     os << ".hPlatform = ";
 
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
-
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
-
     os << ".phDevice = ";
 
     ur_params::serializePtr(os, *(params->pphDevice));
@@ -15444,13 +14729,11 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-
     os << ".pDeviceTimestamp = ";
 
     ur_params::serializePtr(os, *(params->ppDeviceTimestamp));
 
     os << ", ";
-
     os << ".pHostTimestamp = ";
 
     ur_params::serializePtr(os, *(params->ppHostTimestamp));

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -4584,20 +4584,36 @@ inline void
 ur_params::serializeUnion(std::ostream &os,
                           const union ur_device_partition_value_t params,
                           const enum ur_device_partition_t tag) {
+    os << "(union ur_device_partition_value_t){";
+
     switch (tag) {
     case UR_DEVICE_PARTITION_EQUALLY:
-        os << params.equally;
+
+        os << ".equally = ";
+
+        os << (params.equally);
+
         break;
     case UR_DEVICE_PARTITION_BY_COUNTS:
-        os << params.count;
+
+        os << ".count = ";
+
+        os << (params.count);
+
         break;
     case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
-        os << params.affinity_domain;
+
+        os << ".affinity_domain = ";
+
+        ur_params::serializeFlag<ur_device_affinity_domain_flag_t>(
+            os, (params.affinity_domain));
+
         break;
     default:
         os << "<unknown>";
         break;
     }
+    os << "}";
 }
 inline std::ostream &
 operator<<(std::ostream &os,
@@ -7446,23 +7462,42 @@ inline void
 ur_params::serializeUnion(std::ostream &os,
                           const union ur_program_metadata_value_t params,
                           const enum ur_program_metadata_type_t tag) {
+    os << "(union ur_program_metadata_value_t){";
+
     switch (tag) {
     case UR_PROGRAM_METADATA_TYPE_UINT32:
-        os << params.data32;
+
+        os << ".data32 = ";
+
+        os << (params.data32);
+
         break;
     case UR_PROGRAM_METADATA_TYPE_UINT64:
-        os << params.data64;
+
+        os << ".data64 = ";
+
+        os << (params.data64);
+
         break;
     case UR_PROGRAM_METADATA_TYPE_STRING:
-        os << params.pString;
+
+        os << ".pString = ";
+
+        ur_params::serializePtr(os, (params.pString));
+
         break;
     case UR_PROGRAM_METADATA_TYPE_BYTE_ARRAY:
-        os << params.pData;
+
+        os << ".pData = ";
+
+        ur_params::serializePtr(os, (params.pData));
+
         break;
     default:
         os << "<unknown>";
         break;
     }
+    os << "}";
 }
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_program_metadata_t params) {

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -42,6 +42,10 @@ template <>
 inline void serializeFlag<ur_device_affinity_domain_flag_t>(std::ostream &os,
                                                             uint32_t flag);
 
+inline void print_union(std::ostream &os,
+                        const union ur_device_partition_value_t params,
+                        const enum ur_device_partition_t tag);
+
 template <>
 inline void serializeFlag<ur_device_fp_capability_flag_t>(std::ostream &os,
                                                           uint32_t flag);
@@ -124,6 +128,10 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
 template <>
 inline void serializeFlag<ur_physical_mem_flag_t>(std::ostream &os,
                                                   uint32_t flag);
+
+inline void print_union(std::ostream &os,
+                        const union ur_program_metadata_value_t params,
+                        const enum ur_program_metadata_type_t tag);
 
 template <>
 inline void serializeTagged(std::ostream &os, const void *ptr,
@@ -211,8 +219,6 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_affinity_domain_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_partition_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const union ur_device_partition_value_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_device_partition_property_t params);
@@ -313,8 +319,6 @@ inline std::ostream &
 operator<<(std::ostream &os, const struct ur_physical_mem_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_program_metadata_type_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const union ur_program_metadata_value_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_program_metadata_t params);
 inline std::ostream &operator<<(std::ostream &os,
@@ -1743,6 +1747,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -1759,6 +1764,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -1775,11 +1781,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.x);
 
     os << ", ";
+
     os << ".y = ";
 
     os << (params.y);
 
     os << ", ";
+
     os << ".z = ";
 
     os << (params.z);
@@ -1796,11 +1804,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.width);
 
     os << ", ";
+
     os << ".height = ";
 
     os << (params.height);
 
     os << ", ";
+
     os << ".depth = ";
 
     os << (params.depth);
@@ -2013,11 +2023,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -2063,11 +2075,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".pDeviceTargetSpec = ";
 
     ur_params::serializePtr(os, (params.pDeviceTargetSpec));
@@ -4565,27 +4579,25 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
-inline std::ostream &
-operator<<(std::ostream &os, const union ur_device_partition_value_t params) {
-    os << "(union ur_device_partition_value_t){";
 
-    os << ".equally = ";
-
-    os << (params.equally);
-
-    os << ", ";
-    os << ".count = ";
-
-    os << (params.count);
-
-    os << ", ";
-    os << ".affinity_domain = ";
-
-    ur_params::serializeFlag<ur_device_affinity_domain_flag_t>(
-        os, (params.affinity_domain));
-
-    os << "}";
-    return os;
+inline void
+ur_params::print_union(std::ostream &os,
+                       const union ur_device_partition_value_t params,
+                       const enum ur_device_partition_t tag) {
+    switch (tag) {
+    case UR_DEVICE_PARTITION_EQUALLY:
+        os << params.equally;
+        break;
+    case UR_DEVICE_PARTITION_BY_COUNTS:
+        os << params.count;
+        break;
+    case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN:
+        os << params.affinity_domain;
+        break;
+    default:
+        os << "<unknown>";
+        break;
+    }
 }
 inline std::ostream &
 operator<<(std::ostream &os,
@@ -4597,9 +4609,9 @@ operator<<(std::ostream &os,
     os << (params.type);
 
     os << ", ";
-    os << ".value = ";
 
-    os << (params.value);
+    os << ".value = ";
+    ur_params::print_union(os, params.value, params.type);
 
     os << "}";
     return os;
@@ -4614,16 +4626,19 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, (params.pProperties));
 
     os << ", ";
+
     os << ".PropCount = ";
 
     os << (params.PropCount);
@@ -4888,11 +4903,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -5244,11 +5261,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_context_flag_t>(os, (params.flags));
@@ -5462,11 +5481,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -5979,6 +6000,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.channelOrder);
 
     os << ", ";
+
     os << ".channelType = ";
 
     os << (params.channelType);
@@ -5995,51 +6017,61 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".type = ";
 
     os << (params.type);
 
     os << ", ";
+
     os << ".width = ";
 
     os << (params.width);
 
     os << ", ";
+
     os << ".height = ";
 
     os << (params.height);
 
     os << ", ";
+
     os << ".depth = ";
 
     os << (params.depth);
 
     os << ", ";
+
     os << ".arraySize = ";
 
     os << (params.arraySize);
 
     os << ", ";
+
     os << ".rowPitch = ";
 
     os << (params.rowPitch);
 
     os << ", ";
+
     os << ".slicePitch = ";
 
     os << (params.slicePitch);
 
     os << ", ";
+
     os << ".numMipLevel = ";
 
     os << (params.numMipLevel);
 
     os << ", ";
+
     os << ".numSamples = ";
 
     os << (params.numSamples);
@@ -6056,11 +6088,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".pHost = ";
 
     ur_params::serializePtr(os, (params.pHost));
@@ -6078,11 +6112,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".channel = ";
 
     os << (params.channel);
@@ -6100,11 +6136,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".location = ";
 
     os << (params.location);
@@ -6121,16 +6159,19 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".origin = ";
 
     os << (params.origin);
 
     os << ", ";
+
     os << ".size = ";
 
     os << (params.size);
@@ -6160,11 +6201,13 @@ operator<<(std::ostream &os, const struct ur_mem_native_properties_t params) {
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -6345,21 +6388,25 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".normalizedCoords = ";
 
     os << (params.normalizedCoords);
 
     os << ", ";
+
     os << ".addressingMode = ";
 
     os << (params.addressingMode);
 
     os << ", ";
+
     os << ".filterMode = ";
 
     os << (params.filterMode);
@@ -6377,11 +6424,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -6944,16 +6993,19 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".hints = ";
 
     ur_params::serializeFlag<ur_usm_advice_flag_t>(os, (params.hints));
 
     os << ", ";
+
     os << ".align = ";
 
     os << (params.align);
@@ -6970,11 +7022,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_host_mem_flag_t>(os, (params.flags));
@@ -6991,11 +7045,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_device_mem_flag_t>(os, (params.flags));
@@ -7012,11 +7068,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_pool_flag_t>(os, (params.flags));
@@ -7033,16 +7091,19 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".maxPoolableSize = ";
 
     os << (params.maxPoolableSize);
 
     os << ", ";
+
     os << ".minDriverAllocSize = ";
 
     os << (params.minDriverAllocSize);
@@ -7341,11 +7402,13 @@ operator<<(std::ostream &os, const struct ur_physical_mem_properties_t params) {
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_physical_mem_flag_t>(os, (params.flags));
@@ -7378,31 +7441,28 @@ inline std::ostream &operator<<(std::ostream &os,
     }
     return os;
 }
-inline std::ostream &
-operator<<(std::ostream &os, const union ur_program_metadata_value_t params) {
-    os << "(union ur_program_metadata_value_t){";
 
-    os << ".data32 = ";
-
-    os << (params.data32);
-
-    os << ", ";
-    os << ".data64 = ";
-
-    os << (params.data64);
-
-    os << ", ";
-    os << ".pString = ";
-
-    ur_params::serializePtr(os, (params.pString));
-
-    os << ", ";
-    os << ".pData = ";
-
-    ur_params::serializePtr(os, (params.pData));
-
-    os << "}";
-    return os;
+inline void
+ur_params::print_union(std::ostream &os,
+                       const union ur_program_metadata_value_t params,
+                       const enum ur_program_metadata_type_t tag) {
+    switch (tag) {
+    case UR_PROGRAM_METADATA_TYPE_UINT32:
+        os << params.data32;
+        break;
+    case UR_PROGRAM_METADATA_TYPE_UINT64:
+        os << params.data64;
+        break;
+    case UR_PROGRAM_METADATA_TYPE_STRING:
+        os << params.pString;
+        break;
+    case UR_PROGRAM_METADATA_TYPE_BYTE_ARRAY:
+        os << params.pData;
+        break;
+    default:
+        os << "<unknown>";
+        break;
+    }
 }
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_program_metadata_t params) {
@@ -7413,19 +7473,21 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, (params.pName));
 
     os << ", ";
+
     os << ".type = ";
 
     os << (params.type);
 
     os << ", ";
+
     os << ".size = ";
 
     os << (params.size);
 
     os << ", ";
-    os << ".value = ";
 
-    os << (params.value);
+    os << ".value = ";
+    ur_params::print_union(os, params.value, params.type);
 
     os << "}";
     return os;
@@ -7439,16 +7501,19 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".count = ";
 
     os << (params.count);
 
     os << ", ";
+
     os << ".pMetadatas = {";
     for (size_t i = 0; (params.pMetadatas) != NULL && i < params.count; ++i) {
         if (i != 0) {
@@ -7770,11 +7835,13 @@ operator<<(std::ostream &os,
     os << (params.id);
 
     os << ", ";
+
     os << ".size = ";
 
     os << (params.size);
 
     os << ", ";
+
     os << ".pValue = ";
 
     ur_params::serializePtr(os, (params.pValue));
@@ -7792,11 +7859,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -7814,6 +7883,7 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -7831,6 +7901,7 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8316,6 +8387,7 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8333,6 +8405,7 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8350,6 +8423,7 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -8367,11 +8441,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".memoryAccess = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, (params.memoryAccess));
@@ -8389,11 +8465,13 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -8749,11 +8827,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_queue_flag_t>(os, (params.flags));
@@ -8770,11 +8850,13 @@ operator<<(std::ostream &os, const struct ur_queue_index_properties_t params) {
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".computeIndex = ";
 
     os << (params.computeIndex);
@@ -8791,11 +8873,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".pNativeData = ";
 
     ur_params::serializePtr(os, (params.pNativeData));
@@ -8812,11 +8896,13 @@ operator<<(std::ostream &os, const struct ur_queue_native_properties_t params) {
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -9207,11 +9293,13 @@ operator<<(std::ostream &os, const struct ur_event_native_properties_t params) {
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".isNativeHandleOwned = ";
 
     os << (params.isNativeHandleOwned);
@@ -9436,26 +9524,31 @@ operator<<(std::ostream &os,
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
+
     os << ".minMipmapLevelClamp = ";
 
     os << (params.minMipmapLevelClamp);
 
     os << ", ";
+
     os << ".maxMipmapLevelClamp = ";
 
     os << (params.maxMipmapLevelClamp);
 
     os << ", ";
+
     os << ".maxAnisotropy = ";
 
     os << (params.maxAnisotropy);
 
     os << ", ";
+
     os << ".mipFilterMode = ";
 
     os << (params.mipFilterMode);
@@ -9472,6 +9565,7 @@ operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params) {
     os << (params.stype);
 
     os << ", ";
+
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
@@ -9572,11 +9666,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
@@ -9594,11 +9690,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
@@ -9615,21 +9713,25 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".phImageMem = ";
 
     ur_params::serializePtr(os, *(params->pphImageMem));
@@ -9646,11 +9748,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
@@ -9668,31 +9772,37 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
 
     os << ", ";
+
     os << ".phImage = ";
 
     ur_params::serializePtr(os, *(params->pphImage));
@@ -9709,36 +9819,43 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".hSampler = ";
 
     ur_params::serializePtr(os, *(params->phSampler));
 
     os << ", ";
+
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
 
     os << ", ";
+
     os << ".phImage = ";
 
     ur_params::serializePtr(os, *(params->pphImage));
@@ -9755,57 +9872,68 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".imageCopyFlags = ";
 
     ur_params::serializeFlag<ur_exp_image_copy_flag_t>(
         os, *(params->pimageCopyFlags));
 
     os << ", ";
+
     os << ".srcOffset = ";
 
     os << *(params->psrcOffset);
 
     os << ", ";
+
     os << ".dstOffset = ";
 
     os << *(params->pdstOffset);
 
     os << ", ";
+
     os << ".copyExtent = ";
 
     os << *(params->pcopyExtent);
 
     os << ", ";
+
     os << ".hostExtent = ";
 
     os << *(params->phostExtent);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -9819,6 +9947,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -9835,16 +9964,19 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".pPropValue = ";
 
     ur_params::serializePtr(os, *(params->ppPropValue));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -9861,21 +9993,25 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hImageMem = ";
 
     ur_params::serializePtr(os, *(params->phImageMem));
 
     os << ", ";
+
     os << ".mipmapLevel = ";
 
     os << *(params->pmipmapLevel);
 
     os << ", ";
+
     os << ".phImageMem = ";
 
     ur_params::serializePtr(os, *(params->pphImageMem));
@@ -9892,11 +10028,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hMem = ";
 
     ur_params::serializePtr(os, *(params->phMem));
@@ -9913,21 +10051,25 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".fileDescriptor = ";
 
     os << *(params->pfileDescriptor);
 
     os << ", ";
+
     os << ".phInteropMem = ";
 
     ur_params::serializePtr(os, *(params->pphInteropMem));
@@ -9944,26 +10086,31 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".hInteropMem = ";
 
     ur_params::serializePtr(os, *(params->phInteropMem));
 
     os << ", ";
+
     os << ".phImageMem = ";
 
     ur_params::serializePtr(os, *(params->pphImageMem));
@@ -9980,11 +10127,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hInteropMem = ";
 
     ur_params::serializePtr(os, *(params->phInteropMem));
@@ -10002,16 +10151,19 @@ operator<<(std::ostream &os, const struct
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".fileDescriptor = ";
 
     os << *(params->pfileDescriptor);
 
     os << ", ";
+
     os << ".phInteropSemaphoreHandle = ";
 
     ur_params::serializePtr(os, *(params->pphInteropSemaphoreHandle));
@@ -10029,11 +10181,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hInteropSemaphore = ";
 
     ur_params::serializePtr(os, *(params->phInteropSemaphore));
@@ -10051,16 +10205,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hSemaphore = ";
 
     ur_params::serializePtr(os, *(params->phSemaphore));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10074,6 +10231,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10091,16 +10249,19 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hSemaphore = ";
 
     ur_params::serializePtr(os, *(params->phSemaphore));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10114,6 +10275,7 @@ inline std::ostream &operator<<(
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10130,16 +10292,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pCommandBufferDesc = ";
 
     ur_params::serializePtr(os, *(params->ppCommandBufferDesc));
 
     os << ", ";
+
     os << ".phCommandBuffer = ";
 
     ur_params::serializePtr(os, *(params->pphCommandBuffer));
@@ -10189,41 +10354,49 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hKernel = ";
 
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".workDim = ";
 
     os << *(params->pworkDim);
 
     os << ", ";
+
     os << ".pGlobalWorkOffset = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkOffset));
 
     os << ", ";
+
     os << ".pGlobalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkSize));
 
     os << ", ";
+
     os << ".pLocalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppLocalWorkSize));
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10240,31 +10413,37 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10281,41 +10460,49 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hSrcMem = ";
 
     ur_params::serializePtr(os, *(params->phSrcMem));
 
     os << ", ";
+
     os << ".hDstMem = ";
 
     ur_params::serializePtr(os, *(params->phDstMem));
 
     os << ", ";
+
     os << ".srcOffset = ";
 
     os << *(params->psrcOffset);
 
     os << ", ";
+
     os << ".dstOffset = ";
 
     os << *(params->pdstOffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10333,36 +10520,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10379,36 +10573,43 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10426,61 +10627,73 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hSrcMem = ";
 
     ur_params::serializePtr(os, *(params->phSrcMem));
 
     os << ", ";
+
     os << ".hDstMem = ";
 
     ur_params::serializePtr(os, *(params->phDstMem));
 
     os << ", ";
+
     os << ".srcOrigin = ";
 
     os << *(params->psrcOrigin);
 
     os << ", ";
+
     os << ".dstOrigin = ";
 
     os << *(params->pdstOrigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".srcRowPitch = ";
 
     os << *(params->psrcRowPitch);
 
     os << ", ";
+
     os << ".srcSlicePitch = ";
 
     os << *(params->psrcSlicePitch);
 
     os << ", ";
+
     os << ".dstRowPitch = ";
 
     os << *(params->pdstRowPitch);
 
     os << ", ";
+
     os << ".dstSlicePitch = ";
 
     os << *(params->pdstSlicePitch);
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10498,61 +10711,73 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".bufferOffset = ";
 
     os << *(params->pbufferOffset);
 
     os << ", ";
+
     os << ".hostOffset = ";
 
     os << *(params->phostOffset);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
+
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
+
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
+
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10570,61 +10795,73 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".bufferOffset = ";
 
     os << *(params->pbufferOffset);
 
     os << ", ";
+
     os << ".hostOffset = ";
 
     os << *(params->phostOffset);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
+
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
+
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
+
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".numSyncPointsInWaitList = ";
 
     os << *(params->pnumSyncPointsInWaitList);
 
     os << ", ";
+
     os << ".pSyncPointWaitList = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
 
     os << ", ";
+
     os << ".pSyncPoint = ";
 
     ur_params::serializePtr(os, *(params->ppSyncPoint));
@@ -10641,16 +10878,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phCommandBuffer));
 
     os << ", ";
+
     os << ".hQueue = ";
 
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10664,6 +10904,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10679,6 +10920,7 @@ operator<<(std::ostream &os, const struct ur_context_create_params_t *params) {
     os << *(params->pDeviceCount);
 
     os << ", ";
+
     os << ".phDevices = {";
     for (size_t i = 0;
          *(params->pphDevices) != NULL && i < *params->pDeviceCount; ++i) {
@@ -10691,11 +10933,13 @@ operator<<(std::ostream &os, const struct ur_context_create_params_t *params) {
     os << "}";
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phContext = ";
 
     ur_params::serializePtr(os, *(params->pphContext));
@@ -10732,21 +10976,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -10763,6 +11011,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".phNativeContext = ";
 
     ur_params::serializePtr(os, *(params->pphNativeContext));
@@ -10779,11 +11028,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeContext));
 
     os << ", ";
+
     os << ".numDevices = ";
 
     os << *(params->pnumDevices);
 
     os << ", ";
+
     os << ".phDevices = {";
     for (size_t i = 0;
          *(params->pphDevices) != NULL && i < *params->pnumDevices; ++i) {
@@ -10796,11 +11047,13 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phContext = ";
 
     ur_params::serializePtr(os, *(params->pphContext));
@@ -10817,11 +11070,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pfnDeleter = ";
 
     os << *(params->ppfnDeleter);
 
     os << ", ";
+
     os << ".pUserData = ";
 
     ur_params::serializePtr(os, *(params->ppUserData));
@@ -10838,36 +11093,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hKernel = ";
 
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".workDim = ";
 
     os << *(params->pworkDim);
 
     os << ", ";
+
     os << ".pGlobalWorkOffset = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkOffset));
 
     os << ", ";
+
     os << ".pGlobalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppGlobalWorkSize));
 
     os << ", ";
+
     os << ".pLocalWorkSize = ";
 
     ur_params::serializePtr(os, *(params->ppLocalWorkSize));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10881,6 +11143,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10897,11 +11160,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10915,6 +11180,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10931,11 +11197,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -10949,6 +11217,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -10965,36 +11234,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11008,6 +11284,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11024,36 +11301,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11067,6 +11351,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11083,61 +11368,73 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
+
     os << ".bufferOrigin = ";
 
     os << *(params->pbufferOrigin);
 
     os << ", ";
+
     os << ".hostOrigin = ";
 
     os << *(params->phostOrigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
+
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
+
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
+
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11151,6 +11448,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11167,61 +11465,73 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
+
     os << ".bufferOrigin = ";
 
     os << *(params->pbufferOrigin);
 
     os << ", ";
+
     os << ".hostOrigin = ";
 
     os << *(params->phostOrigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".bufferRowPitch = ";
 
     os << *(params->pbufferRowPitch);
 
     os << ", ";
+
     os << ".bufferSlicePitch = ";
 
     os << *(params->pbufferSlicePitch);
 
     os << ", ";
+
     os << ".hostRowPitch = ";
 
     os << *(params->phostRowPitch);
 
     os << ", ";
+
     os << ".hostSlicePitch = ";
 
     os << *(params->phostSlicePitch);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11235,6 +11545,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11251,36 +11562,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBufferSrc = ";
 
     ur_params::serializePtr(os, *(params->phBufferSrc));
 
     os << ", ";
+
     os << ".hBufferDst = ";
 
     ur_params::serializePtr(os, *(params->phBufferDst));
 
     os << ", ";
+
     os << ".srcOffset = ";
 
     os << *(params->psrcOffset);
 
     os << ", ";
+
     os << ".dstOffset = ";
 
     os << *(params->pdstOffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11294,6 +11612,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11310,56 +11629,67 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBufferSrc = ";
 
     ur_params::serializePtr(os, *(params->phBufferSrc));
 
     os << ", ";
+
     os << ".hBufferDst = ";
 
     ur_params::serializePtr(os, *(params->phBufferDst));
 
     os << ", ";
+
     os << ".srcOrigin = ";
 
     os << *(params->psrcOrigin);
 
     os << ", ";
+
     os << ".dstOrigin = ";
 
     os << *(params->pdstOrigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".srcRowPitch = ";
 
     os << *(params->psrcRowPitch);
 
     os << ", ";
+
     os << ".srcSlicePitch = ";
 
     os << *(params->psrcSlicePitch);
 
     os << ", ";
+
     os << ".dstRowPitch = ";
 
     os << *(params->pdstRowPitch);
 
     os << ", ";
+
     os << ".dstSlicePitch = ";
 
     os << *(params->pdstSlicePitch);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11373,6 +11703,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11389,36 +11720,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".pPattern = ";
 
     ur_params::serializePtr(os, *(params->ppPattern));
 
     os << ", ";
+
     os << ".patternSize = ";
 
     os << *(params->ppatternSize);
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11432,6 +11770,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11448,46 +11787,55 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
 
     os << ", ";
+
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
+
     os << ".origin = ";
 
     os << *(params->porigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".rowPitch = ";
 
     os << *(params->prowPitch);
 
     os << ", ";
+
     os << ".slicePitch = ";
 
     os << *(params->pslicePitch);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11501,6 +11849,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11517,46 +11866,55 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hImage = ";
 
     ur_params::serializePtr(os, *(params->phImage));
 
     os << ", ";
+
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
+
     os << ".origin = ";
 
     os << *(params->porigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".rowPitch = ";
 
     os << *(params->prowPitch);
 
     os << ", ";
+
     os << ".slicePitch = ";
 
     os << *(params->pslicePitch);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11570,6 +11928,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11586,36 +11945,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hImageSrc = ";
 
     ur_params::serializePtr(os, *(params->phImageSrc));
 
     os << ", ";
+
     os << ".hImageDst = ";
 
     ur_params::serializePtr(os, *(params->phImageDst));
 
     os << ", ";
+
     os << ".srcOrigin = ";
 
     os << *(params->psrcOrigin);
 
     os << ", ";
+
     os << ".dstOrigin = ";
 
     os << *(params->pdstOrigin);
 
     os << ", ";
+
     os << ".region = ";
 
     os << *(params->pregion);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11629,6 +11995,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11645,36 +12012,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hBuffer = ";
 
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".blockingMap = ";
 
     os << *(params->pblockingMap);
 
     os << ", ";
+
     os << ".mapFlags = ";
 
     ur_params::serializeFlag<ur_map_flag_t>(os, *(params->pmapFlags));
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11688,11 +12062,13 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
 
     os << ", ";
+
     os << ".ppRetMap = ";
 
     ur_params::serializePtr(os, *(params->pppRetMap));
@@ -11709,21 +12085,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hMem = ";
 
     ur_params::serializePtr(os, *(params->phMem));
 
     os << ", ";
+
     os << ".pMappedPtr = ";
 
     ur_params::serializePtr(os, *(params->ppMappedPtr));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11737,6 +12117,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11753,31 +12134,37 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".ptr = ";
 
     ur_params::serializePtr(os, *(params->pptr));
 
     os << ", ";
+
     os << ".patternSize = ";
 
     os << *(params->ppatternSize);
 
     os << ", ";
+
     os << ".pPattern = ";
 
     ur_params::serializePtr(os, *(params->ppPattern));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11791,6 +12178,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11807,31 +12195,37 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11845,6 +12239,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11861,26 +12256,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_usm_migration_flag_t>(os, *(params->pflags));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11894,6 +12294,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11910,21 +12311,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".advice = ";
 
     ur_params::serializeFlag<ur_usm_advice_flag_t>(os, *(params->padvice));
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -11941,41 +12346,49 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
+
     os << ".pitch = ";
 
     os << *(params->ppitch);
 
     os << ", ";
+
     os << ".patternSize = ";
 
     os << *(params->ppatternSize);
 
     os << ", ";
+
     os << ".pPattern = ";
 
     ur_params::serializePtr(os, *(params->ppPattern));
 
     os << ", ";
+
     os << ".width = ";
 
     os << *(params->pwidth);
 
     os << ", ";
+
     os << ".height = ";
 
     os << *(params->pheight);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -11989,6 +12402,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12005,46 +12419,55 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".dstPitch = ";
 
     os << *(params->pdstPitch);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".srcPitch = ";
 
     os << *(params->psrcPitch);
 
     os << ", ";
+
     os << ".width = ";
 
     os << *(params->pwidth);
 
     os << ", ";
+
     os << ".height = ";
 
     os << *(params->pheight);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12058,6 +12481,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12074,41 +12498,49 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".name = ";
 
     ur_params::serializePtr(os, *(params->pname));
 
     os << ", ";
+
     os << ".blockingWrite = ";
 
     os << *(params->pblockingWrite);
 
     os << ", ";
+
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12122,6 +12554,7 @@ inline std::ostream &operator<<(
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12138,41 +12571,49 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".name = ";
 
     ur_params::serializePtr(os, *(params->pname));
 
     os << ", ";
+
     os << ".blockingRead = ";
 
     os << *(params->pblockingRead);
 
     os << ", ";
+
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12186,6 +12627,7 @@ inline std::ostream &operator<<(
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12202,36 +12644,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pipe_symbol = ";
 
     ur_params::serializePtr(os, *(params->ppipe_symbol));
 
     os << ", ";
+
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
+
     os << ".pDst = ";
 
     ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12245,6 +12694,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12261,36 +12711,43 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pipe_symbol = ";
 
     ur_params::serializePtr(os, *(params->ppipe_symbol));
 
     os << ", ";
+
     os << ".blocking = ";
 
     os << *(params->pblocking);
 
     os << ", ";
+
     os << ".pSrc = ";
 
     ur_params::serializePtr(os, *(params->ppSrc));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
                        i < *params->pnumEventsInWaitList;
@@ -12304,6 +12761,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12319,21 +12777,25 @@ operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12350,21 +12812,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12380,6 +12846,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << *(params->pnumEvents);
 
     os << ", ";
+
     os << ".phEventWaitList = {";
     for (size_t i = 0;
          *(params->pphEventWaitList) != NULL && i < *params->pnumEvents; ++i) {
@@ -12423,6 +12890,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
+
     os << ".phNativeEvent = ";
 
     ur_params::serializePtr(os, *(params->pphNativeEvent));
@@ -12439,16 +12907,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeEvent));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));
@@ -12465,16 +12936,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phEvent));
 
     os << ", ";
+
     os << ".execStatus = ";
 
     os << *(params->pexecStatus);
 
     os << ", ";
+
     os << ".pfnNotify = ";
 
     os << *(params->ppfnNotify);
 
     os << ", ";
+
     os << ".pUserData = ";
 
     ur_params::serializePtr(os, *(params->ppUserData));
@@ -12490,11 +12964,13 @@ operator<<(std::ostream &os, const struct ur_kernel_create_params_t *params) {
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pKernelName = ";
 
     ur_params::serializePtr(os, *(params->ppKernelName));
 
     os << ", ";
+
     os << ".phKernel = ";
 
     ur_params::serializePtr(os, *(params->pphKernel));
@@ -12510,21 +12986,25 @@ operator<<(std::ostream &os, const struct ur_kernel_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12541,26 +13021,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12577,26 +13062,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -12633,6 +13123,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".phNativeKernel = ";
 
     ur_params::serializePtr(os, *(params->pphNativeKernel));
@@ -12649,21 +13140,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeKernel));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phKernel = ";
 
     ur_params::serializePtr(os, *(params->pphKernel));
@@ -12680,21 +13175,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
+
     os << ".argSize = ";
 
     os << *(params->pargSize);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".pArgValue = ";
 
     ur_params::serializePtr(os, *(params->ppArgValue));
@@ -12711,16 +13210,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
+
     os << ".argSize = ";
 
     os << *(params->pargSize);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
@@ -12737,16 +13239,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".pArgValue = ";
 
     ur_params::serializePtr(os, *(params->ppArgValue));
@@ -12763,21 +13268,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
@@ -12794,16 +13303,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".hArgValue = ";
 
     ur_params::serializePtr(os, *(params->phArgValue));
@@ -12820,16 +13332,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".argIndex = ";
 
     os << *(params->pargIndex);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".hArgValue = ";
 
     ur_params::serializePtr(os, *(params->phArgValue));
@@ -12846,11 +13361,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phKernel));
 
     os << ", ";
+
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
+
     os << ".pSpecConstants = ";
 
     ur_params::serializePtr(os, *(params->ppSpecConstants));
@@ -12867,26 +13384,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, *(params->pflags));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".pHost = ";
 
     ur_params::serializePtr(os, *(params->ppHost));
 
     os << ", ";
+
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -12903,21 +13425,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, *(params->pflags));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phBuffer = ";
 
     ur_params::serializePtr(os, *(params->pphBuffer));
@@ -12954,21 +13480,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phBuffer));
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_mem_flag_t>(os, *(params->pflags));
 
     os << ", ";
+
     os << ".bufferCreateType = ";
 
     os << *(params->pbufferCreateType);
 
     os << ", ";
+
     os << ".pRegion = ";
 
     ur_params::serializePtr(os, *(params->ppRegion));
 
     os << ", ";
+
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -12985,6 +13515,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phMem));
 
     os << ", ";
+
     os << ".phNativeMem = ";
 
     ur_params::serializePtr(os, *(params->pphNativeMem));
@@ -13001,16 +13532,19 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phNativeMem));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -13027,26 +13561,31 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phNativeMem));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pImageFormat = ";
 
     ur_params::serializePtr(os, *(params->ppImageFormat));
 
     os << ", ";
+
     os << ".pImageDesc = ";
 
     ur_params::serializePtr(os, *(params->ppImageDesc));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phMem = ";
 
     ur_params::serializePtr(os, *(params->pphMem));
@@ -13062,21 +13601,25 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phMemory));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13093,21 +13636,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phMemory));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13124,21 +13671,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phPhysicalMem = ";
 
     ur_params::serializePtr(os, *(params->pphPhysicalMem));
@@ -13176,6 +13727,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << *(params->pNumEntries);
 
     os << ", ";
+
     os << ".phPlatforms = {";
     for (size_t i = 0;
          *(params->pphPlatforms) != NULL && i < *params->pNumEntries; ++i) {
@@ -13188,6 +13740,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".pNumPlatforms = ";
 
     ur_params::serializePtr(os, *(params->ppNumPlatforms));
@@ -13204,21 +13757,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13235,6 +13792,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".phNativePlatform = ";
 
     ur_params::serializePtr(os, *(params->pphNativePlatform));
@@ -13251,11 +13809,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phNativePlatform));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phPlatform = ";
 
     ur_params::serializePtr(os, *(params->pphPlatform));
@@ -13272,11 +13832,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".ppMessage = ";
 
     ur_params::serializePtr(os, *(params->pppMessage));
 
     os << ", ";
+
     os << ".pError = ";
 
     ur_params::serializePtr(os, *(params->ppError));
@@ -13293,6 +13855,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".pVersion = ";
 
     ur_params::serializePtr(os, *(params->ppVersion));
@@ -13309,11 +13872,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".pFrontendOption = ";
 
     ur_params::serializePtr(os, *(params->ppFrontendOption));
 
     os << ", ";
+
     os << ".ppPlatformOption = ";
 
     ur_params::serializePtr(os, *(params->pppPlatformOption));
@@ -13330,21 +13895,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pIL = ";
 
     ur_params::serializePtr(os, *(params->ppIL));
 
     os << ", ";
+
     os << ".length = ";
 
     os << *(params->plength);
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -13361,26 +13930,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".pBinary = ";
 
     ur_params::serializePtr(os, *(params->ppBinary));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -13396,11 +13970,13 @@ operator<<(std::ostream &os, const struct ur_program_build_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pOptions = ";
 
     ur_params::serializePtr(os, *(params->ppOptions));
@@ -13416,11 +13992,13 @@ operator<<(std::ostream &os, const struct ur_program_compile_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pOptions = ";
 
     ur_params::serializePtr(os, *(params->ppOptions));
@@ -13436,11 +14014,13 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
+
     os << ".phPrograms = {";
     for (size_t i = 0; *(params->pphPrograms) != NULL && i < *params->pcount;
          ++i) {
@@ -13453,11 +14033,13 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".pOptions = ";
 
     ur_params::serializePtr(os, *(params->ppOptions));
 
     os << ", ";
+
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -13494,16 +14076,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".pFunctionName = ";
 
     ur_params::serializePtr(os, *(params->ppFunctionName));
 
     os << ", ";
+
     os << ".ppFunctionPointer = ";
 
     ur_params::serializePtr(os, *(params->pppFunctionPointer));
@@ -13520,21 +14105,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13551,26 +14140,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13587,11 +14181,13 @@ inline std::ostream &operator<<(
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".count = ";
 
     os << *(params->pcount);
 
     os << ", ";
+
     os << ".pSpecConstants = {";
     for (size_t i = 0;
          *(params->ppSpecConstants) != NULL && i < *params->pcount; ++i) {
@@ -13615,6 +14211,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phProgram));
 
     os << ", ";
+
     os << ".phNativeProgram = ";
 
     ur_params::serializePtr(os, *(params->pphNativeProgram));
@@ -13631,16 +14228,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeProgram));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phProgram = ";
 
     ur_params::serializePtr(os, *(params->pphProgram));
@@ -13656,21 +14256,25 @@ operator<<(std::ostream &os, const struct ur_queue_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13686,16 +14290,19 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phQueue = ";
 
     ur_params::serializePtr(os, *(params->pphQueue));
@@ -13732,11 +14339,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phQueue));
 
     os << ", ";
+
     os << ".pDesc = ";
 
     ur_params::serializePtr(os, *(params->ppDesc));
 
     os << ", ";
+
     os << ".phNativeQueue = ";
 
     ur_params::serializePtr(os, *(params->pphNativeQueue));
@@ -13753,21 +14362,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeQueue));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phQueue = ";
 
     ur_params::serializePtr(os, *(params->pphQueue));
@@ -13803,11 +14416,13 @@ operator<<(std::ostream &os, const struct ur_sampler_create_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pDesc = ";
 
     ur_params::serializePtr(os, *(params->ppDesc));
 
     os << ", ";
+
     os << ".phSampler = ";
 
     ur_params::serializePtr(os, *(params->pphSampler));
@@ -13844,21 +14459,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phSampler));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -13875,6 +14494,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phSampler));
 
     os << ", ";
+
     os << ".phNativeSampler = ";
 
     ur_params::serializePtr(os, *(params->pphNativeSampler));
@@ -13891,16 +14511,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeSampler));
 
     os << ", ";
+
     os << ".hContext = ";
 
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phSampler = ";
 
     ur_params::serializePtr(os, *(params->pphSampler));
@@ -13916,21 +14539,25 @@ operator<<(std::ostream &os, const struct ur_usm_host_alloc_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
+
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
@@ -13947,26 +14574,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
+
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
@@ -13983,26 +14615,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
+
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
@@ -14018,6 +14655,7 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
@@ -14034,26 +14672,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14069,11 +14712,13 @@ operator<<(std::ostream &os, const struct ur_usm_pool_create_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pPoolDesc = ";
 
     ur_params::serializePtr(os, *(params->ppPoolDesc));
 
     os << ", ";
+
     os << ".ppPool = ";
 
     ur_params::serializePtr(os, *(params->pppPool));
@@ -14111,21 +14756,25 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPool));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14142,41 +14791,49 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pUSMDesc = ";
 
     ur_params::serializePtr(os, *(params->ppUSMDesc));
 
     os << ", ";
+
     os << ".pool = ";
 
     ur_params::serializePtr(os, *(params->ppool));
 
     os << ", ";
+
     os << ".widthInBytes = ";
 
     os << *(params->pwidthInBytes);
 
     os << ", ";
+
     os << ".height = ";
 
     os << *(params->pheight);
 
     os << ", ";
+
     os << ".elementSizeBytes = ";
 
     os << *(params->pelementSizeBytes);
 
     os << ", ";
+
     os << ".ppMem = ";
 
     ur_params::serializePtr(os, *(params->pppMem));
 
     os << ", ";
+
     os << ".pResultPitch = ";
 
     ur_params::serializePtr(os, *(params->ppResultPitch));
@@ -14192,11 +14849,13 @@ operator<<(std::ostream &os, const struct ur_usm_import_exp_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
@@ -14212,6 +14871,7 @@ operator<<(std::ostream &os, const struct ur_usm_release_exp_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pMem = ";
 
     ur_params::serializePtr(os, *(params->ppMem));
@@ -14228,6 +14888,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->pcommandDevice));
 
     os << ", ";
+
     os << ".peerDevice = ";
 
     ur_params::serializePtr(os, *(params->ppeerDevice));
@@ -14244,6 +14905,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->pcommandDevice));
 
     os << ", ";
+
     os << ".peerDevice = ";
 
     ur_params::serializePtr(os, *(params->ppeerDevice));
@@ -14260,26 +14922,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->pcommandDevice));
 
     os << ", ";
+
     os << ".peerDevice = ";
 
     ur_params::serializePtr(os, *(params->ppeerDevice));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14296,26 +14963,31 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".hDevice = ";
 
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14332,16 +15004,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".ppStart = ";
 
     ur_params::serializePtr(os, *(params->pppStart));
@@ -14358,11 +15033,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
@@ -14378,26 +15055,31 @@ operator<<(std::ostream &os, const struct ur_virtual_mem_map_params_t *params) {
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".hPhysicalMem = ";
 
     ur_params::serializePtr(os, *(params->phPhysicalMem));
 
     os << ", ";
+
     os << ".offset = ";
 
     os << *(params->poffset);
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_virtual_mem_access_flag_t>(os,
@@ -14415,11 +15097,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
@@ -14436,16 +15120,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".flags = ";
 
     ur_params::serializeFlag<ur_virtual_mem_access_flag_t>(os,
@@ -14463,31 +15150,37 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phContext));
 
     os << ", ";
+
     os << ".pStart = ";
 
     ur_params::serializePtr(os, *(params->ppStart));
 
     os << ", ";
+
     os << ".size = ";
 
     os << *(params->psize);
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14503,16 +15196,19 @@ inline std::ostream &operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".DeviceType = ";
 
     os << *(params->pDeviceType);
 
     os << ", ";
+
     os << ".NumEntries = ";
 
     os << *(params->pNumEntries);
 
     os << ", ";
+
     os << ".phDevices = {";
     for (size_t i = 0;
          *(params->pphDevices) != NULL && i < *params->pNumEntries; ++i) {
@@ -14525,6 +15221,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".pNumDevices = ";
 
     ur_params::serializePtr(os, *(params->ppNumDevices));
@@ -14540,21 +15237,25 @@ operator<<(std::ostream &os, const struct ur_device_get_info_params_t *params) {
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".propName = ";
 
     os << *(params->ppropName);
 
     os << ", ";
+
     os << ".propSize = ";
 
     os << *(params->ppropSize);
 
     os << ", ";
+
     os << ".pPropValue = ";
     ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
                                *(params->ppropSize));
 
     os << ", ";
+
     os << ".pPropSizeRet = ";
 
     ur_params::serializePtr(os, *(params->ppPropSizeRet));
@@ -14591,16 +15292,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".NumDevices = ";
 
     os << *(params->pNumDevices);
 
     os << ", ";
+
     os << ".phSubDevices = {";
     for (size_t i = 0;
          *(params->pphSubDevices) != NULL && i < *params->pNumDevices; ++i) {
@@ -14613,6 +15317,7 @@ operator<<(std::ostream &os,
     os << "}";
 
     os << ", ";
+
     os << ".pNumDevicesRet = ";
 
     ur_params::serializePtr(os, *(params->ppNumDevicesRet));
@@ -14629,16 +15334,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pBinaries = ";
 
     ur_params::serializePtr(os, *(params->ppBinaries));
 
     os << ", ";
+
     os << ".NumBinaries = ";
 
     os << *(params->pNumBinaries);
 
     os << ", ";
+
     os << ".pSelectedBinary = ";
 
     ur_params::serializePtr(os, *(params->ppSelectedBinary));
@@ -14655,6 +15363,7 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".phNativeDevice = ";
 
     ur_params::serializePtr(os, *(params->pphNativeDevice));
@@ -14671,16 +15380,19 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phNativeDevice));
 
     os << ", ";
+
     os << ".hPlatform = ";
 
     ur_params::serializePtr(os, *(params->phPlatform));
 
     os << ", ";
+
     os << ".pProperties = ";
 
     ur_params::serializePtr(os, *(params->ppProperties));
 
     os << ", ";
+
     os << ".phDevice = ";
 
     ur_params::serializePtr(os, *(params->pphDevice));
@@ -14697,11 +15409,13 @@ operator<<(std::ostream &os,
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
+
     os << ".pDeviceTimestamp = ";
 
     ur_params::serializePtr(os, *(params->ppDeviceTimestamp));
 
     os << ", ";
+
     os << ".pHostTimestamp = ";
 
     ur_params::serializePtr(os, *(params->ppHostTimestamp));

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -42,9 +42,9 @@ template <>
 inline void serializeFlag<ur_device_affinity_domain_flag_t>(std::ostream &os,
                                                             uint32_t flag);
 
-inline void print_union(std::ostream &os,
-                        const union ur_device_partition_value_t params,
-                        const enum ur_device_partition_t tag);
+inline void serializeUnion(std::ostream &os,
+                           const union ur_device_partition_value_t params,
+                           const enum ur_device_partition_t tag);
 
 template <>
 inline void serializeFlag<ur_device_fp_capability_flag_t>(std::ostream &os,
@@ -129,9 +129,9 @@ template <>
 inline void serializeFlag<ur_physical_mem_flag_t>(std::ostream &os,
                                                   uint32_t flag);
 
-inline void print_union(std::ostream &os,
-                        const union ur_program_metadata_value_t params,
-                        const enum ur_program_metadata_type_t tag);
+inline void serializeUnion(std::ostream &os,
+                           const union ur_program_metadata_value_t params,
+                           const enum ur_program_metadata_type_t tag);
 
 template <>
 inline void serializeTagged(std::ostream &os, const void *ptr,
@@ -4581,9 +4581,9 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline void
-ur_params::print_union(std::ostream &os,
-                       const union ur_device_partition_value_t params,
-                       const enum ur_device_partition_t tag) {
+ur_params::serializeUnion(std::ostream &os,
+                          const union ur_device_partition_value_t params,
+                          const enum ur_device_partition_t tag) {
     switch (tag) {
     case UR_DEVICE_PARTITION_EQUALLY:
         os << params.equally;
@@ -4611,7 +4611,7 @@ operator<<(std::ostream &os,
     os << ", ";
 
     os << ".value = ";
-    ur_params::print_union(os, params.value, params.type);
+    ur_params::serializeUnion(os, (params.value), params.type);
 
     os << "}";
     return os;
@@ -7443,9 +7443,9 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline void
-ur_params::print_union(std::ostream &os,
-                       const union ur_program_metadata_value_t params,
-                       const enum ur_program_metadata_type_t tag) {
+ur_params::serializeUnion(std::ostream &os,
+                          const union ur_program_metadata_value_t params,
+                          const enum ur_program_metadata_type_t tag) {
     switch (tag) {
     case UR_PROGRAM_METADATA_TYPE_UINT32:
         os << params.data32;
@@ -7487,7 +7487,7 @@ inline std::ostream &operator<<(std::ostream &os,
     os << ", ";
 
     os << ".value = ";
-    ur_params::print_union(os, params.value, params.type);
+    ur_params::serializeUnion(os, (params.value), params.type);
 
     os << "}";
     return os;

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -306,6 +306,49 @@ struct UrContextGetInfoParamsDevicesArray : UrContextGetInfoParams {
     };
 };
 
+struct UrProgramMetadataTest {
+    UrProgramMetadataTest() {
+        meta.pName = "MY_META";
+        meta.size = 0;
+        meta.type = UR_PROGRAM_METADATA_TYPE_UINT32;
+        ur_program_metadata_value_t value{};
+        value.data32 = 42;
+        meta.value = value;
+    }
+
+    ur_program_metadata_t &get_struct() { return meta; }
+    const char *get_expected() {
+        return "\\(struct ur_program_metadata_t\\)"
+               "\\{"
+               ".pName = .+ \\(MY_META\\), "
+               ".type = UR_PROGRAM_METADATA_TYPE_UINT32, "
+               ".size = 0, "
+               ".value = 42"
+               "\\}";
+    }
+    ur_program_metadata_t meta;
+};
+
+struct UrDevicePartitionPropertyTest {
+    UrDevicePartitionPropertyTest() {
+        prop.type = UR_DEVICE_PARTITION_EQUALLY;
+        ur_device_partition_value_t value{};
+        value.equally = 4;
+        prop.value = value;
+    }
+
+    ur_device_partition_property_t &get_struct() { return prop; }
+    const char *get_expected() {
+        return "\\(struct ur_device_partition_property_t\\)"
+               "\\{"
+               ".type = UR_DEVICE_PARTITION_EQUALLY, "
+               ".value = 4"
+               "\\}";
+    }
+
+    ur_device_partition_property_t prop;
+};
+
 using testing::Types;
 typedef Types<
     UrInitParamsNoFlags, UrInitParamsInvalidFlags, UrUsmHostAllocParamsEmpty,
@@ -313,7 +356,8 @@ typedef Types<
     UrUsmHostAllocParamsUsmDesc, UrUsmHostAllocParamsHostDesc,
     UrDeviceGetInfoParamsEmpty, UrDeviceGetInfoParamsName,
     UrDeviceGetInfoParamsQueueFlag, UrDeviceGetInfoParamsPartitionArray,
-    UrContextGetInfoParamsDevicesArray, UrDeviceGetInfoParamsInvalidSize>
+    UrContextGetInfoParamsDevicesArray, UrDeviceGetInfoParamsInvalidSize,
+    UrProgramMetadataTest, UrDevicePartitionPropertyTest>
     Implementations;
 
 using ::testing::MatchesRegex;

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -323,7 +323,9 @@ struct UrProgramMetadataTest {
                ".pName = .+ \\(MY_META\\), "
                ".type = UR_PROGRAM_METADATA_TYPE_UINT32, "
                ".size = 0, "
-               ".value = 42"
+               ".value = \\(union ur_program_metadata_value_t\\)\\{"
+               ".data32 = 42"
+               "\\}"
                "\\}";
     }
     ur_program_metadata_t meta;
@@ -342,7 +344,9 @@ struct UrDevicePartitionPropertyTest {
         return "\\(struct ur_device_partition_property_t\\)"
                "\\{"
                ".type = UR_DEVICE_PARTITION_EQUALLY, "
-               ".value = 4"
+               ".value = \\(union ur_device_partition_value_t\\)\\{"
+               ".equally = 4"
+               "\\}"
                "\\}";
     }
 


### PR DESCRIPTION
This PR:
* Introduces some new yaml syntax for handling unions.
   * A union must specify a tag which is a type that will be used to access the union
   * Each member of the union must also specify a `tag` which will refer to a value for which accessing this member is value.
   * Use of a union as a member must include `tagged_by(param)` in the description to specify which parameter is used as the tag for the union.
* Safely prints union types in `ur_params.hpp`


~~[TODO] I will add some checks into the generator script to verify these conditions.~~

Closes #538 