### PR TITLE
[UR] Support platform dependant typedefs

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -11,6 +11,7 @@
  """
 import platform
 from ctypes import *
+from ctypes.wintypes import HANDLE
 from enum import *
 
 # ctypes does not define c_intptr_t, so let's define it here manually
@@ -459,6 +460,15 @@ class ur_rect_region_t(Structure):
         ("height", c_ulonglong),                                        ## [in] height (scalar)
         ("depth", c_ulonglong)                                          ## [in] scalar (scalar)
     ]
+
+###############################################################################
+## @brief File Descriptor type.
+if platform.system() == "Windows":
+    class ur_file_descriptor_t(HANDLE):
+        pass
+else:
+    class ur_file_descriptor_t(c_int):
+        pass
 
 ###############################################################################
 ## @brief Supported device initialization flags

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -21,7 +21,9 @@
 #include <stdint.h>
 #if defined(_WIN32)
 #define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
+#undef WIN32_LEAN_AND_MEAN
 #undef NOMINMAX
 #endif
 

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -490,6 +490,14 @@ typedef struct ur_rect_region_t {
 
 } ur_rect_region_t;
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief File Descriptor type.
+#if defined(_WIN32)
+typedef HANDLE ur_file_descriptor_t;
+#else
+typedef int ur_file_descriptor_t;
+#endif
+
 #if !defined(__GNUC__)
 #pragma endregion
 #endif

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -19,6 +19,9 @@
 // standard headers
 #include <stddef.h>
 #include <stdint.h>
+#if defined(_WIN32)
+#include "windows.h"
+#endif
 
 #if defined(__cplusplus)
 extern "C" {

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -20,7 +20,9 @@
 #include <stddef.h>
 #include <stdint.h>
 #if defined(_WIN32)
+#define NOMINMAX
 #include "windows.h"
+#undef NOMINMAX
 #endif
 
 #if defined(__cplusplus)

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -140,7 +140,12 @@ n/a
 * A typedef requires the following scalar fields: {`desc`, `name`, `value`}
   - `desc` will be used as the typedef's description comment
   - `name` must be a unique ISO-C standard identifier, start with `$` tag, be snake_case and end with `_t`
-  - `value` must be an ISO-C standard identifier
+  - `value` must either be:
+      - an ISO-C standard identifier
+      - a list of objects
+        - `if` must be by one of {`Linux`, `Windows`, `Darwin`}
+        - `else` must be None
+        - `value` must be an ISO-C standard identifier
 * A typedef may take the following optional scalar fields: {`class`, `condition`, `altvalue`, `ordinal`, `version`}
   - `class` will be used to scope the typedef declaration within the specified C++ class
   - `condition` will be used as a C/C++ preprocessor `#if` conditional expression

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -323,5 +323,5 @@ name: $x_file_descriptor_t
 value:
     - if: Windows
       value: HANDLE
-    - else: ""
+    - else:
       value: int

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -316,3 +316,12 @@ members:
     - type: uint64_t
       name: depth
       desc: "[in] scalar (scalar)"
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "File Descriptor type."
+name: $x_file_descriptor_t
+value:
+    - if: Windows
+      value: HANDLE
+    - else: ""
+      value: int

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -347,6 +347,22 @@ def _validate_doc(f, d, tags, line_num):
         if d.get('tag') is None:
             raise Exception(f"{d['name']} must include a 'tag' part of the union.")
         
+
+    def __validate_typedef_values(d):
+        if not isinstance(d['value'], list):
+            return
+    
+        for cond in d['value']:
+            if not ('if' in cond or 'else' in cond):
+                raise Exception("typedef values must include an 'if' or 'else' field")
+            
+            valid_platforms = ['Linux', 'Windows', 'Darwin']
+            if 'if' in cond and cond['if'] not in valid_platforms:
+                raise Exception(f"Invalid platform selected '{cond['if']}' : must be one of {valid_platforms}")
+            
+            if 'else' in cond and cond['else'] is not None:
+                raise Exception("typedef 'else' field is required to be None")
+
     try:
         if 'type' not in d:
             raise Exception("every document must have 'type'")
@@ -381,6 +397,7 @@ def _validate_doc(f, d, tags, line_num):
                 raise Exception("'typedef' requires the following scalar fields: {`desc`, `name`, `value`}")
 
             __validate_type(d, 'name', tags)
+            __validate_typedef_values(d)
             __validate_details(d)
             __validate_ordinal(d)
             __validate_version(d)

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -32,6 +32,9 @@ from templates import helper as th
 // standard headers
 #include <stdint.h>
 #include <stddef.h>
+#if defined(_WIN32)
+#include "windows.h"
+#endif
 %endif
 
 #if defined(__cplusplus)
@@ -75,14 +78,13 @@ extern "C" {
 %if isinstance(obj['value'], list):
 <% first = True%>\
 %for cond in obj['value']:
-%if cond.get('if') is not None:
+%if 'if' in cond:
 ${"#if" if first else "#elif"} ${th.convert_platform_to_define(cond['if'])}
 <% first = False %>\
-typedef ${th.subt(n, tags, cond['value'])} ${th.make_type_name(n, tags, obj)};
-%elif cond.get('else') is not None:
+%elif 'else' in cond:
 #else
-typedef ${th.subt(n, tags, cond['value'])} ${th.make_type_name(n, tags, obj)};
 %endif
+typedef ${th.subt(n, tags, cond['value'])} ${th.make_type_name(n, tags, obj)};
 %endfor
 #endif
 %else:

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -72,7 +72,22 @@ extern "C" {
 %endif
 ## TYPEDEF ####################################################################
 %elif re.match(r"typedef", obj['type']):
+%if isinstance(obj['value'], list):
+<% first = True%>\
+%for cond in obj['value']:
+%if cond.get('if') is not None:
+${"#if" if first else "#elif"} ${th.convert_platform_to_define(cond['if'])}
+<% first = False %>\
+typedef ${th.subt(n, tags, cond['value'])} ${th.make_type_name(n, tags, obj)};
+%elif cond.get('else') is not None:
+#else
+typedef ${th.subt(n, tags, cond['value'])} ${th.make_type_name(n, tags, obj)};
+%endif
+%endfor
+#endif
+%else:
 typedef ${th.subt(n, tags, obj['value'])} ${th.make_type_name(n, tags, obj)};
+%endif
 ## FPTR TYPEDEF ###############################################################
 %elif re.match(r"fptr_typedef", obj['type']):
 typedef ${th.subt(n, tags, obj['return'])} (*${th.make_func_name(n, tags, obj)})(

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -33,7 +33,9 @@ from templates import helper as th
 #include <stdint.h>
 #include <stddef.h>
 #if defined(_WIN32)
+#define NOMINMAX
 #include "windows.h"
+#undef NOMINMAX
 #endif
 %endif
 

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -34,7 +34,9 @@ from templates import helper as th
 #include <stddef.h>
 #if defined(_WIN32)
 #define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
+#undef WIN32_LEAN_AND_MEAN
 #undef NOMINMAX
 #endif
 %endif

--- a/scripts/templates/api.py.mako
+++ b/scripts/templates/api.py.mako
@@ -54,9 +54,9 @@ ${th.make_macro_name(n, tags, obj)} = ${th.subt(n, tags, obj['value'])}
 %if isinstance(obj['value'], list):
 <% first = True%>\
 %for cond in obj['value']:
-%if cond.get('if') is not None:
+%if 'if' in cond:
 ${"if" if first else "elif"} platform.system() == "${cond['if']}":<% first = False %>
-%elif cond.get('else') is not None:
+%elif 'else' in cond:
 else:
 %endif
     class ${th.make_type_name(n, tags, obj)}(${th.get_ctype_name(n, tags, {'type': cond['value']})}):

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -1258,3 +1258,12 @@ def get_create_retain_release_functions(specs, namespace, tags):
     )
 
     return {"create": create_funcs, "retain": retain_funcs, "release": release_funcs}
+
+def convert_platform_to_define(platform:str ) -> str:
+    if platform == "Windows":
+        return "defined(_WIN32)"
+    if platform == "Linux":
+        return "defined(__linux__)"
+    if platform == "Darwin":
+        return "defined(__APPLE__)"
+    raise Exception(f"Invalid Platform: {platform}")


### PR DESCRIPTION
This PR will enable platform dependent types to be defined as part of the UR specification. The supported platform types are: "Windows", "Linux" & "Darwin". This is useful to model platform specific types in UR such as a file descriptor.

#### TODO
- [x] Document new syntax on `typedef` value in YaML.md
- [x] Introduce validation checks for new yaml syntax
- [x] Clean up code generation
- [x] See if `windows.h` has to be included since we refer to `HANDLE`


Closes #704 