### PR TITLE
[Bindless Images][Exp] Add opaque file descriptor handle

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -2085,6 +2085,11 @@ class ur_exp_interop_semaphore_handle_t(c_void_p):
     pass
 
 ###############################################################################
+## @brief Handle of file descriptor
+class ur_exp_file_descriptor_handle_t(c_void_p):
+    pass
+
+###############################################################################
 ## @brief Dictates the type of memory copy.
 class ur_exp_image_copy_flags_v(IntEnum):
     HOST_TO_DEVICE = UR_BIT(0)                      ## Host to device
@@ -3116,9 +3121,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesImportOpaqueFDExp
 if __use_win_types:
-    _urBindlessImagesImportOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, c_ulong, POINTER(ur_exp_interop_mem_handle_t) )
+    _urBindlessImagesImportOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, ur_exp_file_descriptor_handle_t, POINTER(ur_exp_interop_mem_handle_t) )
 else:
-    _urBindlessImagesImportOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, c_ulong, POINTER(ur_exp_interop_mem_handle_t) )
+    _urBindlessImagesImportOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, ur_exp_file_descriptor_handle_t, POINTER(ur_exp_interop_mem_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesMapExternalArrayExp
@@ -3137,9 +3142,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
 if __use_win_types:
-    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(ur_exp_interop_semaphore_handle_t) )
+    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, ur_exp_file_descriptor_handle_t, POINTER(ur_exp_interop_semaphore_handle_t) )
 else:
-    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(ur_exp_interop_semaphore_handle_t) )
+    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, ur_exp_file_descriptor_handle_t, POINTER(ur_exp_interop_semaphore_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesDestroyExternalSemaphoreExp

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -6601,6 +6601,10 @@ typedef struct ur_exp_interop_mem_handle_t_ *ur_exp_interop_mem_handle_t;
 typedef struct ur_exp_interop_semaphore_handle_t_ *ur_exp_interop_semaphore_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Handle of file descriptor
+typedef struct ur_exp_file_descriptor_handle_t_ *ur_exp_file_descriptor_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Dictates the type of memory copy.
 typedef uint32_t ur_exp_image_copy_flags_t;
 typedef enum ur_exp_image_copy_flag_t {
@@ -7032,6 +7036,7 @@ urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///         + `NULL == hFileDescriptor`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -7039,11 +7044,11 @@ urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImportOpaqueFDExp(
-    ur_context_handle_t hContext,             ///< [in] handle of the context object
-    ur_device_handle_t hDevice,               ///< [in] handle of the device object
-    size_t size,                              ///< [in] size of the external memory
-    uint32_t fileDescriptor,                  ///< [in] the file descriptor
-    ur_exp_interop_mem_handle_t *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_context_handle_t hContext,                    ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                      ///< [in] handle of the device object
+    size_t size,                                     ///< [in] size of the external memory
+    ur_exp_file_descriptor_handle_t hFileDescriptor, ///< [in] the file descriptor handle
+    ur_exp_interop_mem_handle_t *phInteropMem        ///< [out] interop memory handle to the external memory
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7119,6 +7124,7 @@ urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///         + `NULL == hFileDescriptor`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phInteropSemaphoreHandle`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -7127,7 +7133,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext,                               ///< [in] handle of the context object
     ur_device_handle_t hDevice,                                 ///< [in] handle of the device object
-    uint32_t fileDescriptor,                                    ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t hFileDescriptor,            ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
 );
 
@@ -9198,7 +9204,7 @@ typedef struct ur_bindless_images_import_opaque_fd_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
     size_t *psize;
-    uint32_t *pfileDescriptor;
+    ur_exp_file_descriptor_handle_t *phFileDescriptor;
     ur_exp_interop_mem_handle_t **pphInteropMem;
 } ur_bindless_images_import_opaque_fd_exp_params_t;
 
@@ -9232,7 +9238,7 @@ typedef struct ur_bindless_images_release_interop_exp_params_t {
 typedef struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    uint32_t *pfileDescriptor;
+    ur_exp_file_descriptor_handle_t *phFileDescriptor;
     ur_exp_interop_semaphore_handle_t **pphInteropSemaphoreHandle;
 } ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1375,7 +1375,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportOpaqueFDExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
     size_t,
-    uint32_t,
+    ur_exp_file_descriptor_handle_t,
     ur_exp_interop_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1400,7 +1400,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseInteropExp_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreOpaqueFDExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    uint32_t,
+    ur_exp_file_descriptor_handle_t,
     ur_exp_interop_semaphore_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -119,6 +119,7 @@ Types
 * ${x}_exp_image_mem_handle_t
 * ${x}_exp_interop_mem_handle_t
 * ${x}_exp_interop_semaphore_handle_t
+* ${x}_exp_file_descriptor_handle_t
 
 Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -160,6 +161,8 @@ Changelog
 |          || Added mip filter mode.                                  |
 +----------+----------------------------------------------------------+
 | 3.0      | Added device query for bindless images on shared USM    |
++----------+---------------------------------------------------------+
+| 4.0      | Added opaque handle for file descriptors                |
 +----------+---------------------------------------------------------+
 
 Contributors

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -23,6 +23,11 @@ desc: "Handle of interop semaphore"
 class: $xBindlessImages
 name: "$x_exp_interop_semaphore_handle_t"
 --- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of file descriptor"
+class: $xBindlessImages
+name: "$x_exp_file_descriptor_handle_t"
+--- #--------------------------------------------------------------------------
 type: enum
 extend: true
 typed_etors: true
@@ -518,9 +523,9 @@ params:
     - type: size_t
       name: size
       desc: "[in] size of the external memory"
-    - type: uint32_t
-      name: fileDescriptor
-      desc: "[in] the file descriptor"
+    - type: $x_exp_file_descriptor_handle_t
+      name: hFileDescriptor
+      desc: "[in] the file descriptor handle"
     - type: $x_exp_interop_mem_handle_t*
       name: phInteropMem
       desc: "[out] interop memory handle to the external memory"
@@ -597,9 +602,9 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: uint32_t
-      name: fileDescriptor
-      desc: "[in] the file descriptor"
+    - type: $x_exp_file_descriptor_handle_t
+      name: hFileDescriptor
+      desc: "[in] the file descriptor handle"
     - type: $x_exp_interop_semaphore_handle_t*
       name: phInteropSemaphoreHandle
       desc: "[out] interop semaphore handle to the external semaphore"

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -4128,7 +4128,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
     ) try {
@@ -4138,7 +4139,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     auto pfnImportOpaqueFDExp =
         d_context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
     if (nullptr != pfnImportOpaqueFDExp) {
-        result = pfnImportOpaqueFDExp(hContext, hDevice, size, fileDescriptor,
+        result = pfnImportOpaqueFDExp(hContext, hDevice, size, hFileDescriptor,
                                       phInteropMem);
     } else {
         // generic implementation
@@ -4213,7 +4214,8 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
     ) try {
@@ -4225,7 +4227,7 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
             .pfnImportExternalSemaphoreOpaqueFDExp;
     if (nullptr != pfnImportExternalSemaphoreOpaqueFDExp) {
         result = pfnImportExternalSemaphoreOpaqueFDExp(
-            hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+            hContext, hDevice, hFileDescriptor, phInteropSemaphoreHandle);
     } else {
         // generic implementation
         *phInteropSemaphoreHandle =

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -9923,9 +9923,9 @@ inline std::ostream &operator<<(
     os << *(params->psize);
 
     os << ", ";
-    os << ".fileDescriptor = ";
+    os << ".hFileDescriptor = ";
 
-    os << *(params->pfileDescriptor);
+    ur_params::serializePtr(os, *(params->phFileDescriptor));
 
     os << ", ";
     os << ".phInteropMem = ";
@@ -10007,9 +10007,9 @@ operator<<(std::ostream &os, const struct
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-    os << ".fileDescriptor = ";
+    os << ".hFileDescriptor = ";
 
-    os << *(params->pfileDescriptor);
+    ur_params::serializePtr(os, *(params->phFileDescriptor));
 
     os << ", ";
     os << ".phInteropSemaphoreHandle = ";

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -4700,7 +4700,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -4712,13 +4713,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     }
 
     ur_bindless_images_import_opaque_fd_exp_params_t params = {
-        &hContext, &hDevice, &size, &fileDescriptor, &phInteropMem};
+        &hContext, &hDevice, &size, &hFileDescriptor, &phInteropMem};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
                              "urBindlessImagesImportOpaqueFDExp", &params);
 
     ur_result_t result = pfnImportOpaqueFDExp(hContext, hDevice, size,
-                                              fileDescriptor, phInteropMem);
+                                              hFileDescriptor, phInteropMem);
 
     context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
                        "urBindlessImagesImportOpaqueFDExp", &params, &result,
@@ -4800,7 +4801,8 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
 ) {
@@ -4813,13 +4815,13 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     }
 
     ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t params =
-        {&hContext, &hDevice, &fileDescriptor, &phInteropSemaphoreHandle};
+        {&hContext, &hDevice, &hFileDescriptor, &phInteropSemaphoreHandle};
     uint64_t instance = context.notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
         "urBindlessImagesImportExternalSemaphoreOpaqueFDExp", &params);
 
     ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, hFileDescriptor, phInteropSemaphoreHandle);
 
     context.notify_end(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -5955,7 +5955,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -5975,13 +5976,17 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
+        if (NULL == hFileDescriptor) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
         if (NULL == phInteropMem) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
     }
 
     ur_result_t result = pfnImportOpaqueFDExp(hContext, hDevice, size,
-                                              fileDescriptor, phInteropMem);
+                                              hFileDescriptor, phInteropMem);
 
     return result;
 }
@@ -6086,7 +6091,8 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
 ) {
@@ -6107,13 +6113,17 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
+        if (NULL == hFileDescriptor) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
         if (NULL == phInteropSemaphoreHandle) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
     }
 
     ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, hFileDescriptor, phInteropSemaphoreHandle);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -30,6 +30,7 @@ ur_exp_image_factory_t ur_exp_image_factory;
 ur_exp_image_mem_factory_t ur_exp_image_mem_factory;
 ur_exp_interop_mem_factory_t ur_exp_interop_mem_factory;
 ur_exp_interop_semaphore_factory_t ur_exp_interop_semaphore_factory;
+ur_exp_file_descriptor_factory_t ur_exp_file_descriptor_factory;
 ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5725,7 +5726,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -5745,8 +5747,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
+    // convert loader handle to platform handle
+    hFileDescriptor =
+        reinterpret_cast<ur_exp_file_descriptor_object_t *>(hFileDescriptor)
+            ->handle;
+
     // forward to device-platform
-    result = pfnImportOpaqueFDExp(hContext, hDevice, size, fileDescriptor,
+    result = pfnImportOpaqueFDExp(hContext, hDevice, size, hFileDescriptor,
                                   phInteropMem);
 
     if (UR_RESULT_SUCCESS != result) {
@@ -5856,7 +5863,8 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
 ) {
@@ -5876,9 +5884,14 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
+    // convert loader handle to platform handle
+    hFileDescriptor =
+        reinterpret_cast<ur_exp_file_descriptor_object_t *>(hFileDescriptor)
+            ->handle;
+
     // forward to device-platform
     result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, hFileDescriptor, phInteropSemaphoreHandle);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -83,6 +83,12 @@ using ur_exp_interop_semaphore_factory_t =
     singleton_factory_t<ur_exp_interop_semaphore_object_t,
                         ur_exp_interop_semaphore_handle_t>;
 
+using ur_exp_file_descriptor_object_t =
+    object_t<ur_exp_file_descriptor_handle_t>;
+using ur_exp_file_descriptor_factory_t =
+    singleton_factory_t<ur_exp_file_descriptor_object_t,
+                        ur_exp_file_descriptor_handle_t>;
+
 using ur_exp_command_buffer_object_t = object_t<ur_exp_command_buffer_handle_t>;
 using ur_exp_command_buffer_factory_t =
     singleton_factory_t<ur_exp_command_buffer_object_t,

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6303,6 +6303,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///         + `NULL == hFileDescriptor`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -6312,7 +6313,8 @@ ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
     ) try {
@@ -6322,7 +6324,7 @@ ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImportOpaqueFDExp(hContext, hDevice, size, fileDescriptor,
+    return pfnImportOpaqueFDExp(hContext, hDevice, size, hFileDescriptor,
                                 phInteropMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
@@ -6424,6 +6426,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///         + `NULL == hFileDescriptor`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phInteropSemaphoreHandle`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -6431,7 +6434,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
     ) try {
@@ -6443,7 +6447,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     }
 
     return pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, hFileDescriptor, phInteropSemaphoreHandle);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5325,6 +5325,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///         + `NULL == hFileDescriptor`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -5334,7 +5335,8 @@ ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -5423,6 +5425,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///         + `NULL == hFileDescriptor`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phInteropSemaphoreHandle`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -5430,7 +5433,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_file_descriptor_handle_t
+        hFileDescriptor, ///< [in] the file descriptor handle
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
 ) {


### PR DESCRIPTION
Add `ur_exp_file_descriptor_handle_t` to support platform dependent file descriptors.