### PR TITLE
Set global compile flags for UR targets only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,17 +52,7 @@ if(MSVC)
     set(CUSTOM_COMMAND_BINARY_DIR ${CUSTOM_COMMAND_BINARY_DIR}/$<CONFIG>)
 endif()
 
-# CXX flags setup
 if(NOT MSVC)
-    add_compile_options(-fPIC -Wall -Wpedantic
-        $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
-        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>)
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        add_compile_options(-D_FORTIFY_SOURCE=2)
-    endif()
-    if(UR_DEVELOPER_MODE)
-        add_compile_options(-Werror -fno-omit-frame-pointer -fstack-protector-strong)
-    endif()
     # Determine if libstdc++ is being used.
     check_cxx_source_compiles("
         #include <array>
@@ -77,14 +67,6 @@ if(NOT MSVC)
         # requires linking against libstdc++fs.a, on systems where <filesystem>
         # is available we still need to link this library.
         link_libraries(stdc++fs)
-    endif()
-elseif(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-    add_compile_options(/MP /W3 /MD$<$<CONFIG:Debug>:d>)
-
-    if(UR_DEVELOPER_MODE)
-        add_compile_options(/WX /GS)
     endif()
 endif()
 

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -57,6 +57,48 @@ macro(add_sanitizer_flag flag)
     set(CMAKE_REQUIRED_LIBRARIES ${SAVED_CMAKE_REQUIRED_LIBRARIES})
 endmacro()
 
+function(add_ur_target_compile_options name)
+    if(NOT MSVC)
+        target_compile_options(${name} PRIVATE
+            -fPIC
+            -Wall
+            -Wpedantic
+            $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
+            $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
+        )
+        if (CMAKE_BUILD_TYPE STREQUAL "Release")
+            target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        endif()
+        if(UR_DEVELOPER_MODE)
+            target_compile_options(${name} PRIVATE
+                -Werror
+                -fno-omit-frame-pointer
+                -fstack-protector-strong
+            )
+        endif()
+    elseif(MSVC)
+        target_compile_options(${name} PRIVATE
+            /MP
+            /W3
+            /MD$<$<CONFIG:Debug>:d>
+        )
+
+        if(UR_DEVELOPER_MODE)
+            target_compile_options(${name} PRIVATE /WX /GS)
+        endif()
+    endif()
+endfunction()
+
+function(add_ur_executable name)
+    add_executable(${name} ${ARGN})
+    add_ur_target_compile_options(${name})
+endfunction()
+
+function(add_ur_library name)
+    add_library(${name} ${ARGN})
+    add_ur_target_compile_options(${name})
+endfunction()
+
 include(FetchContent)
 
 # A wrapper around FetchContent_Declare that supports git sparse checkout.

--- a/examples/collector/CMakeLists.txt
+++ b/examples/collector/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(TARGET_NAME collector)
 
-add_library(${TARGET_NAME} SHARED
+add_ur_library(${TARGET_NAME} SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/collector.cpp
 )
 

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(TARGET_NAME hello_world)
 
-add_executable(${TARGET_NAME}
+add_ur_executable(${TARGET_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.cpp
 )
 

--- a/source/adapters/null/CMakeLists.txt
+++ b/source/adapters/null/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(TARGET_NAME ur_adapter_null)
 
-add_library(${TARGET_NAME}
+add_ur_library(${TARGET_NAME}
     SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_null.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_null.cpp

--- a/source/common/umf_pools/CMakeLists.txt
+++ b/source/common/umf_pools/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(disjoint_pool STATIC
+add_ur_library(disjoint_pool STATIC
     disjoint_pool.cpp
     disjoint_pool_config_parser.cpp
 )

--- a/source/common/unified_malloc_framework/CMakeLists.txt
+++ b/source/common/unified_malloc_framework/CMakeLists.txt
@@ -14,11 +14,11 @@ if(UMF_BUILD_SHARED_LIBRARY)
     message(WARNING "Unified Malloc Framework is still an early work in progress."
                      "There are no API/ABI backward compatibility guarantees. There will be breakages."
                      "Do not use the shared library in production software.")
-    add_library(unified_malloc_framework SHARED
+    add_ur_library(unified_malloc_framework SHARED
         ${UMF_SOURCES})
     target_compile_definitions(unified_malloc_framework PUBLIC UMF_SHARED_LIBRARY)
 else()
-    add_library(unified_malloc_framework STATIC
+    add_ur_library(unified_malloc_framework STATIC
         ${UMF_SOURCES})
 endif()
 

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -9,7 +9,7 @@ configure_file(
     @ONLY
 )
 
-add_library(ur_loader
+add_ur_library(ur_loader
     SHARED
     ""
     ${CMAKE_CURRENT_BINARY_DIR}/UrLoaderVersion.rc

--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -7,7 +7,7 @@ set(UR_CONFORMANCE_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 function(add_conformance_test name)
     set(TEST_TARGET_NAME test-${name})
-    add_executable(${TEST_TARGET_NAME}
+    add_ur_executable(${TEST_TARGET_NAME}
         ${ARGN}
         ${UR_CONFORMANCE_TEST_DIR}/source/environment.cpp
         ${UR_CONFORMANCE_TEST_DIR}/source/main.cpp)

--- a/test/conformance/testing/CMakeLists.txt
+++ b/test/conformance/testing/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(ur_testing STATIC 
+add_ur_library(ur_testing STATIC 
     source/utils.cpp)
 target_include_directories(ur_testing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(ur_testing PRIVATE gtest_main unified-runtime::headers)

--- a/test/layers/validation/CMakeLists.txt
+++ b/test/layers/validation/CMakeLists.txt
@@ -7,7 +7,7 @@ set(UR_VALIDATION_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 function(add_validation_test name)
     set(TEST_TARGET_NAME validation_test-${name})
-    add_executable(${TEST_TARGET_NAME}
+    add_ur_executable(${TEST_TARGET_NAME}
         ${ARGN})
     target_link_libraries(${TEST_TARGET_NAME}
         PRIVATE

--- a/test/loader/adapter_registry/CMakeLists.txt
+++ b/test/loader/adapter_registry/CMakeLists.txt
@@ -7,7 +7,7 @@ function(add_adapter_reg_search_test name)
     cmake_parse_arguments(TEST "" "" "SEARCH_PATH;ENVS;SOURCES" ${ARGN})
 
     set(TEST_TARGET_NAME adapter-reg-test-${name})
-    add_executable(${TEST_TARGET_NAME}
+    add_ur_executable(${TEST_TARGET_NAME}
         ${TEST_SOURCES})
 
     if(WIN32)

--- a/test/loader/platforms/CMakeLists.txt
+++ b/test/loader/platforms/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_executable(test-loader-platforms
+add_ur_executable(test-loader-platforms
     platforms.cpp
 )
 

--- a/test/unified_malloc_framework/CMakeLists.txt
+++ b/test/unified_malloc_framework/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(UR_UMF_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_library(umf_test_helpers STATIC
+add_ur_library(umf_test_helpers STATIC
     ${UR_UMF_TEST_DIR}/common/pool.c
     ${UR_UMF_TEST_DIR}/common/provider.c
 )
@@ -14,7 +14,7 @@ target_link_libraries(umf_test_helpers PRIVATE ${PROJECT_NAME}::common)
 
 function(add_umf_test name)
     set(TEST_TARGET_NAME umf_test-${name})
-    add_executable(${TEST_TARGET_NAME}
+    add_ur_executable(${TEST_TARGET_NAME}
         ${ARGN})
     target_link_libraries(${TEST_TARGET_NAME}
         PRIVATE

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(unit_tests_helpers INTERFACE
 function(add_unit_test name)
     set(TEST_TARGET_NAME test-${name})
 
-    add_executable(${TEST_TARGET_NAME}
+    add_ur_executable(${TEST_TARGET_NAME}
         ${ARGN}
     )
     target_link_libraries(${TEST_TARGET_NAME}

--- a/test/unit/logger/CMakeLists.txt
+++ b/test/unit/logger/CMakeLists.txt
@@ -8,7 +8,7 @@ add_unit_test(logger
 )
 
 set(TEST_TARGET_NAME test-logger_env_var)
-add_executable(${TEST_TARGET_NAME}
+add_ur_executable(${TEST_TARGET_NAME}
     env_var.cpp
 )
 target_link_libraries(${TEST_TARGET_NAME}

--- a/test/usm/CMakeLists.txt
+++ b/test/usm/CMakeLists.txt
@@ -7,7 +7,7 @@ set(UR_USM_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 function(add_usm_test name)
     set(TEST_TARGET_NAME usm_test-${name})
-    add_executable(${TEST_TARGET_NAME}
+    add_ur_executable(${TEST_TARGET_NAME}
         ${UR_USM_TEST_DIR}/../conformance/source/environment.cpp
         ${UR_USM_TEST_DIR}/../conformance/source/main.cpp
         ${ARGN})

--- a/tools/urtrace/CMakeLists.txt
+++ b/tools/urtrace/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(TARGET_NAME ur_collector)
 
-add_library(${TARGET_NAME} SHARED
+add_ur_library(${TARGET_NAME} SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/collector.cpp
 )
 


### PR DESCRIPTION
Currently, some of compile flags are set globally for the whole project and third-party libraries. Wrap all Unified Runtime CMake targets so that compile and linking flags can be added globally but without affecting third-party repositories' builds.