### PR TITLE
Update adapter branch with newer CUDA plugin version

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -63,7 +63,9 @@ function(FetchSource GIT_REPOSITORY GIT_TAG GIT_DIR DEST)
     message(STATUS "Fetching sparse source ${GIT_DIR} from ${GIT_REPOSITORY} ${GIT_TAG}")
     IF(NOT EXISTS ${DEST})
         file(MAKE_DIRECTORY ${DEST})
-        execute_process(COMMAND git init -b main
+        execute_process(COMMAND git init
+            WORKING_DIRECTORY ${DEST})
+        execute_process(COMMAND git checkout -b main
             WORKING_DIRECTORY ${DEST})
         execute_process(COMMAND git remote add origin ${GIT_REPOSITORY}
             WORKING_DIRECTORY ${DEST})

--- a/include/ur.py
+++ b/include/ur.py
@@ -2031,6 +2031,10 @@ class ur_function_v(IntEnum):
     USM_P2P_ENABLE_PEER_ACCESS_EXP = 165            ## Enumerator for ::urUsmP2PEnablePeerAccessExp
     USM_P2P_DISABLE_PEER_ACCESS_EXP = 166           ## Enumerator for ::urUsmP2PDisablePeerAccessExp
     USM_P2P_PEER_ACCESS_GET_INFO_EXP = 167          ## Enumerator for ::urUsmP2PPeerAccessGetInfoExp
+    COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP = 168 ## Enumerator for ::urCommandBufferAppendMembufferWriteExp
+    COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP = 169  ## Enumerator for ::urCommandBufferAppendMembufferReadExp
+    COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP = 170## Enumerator for ::urCommandBufferAppendMembufferWriteRectExp
+    COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP = 171 ## Enumerator for ::urCommandBufferAppendMembufferReadRectExp
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -3340,11 +3344,39 @@ else:
     _urCommandBufferAppendMembufferCopyExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
+## @brief Function-pointer for urCommandBufferAppendMembufferWriteExp
+if __use_win_types:
+    _urCommandBufferAppendMembufferWriteExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferAppendMembufferWriteExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferAppendMembufferReadExp
+if __use_win_types:
+    _urCommandBufferAppendMembufferReadExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferAppendMembufferReadExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
 ## @brief Function-pointer for urCommandBufferAppendMembufferCopyRectExp
 if __use_win_types:
     _urCommandBufferAppendMembufferCopyRectExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 else:
     _urCommandBufferAppendMembufferCopyRectExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferAppendMembufferWriteRectExp
+if __use_win_types:
+    _urCommandBufferAppendMembufferWriteRectExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferAppendMembufferWriteRectExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+
+###############################################################################
+## @brief Function-pointer for urCommandBufferAppendMembufferReadRectExp
+if __use_win_types:
+    _urCommandBufferAppendMembufferReadRectExp_t = WINFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
+else:
+    _urCommandBufferAppendMembufferReadRectExp_t = CFUNCTYPE( ur_result_t, ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, c_size_t, c_size_t, c_size_t, c_size_t, c_void_p, c_ulong, POINTER(ur_exp_command_buffer_sync_point_t), POINTER(ur_exp_command_buffer_sync_point_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urCommandBufferEnqueueExp
@@ -3365,7 +3397,11 @@ class ur_command_buffer_exp_dditable_t(Structure):
         ("pfnAppendKernelLaunchExp", c_void_p),                         ## _urCommandBufferAppendKernelLaunchExp_t
         ("pfnAppendMemcpyUSMExp", c_void_p),                            ## _urCommandBufferAppendMemcpyUSMExp_t
         ("pfnAppendMembufferCopyExp", c_void_p),                        ## _urCommandBufferAppendMembufferCopyExp_t
+        ("pfnAppendMembufferWriteExp", c_void_p),                       ## _urCommandBufferAppendMembufferWriteExp_t
+        ("pfnAppendMembufferReadExp", c_void_p),                        ## _urCommandBufferAppendMembufferReadExp_t
         ("pfnAppendMembufferCopyRectExp", c_void_p),                    ## _urCommandBufferAppendMembufferCopyRectExp_t
+        ("pfnAppendMembufferWriteRectExp", c_void_p),                   ## _urCommandBufferAppendMembufferWriteRectExp_t
+        ("pfnAppendMembufferReadRectExp", c_void_p),                    ## _urCommandBufferAppendMembufferReadRectExp_t
         ("pfnEnqueueExp", c_void_p)                                     ## _urCommandBufferEnqueueExp_t
     ]
 
@@ -3867,7 +3903,11 @@ class UR_DDI:
         self.urCommandBufferAppendKernelLaunchExp = _urCommandBufferAppendKernelLaunchExp_t(self.__dditable.CommandBufferExp.pfnAppendKernelLaunchExp)
         self.urCommandBufferAppendMemcpyUSMExp = _urCommandBufferAppendMemcpyUSMExp_t(self.__dditable.CommandBufferExp.pfnAppendMemcpyUSMExp)
         self.urCommandBufferAppendMembufferCopyExp = _urCommandBufferAppendMembufferCopyExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferCopyExp)
+        self.urCommandBufferAppendMembufferWriteExp = _urCommandBufferAppendMembufferWriteExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferWriteExp)
+        self.urCommandBufferAppendMembufferReadExp = _urCommandBufferAppendMembufferReadExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferReadExp)
         self.urCommandBufferAppendMembufferCopyRectExp = _urCommandBufferAppendMembufferCopyRectExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferCopyRectExp)
+        self.urCommandBufferAppendMembufferWriteRectExp = _urCommandBufferAppendMembufferWriteRectExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferWriteRectExp)
+        self.urCommandBufferAppendMembufferReadRectExp = _urCommandBufferAppendMembufferReadRectExp_t(self.__dditable.CommandBufferExp.pfnAppendMembufferReadRectExp)
         self.urCommandBufferEnqueueExp = _urCommandBufferEnqueueExp_t(self.__dditable.CommandBufferExp.pfnEnqueueExp)
 
         # call driver to get function pointers

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -5332,6 +5332,10 @@ typedef enum ur_function_t {
     UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP = 165,                          ///< Enumerator for ::urUsmP2PEnablePeerAccessExp
     UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP = 166,                         ///< Enumerator for ::urUsmP2PDisablePeerAccessExp
     UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP = 167,                        ///< Enumerator for ::urUsmP2PPeerAccessGetInfoExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP = 168,               ///< Enumerator for ::urCommandBufferAppendMembufferWriteExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP = 169,                ///< Enumerator for ::urCommandBufferAppendMembufferReadExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP = 170,          ///< Enumerator for ::urCommandBufferAppendMembufferWriteRectExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP = 171,           ///< Enumerator for ::urCommandBufferAppendMembufferReadRectExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7378,6 +7382,72 @@ urCommandBufferAppendMembufferCopyExp(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory write command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer,                                      ///< [in] handle of the buffer object.
+    size_t offset,                                                ///< [in] offset in bytes in the buffer object.
+    size_t size,                                                  ///< [in] size in bytes of data being written.
+    const void *pSrc,                                             ///< [in] pointer to host memory where data is to be written from.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory read command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer,                                      ///< [in] handle of the buffer object.
+    size_t offset,                                                ///< [in] offset in bytes in the buffer object.
+    size_t size,                                                  ///< [in] size in bytes of data being written.
+    void *pDst,                                                   ///< [in] pointer to host memory where data is to be written to.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Append a rectangular memory copy command to a command-buffer object
 ///
 /// @returns
@@ -7409,6 +7479,87 @@ urCommandBufferAppendMembufferCopyRectExp(
     size_t srcSlicePitch,                                         ///< [in] Slice pitch of the source memory.
     size_t dstRowPitch,                                           ///< [in] Row pitch of the destination memory.
     size_t dstSlicePitch,                                         ///< [in] Slice pitch of the destination memory.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory write command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer,                                      ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset,                                ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,                                  ///< [in] 3D offset in the host region.
+    ur_rect_region_t region,                                      ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t bufferRowPitch,                                        ///< [in] length of each row in bytes in the buffer object.
+    size_t bufferSlicePitch,                                      ///< [in] length of each 2D slice in bytes in the buffer object being
+                                                                  ///< written.
+    size_t hostRowPitch,                                          ///< [in] length of each row in bytes in the host memory region pointed to
+                                                                  ///< by pSrc.
+    size_t hostSlicePitch,                                        ///< [in] length of each 2D slice in bytes in the host memory region
+                                                                  ///< pointed to by pSrc.
+    void *pSrc,                                                   ///< [in] pointer to host memory where data is to be written from.
+    uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory read command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+UR_APIEXPORT ur_result_t UR_APICALL
+urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer,                                      ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset,                                ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,                                  ///< [in] 3D offset in the host region.
+    ur_rect_region_t region,                                      ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t bufferRowPitch,                                        ///< [in] length of each row in bytes in the buffer object.
+    size_t bufferSlicePitch,                                      ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t hostRowPitch,                                          ///< [in] length of each row in bytes in the host memory region pointed to
+                                                                  ///< by pDst.
+    size_t hostSlicePitch,                                        ///< [in] length of each 2D slice in bytes in the host memory region
+                                                                  ///< pointed to by pDst.
+    void *pDst,                                                   ///< [in] pointer to host memory where data is to be read into.
     uint32_t numSyncPointsInWaitList,                             ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
     ur_exp_command_buffer_sync_point_t *pSyncPoint                ///< [out][optional] sync point associated with this command
@@ -9256,6 +9407,36 @@ typedef struct ur_command_buffer_append_membuffer_copy_exp_params_t {
 } ur_command_buffer_append_membuffer_copy_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferAppendMembufferWriteExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_append_membuffer_write_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_mem_handle_t *phBuffer;
+    size_t *poffset;
+    size_t *psize;
+    const void **ppSrc;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_append_membuffer_write_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferAppendMembufferReadExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_append_membuffer_read_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_mem_handle_t *phBuffer;
+    size_t *poffset;
+    size_t *psize;
+    void **ppDst;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_append_membuffer_read_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urCommandBufferAppendMembufferCopyRectExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -9274,6 +9455,46 @@ typedef struct ur_command_buffer_append_membuffer_copy_rect_exp_params_t {
     const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
     ur_exp_command_buffer_sync_point_t **ppSyncPoint;
 } ur_command_buffer_append_membuffer_copy_rect_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferAppendMembufferWriteRectExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_append_membuffer_write_rect_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_mem_handle_t *phBuffer;
+    ur_rect_offset_t *pbufferOffset;
+    ur_rect_offset_t *phostOffset;
+    ur_rect_region_t *pregion;
+    size_t *pbufferRowPitch;
+    size_t *pbufferSlicePitch;
+    size_t *phostRowPitch;
+    size_t *phostSlicePitch;
+    void **ppSrc;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_append_membuffer_write_rect_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urCommandBufferAppendMembufferReadRectExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_command_buffer_append_membuffer_read_rect_exp_params_t {
+    ur_exp_command_buffer_handle_t *phCommandBuffer;
+    ur_mem_handle_t *phBuffer;
+    ur_rect_offset_t *pbufferOffset;
+    ur_rect_offset_t *phostOffset;
+    ur_rect_region_t *pregion;
+    size_t *pbufferRowPitch;
+    size_t *pbufferSlicePitch;
+    size_t *phostRowPitch;
+    size_t *phostSlicePitch;
+    void **ppDst;
+    uint32_t *pnumSyncPointsInWaitList;
+    const ur_exp_command_buffer_sync_point_t **ppSyncPointWaitList;
+    ur_exp_command_buffer_sync_point_t **ppSyncPoint;
+} ur_command_buffer_append_membuffer_read_rect_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urCommandBufferEnqueueExp

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1676,6 +1676,30 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferCopyExp_t)(
     ur_exp_command_buffer_sync_point_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferAppendMembufferWriteExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferWriteExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_mem_handle_t,
+    size_t,
+    size_t,
+    const void *,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferAppendMembufferReadExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferReadExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_mem_handle_t,
+    size_t,
+    size_t,
+    void *,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urCommandBufferAppendMembufferCopyRectExp
 typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferCopyRectExp_t)(
     ur_exp_command_buffer_handle_t,
@@ -1688,6 +1712,40 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferCopyRectExp_t)
     size_t,
     size_t,
     size_t,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferAppendMembufferWriteRectExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferWriteRectExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_mem_handle_t,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    size_t,
+    size_t,
+    void *,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urCommandBufferAppendMembufferReadRectExp
+typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferAppendMembufferReadRectExp_t)(
+    ur_exp_command_buffer_handle_t,
+    ur_mem_handle_t,
+    ur_rect_offset_t,
+    ur_rect_offset_t,
+    ur_rect_region_t,
+    size_t,
+    size_t,
+    size_t,
+    size_t,
+    void *,
     uint32_t,
     const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *);
@@ -1711,7 +1769,11 @@ typedef struct ur_command_buffer_exp_dditable_t {
     ur_pfnCommandBufferAppendKernelLaunchExp_t pfnAppendKernelLaunchExp;
     ur_pfnCommandBufferAppendMemcpyUSMExp_t pfnAppendMemcpyUSMExp;
     ur_pfnCommandBufferAppendMembufferCopyExp_t pfnAppendMembufferCopyExp;
+    ur_pfnCommandBufferAppendMembufferWriteExp_t pfnAppendMembufferWriteExp;
+    ur_pfnCommandBufferAppendMembufferReadExp_t pfnAppendMembufferReadExp;
     ur_pfnCommandBufferAppendMembufferCopyRectExp_t pfnAppendMembufferCopyRectExp;
+    ur_pfnCommandBufferAppendMembufferWriteRectExp_t pfnAppendMembufferWriteRectExp;
+    ur_pfnCommandBufferAppendMembufferReadRectExp_t pfnAppendMembufferReadRectExp;
     ur_pfnCommandBufferEnqueueExp_t pfnEnqueueExp;
 } ur_command_buffer_exp_dditable_t;
 

--- a/scripts/core/EXP-COMMAND-BUFFER.rst
+++ b/scripts/core/EXP-COMMAND-BUFFER.rst
@@ -94,7 +94,11 @@ Currently only the following commands are supported:
 * ${x}CommandBufferAppendMemcpyUSMExp
 * ${x}CommandBufferAppendMembufferCopyExp
 * ${x}CommandBufferAppendMembufferCopyRectExp
-
+* ${x}CommandBufferAppendMembufferReadExp
+* ${x}CommandBufferAppendMembufferReadRectExp
+* ${x}CommandBufferAppendMembufferWriteExp
+* ${x}CommandBufferAppendMembufferWriteRectExp
+  
 It is planned to eventually support any command type from the Core API which can
 actually be appended to the equiavalent adapter native constructs.
 
@@ -161,6 +165,11 @@ Enums
     * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMCPY_USM_EXP
     * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_EXP
     * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP
+    * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP
+    * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP
+    * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP
+    * ${X}_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP
+
 
 
 Types
@@ -180,19 +189,25 @@ Functions
 * ${x}CommandBufferAppendMemcpyUSMExp
 * ${x}CommandBufferAppendMembufferCopyExp
 * ${x}CommandBufferAppendMembufferCopyRectExp
+* ${x}CommandBufferAppendMembufferReadExp
+* ${x}CommandBufferAppendMembufferReadRectExp
+* ${x}CommandBufferAppendMembufferWriteExp
+* ${x}CommandBufferAppendMembufferWriteRectExp
 * ${x}CommandBufferEnqueueExp
 
 Changelog
 --------------------------------------------------------------------------------
 
-+-----------+------------------------+
-| Revision  | Changes                |
-+===========+========================+
-| 1.0       | Initial Draft           |
-+-----------+------------------------+
++-----------+-------------------------------------------------------+
+| Revision  | Changes                                               |
++===========+=======================================================+
+| 1.0       | Initial Draft                                         |
+| 1.1       | add function definitions for buffer read and write    |
++-----------+-------------------------------------------------------+
 
 Contributors
 --------------------------------------------------------------------------------
 
 * Ben Tracy `ben.tracy@codeplay.com <ben.tracy@codeplay.com>`_
 * Ewan Crawford `ewan@codeplay.com <ewan@codeplay.com>`_
+* Maxime France-Pillois `maxime.francepillois@codeplay.com <maxime.francepillois@codeplay.com>`_

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -259,6 +259,84 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
+desc: "Append a memory write command to a command-buffer object"
+class: $xCommandBuffer
+name: AppendMembufferWriteExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: $x_mem_handle_t
+      name: hBuffer
+      desc: "[in] handle of the buffer object."
+    - type: "size_t"
+      name: offset
+      desc: "[in] offset in bytes in the buffer object."
+    - type: "size_t"
+      name: size
+      desc: "[in] size in bytes of data being written."
+    - type: "const void*"
+      name: pSrc
+      desc: "[in] pointer to host memory where data is to be written from."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pSyncPointWaitList
+      desc: "[in][optional] A list of sync points that this command depends on."
+    - type: "$x_exp_command_buffer_sync_point_t*"
+      name: pSyncPoint
+      desc: "[out][optional] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a memory read command to a command-buffer object"
+class: $xCommandBuffer
+name: AppendMembufferReadExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: $x_mem_handle_t
+      name: hBuffer
+      desc: "[in] handle of the buffer object."
+    - type: "size_t"
+      name: offset
+      desc: "[in] offset in bytes in the buffer object."
+    - type: "size_t"
+      name: size
+      desc: "[in] size in bytes of data being written."
+    - type: "void*"
+      name: pDst
+      desc: "[in] pointer to host memory where data is to be written to."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pSyncPointWaitList
+      desc: "[in][optional] A list of sync points that this command depends on."
+    - type: "$x_exp_command_buffer_sync_point_t*"
+      name: pSyncPoint
+      desc: "[out][optional] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: function
 desc: "Append a rectangular memory copy command to a command-buffer object"
 class: $xCommandBuffer
 name: AppendMembufferCopyRectExp
@@ -293,6 +371,114 @@ params:
     - type: "size_t"
       name: dstSlicePitch
       desc: "[in] Slice pitch of the destination memory."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pSyncPointWaitList
+      desc: "[in][optional] A list of sync points that this command depends on."
+    - type: $x_exp_command_buffer_sync_point_t*
+      name: pSyncPoint
+      desc: "[out][optional] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a rectangular memory write command to a command-buffer object"
+class: $xCommandBuffer
+name: AppendMembufferWriteRectExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: $x_mem_handle_t
+      name: hBuffer
+      desc: "[in] handle of the buffer object."
+    - type: $x_rect_offset_t
+      name: bufferOffset
+      desc: "[in] 3D offset in the buffer."
+    - type: $x_rect_offset_t
+      name: hostOffset
+      desc: "[in] 3D offset in the host region."
+    - type: $x_rect_region_t
+      name: region
+      desc: "[in] 3D rectangular region descriptor: width, height, depth."
+    - type: "size_t"
+      name: bufferRowPitch
+      desc: "[in] length of each row in bytes in the buffer object."
+    - type: "size_t"
+      name: bufferSlicePitch
+      desc: "[in] length of each 2D slice in bytes in the buffer object being written."
+    - type: "size_t"
+      name: hostRowPitch
+      desc: "[in] length of each row in bytes in the host memory region pointed to by pSrc."
+    - type: "size_t"
+      name: hostSlicePitch
+      desc: "[in] length of each 2D slice in bytes in the host memory region pointed to by pSrc."
+    - type: "void*"
+      name: pSrc
+      desc: "[in] pointer to host memory where data is to be written from."
+    - type: uint32_t
+      name: numSyncPointsInWaitList
+      desc: "[in] The number of sync points in the provided dependency list."
+    - type: "const $x_exp_command_buffer_sync_point_t*"
+      name: pSyncPointWaitList
+      desc: "[in][optional] A list of sync points that this command depends on."
+    - type: $x_exp_command_buffer_sync_point_t*
+      name: pSyncPoint
+      desc: "[out][optional] sync point associated with this command"
+returns:
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+    - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
+        - "`pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`"
+        - "`pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`"
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Append a rectangular memory read command to a command-buffer object"
+class: $xCommandBuffer
+name: AppendMembufferReadRectExp
+params:
+    - type: $x_exp_command_buffer_handle_t
+      name: hCommandBuffer
+      desc: "[in] handle of the command-buffer object."
+    - type: $x_mem_handle_t
+      name: hBuffer
+      desc: "[in] handle of the buffer object."
+    - type: $x_rect_offset_t
+      name: bufferOffset
+      desc: "[in] 3D offset in the buffer."
+    - type: $x_rect_offset_t
+      name: hostOffset
+      desc: "[in] 3D offset in the host region."
+    - type: $x_rect_region_t
+      name: region
+      desc: "[in] 3D rectangular region descriptor: width, height, depth."
+    - type: "size_t"
+      name: bufferRowPitch
+      desc: "[in] length of each row in bytes in the buffer object."
+    - type: "size_t"
+      name: bufferSlicePitch
+      desc: "[in] length of each 2D slice in bytes in the buffer object being read."
+    - type: "size_t"
+      name: hostRowPitch
+      desc: "[in] length of each row in bytes in the host memory region pointed to by pDst."
+    - type: "size_t"
+      name: hostSlicePitch
+      desc: "[in] length of each 2D slice in bytes in the host memory region pointed to by pDst."
+    - type: "void*"
+      name: pDst
+      desc: "[in] pointer to host memory where data is to be read into."
     - type: uint32_t
       name: numSyncPointsInWaitList
       desc: "[in] The number of sync points in the provided dependency list."

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -490,3 +490,15 @@ etors:
 - name: USM_P2P_PEER_ACCESS_GET_INFO_EXP
   desc: Enumerator for $xUsmP2PPeerAccessGetInfoExp
   value: '167'
+- name: COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP
+  desc: Enumerator for $xCommandBufferAppendMembufferWriteExp
+  value: '168'
+- name: COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP
+  desc: Enumerator for $xCommandBufferAppendMembufferReadExp
+  value: '169'
+- name: COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP
+  desc: Enumerator for $xCommandBufferAppendMembufferWriteRectExp
+  value: '170'
+- name: COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP
+  desc: Enumerator for $xCommandBufferAppendMembufferReadRectExp
+  value: '171'

--- a/source/adapters/0001-SYCL-CUDA-remove-sycl-namespaces-from-ur-adapter.patch
+++ b/source/adapters/0001-SYCL-CUDA-remove-sycl-namespaces-from-ur-adapter.patch
@@ -1,23 +1,174 @@
-From e30434a4a9e893f24e0bb18051576f297d1f4f08 Mon Sep 17 00:00:00 2001
+From fd78871a6bd2ff41ff37b8bd786c17f59911c677 Mon Sep 17 00:00:00 2001
 From: pbalcer <piotr.balcer@intel.com>
-Date: Thu, 29 Jun 2023 14:26:26 +0200
-Subject: [PATCH] [SYCL][CUDA] remove sycl namespaces from ur adapter
+Date: Thu, 29 Jun 2023 15:11:43 +0200
+Subject: [PATCH] [SYCL][CUDA] remove sycl dependencies from cuda ur adapter
 
+This was preventing out-of-tree build of the adapter for standalone
+use with unified runtime.
+
+Signed-off-by: Piotr Balcer <piotr.balcer@intel.com>
 ---
+ .../ur/adapters/cuda/command_buffer.cpp       |  52 ++---
  .../ur/adapters/cuda/common.cpp               |   6 +-
  .../ur/adapters/cuda/common.hpp               |   5 -
  .../ur/adapters/cuda/context.cpp              |   2 +-
- .../ur/adapters/cuda/device.cpp               | 170 +++++++++---------
+ .../ur/adapters/cuda/device.cpp               | 209 +++++++++---------
  .../ur/adapters/cuda/enqueue.cpp              |   2 +-
- .../ur/adapters/cuda/event.cpp                |  12 +-
- .../ur/adapters/cuda/kernel.cpp               |  26 +--
- .../ur/adapters/cuda/memory.cpp               |   4 +-
+ .../ur/adapters/cuda/event.cpp                |  17 +-
+ .../ur/adapters/cuda/kernel.cpp               |  42 ++--
+ .../ur/adapters/cuda/memory.cpp               |   5 +-
  .../ur/adapters/cuda/queue.cpp                |   2 +-
  .../ur/adapters/cuda/sampler.cpp              |   2 +-
- 10 files changed, 113 insertions(+), 118 deletions(-)
+ 11 files changed, 167 insertions(+), 177 deletions(-)
 
+diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+index c83e9e732303..57956cb64a67 100644
+--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
++++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+@@ -19,8 +19,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
+   (void)hDevice;
+   (void)pCommandBufferDesc;
+   (void)phCommandBuffer;
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -28,8 +28,8 @@ UR_APIEXPORT ur_result_t UR_APICALL
+ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
+   (void)hCommandBuffer;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -37,8 +37,8 @@ UR_APIEXPORT ur_result_t UR_APICALL
+ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
+   (void)hCommandBuffer;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -46,8 +46,8 @@ UR_APIEXPORT ur_result_t UR_APICALL
+ urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
+   (void)hCommandBuffer;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -68,8 +68,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -86,8 +86,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemcpyUSMExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -107,8 +107,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -134,8 +134,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -155,8 +155,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -175,8 +175,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -203,8 +203,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -232,8 +232,8 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+   (void)pSyncPointWaitList;
+   (void)pSyncPoint;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
+ 
+@@ -247,7 +247,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+   (void)phEventWaitList;
+   (void)phEvent;
+ 
+-  sycl::detail::ur::die("Experimental Command-buffer feature is not "
+-                        "implemented for CUDA adapter.");
++  detail::ur::die("Experimental Command-buffer feature is not "
++                  "implemented for CUDA adapter.");
+   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+ }
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
-index 86975e509..83264160e 100644
+index 86975e509725..83264160e700 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
 @@ -72,17 +72,17 @@ std::string getCudaVersionString() {
@@ -42,7 +193,7 @@ index 86975e509..83264160e 100644
  }
  
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
-index 5cfa60901..82b38c10d 100644
+index 5cfa609018b2..82b38c10d449 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
 @@ -8,7 +8,6 @@
@@ -69,7 +220,7 @@ index 5cfa60901..82b38c10d 100644
 -} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 -} // namespace sycl
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/context.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/context.cpp
-index 74a32bdac..2b621383d 100644
+index 74a32bdac274..2b621383da09 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/context.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/context.cpp
 @@ -66,7 +66,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetInfo(
@@ -82,7 +233,7 @@ index 74a32bdac..2b621383d 100644
                               CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
                               hContext->getDevice()->get()) == CUDA_SUCCESS);
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
-index 24f9d52a0..c6b6bc07e 100644
+index 52d4e3badc8f..a81599d629a7 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
 @@ -15,7 +15,7 @@
@@ -177,7 +328,7 @@ index 24f9d52a0..c6b6bc07e 100644
  
      return ReturnValue(size_t(MaxWorkGroupSize));
    }
-@@ -172,12 +172,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -172,14 +172,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS: {
      // Number of sub-groups = max block size / warp size + possible remainder
      int MaxThreads = 0;
@@ -188,10 +339,14 @@ index 24f9d52a0..c6b6bc07e 100644
                               hDevice->get()) == CUDA_SUCCESS);
      int WarpSize = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
+-                             hDevice->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetAttribute(&WarpSize,
++                                               CU_DEVICE_ATTRIBUTE_WARP_SIZE,
++                                               hDevice->get()) == CUDA_SUCCESS);
      int MaxWarps = (MaxThreads + WarpSize - 1) / WarpSize;
+     return ReturnValue(MaxWarps);
+   }
 @@ -187,7 +187,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      // Volta provides independent thread scheduling
      // TODO: Revisit for previous generation GPUs
@@ -228,37 +383,43 @@ index 24f9d52a0..c6b6bc07e 100644
          cuDeviceGetAttribute(&Major,
                               CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
                               hDevice->get()) == CUDA_SUCCESS);
-@@ -266,7 +266,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -266,18 +266,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
      // NVIDIA devices only support one sub-group size (the warp size)
      int WarpSize = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
+-                             hDevice->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetAttribute(&WarpSize,
++                                               CU_DEVICE_ATTRIBUTE_WARP_SIZE,
++                                               hDevice->get()) == CUDA_SUCCESS);
      size_t Sizes[1] = {static_cast<size_t>(WarpSize)};
-@@ -274,10 +274,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+     return ReturnValue(Sizes, 1);
    }
    case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY: {
      int ClockFreq = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
+-                             hDevice->get()) == CUDA_SUCCESS);
 -    sycl::detail::ur::assertion(ClockFreq >= 0);
++    detail::ur::assertion(cuDeviceGetAttribute(&ClockFreq,
++                                               CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
++                                               hDevice->get()) == CUDA_SUCCESS);
 +    detail::ur::assertion(ClockFreq >= 0);
      return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
    }
    case UR_DEVICE_INFO_ADDRESS_BITS: {
-@@ -292,7 +292,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -292,8 +292,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      // CL_DEVICE_TYPE_CUSTOM.
  
      size_t Global = 0;
 -    sycl::detail::ur::assertion(cuDeviceTotalMem(&Global, hDevice->get()) ==
+-                                CUDA_SUCCESS);
 +    detail::ur::assertion(cuDeviceTotalMem(&Global, hDevice->get()) ==
-                                 CUDA_SUCCESS);
++                          CUDA_SUCCESS);
  
      auto QuarterGlobal = static_cast<uint32_t>(Global / 4u);
+ 
 @@ -308,7 +308,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      if (std::getenv("SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT") != nullptr) {
        Enabled = true;
@@ -426,8 +587,9 @@ index 24f9d52a0..c6b6bc07e 100644
      size_t Bytes = 0;
      // Runtime API has easy access to this value, driver API info is scarse.
 -    sycl::detail::ur::assertion(cuDeviceTotalMem(&Bytes, hDevice->get()) ==
+-                                CUDA_SUCCESS);
 +    detail::ur::assertion(cuDeviceTotalMem(&Bytes, hDevice->get()) ==
-                                 CUDA_SUCCESS);
++                          CUDA_SUCCESS);
      return ReturnValue(uint64_t{Bytes});
    }
    case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
@@ -458,9 +620,11 @@ index 24f9d52a0..c6b6bc07e 100644
    case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
      int ECCEnabled = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED,
+-                             hDevice->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetAttribute(&ECCEnabled,
++                                               CU_DEVICE_ATTRIBUTE_ECC_ENABLED,
++                                               hDevice->get()) == CUDA_SUCCESS);
  
 -    sycl::detail::ur::assertion((ECCEnabled == 0) | (ECCEnabled == 1));
 +    detail::ur::assertion((ECCEnabled == 0) | (ECCEnabled == 1));
@@ -470,25 +634,30 @@ index 24f9d52a0..c6b6bc07e 100644
    case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY: {
      int IsIntegrated = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED,
+-                             hDevice->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetAttribute(&IsIntegrated,
++                                               CU_DEVICE_ATTRIBUTE_INTEGRATED,
++                                               hDevice->get()) == CUDA_SUCCESS);
  
 -    sycl::detail::ur::assertion((IsIntegrated == 0) | (IsIntegrated == 1));
 +    detail::ur::assertion((IsIntegrated == 0) | (IsIntegrated == 1));
      auto result = static_cast<bool>(IsIntegrated);
      return ReturnValue(result);
    }
-@@ -620,7 +620,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -620,9 +620,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    case UR_DEVICE_INFO_NAME: {
      static constexpr size_t MaxDeviceNameLength = 256u;
      char Name[MaxDeviceNameLength];
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetName(Name, MaxDeviceNameLength, hDevice->get()) ==
-         CUDA_SUCCESS);
+-        cuDeviceGetName(Name, MaxDeviceNameLength, hDevice->get()) ==
+-        CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetName(Name, MaxDeviceNameLength,
++                                          hDevice->get()) == CUDA_SUCCESS);
      return ReturnValue(Name, strlen(Name) + 1);
-@@ -641,13 +641,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+   }
+   case UR_DEVICE_INFO_VENDOR: {
+@@ -641,13 +640,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    case UR_DEVICE_INFO_VERSION: {
      std::stringstream SS;
      int Major;
@@ -504,7 +673,7 @@ index 24f9d52a0..c6b6bc07e 100644
          cuDeviceGetAttribute(&Minor,
                               CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
                               hDevice->get()) == CUDA_SUCCESS);
-@@ -666,11 +666,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -666,11 +665,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      int Major = 0;
      int Minor = 0;
  
@@ -518,14 +687,16 @@ index 24f9d52a0..c6b6bc07e 100644
          cuDeviceGetAttribute(&Minor,
                               CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
                               hDevice->get()) == CUDA_SUCCESS);
-@@ -847,27 +847,27 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -847,27 +846,27 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
      size_t FreeMemory = 0;
      size_t TotalMemory = 0;
 -    sycl::detail::ur::assertion(cuMemGetInfo(&FreeMemory, &TotalMemory) ==
+-                                    CUDA_SUCCESS,
+-                                "failed cuMemGetInfo() API.");
 +    detail::ur::assertion(cuMemGetInfo(&FreeMemory, &TotalMemory) ==
-                                     CUDA_SUCCESS,
-                                 "failed cuMemGetInfo() API.");
++                              CUDA_SUCCESS,
++                          "failed cuMemGetInfo() API.");
      return ReturnValue(FreeMemory);
    }
    case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
@@ -551,7 +722,7 @@ index 24f9d52a0..c6b6bc07e 100644
      return ReturnValue(Value);
    }
    case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
-@@ -875,10 +875,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -875,20 +874,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    }
    case UR_DEVICE_INFO_DEVICE_ID: {
      int Value = 0;
@@ -564,20 +735,21 @@ index 24f9d52a0..c6b6bc07e 100644
      return ReturnValue(Value);
    }
    case UR_DEVICE_INFO_UUID: {
-@@ -888,10 +888,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
-     int Minor = DriverVersion % 1000 / 10;
      CUuuid UUID;
-     if ((Major > 11) || (Major == 11 && Minor >= 4)) {
--      sycl::detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
-+      detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
-                                   CUDA_SUCCESS);
-     } else {
--      sycl::detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
-+      detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
-                                   CUDA_SUCCESS);
-     }
+ #if (CUDA_VERSION >= 11040)
+-    sycl::detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
+-                                CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
++                          CUDA_SUCCESS);
+ #else
+-    sycl::detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
+-                                CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
++                          CUDA_SUCCESS);
+ #endif
      std::array<unsigned char, 16> Name;
-@@ -900,13 +900,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
+@@ -896,13 +895,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    }
    case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH: {
      int Major = 0;
@@ -593,7 +765,7 @@ index 24f9d52a0..c6b6bc07e 100644
          cuDeviceGetAttribute(&Minor,
                               CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
                               hDevice->get()) == CUDA_SUCCESS);
-@@ -922,7 +922,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -918,7 +917,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      } else if (IsOrinAGX) {
        MemoryClockKHz = 3200000;
      } else {
@@ -602,7 +774,7 @@ index 24f9d52a0..c6b6bc07e 100644
            cuDeviceGetAttribute(&MemoryClockKHz,
                                 CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE,
                                 hDevice->get()) == CUDA_SUCCESS);
-@@ -932,7 +932,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -928,7 +927,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      if (IsOrinAGX) {
        MemoryBusWidth = 256;
      } else {
@@ -611,7 +783,7 @@ index 24f9d52a0..c6b6bc07e 100644
            cuDeviceGetAttribute(&MemoryBusWidth,
                                 CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
                                 hDevice->get()) == CUDA_SUCCESS);
-@@ -977,7 +977,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -973,7 +972,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
          &MaxRegisters, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
          hDevice->get()));
  
@@ -620,25 +792,27 @@ index 24f9d52a0..c6b6bc07e 100644
  
      return ReturnValue(static_cast<uint32_t>(MaxRegisters));
    }
-@@ -988,11 +988,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+@@ -984,12 +983,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
    case UR_DEVICE_INFO_PCI_ADDRESS: {
      constexpr size_t AddressBufferSize = 13;
      char AddressBuffer[AddressBufferSize];
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()) ==
-         CUDA_SUCCESS);
+-        cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()) ==
+-        CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize,
++                                              hDevice->get()) == CUDA_SUCCESS);
      // CUDA API (8.x - 12.1) guarantees 12 bytes + \0 are written
 -    sycl::detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) ==
-+    detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) ==
-                                 12);
+-                                12);
++    detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) == 12);
      return ReturnValue(AddressBuffer,
                         strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
+   }
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
-index 52c4c3895..55c56aee2 100644
+index 1cfc5cc40a4a..792f69092682 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
-@@ -806,7 +806,7 @@ static size_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc) {
+@@ -794,7 +794,7 @@ static size_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc) {
    case CU_AD_FORMAT_FLOAT:
      return 4;
    default:
@@ -648,7 +822,7 @@ index 52c4c3895..55c56aee2 100644
    }
  }
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
-index 8916197b7..9d86189b9 100644
+index 8916197b73f1..066c0498f1d0 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
 @@ -119,7 +119,7 @@ ur_result_t ur_event_handle_t_::record() {
@@ -687,26 +861,31 @@ index 8916197b7..9d86189b9 100644
    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
  }
  
-@@ -254,7 +254,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
+@@ -254,8 +254,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
  
    const auto RefCount = hEvent->incrementReferenceCount();
  
 -  sycl::detail::ur::assertion(
-+  detail::ur::assertion(
-       RefCount != 0, "Reference count overflow detected in urEventRetain.");
+-      RefCount != 0, "Reference count overflow detected in urEventRetain.");
++  detail::ur::assertion(RefCount != 0,
++                        "Reference count overflow detected in urEventRetain.");
  
    return UR_RESULT_SUCCESS;
-@@ -265,7 +265,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
+ }
+@@ -265,9 +265,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
  
    // double delete or someone is messing with the ref count.
    // either way, cannot safely proceed.
 -  sycl::detail::ur::assertion(
-+  detail::ur::assertion(
-       hEvent->getReferenceCount() != 0,
-       "Reference count overflow detected in urEventRelease.");
+-      hEvent->getReferenceCount() != 0,
+-      "Reference count overflow detected in urEventRelease.");
++  detail::ur::assertion(hEvent->getReferenceCount() != 0,
++                        "Reference count overflow detected in urEventRelease.");
  
+   // decrement ref count. If it is 0, delete the event.
+   if (hEvent->decrementReferenceCount() == 0) {
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
-index 358f59c49..cae080401 100644
+index 358f59c499e1..7d46ce039bab 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
 @@ -73,24 +73,24 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
@@ -758,43 +937,55 @@ index 358f59c49..cae080401 100644
          cuFuncGetAttribute(&Bytes, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
                             hKernel->get()) == CUDA_SUCCESS);
      return ReturnValue(uint64_t(Bytes));
-@@ -130,7 +130,7 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+@@ -130,17 +130,17 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
    case UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {
      // Work groups should be multiples of the warp size
      int WarpSize = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
+-                             hDevice->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetAttribute(&WarpSize,
++                                               CU_DEVICE_ATTRIBUTE_WARP_SIZE,
++                                               hDevice->get()) == CUDA_SUCCESS);
      return ReturnValue(static_cast<size_t>(WarpSize));
-@@ -138,7 +138,7 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+   }
    case UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE: {
      // OpenCL PRIVATE == CUDA LOCAL
      int Bytes = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuFuncGetAttribute(&Bytes, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
-                            hKernel->get()) == CUDA_SUCCESS);
+-        cuFuncGetAttribute(&Bytes, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
+-                           hKernel->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuFuncGetAttribute(&Bytes,
++                                             CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
++                                             hKernel->get()) == CUDA_SUCCESS);
      return ReturnValue(uint64_t(Bytes));
-@@ -231,7 +231,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
+   }
+   default:
+@@ -231,9 +231,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
      return ReturnValue("");
    case UR_KERNEL_INFO_NUM_REGS: {
      int NumRegs = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuFuncGetAttribute(&NumRegs, CU_FUNC_ATTRIBUTE_NUM_REGS,
-                            hKernel->get()) == CUDA_SUCCESS);
+-        cuFuncGetAttribute(&NumRegs, CU_FUNC_ATTRIBUTE_NUM_REGS,
+-                           hKernel->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuFuncGetAttribute(&NumRegs,
++                                             CU_FUNC_ATTRIBUTE_NUM_REGS,
++                                             hKernel->get()) == CUDA_SUCCESS);
      return ReturnValue(static_cast<uint32_t>(NumRegs));
-@@ -254,7 +254,7 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+   }
+   default:
+@@ -254,15 +254,15 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
    case UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE: {
      // Sub-group size is equivalent to warp size
      int WarpSize = 0;
 -    sycl::detail::ur::assertion(
-+    detail::ur::assertion(
-         cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
-                              hDevice->get()) == CUDA_SUCCESS);
+-        cuDeviceGetAttribute(&WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE,
+-                             hDevice->get()) == CUDA_SUCCESS);
++    detail::ur::assertion(cuDeviceGetAttribute(&WarpSize,
++                                               CU_DEVICE_ATTRIBUTE_WARP_SIZE,
++                                               hDevice->get()) == CUDA_SUCCESS);
      return ReturnValue(static_cast<uint32_t>(WarpSize));
-@@ -262,7 +262,7 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+   }
    case UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS: {
      // Number of sub-groups = max block size / warp size + possible remainder
      int MaxThreads = 0;
@@ -804,19 +995,20 @@ index 358f59c49..cae080401 100644
                             hKernel->get()) == CUDA_SUCCESS);
      int WarpSize = 0;
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
-index b19acea31..ecf840330 100644
+index b19acea3159f..f0c276579476 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
-@@ -162,7 +162,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
+@@ -162,8 +162,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
      // error for which it is unclear if the function that reported it succeeded
      // or not. Either way, the state of the program is compromised and likely
      // unrecoverable.
 -    sycl::detail::ur::die(
-+    detail::ur::die(
-         "Unrecoverable program state reached in urMemRelease");
+-        "Unrecoverable program state reached in urMemRelease");
++    detail::ur::die("Unrecoverable program state reached in urMemRelease");
    }
  
-@@ -331,7 +331,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
+   return UR_RESULT_SUCCESS;
+@@ -331,7 +330,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
      PixelTypeSizeBytes = 4;
      break;
    default:
@@ -826,7 +1018,7 @@ index b19acea31..ecf840330 100644
    }
  
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
-index 05443eeed..32391fec5 100644
+index 05443eeed89d..32391fec5c13 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
 @@ -265,7 +265,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
@@ -839,7 +1031,7 @@ index 05443eeed..32391fec5 100644
    std::vector<CUstream> ComputeCuStreams(1, CuStream);
    std::vector<CUstream> TransferCuStreams(0);
 diff --git a/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.cpp b/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.cpp
-index 36ec89fb9..836e47f98 100644
+index 36ec89fb9da3..836e47f988e5 100644
 --- a/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.cpp
 +++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.cpp
 @@ -73,7 +73,7 @@ urSamplerRelease(ur_sampler_handle_t hSampler) {

--- a/source/adapters/CMakeLists.txt
+++ b/source/adapters/CMakeLists.txt
@@ -9,9 +9,14 @@ add_subdirectory(null)
 if(UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_CUDA)
     # fetch adapter sources from SYCL
     set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external")
-    FetchSource(https://github.com/intel/llvm.git sycl-nightly/20230628 "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
+    FetchSource(https://github.com/intel/llvm.git sycl-nightly/20230706 "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
 
-    execute_process(COMMAND git apply --quiet ../0001-SYCL-CUDA-remove-sycl-namespaces-from-ur-adapter.patch
+    get_program_version_major_minor(git GIT_VERSION)
+    set(GIT_QUIET_OPTION "")
+    if(GIT_VERSION VERSION_GREATER_EQUAL "3.35.0")
+        set(GIT_QUIET_OPTION "--quiet")
+    endif()
+    execute_process(COMMAND git apply ${GIT_QUIET_OPTION} ../0001-SYCL-CUDA-remove-sycl-namespaces-from-ur-adapter.patch
         WORKING_DIRECTORY ${SYCL_ADAPTER_DIR})
 endif()
 

--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -73,30 +73,30 @@ target_include_directories(LevelZeroLoader-Headers
 
 add_library(${TARGET_NAME}
     SHARED
-    ${L0_DIR}/ur_loader_interface.cpp
-    ${L0_DIR}/ur_level_zero_common.hpp
-    ${L0_DIR}/ur_level_zero_context.hpp
-    ${L0_DIR}/ur_level_zero_device.hpp
-    ${L0_DIR}/ur_level_zero_event.hpp
-    ${L0_DIR}/ur_level_zero_usm.hpp
-    ${L0_DIR}/ur_level_zero_mem.hpp
-    ${L0_DIR}/ur_level_zero_kernel.hpp
-    ${L0_DIR}/ur_level_zero_platform.hpp
-    ${L0_DIR}/ur_level_zero_program.hpp
-    ${L0_DIR}/ur_level_zero_queue.hpp
-    ${L0_DIR}/ur_level_zero_sampler.hpp
+    ${L0_DIR}/ur_interface_loader.cpp
+    ${L0_DIR}/common.hpp
+    ${L0_DIR}/context.hpp
+    ${L0_DIR}/device.hpp
+    ${L0_DIR}/event.hpp
+    ${L0_DIR}/usm.hpp
+    ${L0_DIR}/memory.hpp
+    ${L0_DIR}/kernel.hpp
+    ${L0_DIR}/platform.hpp
+    ${L0_DIR}/program.hpp
+    ${L0_DIR}/queue.hpp
+    ${L0_DIR}/sampler.hpp
     ${L0_DIR}/ur_level_zero.cpp
-    ${L0_DIR}/ur_level_zero_common.cpp
-    ${L0_DIR}/ur_level_zero_context.cpp
-    ${L0_DIR}/ur_level_zero_device.cpp
-    ${L0_DIR}/ur_level_zero_event.cpp
-    ${L0_DIR}/ur_level_zero_usm.cpp
-    ${L0_DIR}/ur_level_zero_mem.cpp
-    ${L0_DIR}/ur_level_zero_kernel.cpp
-    ${L0_DIR}/ur_level_zero_platform.cpp
-    ${L0_DIR}/ur_level_zero_program.cpp
-    ${L0_DIR}/ur_level_zero_queue.cpp
-    ${L0_DIR}/ur_level_zero_sampler.cpp
+    ${L0_DIR}/common.cpp
+    ${L0_DIR}/context.cpp
+    ${L0_DIR}/device.cpp
+    ${L0_DIR}/event.cpp
+    ${L0_DIR}/usm.cpp
+    ${L0_DIR}/memory.cpp
+    ${L0_DIR}/kernel.cpp
+    ${L0_DIR}/platform.cpp
+    ${L0_DIR}/program.cpp
+    ${L0_DIR}/queue.cpp
+    ${L0_DIR}/sampler.cpp
     ${L0_DIR}/../../ur.cpp
     ${L0_DIR}/../../usm_allocator.cpp
     ${L0_DIR}/../../usm_allocator.hpp

--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
     message(STATUS "Download Level Zero loader and headers from github.com")
 
     set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-    set(LEVEL_ZERO_LOADER_TAG v1.8.8)
+    set(LEVEL_ZERO_LOADER_TAG v1.11.0)
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
     set(CMAKE_INCLUDE_CURRENT_DIR OFF)

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -4506,6 +4506,75 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    const void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMembufferWriteExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferWriteExp;
+    if (nullptr != pfnAppendMembufferWriteExp) {
+        result = pfnAppendMembufferWriteExp(hCommandBuffer, hBuffer, offset,
+                                            size, pSrc, numSyncPointsInWaitList,
+                                            pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    void *pDst, ///< [in] pointer to host memory where data is to be written to.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMembufferReadExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferReadExp;
+    if (nullptr != pfnAppendMembufferReadExp) {
+        result = pfnAppendMembufferReadExp(hCommandBuffer, hBuffer, offset,
+                                           size, pDst, numSyncPointsInWaitList,
+                                           pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
@@ -4539,6 +4608,102 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
             hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
             srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
             numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pSrc.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pSrc.
+    void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMembufferWriteRectExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferWriteRectExp;
+    if (nullptr != pfnAppendMembufferWriteRectExp) {
+        result = pfnAppendMembufferWriteRectExp(
+            hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+            bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
+            pSrc, numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pDst.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pDst.
+    void *pDst, ///< [in] pointer to host memory where data is to be read into.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAppendMembufferReadRectExp =
+        d_context.urDdiTable.CommandBufferExp.pfnAppendMembufferReadRectExp;
+    if (nullptr != pfnAppendMembufferReadRectExp) {
+        result = pfnAppendMembufferReadRectExp(
+            hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+            bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
+            pDst, numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
     } else {
         // generic implementation
     }
@@ -4857,8 +5022,20 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     pDdiTable->pfnAppendMembufferCopyExp =
         driver::urCommandBufferAppendMembufferCopyExp;
 
+    pDdiTable->pfnAppendMembufferWriteExp =
+        driver::urCommandBufferAppendMembufferWriteExp;
+
+    pDdiTable->pfnAppendMembufferReadExp =
+        driver::urCommandBufferAppendMembufferReadExp;
+
     pDdiTable->pfnAppendMembufferCopyRectExp =
         driver::urCommandBufferAppendMembufferCopyRectExp;
+
+    pDdiTable->pfnAppendMembufferWriteRectExp =
+        driver::urCommandBufferAppendMembufferWriteRectExp;
+
+    pDdiTable->pfnAppendMembufferReadRectExp =
+        driver::urCommandBufferAppendMembufferReadRectExp;
 
     pDdiTable->pfnEnqueueExp = driver::urCommandBufferEnqueueExp;
 

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -9222,6 +9222,22 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP:
         os << "UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP";
         break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP";
+        break;
+
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -10217,6 +10233,99 @@ inline std::ostream &operator<<(
     return os;
 }
 
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_command_buffer_append_membuffer_write_exp_params_t
+               *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phBuffer));
+
+    os << ", ";
+    os << ".offset = ";
+
+    os << *(params->poffset);
+
+    os << ", ";
+    os << ".size = ";
+
+    os << *(params->psize);
+
+    os << ", ";
+    os << ".pSrc = ";
+
+    ur_params::serializePtr(os, *(params->ppSrc));
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pSyncPointWaitList = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_append_membuffer_read_exp_params_t *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phBuffer));
+
+    os << ", ";
+    os << ".offset = ";
+
+    os << *(params->poffset);
+
+    os << ", ";
+    os << ".size = ";
+
+    os << *(params->psize);
+
+    os << ", ";
+    os << ".pDst = ";
+
+    ur_params::serializePtr(os, *(params->ppDst));
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pSyncPointWaitList = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
 inline std::ostream &operator<<(
     std::ostream &os,
     const struct ur_command_buffer_append_membuffer_copy_rect_exp_params_t
@@ -10270,6 +10379,150 @@ inline std::ostream &operator<<(
     os << ".dstSlicePitch = ";
 
     os << *(params->pdstSlicePitch);
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pSyncPointWaitList = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_append_membuffer_write_rect_exp_params_t
+        *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phBuffer));
+
+    os << ", ";
+    os << ".bufferOffset = ";
+
+    os << *(params->pbufferOffset);
+
+    os << ", ";
+    os << ".hostOffset = ";
+
+    os << *(params->phostOffset);
+
+    os << ", ";
+    os << ".region = ";
+
+    os << *(params->pregion);
+
+    os << ", ";
+    os << ".bufferRowPitch = ";
+
+    os << *(params->pbufferRowPitch);
+
+    os << ", ";
+    os << ".bufferSlicePitch = ";
+
+    os << *(params->pbufferSlicePitch);
+
+    os << ", ";
+    os << ".hostRowPitch = ";
+
+    os << *(params->phostRowPitch);
+
+    os << ", ";
+    os << ".hostSlicePitch = ";
+
+    os << *(params->phostSlicePitch);
+
+    os << ", ";
+    os << ".pSrc = ";
+
+    ur_params::serializePtr(os, *(params->ppSrc));
+
+    os << ", ";
+    os << ".numSyncPointsInWaitList = ";
+
+    os << *(params->pnumSyncPointsInWaitList);
+
+    os << ", ";
+    os << ".pSyncPointWaitList = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPointWaitList));
+
+    os << ", ";
+    os << ".pSyncPoint = ";
+
+    ur_params::serializePtr(os, *(params->ppSyncPoint));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    const struct ur_command_buffer_append_membuffer_read_rect_exp_params_t
+        *params) {
+
+    os << ".hCommandBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phCommandBuffer));
+
+    os << ", ";
+    os << ".hBuffer = ";
+
+    ur_params::serializePtr(os, *(params->phBuffer));
+
+    os << ", ";
+    os << ".bufferOffset = ";
+
+    os << *(params->pbufferOffset);
+
+    os << ", ";
+    os << ".hostOffset = ";
+
+    os << *(params->phostOffset);
+
+    os << ", ";
+    os << ".region = ";
+
+    os << *(params->pregion);
+
+    os << ", ";
+    os << ".bufferRowPitch = ";
+
+    os << *(params->pbufferRowPitch);
+
+    os << ", ";
+    os << ".bufferSlicePitch = ";
+
+    os << *(params->pbufferSlicePitch);
+
+    os << ", ";
+    os << ".hostRowPitch = ";
+
+    os << *(params->phostRowPitch);
+
+    os << ", ";
+    os << ".hostSlicePitch = ";
+
+    os << *(params->phostSlicePitch);
+
+    os << ", ";
+    os << ".pDst = ";
+
+    ur_params::serializePtr(os, *(params->ppDst));
 
     os << ", ";
     os << ".numSyncPointsInWaitList = ";
@@ -14496,9 +14749,27 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
         os << (const struct ur_command_buffer_append_membuffer_copy_exp_params_t
                    *)params;
     } break;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP: {
+        os << (const struct
+               ur_command_buffer_append_membuffer_write_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP: {
+        os << (const struct ur_command_buffer_append_membuffer_read_exp_params_t
+                   *)params;
+    } break;
     case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP: {
         os << (const struct
                ur_command_buffer_append_membuffer_copy_rect_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP: {
+        os << (const struct
+               ur_command_buffer_append_membuffer_write_rect_exp_params_t *)
+                params;
+    } break;
+    case UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP: {
+        os << (const struct
+               ur_command_buffer_append_membuffer_read_rect_exp_params_t *)
                 params;
     } break;
     case UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP: {

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -5156,6 +5156,101 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    const void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferWriteExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferWriteExp;
+
+    if (nullptr == pfnAppendMembufferWriteExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_membuffer_write_exp_params_t params = {
+        &hCommandBuffer,
+        &hBuffer,
+        &offset,
+        &size,
+        &pSrc,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP,
+        "urCommandBufferAppendMembufferWriteExp", &params);
+
+    ur_result_t result = pfnAppendMembufferWriteExp(
+        hCommandBuffer, hBuffer, offset, size, pSrc, numSyncPointsInWaitList,
+        pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_EXP,
+                       "urCommandBufferAppendMembufferWriteExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    void *pDst, ///< [in] pointer to host memory where data is to be written to.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferReadExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferReadExp;
+
+    if (nullptr == pfnAppendMembufferReadExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_membuffer_read_exp_params_t params = {
+        &hCommandBuffer,
+        &hBuffer,
+        &offset,
+        &size,
+        &pDst,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP,
+        "urCommandBufferAppendMembufferReadExp", &params);
+
+    ur_result_t result = pfnAppendMembufferReadExp(
+        hCommandBuffer, hBuffer, offset, size, pDst, numSyncPointsInWaitList,
+        pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_EXP,
+                       "urCommandBufferAppendMembufferReadExp", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
@@ -5212,6 +5307,140 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     context.notify_end(
         UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_COPY_RECT_EXP,
         "urCommandBufferAppendMembufferCopyRectExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pSrc.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pSrc.
+    void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferWriteRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferWriteRectExp;
+
+    if (nullptr == pfnAppendMembufferWriteRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_membuffer_write_rect_exp_params_t params = {
+        &hCommandBuffer,
+        &hBuffer,
+        &bufferOffset,
+        &hostOffset,
+        &region,
+        &bufferRowPitch,
+        &bufferSlicePitch,
+        &hostRowPitch,
+        &hostSlicePitch,
+        &pSrc,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP,
+        "urCommandBufferAppendMembufferWriteRectExp", &params);
+
+    ur_result_t result = pfnAppendMembufferWriteRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_WRITE_RECT_EXP,
+        "urCommandBufferAppendMembufferWriteRectExp", &params, &result,
+        instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pDst.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pDst.
+    void *pDst, ///< [in] pointer to host memory where data is to be read into.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferReadRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferReadRectExp;
+
+    if (nullptr == pfnAppendMembufferReadRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_command_buffer_append_membuffer_read_rect_exp_params_t params = {
+        &hCommandBuffer,
+        &hBuffer,
+        &bufferOffset,
+        &hostOffset,
+        &region,
+        &bufferRowPitch,
+        &bufferSlicePitch,
+        &hostRowPitch,
+        &hostSlicePitch,
+        &pDst,
+        &numSyncPointsInWaitList,
+        &pSyncPointWaitList,
+        &pSyncPoint};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP,
+        "urCommandBufferAppendMembufferReadRectExp", &params);
+
+    ur_result_t result = pfnAppendMembufferReadRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    context.notify_end(
+        UR_FUNCTION_COMMAND_BUFFER_APPEND_MEMBUFFER_READ_RECT_EXP,
+        "urCommandBufferAppendMembufferReadRectExp", &params, &result,
         instance);
 
     return result;
@@ -5596,10 +5825,28 @@ __urdlllocal ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     pDdiTable->pfnAppendMembufferCopyExp =
         ur_tracing_layer::urCommandBufferAppendMembufferCopyExp;
 
+    dditable.pfnAppendMembufferWriteExp = pDdiTable->pfnAppendMembufferWriteExp;
+    pDdiTable->pfnAppendMembufferWriteExp =
+        ur_tracing_layer::urCommandBufferAppendMembufferWriteExp;
+
+    dditable.pfnAppendMembufferReadExp = pDdiTable->pfnAppendMembufferReadExp;
+    pDdiTable->pfnAppendMembufferReadExp =
+        ur_tracing_layer::urCommandBufferAppendMembufferReadExp;
+
     dditable.pfnAppendMembufferCopyRectExp =
         pDdiTable->pfnAppendMembufferCopyRectExp;
     pDdiTable->pfnAppendMembufferCopyRectExp =
         ur_tracing_layer::urCommandBufferAppendMembufferCopyRectExp;
+
+    dditable.pfnAppendMembufferWriteRectExp =
+        pDdiTable->pfnAppendMembufferWriteRectExp;
+    pDdiTable->pfnAppendMembufferWriteRectExp =
+        ur_tracing_layer::urCommandBufferAppendMembufferWriteRectExp;
+
+    dditable.pfnAppendMembufferReadRectExp =
+        pDdiTable->pfnAppendMembufferReadRectExp;
+    pDdiTable->pfnAppendMembufferReadRectExp =
+        ur_tracing_layer::urCommandBufferAppendMembufferReadRectExp;
 
     dditable.pfnEnqueueExp = pDdiTable->pfnEnqueueExp;
     pDdiTable->pfnEnqueueExp = ur_tracing_layer::urCommandBufferEnqueueExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -6416,6 +6416,111 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    const void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferWriteExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferWriteExp;
+
+    if (nullptr == pfnAppendMembufferWriteExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pSrc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+    }
+
+    ur_result_t result = pfnAppendMembufferWriteExp(
+        hCommandBuffer, hBuffer, offset, size, pSrc, numSyncPointsInWaitList,
+        pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    void *pDst, ///< [in] pointer to host memory where data is to be written to.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferReadExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferReadExp;
+
+    if (nullptr == pfnAppendMembufferReadExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDst) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+    }
+
+    ur_result_t result = pfnAppendMembufferReadExp(
+        hCommandBuffer, hBuffer, offset, size, pDst, numSyncPointsInWaitList,
+        pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
@@ -6471,6 +6576,138 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_result_t result = pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
         srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pSrc.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pSrc.
+    void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferWriteRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferWriteRectExp;
+
+    if (nullptr == pfnAppendMembufferWriteRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pSrc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+    }
+
+    ur_result_t result = pfnAppendMembufferWriteRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pDst.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pDst.
+    void *pDst, ///< [in] pointer to host memory where data is to be read into.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    auto pfnAppendMembufferReadRectExp =
+        context.urDdiTable.CommandBufferExp.pfnAppendMembufferReadRectExp;
+
+    if (nullptr == pfnAppendMembufferReadRectExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hCommandBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hBuffer) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pDst) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+
+        if (pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP;
+        }
+    }
+
+    ur_result_t result = pfnAppendMembufferReadRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
     return result;
@@ -6892,10 +7129,28 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     pDdiTable->pfnAppendMembufferCopyExp =
         ur_validation_layer::urCommandBufferAppendMembufferCopyExp;
 
+    dditable.pfnAppendMembufferWriteExp = pDdiTable->pfnAppendMembufferWriteExp;
+    pDdiTable->pfnAppendMembufferWriteExp =
+        ur_validation_layer::urCommandBufferAppendMembufferWriteExp;
+
+    dditable.pfnAppendMembufferReadExp = pDdiTable->pfnAppendMembufferReadExp;
+    pDdiTable->pfnAppendMembufferReadExp =
+        ur_validation_layer::urCommandBufferAppendMembufferReadExp;
+
     dditable.pfnAppendMembufferCopyRectExp =
         pDdiTable->pfnAppendMembufferCopyRectExp;
     pDdiTable->pfnAppendMembufferCopyRectExp =
         ur_validation_layer::urCommandBufferAppendMembufferCopyRectExp;
+
+    dditable.pfnAppendMembufferWriteRectExp =
+        pDdiTable->pfnAppendMembufferWriteRectExp;
+    pDdiTable->pfnAppendMembufferWriteRectExp =
+        ur_validation_layer::urCommandBufferAppendMembufferWriteRectExp;
+
+    dditable.pfnAppendMembufferReadRectExp =
+        pDdiTable->pfnAppendMembufferReadRectExp;
+    pDdiTable->pfnAppendMembufferReadRectExp =
+        ur_validation_layer::urCommandBufferAppendMembufferReadRectExp;
 
     dditable.pfnEnqueueExp = pDdiTable->pfnEnqueueExp;
     pDdiTable->pfnEnqueueExp = ur_validation_layer::urCommandBufferEnqueueExp;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6261,6 +6261,95 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    const void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMembufferWriteExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferWriteExp;
+    if (nullptr == pfnAppendMembufferWriteExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
+
+    // forward to device-platform
+    result = pfnAppendMembufferWriteExp(hCommandBuffer, hBuffer, offset, size,
+                                        pSrc, numSyncPointsInWaitList,
+                                        pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    void *pDst, ///< [in] pointer to host memory where data is to be written to.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMembufferReadExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferReadExp;
+    if (nullptr == pfnAppendMembufferReadExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
+
+    // forward to device-platform
+    result = pfnAppendMembufferReadExp(hCommandBuffer, hBuffer, offset, size,
+                                       pDst, numSyncPointsInWaitList,
+                                       pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMembufferCopyRectExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     ur_exp_command_buffer_handle_t
@@ -6311,6 +6400,122 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     result = pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
         srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferWriteRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pSrc.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pSrc.
+    void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMembufferWriteRectExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferWriteRectExp;
+    if (nullptr == pfnAppendMembufferWriteRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
+
+    // forward to device-platform
+    result = pfnAppendMembufferWriteRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urCommandBufferAppendMembufferReadRectExp
+__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pDst.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pDst.
+    void *pDst, ///< [in] pointer to host memory where data is to be read into.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->dditable;
+    auto pfnAppendMembufferReadRectExp =
+        dditable->ur.CommandBufferExp.pfnAppendMembufferReadRectExp;
+    if (nullptr == pfnAppendMembufferReadRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hCommandBuffer =
+        reinterpret_cast<ur_exp_command_buffer_object_t *>(hCommandBuffer)
+            ->handle;
+
+    // convert loader handle to platform handle
+    hBuffer = reinterpret_cast<ur_mem_object_t *>(hBuffer)->handle;
+
+    // forward to device-platform
+    result = pfnAppendMembufferReadRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 
     return result;
@@ -6738,8 +6943,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
                 ur_loader::urCommandBufferAppendMemcpyUSMExp;
             pDdiTable->pfnAppendMembufferCopyExp =
                 ur_loader::urCommandBufferAppendMembufferCopyExp;
+            pDdiTable->pfnAppendMembufferWriteExp =
+                ur_loader::urCommandBufferAppendMembufferWriteExp;
+            pDdiTable->pfnAppendMembufferReadExp =
+                ur_loader::urCommandBufferAppendMembufferReadExp;
             pDdiTable->pfnAppendMembufferCopyRectExp =
                 ur_loader::urCommandBufferAppendMembufferCopyRectExp;
+            pDdiTable->pfnAppendMembufferWriteRectExp =
+                ur_loader::urCommandBufferAppendMembufferWriteRectExp;
+            pDdiTable->pfnAppendMembufferReadRectExp =
+                ur_loader::urCommandBufferAppendMembufferReadRectExp;
             pDdiTable->pfnEnqueueExp = ur_loader::urCommandBufferEnqueueExp;
         } else {
             // return pointers directly to platform's DDIs

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6790,6 +6790,103 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory write command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    const void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMembufferWriteExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMembufferWriteExp;
+    if (nullptr == pfnAppendMembufferWriteExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMembufferWriteExp(hCommandBuffer, hBuffer, offset, size,
+                                      pSrc, numSyncPointsInWaitList,
+                                      pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory read command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    void *pDst, ///< [in] pointer to host memory where data is to be written to.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMembufferReadExp =
+        ur_lib::context->urDdiTable.CommandBufferExp.pfnAppendMembufferReadExp;
+    if (nullptr == pfnAppendMembufferReadExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMembufferReadExp(hCommandBuffer, hBuffer, offset, size,
+                                     pDst, numSyncPointsInWaitList,
+                                     pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Append a rectangular memory copy command to a command-buffer object
 ///
 /// @returns
@@ -6841,6 +6938,132 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     return pfnAppendMembufferCopyRectExp(
         hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
         srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory write command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pSrc.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pSrc.
+    void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMembufferWriteRectExp =
+        ur_lib::context->urDdiTable.CommandBufferExp
+            .pfnAppendMembufferWriteRectExp;
+    if (nullptr == pfnAppendMembufferWriteRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMembufferWriteRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
+        numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory read command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pDst.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pDst.
+    void *pDst, ///< [in] pointer to host memory where data is to be read into.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+    ) try {
+    auto pfnAppendMembufferReadRectExp =
+        ur_lib::context->urDdiTable.CommandBufferExp
+            .pfnAppendMembufferReadRectExp;
+    if (nullptr == pfnAppendMembufferReadRectExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAppendMembufferReadRectExp(
+        hCommandBuffer, hBuffer, bufferOffset, hostOffset, region,
+        bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
     return exceptionToResult(std::current_exception());

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5702,6 +5702,85 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory write command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    const void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a memory read command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferReadExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    size_t offset,           ///< [in] offset in bytes in the buffer object.
+    size_t size,             ///< [in] size in bytes of data being written.
+    void *pDst, ///< [in] pointer to host memory where data is to be written to.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Append a rectangular memory copy command to a command-buffer object
 ///
 /// @returns
@@ -5736,6 +5815,110 @@ ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
     size_t srcSlicePitch, ///< [in] Slice pitch of the source memory.
     size_t dstRowPitch,   ///< [in] Row pitch of the destination memory.
     size_t dstSlicePitch, ///< [in] Slice pitch of the destination memory.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory write command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pSrc`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferWriteRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being
+                          ///< written.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pSrc.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pSrc.
+    void *
+        pSrc, ///< [in] pointer to host memory where data is to be written from.
+    uint32_t
+        numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
+    const ur_exp_command_buffer_sync_point_t *
+        pSyncPointWaitList, ///< [in][optional] A list of sync points that this command depends on.
+    ur_exp_command_buffer_sync_point_t
+        *pSyncPoint ///< [out][optional] sync point associated with this command
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Append a rectangular memory read command to a command-buffer object
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hCommandBuffer`
+///         + `NULL == hBuffer`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pDst`
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
+///     - ::UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP
+///         + `pSyncPointWaitList == NULL && numSyncPointsInWaitList > 0`
+///         + `pSyncPointWaitList != NULL && numSyncPointsInWaitList == 0`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+ur_result_t UR_APICALL urCommandBufferAppendMembufferReadRectExp(
+    ur_exp_command_buffer_handle_t
+        hCommandBuffer,      ///< [in] handle of the command-buffer object.
+    ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
+    ur_rect_offset_t bufferOffset, ///< [in] 3D offset in the buffer.
+    ur_rect_offset_t hostOffset,   ///< [in] 3D offset in the host region.
+    ur_rect_region_t
+        region, ///< [in] 3D rectangular region descriptor: width, height, depth.
+    size_t
+        bufferRowPitch, ///< [in] length of each row in bytes in the buffer object.
+    size_t
+        bufferSlicePitch, ///< [in] length of each 2D slice in bytes in the buffer object being read.
+    size_t
+        hostRowPitch, ///< [in] length of each row in bytes in the host memory region pointed to
+                      ///< by pDst.
+    size_t
+        hostSlicePitch, ///< [in] length of each 2D slice in bytes in the host memory region
+                        ///< pointed to by pDst.
+    void *pDst, ///< [in] pointer to host memory where data is to be read into.
     uint32_t
         numSyncPointsInWaitList, ///< [in] The number of sync points in the provided dependency list.
     const ur_exp_command_buffer_sync_point_t *

--- a/test/loader/adapter_registry/search_order.cpp
+++ b/test/loader/adapter_registry/search_order.cpp
@@ -11,7 +11,7 @@ void assertRegistryPathSequence(std::vector<fs::path> testAdapterPaths,
     static size_t assertIndex = 0;
 
     auto pathIt = std::find_if(testAdapterPaths.cbegin(),
-                               testAdapterPaths.cend(), predicate);
+                               testAdapterPaths.cend(), std::move(predicate));
     size_t index = std::distance(testAdapterPaths.cbegin(), pathIt);
     ASSERT_EQ(index, assertIndex++);
 }


### PR DESCRIPTION
This PR:
- Merges in UR tag c7b0caf4e3ce5330bd0669db6e8e498b48e8ad27
- Applies rebased version patch from https://patch-diff.githubusercontent.com/raw/intel/llvm/pull/10135.patch
- Refactors cmake to support older versions of git
  - `-b` option in `git init` is only supported from version `2.28.0`
  - `--quiet` option in `git apply` is only supported from version `2.35.0`

Since this is a PR with lots of unrelated changes the files to consider are:
- [helpers.cmake](https://github.com/oneapi-src/unified-runtime/pull/707/files#diff-6db7226737579aec6c1e2537e53fc3c692eda5c93911a32eed3afab00c09e092)
- [cuda patch](https://github.com/oneapi-src/unified-runtime/pull/707/files#diff-87deb274925b8fa80cdf2de6e7b63f1994f1240be24af4d6d9a0375519bf3327)
- [adapters cmake](https://github.com/oneapi-src/unified-runtime/pull/707/files#diff-81ff425ff9a358119ab0c263526d1f03a3e0c51ff2b096c018832ee0656ef5ea)
- [level zero cmake](https://github.com/oneapi-src/unified-runtime/pull/707/files#diff-6b7a2edb3c526680aceef4ade97db0bdee8ed5291796d9f7aa1e0a82e59eff3d)
