### PR TITLE
Implement adapter instance handles 

### DIFF
--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -24,6 +24,8 @@ extern "C" {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urPlatformGet
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformGet_t)(
+    ur_adapter_handle_t *,
+    uint32_t,
     uint32_t,
     ur_platform_handle_t *,
     uint32_t *);
@@ -51,13 +53,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
     ur_platform_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urPlatformGetLastError
-typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetLastError_t)(
-    ur_platform_handle_t,
-    const char **,
-    int32_t *);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urPlatformGetApiVersion
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetApiVersion_t)(
     ur_platform_handle_t,
@@ -77,7 +72,6 @@ typedef struct ur_platform_dditable_t {
     ur_pfnPlatformGetInfo_t pfnGetInfo;
     ur_pfnPlatformGetNativeHandle_t pfnGetNativeHandle;
     ur_pfnPlatformCreateWithNativeHandle_t pfnCreateWithNativeHandle;
-    ur_pfnPlatformGetLastError_t pfnGetLastError;
     ur_pfnPlatformGetApiVersion_t pfnGetApiVersion;
     ur_pfnPlatformGetBackendOption_t pfnGetBackendOption;
 } ur_platform_dditable_t;
@@ -1878,10 +1872,48 @@ typedef ur_result_t(UR_APICALL *ur_pfnTearDown_t)(
     void *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterGet
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterGet_t)(
+    uint32_t,
+    ur_adapter_handle_t *,
+    uint32_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterRelease
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterRelease_t)(
+    ur_adapter_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterRetain
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterRetain_t)(
+    ur_adapter_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterGetLastError
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetLastError_t)(
+    ur_adapter_handle_t,
+    const char **,
+    int32_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetInfo_t)(
+    ur_adapter_handle_t,
+    ur_adapter_info_t,
+    size_t,
+    void *,
+    size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Global functions pointers
 typedef struct ur_global_dditable_t {
     ur_pfnInit_t pfnInit;
     ur_pfnTearDown_t pfnTearDown;
+    ur_pfnAdapterGet_t pfnAdapterGet;
+    ur_pfnAdapterRelease_t pfnAdapterRelease;
+    ur_pfnAdapterRetain_t pfnAdapterRetain;
+    ur_pfnAdapterGetLastError_t pfnAdapterGetLastError;
+    ur_pfnAdapterGetInfo_t pfnAdapterGetInfo;
 } ur_global_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -51,12 +51,18 @@ Initialization and Discovery
 
 .. parsed-literal::
 
+    // Discover all available adapters
+    uint32_t adapterCount = 0;
+    ${x}AdapterGet(0, nullptr, &adapterCount);
+    std::vector<${x}_adapter_handle_t> adapters(adapterCount);
+    ${x}AdapterGet(adapterCount, adapters.data(), nullptr);
+
     // Discover all the platform instances
     uint32_t platformCount = 0;
-    ${x}PlatformGet(0, nullptr, &platformCount);
+    ${x}PlatformGet(adapters.data(), adapterCount, 0, nullptr, &platformCount);
 
     std::vector<${x}_platform_handle_t> platforms(platformCount);
-    ${x}PlatformGet(platform.size(), platforms.data(), &platformCount);
+    ${x}PlatformGet(adapters.data(), adapterCount, platform.size(), platforms.data(), &platformCount);
 
     // Get number of total GPU devices in the platform
     uint32_t deviceCount = 0;

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -65,6 +65,11 @@ class: $xLoaderConfig
 name: "$x_loader_config_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle
+desc: "Handle of an adapter instance"
+class: $xAdapter
+name: "$x_adapter_handle_t"
+--- #--------------------------------------------------------------------------
+type: handle
 desc: "Handle of a platform instance"
 class: $xPlatform
 name: "$x_platform_handle_t"

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -13,7 +13,7 @@ desc: "Intel $OneApi Unified Runtime APIs for Platform"
 ordinal: "1"
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Retrieves all available platforms"
+desc: "Retrieves all available platforms for the given adapters"
 class: $xPlatform
 name: Get
 decl: static
@@ -24,6 +24,12 @@ details:
     - "Multiple calls to this function will return identical platforms handles, in the same order."
     - "The application may call this function from simultaneous threads, the implementation must be thread-safe"
 params:
+    - type: "$x_adapter_handle_t*"
+      name: "phAdapters"
+      desc: "[in][range(0, NumAdapters)] array of adapters to query for platforms."
+    - type: "uint32_t"
+      name: "NumAdapters"
+      desc: "[in] number of adapters pointed to by phAdapters"
     - type: "uint32_t"
       name: NumEntries
       desc: |
@@ -220,56 +226,6 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_VALUE:
       - "If `pFrontendOption` is not a valid frontend option."
---- #--------------------------------------------------------------------------
-type: function
-desc: "Get the last adapter specific error."
-details: |
-    To be used after another entry-point has returned
-    $X_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
-    the circumstances of the underlying driver error and the error code
-    returned by the failed driver entry-point.
-
-    * Implementations *must* store the message and error code in thread-local
-      storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.
-
-    * The message and error code storage is will only be valid if a previously
-      called entry-point returned $X_RESULT_ERROR_ADAPTER_SPECIFIC.
-
-    * The memory pointed to by the C string returned in `ppMessage` is owned by
-      the adapter and *must* be null terminated.
-
-    * The application *may* call this function from simultaneous threads.
-
-    * The implementation of this function *should* be lock-free.
-
-    Example usage:
-
-    ```cpp
-    if ($xQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
-            $X_RESULT_ERROR_ADAPTER_SPECIFIC) {
-        const char* pMessage;
-        int32_t error;
-        $xPlatformGetLastError(hPlatform, &pMessage, &error);
-    }
-    ```
-class: $xPlatform
-name: GetLastError
-decl: static
-ordinal: "0"
-params:
-    - type: $x_platform_handle_t
-      name: hPlatform
-      desc: "[in] handle of the platform instance"
-    - type: const char**
-      name: ppMessage
-      desc: >
-          [out] pointer to a C string where the adapter specific error message
-          will be stored.
-    - type: int32_t*
-      name: pError
-      desc: >
-          [out] pointer to an integer where the adapter specific error code
-          will be stored.
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Identifies native backend adapters"

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -436,9 +436,6 @@ etors:
 - name: BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP
   desc: Enumerator for $xBindlessImagesSignalExternalSemaphoreExp
   value: '149'
-- name: PLATFORM_GET_LAST_ERROR
-  desc: Enumerator for $xPlatformGetLastError
-  value: '150'
 - name: ENQUEUE_USM_FILL_2D
   desc: Enumerator for $xEnqueueUSMFill2D
   value: '151'
@@ -517,6 +514,21 @@ etors:
 - name: LOADER_CONFIG_ENABLE_LAYER
   desc: Enumerator for $xLoaderConfigEnableLayer
   value: '176'
+- name: ADAPTER_RELEASE
+  desc: Enumerator for $xAdapterRelease
+  value: '177'
+- name: ADAPTER_GET
+  desc: Enumerator for $xAdapterGet
+  value: '178'
+- name: ADAPTER_RETAIN
+  desc: Enumerator for $xAdapterRetain
+  value: '179'
+- name: ADAPTER_GET_LAST_ERROR
+  desc: Enumerator for $xAdapterGetLastError
+  value: '180'
+- name: ADAPTER_GET_INFO
+  desc: Enumerator for $xAdapterGetInfo
+  value: '181'
 ---
 type: enum
 desc: Defines structure types

--- a/scripts/core/runtime.yml
+++ b/scripts/core/runtime.yml
@@ -174,3 +174,191 @@ params:
       desc: "[in] pointer to tear down parameters"
 returns:
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves all available adapters"
+class: $x
+name: AdapterGet
+decl: static
+ordinal: "2"
+details:
+    - "Adapter implementations must return exactly one adapter handle from this entry point."
+    - "The loader may return more than one adapter handle when there are multiple available."
+    - "Each returned adapter has its reference count incremented and should be released with a subsequent call to $xAdapterRelease."
+    - "Adapters may perform adapter-specific state initialization when the first reference to them is taken."
+    - "An application may call this entry point multiple times to acquire multiple references to the adapter handle(s)."
+params:
+    - type: "uint32_t"
+      name: NumEntries
+      desc: |
+            [in] the number of adapters to be added to phAdapters. 
+            If phAdapters is not NULL, then NumEntries should be greater than zero, otherwise $X_RESULT_ERROR_INVALID_SIZE,
+            will be returned.
+    - type: "$x_adapter_handle_t*"
+      name: phAdapters
+      desc: |
+            [out][optional][range(0, NumEntries)] array of handle of adapters.
+            If NumEntries is less than the number of adapters available, then $xAdapterGet shall only retrieve that number of platforms.
+    - type: "uint32_t*"
+      name: "pNumAdapters"
+      desc: |
+            [out][optional] returns the total number of adapters available. 
+returns:
+    - $X_RESULT_ERROR_INVALID_SIZE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Releases the adapter handle reference indicating end of its usage"
+class: $x
+name: AdapterRelease
+decl: static
+ordinal: "3"
+details:
+    - "When the reference count of the adapter reaches zero, the adapter may perform adapter-specififc resource teardown"
+params:
+  - type: "$x_adapter_handle_t"
+    name: hAdapter
+    desc: |
+          [in] Adapter handle to release
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Get a reference to the adapter handle."
+class: $x
+name: AdapterRetain
+decl: static
+ordinal: "4"
+details:
+    - "Get a reference to the adapter handle. Increment its reference count"
+params:
+  - type: "$x_adapter_handle_t"
+    name: hAdapter
+    desc: |
+          [in] Adapter handle to retain
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Get the last adapter specific error."
+details: |
+    To be used after another entry-point has returned
+    $X_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
+    the circumstances of the underlying driver error and the error code
+    returned by the failed driver entry-point.
+
+    * Implementations *must* store the message and error code in thread-local
+      storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.
+
+    * The message and error code storage is will only be valid if a previously
+      called entry-point returned $X_RESULT_ERROR_ADAPTER_SPECIFIC.
+
+    * The memory pointed to by the C string returned in `ppMessage` is owned by
+      the adapter and *must* be null terminated.
+
+    * The application *may* call this function from simultaneous threads.
+
+    * The implementation of this function *should* be lock-free.
+
+    Example usage:
+
+    ```cpp
+    if ($xQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
+            $X_RESULT_ERROR_ADAPTER_SPECIFIC) {
+        const char* pMessage;
+        int32_t error;
+        $xAdapterGetLastError(hAdapter, &pMessage, &error);
+    }
+    ```
+class: $x
+name: AdapterGetLastError
+decl: static
+ordinal: "5"
+params:
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter instance"
+    - type: const char**
+      name: ppMessage
+      desc: >
+          [out] pointer to a C string where the adapter specific error message
+          will be stored.
+    - type: int32_t*
+      name: pError
+      desc: >
+          [out] pointer to an integer where the adapter specific error code
+          will be stored.
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Supported adapter info"
+class: $xAdapter
+name: $x_adapter_info_t
+typed_etors: True
+etors:
+    - name: BACKEND
+      desc: "[$x_adapter_backend_t] Identifies the native backend supported by the adapter."
+    - name: REFERENCE_COUNT
+      desc: |
+            [uint32_t] Reference count of the adapter.
+            The reference count returned should be considered immediately stale.
+            It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves information about the adapter"
+class: $x
+name: AdapterGetInfo
+decl: static
+ordinal: "6"
+details:
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function should be lock-free."
+params:
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter"
+    - type: $x_adapter_info_t
+      name: propName
+      desc: "[in] type of the info to retrieve"
+    - type: "size_t"
+      name: propSize
+      desc: |
+            [in] the number of bytes pointed to by pPropValue.
+    - type: "void*"
+      name: pPropValue
+      desc: |
+            [out][optional][typename(propName, propSize)] array of bytes holding the info.
+            If Size is not equal to or greater to the real number of bytes needed to return the info then the $X_RESULT_ERROR_INVALID_SIZE error is returned and pPropValue is not used.
+    - type: "size_t*"
+      name: pPropSizeRet
+      desc: |
+            [out][optional] pointer to the actual number of bytes being queried by pPropValue.
+returns:
+    - $X_RESULT_ERROR_UNSUPPORTED_ENUMERATION:
+        - "If `propName` is not supported by the adapter."
+    - $X_RESULT_ERROR_INVALID_SIZE:
+        - "`propSize == 0 && pPropValue != NULL`"
+        - "If `propSize` is less than the real number of bytes needed to return the info."
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER:
+        - "`propSize != 0 && pPropValue == NULL`"
+        - "`pPropValue == NULL && pPropSizeRet == NULL`"
+    - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Identifies backend of the adapter"
+class: $x
+name: $x_adapter_backend_t
+etors:
+    - name: UNKNOWN
+      value: "0"
+      desc: "The backend is not a recognized one"
+    - name: LEVEL_ZERO
+      value: "1"
+      desc: "The backend is Level Zero"
+    - name: OPENCL
+      value: "2"
+      desc: "The backend is OpenCL"
+    - name: CUDA
+      value: "3"
+      desc: "The backend is CUDA"
+    - name: HIP
+      value: "4"
+      desc: "The backend is HIP"
+    - name: NATIVE_CPU
+      value: "5"
+      desc: "The backend is Native CPU"

--- a/source/adapters/null/ur_null.cpp
+++ b/source/adapters/null/ur_null.cpp
@@ -18,7 +18,28 @@ context_t d_context;
 //////////////////////////////////////////////////////////////////////////
 context_t::context_t() {
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGet = [](uint32_t NumEntries,
+    urDdiTable.Global.pfnAdapterGet = [](uint32_t NumAdapters,
+                                         ur_adapter_handle_t *phAdapters,
+                                         uint32_t *pNumAdapters) {
+        if (phAdapters != nullptr && NumAdapters != 1) {
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        if (pNumAdapters != nullptr) {
+            *pNumAdapters = 1;
+        }
+        if (nullptr != phAdapters) {
+            *reinterpret_cast<void **>(phAdapters) = d_context.get();
+        }
+
+        return UR_RESULT_SUCCESS;
+    };
+    //////////////////////////////////////////////////////////////////////////
+    urDdiTable.Global.pfnAdapterRelease = [](ur_adapter_handle_t) {
+        return UR_RESULT_SUCCESS;
+    };
+    //////////////////////////////////////////////////////////////////////////
+    urDdiTable.Platform.pfnGet = [](ur_adapter_handle_t *phAdapters,
+                                    uint32_t NumAdapters, uint32_t NumEntries,
                                     ur_platform_handle_t *phPlatforms,
                                     uint32_t *pNumPlatforms) {
         if (phPlatforms != nullptr && NumEntries != 1) {

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -56,8 +56,143 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterGet
+__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+    uint32_t
+        NumEntries, ///< [in] the number of adapters to be added to phAdapters.
+    ///< If phAdapters is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_adapter_handle_t *
+        phAdapters, ///< [out][optional][range(0, NumEntries)] array of handle of adapters.
+    ///< If NumEntries is less than the number of adapters available, then
+    ///< ::urAdapterGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumAdapters ///< [out][optional] returns the total number of adapters available.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAdapterGet = d_context.urDdiTable.Global.pfnAdapterGet;
+    if (nullptr != pfnAdapterGet) {
+        result = pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
+    } else {
+        // generic implementation
+        for (size_t i = 0; (nullptr != phAdapters) && (i < NumEntries); ++i) {
+            phAdapters[i] =
+                reinterpret_cast<ur_adapter_handle_t>(d_context.get());
+        }
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterRelease
+__urdlllocal ur_result_t UR_APICALL urAdapterRelease(
+    ur_adapter_handle_t hAdapter ///< [in] Adapter handle to release
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAdapterRelease = d_context.urDdiTable.Global.pfnAdapterRelease;
+    if (nullptr != pfnAdapterRelease) {
+        result = pfnAdapterRelease(hAdapter);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterRetain
+__urdlllocal ur_result_t UR_APICALL urAdapterRetain(
+    ur_adapter_handle_t hAdapter ///< [in] Adapter handle to retain
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAdapterRetain = d_context.urDdiTable.Global.pfnAdapterRetain;
+    if (nullptr != pfnAdapterRetain) {
+        result = pfnAdapterRetain(hAdapter);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterGetLastError
+__urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
+    ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
+    const char **
+        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
+                   ///< will be stored.
+    int32_t *
+        pError ///< [out] pointer to an integer where the adapter specific error code will
+               ///< be stored.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAdapterGetLastError =
+        d_context.urDdiTable.Global.pfnAdapterGetLastError;
+    if (nullptr != pfnAdapterGetLastError) {
+        result = pfnAdapterGetLastError(hAdapter, ppMessage, pError);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterGetInfo
+__urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
+    ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
+    ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPropValue is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPropValue.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnAdapterGetInfo = d_context.urDdiTable.Global.pfnAdapterGetInfo;
+    if (nullptr != pfnAdapterGetInfo) {
+        result = pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue,
+                                   pPropSizeRet);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
+    ur_adapter_handle_t *
+        phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
+    uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
     uint32_t
         NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
     ///< If phPlatforms is not NULL, then NumEntries should be greater than
@@ -75,7 +210,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnGet = d_context.urDdiTable.Platform.pfnGet;
     if (nullptr != pfnGet) {
-        result = pfnGet(NumEntries, phPlatforms, pNumPlatforms);
+        result = pfnGet(phAdapters, NumAdapters, NumEntries, phPlatforms,
+                        pNumPlatforms);
     } else {
         // generic implementation
         for (size_t i = 0; (nullptr != phPlatforms) && (i < NumEntries); ++i) {
@@ -211,32 +347,6 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
     if (nullptr != pfnGetBackendOption) {
         result =
             pfnGetBackendOption(hPlatform, pFrontendOption, ppPlatformOption);
-    } else {
-        // generic implementation
-    }
-
-    return result;
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urPlatformGetLastError
-__urdlllocal ur_result_t UR_APICALL urPlatformGetLastError(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
-                   ///< will be stored.
-    int32_t *
-        pError ///< [out] pointer to an integer where the adapter specific error code will
-               ///< be stored.
-    ) try {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnGetLastError = d_context.urDdiTable.Platform.pfnGetLastError;
-    if (nullptr != pfnGetLastError) {
-        result = pfnGetLastError(hPlatform, ppMessage, pError);
     } else {
         // generic implementation
     }
@@ -4946,6 +5056,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 
     pDdiTable->pfnTearDown = driver::urTearDown;
 
+    pDdiTable->pfnAdapterGet = driver::urAdapterGet;
+
+    pDdiTable->pfnAdapterRelease = driver::urAdapterRelease;
+
+    pDdiTable->pfnAdapterRetain = driver::urAdapterRetain;
+
+    pDdiTable->pfnAdapterGetLastError = driver::urAdapterGetLastError;
+
+    pDdiTable->pfnAdapterGetInfo = driver::urAdapterGetInfo;
+
     return result;
 } catch (...) {
     return exceptionToResult(std::current_exception());
@@ -5428,8 +5548,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
 
     pDdiTable->pfnCreateWithNativeHandle =
         driver::urPlatformCreateWithNativeHandle;
-
-    pDdiTable->pfnGetLastError = driver::urPlatformGetLastError;
 
     pDdiTable->pfnGetApiVersion = driver::urPlatformGetApiVersion;
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -64,8 +64,156 @@ __urdlllocal ur_result_t UR_APICALL urTearDown(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterGet
+__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+    uint32_t
+        NumEntries, ///< [in] the number of adapters to be added to phAdapters.
+    ///< If phAdapters is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_adapter_handle_t *
+        phAdapters, ///< [out][optional][range(0, NumEntries)] array of handle of adapters.
+    ///< If NumEntries is less than the number of adapters available, then
+    ///< ::urAdapterGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumAdapters ///< [out][optional] returns the total number of adapters available.
+) {
+    auto pfnAdapterGet = context.urDdiTable.Global.pfnAdapterGet;
+
+    if (nullptr == pfnAdapterGet) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_adapter_get_params_t params = {&NumEntries, &phAdapters, &pNumAdapters};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ADAPTER_GET, "urAdapterGet", &params);
+
+    ur_result_t result = pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
+
+    context.notify_end(UR_FUNCTION_ADAPTER_GET, "urAdapterGet", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterRelease
+__urdlllocal ur_result_t UR_APICALL urAdapterRelease(
+    ur_adapter_handle_t hAdapter ///< [in] Adapter handle to release
+) {
+    auto pfnAdapterRelease = context.urDdiTable.Global.pfnAdapterRelease;
+
+    if (nullptr == pfnAdapterRelease) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_adapter_release_params_t params = {&hAdapter};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ADAPTER_RELEASE,
+                                             "urAdapterRelease", &params);
+
+    ur_result_t result = pfnAdapterRelease(hAdapter);
+
+    context.notify_end(UR_FUNCTION_ADAPTER_RELEASE, "urAdapterRelease", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterRetain
+__urdlllocal ur_result_t UR_APICALL urAdapterRetain(
+    ur_adapter_handle_t hAdapter ///< [in] Adapter handle to retain
+) {
+    auto pfnAdapterRetain = context.urDdiTable.Global.pfnAdapterRetain;
+
+    if (nullptr == pfnAdapterRetain) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_adapter_retain_params_t params = {&hAdapter};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ADAPTER_RETAIN,
+                                             "urAdapterRetain", &params);
+
+    ur_result_t result = pfnAdapterRetain(hAdapter);
+
+    context.notify_end(UR_FUNCTION_ADAPTER_RETAIN, "urAdapterRetain", &params,
+                       &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterGetLastError
+__urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
+    ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
+    const char **
+        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
+                   ///< will be stored.
+    int32_t *
+        pError ///< [out] pointer to an integer where the adapter specific error code will
+               ///< be stored.
+) {
+    auto pfnAdapterGetLastError =
+        context.urDdiTable.Global.pfnAdapterGetLastError;
+
+    if (nullptr == pfnAdapterGetLastError) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_adapter_get_last_error_params_t params = {&hAdapter, &ppMessage,
+                                                 &pError};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ADAPTER_GET_LAST_ERROR,
+                                             "urAdapterGetLastError", &params);
+
+    ur_result_t result = pfnAdapterGetLastError(hAdapter, ppMessage, pError);
+
+    context.notify_end(UR_FUNCTION_ADAPTER_GET_LAST_ERROR,
+                       "urAdapterGetLastError", &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterGetInfo
+__urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
+    ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
+    ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPropValue is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPropValue.
+) {
+    auto pfnAdapterGetInfo = context.urDdiTable.Global.pfnAdapterGetInfo;
+
+    if (nullptr == pfnAdapterGetInfo) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_adapter_get_info_params_t params = {&hAdapter, &propName, &propSize,
+                                           &pPropValue, &pPropSizeRet};
+    uint64_t instance = context.notify_begin(UR_FUNCTION_ADAPTER_GET_INFO,
+                                             "urAdapterGetInfo", &params);
+
+    ur_result_t result = pfnAdapterGetInfo(hAdapter, propName, propSize,
+                                           pPropValue, pPropSizeRet);
+
+    context.notify_end(UR_FUNCTION_ADAPTER_GET_INFO, "urAdapterGetInfo",
+                       &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
+    ur_adapter_handle_t *
+        phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
+    uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
     uint32_t
         NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
     ///< If phPlatforms is not NULL, then NumEntries should be greater than
@@ -84,12 +232,13 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_platform_get_params_t params = {&NumEntries, &phPlatforms,
-                                       &pNumPlatforms};
+    ur_platform_get_params_t params = {&phAdapters, &NumAdapters, &NumEntries,
+                                       &phPlatforms, &pNumPlatforms};
     uint64_t instance = context.notify_begin(UR_FUNCTION_PLATFORM_GET,
                                              "urPlatformGet", &params);
 
-    ur_result_t result = pfnGet(NumEntries, phPlatforms, pNumPlatforms);
+    ur_result_t result =
+        pfnGet(phAdapters, NumAdapters, NumEntries, phPlatforms, pNumPlatforms);
 
     context.notify_end(UR_FUNCTION_PLATFORM_GET, "urPlatformGet", &params,
                        &result, instance);
@@ -245,36 +394,6 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
     context.notify_end(UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION,
                        "urPlatformGetBackendOption", &params, &result,
                        instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urPlatformGetLastError
-__urdlllocal ur_result_t UR_APICALL urPlatformGetLastError(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
-                   ///< will be stored.
-    int32_t *
-        pError ///< [out] pointer to an integer where the adapter specific error code will
-               ///< be stored.
-) {
-    auto pfnGetLastError = context.urDdiTable.Platform.pfnGetLastError;
-
-    if (nullptr == pfnGetLastError) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_platform_get_last_error_params_t params = {&hPlatform, &ppMessage,
-                                                  &pError};
-    uint64_t instance = context.notify_begin(
-        UR_FUNCTION_PLATFORM_GET_LAST_ERROR, "urPlatformGetLastError", &params);
-
-    ur_result_t result = pfnGetLastError(hPlatform, ppMessage, pError);
-
-    context.notify_end(UR_FUNCTION_PLATFORM_GET_LAST_ERROR,
-                       "urPlatformGetLastError", &params, &result, instance);
 
     return result;
 }
@@ -5715,6 +5834,21 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     dditable.pfnTearDown = pDdiTable->pfnTearDown;
     pDdiTable->pfnTearDown = ur_tracing_layer::urTearDown;
 
+    dditable.pfnAdapterGet = pDdiTable->pfnAdapterGet;
+    pDdiTable->pfnAdapterGet = ur_tracing_layer::urAdapterGet;
+
+    dditable.pfnAdapterRelease = pDdiTable->pfnAdapterRelease;
+    pDdiTable->pfnAdapterRelease = ur_tracing_layer::urAdapterRelease;
+
+    dditable.pfnAdapterRetain = pDdiTable->pfnAdapterRetain;
+    pDdiTable->pfnAdapterRetain = ur_tracing_layer::urAdapterRetain;
+
+    dditable.pfnAdapterGetLastError = pDdiTable->pfnAdapterGetLastError;
+    pDdiTable->pfnAdapterGetLastError = ur_tracing_layer::urAdapterGetLastError;
+
+    dditable.pfnAdapterGetInfo = pDdiTable->pfnAdapterGetInfo;
+    pDdiTable->pfnAdapterGetInfo = ur_tracing_layer::urAdapterGetInfo;
+
     return result;
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -6341,9 +6475,6 @@ __urdlllocal ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     dditable.pfnCreateWithNativeHandle = pDdiTable->pfnCreateWithNativeHandle;
     pDdiTable->pfnCreateWithNativeHandle =
         ur_tracing_layer::urPlatformCreateWithNativeHandle;
-
-    dditable.pfnGetLastError = pDdiTable->pfnGetLastError;
-    pDdiTable->pfnGetLastError = ur_tracing_layer::urPlatformGetLastError;
 
     dditable.pfnGetApiVersion = pDdiTable->pfnGetApiVersion;
     pDdiTable->pfnGetApiVersion = ur_tracing_layer::urPlatformGetApiVersion;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -17,6 +17,10 @@
 
 namespace ur_loader {
 ///////////////////////////////////////////////////////////////////////////////
+using ur_adapter_object_t = object_t<ur_adapter_handle_t>;
+using ur_adapter_factory_t =
+    singleton_factory_t<ur_adapter_object_t, ur_adapter_handle_t>;
+
 using ur_platform_object_t = object_t<ur_platform_handle_t>;
 using ur_platform_factory_t =
     singleton_factory_t<ur_platform_object_t, ur_platform_handle_t>;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -202,7 +202,185 @@ ur_result_t UR_APICALL urTearDown(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Retrieves all available platforms
+/// @brief Retrieves all available adapters
+///
+/// @details
+///     - Adapter implementations must return exactly one adapter handle from
+///       this entry point.
+///     - The loader may return more than one adapter handle when there are
+///       multiple available.
+///     - Each returned adapter has its reference count incremented and should
+///       be released with a subsequent call to ::urAdapterRelease.
+///     - Adapters may perform adapter-specific state initialization when the
+///       first reference to them is taken.
+///     - An application may call this entry point multiple times to acquire
+///       multiple references to the adapter handle(s).
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+ur_result_t UR_APICALL urAdapterGet(
+    uint32_t
+        NumEntries, ///< [in] the number of adapters to be added to phAdapters.
+    ///< If phAdapters is not NULL, then NumEntries should be greater than
+    ///< zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
+    ///< will be returned.
+    ur_adapter_handle_t *
+        phAdapters, ///< [out][optional][range(0, NumEntries)] array of handle of adapters.
+    ///< If NumEntries is less than the number of adapters available, then
+    ///< ::urAdapterGet shall only retrieve that number of platforms.
+    uint32_t *
+        pNumAdapters ///< [out][optional] returns the total number of adapters available.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Releases the adapter handle reference indicating end of its usage
+///
+/// @details
+///     - When the reference count of the adapter reaches zero, the adapter may
+///       perform adapter-specififc resource teardown
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+ur_result_t UR_APICALL urAdapterRelease(
+    ur_adapter_handle_t hAdapter ///< [in] Adapter handle to release
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get a reference to the adapter handle.
+///
+/// @details
+///     - Get a reference to the adapter handle. Increment its reference count
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+ur_result_t UR_APICALL urAdapterRetain(
+    ur_adapter_handle_t hAdapter ///< [in] Adapter handle to retain
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Get the last adapter specific error.
+///
+/// @details
+/// To be used after another entry-point has returned
+/// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
+/// the circumstances of the underlying driver error and the error code
+/// returned by the failed driver entry-point.
+///
+/// * Implementations *must* store the message and error code in thread-local
+///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
+///
+/// * The message and error code storage is will only be valid if a previously
+///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
+///
+/// * The memory pointed to by the C string returned in `ppMessage` is owned by
+///   the adapter and *must* be null terminated.
+///
+/// * The application *may* call this function from simultaneous threads.
+///
+/// * The implementation of this function *should* be lock-free.
+///
+/// Example usage:
+///
+/// ```cpp
+/// if (::urQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
+///         ::UR_RESULT_ERROR_ADAPTER_SPECIFIC) {
+///     const char* pMessage;
+///     int32_t error;
+///     ::urAdapterGetLastError(hAdapter, &pMessage, &error);
+/// }
+/// ```
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == ppMessage`
+///         + `NULL == pError`
+ur_result_t UR_APICALL urAdapterGetLastError(
+    ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
+    const char **
+        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
+                   ///< will be stored.
+    int32_t *
+        pError ///< [out] pointer to an integer where the adapter specific error code will
+               ///< be stored.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves information about the adapter
+///
+/// @details
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be lock-free.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_ADAPTER_INFO_REFERENCE_COUNT < propName`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
+///         + If `propName` is not supported by the adapter.
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         + `propSize == 0 && pPropValue != NULL`
+///         + If `propSize` is less than the real number of bytes needed to return the info.
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `propSize != 0 && pPropValue == NULL`
+///         + `pPropValue == NULL && pPropSizeRet == NULL`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urAdapterGetInfo(
+    ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
+    ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
+    size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
+    void *
+        pPropValue, ///< [out][optional][typename(propName, propSize)] array of bytes holding
+                    ///< the info.
+    ///< If Size is not equal to or greater to the real number of bytes needed
+    ///< to return the info then the ::UR_RESULT_ERROR_INVALID_SIZE error is
+    ///< returned and pPropValue is not used.
+    size_t *
+        pPropSizeRet ///< [out][optional] pointer to the actual number of bytes being queried by pPropValue.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details
 ///     - Multiple calls to this function will return identical platforms
@@ -219,8 +397,13 @@ ur_result_t UR_APICALL urTearDown(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phAdapters`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ur_result_t UR_APICALL urPlatformGet(
+    ur_adapter_handle_t *
+        phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
+    uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
     uint32_t
         NumEntries, ///< [in] the number of platforms to be added to phPlatforms.
     ///< If phPlatforms is not NULL, then NumEntries should be greater than
@@ -399,62 +582,6 @@ ur_result_t UR_APICALL urPlatformGetBackendOption(
     const char **
         ppPlatformOption ///< [out] returns the correct platform specific compiler option based on
                          ///< the frontend option.
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Get the last adapter specific error.
-///
-/// @details
-/// To be used after another entry-point has returned
-/// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
-/// the circumstances of the underlying driver error and the error code
-/// returned by the failed driver entry-point.
-///
-/// * Implementations *must* store the message and error code in thread-local
-///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
-///
-/// * The message and error code storage is will only be valid if a previously
-///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
-///
-/// * The memory pointed to by the C string returned in `ppMessage` is owned by
-///   the adapter and *must* be null terminated.
-///
-/// * The application *may* call this function from simultaneous threads.
-///
-/// * The implementation of this function *should* be lock-free.
-///
-/// Example usage:
-///
-/// ```cpp
-/// if (::urQueueCreate(hContext, hDevice, nullptr, &hQueue) ==
-///         ::UR_RESULT_ERROR_ADAPTER_SPECIFIC) {
-///     const char* pMessage;
-///     int32_t error;
-///     ::urPlatformGetLastError(hPlatform, &pMessage, &error);
-/// }
-/// ```
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hPlatform`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == ppMessage`
-///         + `NULL == pError`
-ur_result_t UR_APICALL urPlatformGetLastError(
-    ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
-    const char **
-        ppMessage, ///< [out] pointer to a C string where the adapter specific error message
-                   ///< will be stored.
-    int32_t *
-        pError ///< [out] pointer to an integer where the adapter specific error code will
-               ///< be stored.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/conformance/platform/CMakeLists.txt
+++ b/test/conformance/platform/CMakeLists.txt
@@ -9,5 +9,4 @@ add_conformance_test(platform
     urPlatformGetApiVersion.cpp
     urPlatformGetBackendOption.cpp
     urPlatformGetInfo.cpp
-    urPlatformGetLastError.cpp
     urPlatformGetNativeHandle.cpp)

--- a/test/conformance/platform/fixtures.h
+++ b/test/conformance/platform/fixtures.h
@@ -20,12 +20,22 @@ struct urTest : ::testing::Test {
             urLoaderConfigEnableLayer(config, "UR_LAYER_FULL_VALIDATION"));
         ASSERT_SUCCESS(urInit(device_flags, config));
         ASSERT_SUCCESS(urLoaderConfigRelease(config));
+
+        uint32_t adapter_count;
+        ASSERT_SUCCESS(urAdapterGet(0, nullptr, &adapter_count));
+        adapters.resize(adapter_count);
+        ASSERT_SUCCESS(urAdapterGet(adapter_count, adapters.data(), nullptr));
     }
 
     void TearDown() override {
+        for (auto adapter : adapters) {
+            ASSERT_SUCCESS(urAdapterRelease(adapter));
+        }
         ur_tear_down_params_t tear_down_params{};
         ASSERT_SUCCESS(urTearDown(&tear_down_params));
     }
+
+    std::vector<ur_adapter_handle_t> adapters;
 };
 
 struct urPlatformsTest : urTest {
@@ -33,10 +43,14 @@ struct urPlatformsTest : urTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urTest::SetUp());
         uint32_t count;
-        ASSERT_SUCCESS(urPlatformGet(0, nullptr, &count));
+        ASSERT_SUCCESS(urPlatformGet(adapters.data(),
+                                     static_cast<uint32_t>(adapters.size()), 0,
+                                     nullptr, &count));
         ASSERT_NE(count, 0);
         platforms.resize(count);
-        ASSERT_SUCCESS(urPlatformGet(count, platforms.data(), nullptr));
+        ASSERT_SUCCESS(urPlatformGet(adapters.data(),
+                                     static_cast<uint32_t>(adapters.size()),
+                                     count, platforms.data(), nullptr));
     }
 
     std::vector<ur_platform_handle_t> platforms;

--- a/test/conformance/platform/urPlatformGet.cpp
+++ b/test/conformance/platform/urPlatformGet.cpp
@@ -9,10 +9,14 @@ using urPlatformGetTest = uur::platform::urTest;
 
 TEST_F(urPlatformGetTest, Success) {
     uint32_t count;
-    ASSERT_SUCCESS(urPlatformGet(0, nullptr, &count));
+    ASSERT_SUCCESS(urPlatformGet(adapters.data(),
+                                 static_cast<uint32_t>(adapters.size()), 0,
+                                 nullptr, &count));
     ASSERT_NE(count, 0);
     std::vector<ur_platform_handle_t> platforms(count);
-    ASSERT_SUCCESS(urPlatformGet(count, platforms.data(), nullptr));
+    ASSERT_SUCCESS(urPlatformGet(adapters.data(),
+                                 static_cast<uint32_t>(adapters.size()), count,
+                                 platforms.data(), nullptr));
     for (auto platform : platforms) {
         ASSERT_NE(nullptr, platform);
     }
@@ -20,8 +24,12 @@ TEST_F(urPlatformGetTest, Success) {
 
 TEST_F(urPlatformGetTest, InvalidNumEntries) {
     uint32_t count;
-    ASSERT_SUCCESS(urPlatformGet(0, nullptr, &count));
+    ASSERT_SUCCESS(urPlatformGet(adapters.data(),
+                                 static_cast<uint32_t>(adapters.size()), 0,
+                                 nullptr, &count));
     std::vector<ur_platform_handle_t> platforms(count);
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urPlatformGet(0, platforms.data(), nullptr));
+                     urPlatformGet(adapters.data(),
+                                   static_cast<uint32_t>(adapters.size()), 0,
+                                   platforms.data(), nullptr));
 }

--- a/test/conformance/runtime/CMakeLists.txt
+++ b/test/conformance/runtime/CMakeLists.txt
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_conformance_test(runtime
+    urAdapterGet.cpp
+    urAdapterGetInfo.cpp
+    urAdapterGetLastError.cpp
+    urAdapterRetain.cpp
+    urAdapterRelease.cpp
     urInit.cpp
     urTearDown.cpp)

--- a/test/conformance/runtime/fixtures.h
+++ b/test/conformance/runtime/fixtures.h
@@ -1,0 +1,50 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <uur/fixtures.h>
+namespace uur {
+namespace runtime {
+
+struct urTest : ::testing::Test {
+
+    void SetUp() override {
+        ur_device_init_flags_t device_flags = 0;
+        ur_loader_config_handle_t config;
+        ASSERT_SUCCESS(urLoaderConfigCreate(&config));
+        ASSERT_SUCCESS(
+            urLoaderConfigEnableLayer(config, "UR_LAYER_FULL_VALIDATION"));
+        ASSERT_SUCCESS(urInit(device_flags, config));
+        ASSERT_SUCCESS(urLoaderConfigRelease(config));
+    }
+
+    void TearDown() override {
+        ur_tear_down_params_t tear_down_params{};
+        ASSERT_SUCCESS(urTearDown(&tear_down_params));
+    }
+};
+
+struct urAdapterTest : urTest {
+
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urTest::SetUp());
+
+        uint32_t adapter_count;
+        ASSERT_SUCCESS(urAdapterGet(0, nullptr, &adapter_count));
+        adapters.resize(adapter_count);
+        ASSERT_SUCCESS(urAdapterGet(adapter_count, adapters.data(), nullptr));
+    }
+
+    void TearDown() override {
+        for (auto adapter : adapters) {
+            ASSERT_SUCCESS(urAdapterRelease(adapter));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(urTest::TearDown());
+    }
+
+    std::vector<ur_adapter_handle_t> adapters;
+};
+
+} // namespace runtime
+} // namespace uur

--- a/test/conformance/runtime/urAdapterGet.cpp
+++ b/test/conformance/runtime/urAdapterGet.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.h"
+
+using urAdapterGetTest = uur::runtime::urTest;
+
+TEST_F(urAdapterGetTest, Success) {
+    uint32_t adapter_count;
+    ASSERT_SUCCESS(urAdapterGet(0, nullptr, &adapter_count));
+    std::vector<ur_adapter_handle_t> adapters(adapter_count);
+    ASSERT_SUCCESS(urAdapterGet(adapter_count, adapters.data(), nullptr));
+}
+
+TEST_F(urAdapterGetTest, InvalidNumEntries) {
+    uint32_t adapter_count;
+    ASSERT_SUCCESS(urAdapterGet(0, nullptr, &adapter_count));
+    std::vector<ur_adapter_handle_t> adapters(adapter_count);
+    ASSERT_SUCCESS(urAdapterGet(0, adapters.data(), nullptr));
+}

--- a/test/conformance/runtime/urAdapterGetInfo.cpp
+++ b/test/conformance/runtime/urAdapterGetInfo.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.h"
+
+#include <cstring>
+
+struct urAdapterGetInfoTest : uur::runtime::urAdapterTest,
+                              ::testing::WithParamInterface<ur_adapter_info_t> {
+
+    void SetUp() {
+        UUR_RETURN_ON_FATAL_FAILURE(uur::runtime::urAdapterTest::SetUp());
+        adapter = adapters[0];
+    }
+
+    ur_adapter_handle_t adapter;
+};
+
+std::unordered_map<ur_adapter_info_t, size_t> adapter_info_size_map = {
+    {UR_ADAPTER_INFO_BACKEND, sizeof(ur_adapter_backend_t)},
+    {UR_ADAPTER_INFO_REFERENCE_COUNT, sizeof(uint32_t)},
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    urAdapterGetInfo, urAdapterGetInfoTest,
+    ::testing::Values(UR_ADAPTER_INFO_BACKEND, UR_ADAPTER_INFO_REFERENCE_COUNT),
+    [](const ::testing::TestParamInfo<ur_adapter_info_t> &info) {
+        std::stringstream ss;
+        ss << info.param;
+        return ss.str();
+    });
+
+TEST_P(urAdapterGetInfoTest, Success) {
+    size_t size = 0;
+    ur_adapter_info_t info_type = GetParam();
+    ASSERT_SUCCESS(urAdapterGetInfo(adapter, info_type, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+
+    if (const auto expected_size = adapter_info_size_map.find(info_type);
+        expected_size != adapter_info_size_map.end()) {
+        ASSERT_EQ(expected_size->second, size);
+    }
+
+    std::vector<char> info_data(size);
+    ASSERT_SUCCESS(
+        urAdapterGetInfo(adapter, info_type, size, info_data.data(), nullptr));
+}
+
+TEST_P(urAdapterGetInfoTest, InvalidNullHandleAdapter) {
+    size_t size = 0;
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urAdapterGetInfo(nullptr, GetParam(), 0, nullptr, &size));
+}
+
+TEST_F(urAdapterGetInfoTest, InvalidEnumerationAdapterInfoType) {
+    size_t size = 0;
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
+                     urAdapterGetInfo(adapter, UR_ADAPTER_INFO_FORCE_UINT32, 0,
+                                      nullptr, &size));
+}
+
+TEST_F(urAdapterGetInfoTest, InvalidSizeZero) {
+    ur_adapter_backend_t backend;
+    ASSERT_EQ_RESULT(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND, 0,
+                                      &backend, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
+}
+
+TEST_F(urAdapterGetInfoTest, InvalidSizeSmall) {
+    ur_adapter_backend_t backend;
+    ASSERT_EQ_RESULT(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND,
+                                      sizeof(backend) - 1, &backend, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
+}
+
+TEST_F(urAdapterGetInfoTest, InvalidNullPointerPropValue) {
+    ur_adapter_backend_t backend;
+    ASSERT_EQ_RESULT(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND,
+                                      sizeof(backend), nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}
+
+TEST_F(urAdapterGetInfoTest, InvalidNullPointerPropSizeRet) {
+    ASSERT_EQ_RESULT(
+        urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND, 0, nullptr, nullptr),
+        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}

--- a/test/conformance/runtime/urAdapterGetLastError.cpp
+++ b/test/conformance/runtime/urAdapterGetLastError.cpp
@@ -5,31 +5,31 @@
 
 #include "fixtures.h"
 
-struct urPlatformGetLastErrorTest : uur::platform::urPlatformTest {
+struct urAdapterGetLastErrorTest : uur::runtime::urAdapterTest {
     int32_t error;
     const char *message = nullptr;
 };
 
-TEST_F(urPlatformGetLastErrorTest, Success) {
+TEST_F(urAdapterGetLastErrorTest, Success) {
     // We can't reliably generate a UR_RESULT_ERROR_ADAPTER_SPECIFIC error to
     // test the full functionality of this entry point, so instead do a minimal
     // smoke test and check that the call returns successfully, even if no
     // actual error was set.
     ASSERT_EQ_RESULT(UR_RESULT_SUCCESS,
-                     urPlatformGetLastError(platform, &message, &error));
+                     urAdapterGetLastError(adapters[0], &message, &error));
 }
 
-TEST_F(urPlatformGetLastErrorTest, InvalidHandle) {
+TEST_F(urAdapterGetLastErrorTest, InvalidHandle) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urPlatformGetLastError(nullptr, &message, &error));
+                     urAdapterGetLastError(nullptr, &message, &error));
 }
 
-TEST_F(urPlatformGetLastErrorTest, InvalidMessagePtr) {
+TEST_F(urAdapterGetLastErrorTest, InvalidMessagePtr) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urPlatformGetLastError(platform, nullptr, &error));
+                     urAdapterGetLastError(adapters[0], nullptr, &error));
 }
 
-TEST_F(urPlatformGetLastErrorTest, InvalidErrorPtr) {
+TEST_F(urAdapterGetLastErrorTest, InvalidErrorPtr) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urPlatformGetLastError(platform, &message, nullptr));
+                     urAdapterGetLastError(adapters[0], &message, nullptr));
 }

--- a/test/conformance/runtime/urAdapterRelease.cpp
+++ b/test/conformance/runtime/urAdapterRelease.cpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.h"
+
+struct urAdapterReleaseTest : uur::runtime::urAdapterTest {
+    void SetUp() {
+        UUR_RETURN_ON_FATAL_FAILURE(uur::runtime::urAdapterTest::SetUp());
+        adapter = adapters[0];
+    }
+
+    ur_adapter_handle_t adapter;
+};
+
+TEST_F(urAdapterReleaseTest, Success) {
+    ASSERT_SUCCESS(urAdapterRetain(adapter));
+    EXPECT_SUCCESS(urAdapterRelease(adapter));
+}
+
+TEST_F(urAdapterReleaseTest, InvalidNullHandleAdapter) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urAdapterRelease(nullptr));
+}

--- a/test/conformance/runtime/urAdapterRetain.cpp
+++ b/test/conformance/runtime/urAdapterRetain.cpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.h"
+
+struct urAdapterRetainTest : uur::runtime::urAdapterTest {
+    void SetUp() {
+        UUR_RETURN_ON_FATAL_FAILURE(uur::runtime::urAdapterTest::SetUp());
+        adapter = adapters[0];
+    }
+
+    ur_adapter_handle_t adapter;
+};
+
+TEST_F(urAdapterRetainTest, Success) {
+    ASSERT_SUCCESS(urAdapterRetain(adapter));
+    EXPECT_SUCCESS(urAdapterRelease(adapter));
+}
+
+TEST_F(urAdapterRetainTest, InvalidNullHandleAdapter) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urAdapterRetain(nullptr));
+}

--- a/test/conformance/testing/include/uur/environment.h
+++ b/test/conformance/testing/include/uur/environment.h
@@ -28,6 +28,7 @@ struct PlatformEnvironment : ::testing::Environment {
     PlatformOptions parsePlatformOptions(int argc, char **argv);
 
     PlatformOptions platform_options;
+    std::vector<ur_adapter_handle_t> adapters{};
     ur_platform_handle_t platform = nullptr;
     std::string error;
     static PlatformEnvironment *instance;

--- a/test/layers/tracing/hello_world.out.match
+++ b/test/layers/tracing/hello_world.out.match
@@ -1,21 +1,27 @@
 function_with_args_begin(1) - urInit(.device_flags = 0);
 function_with_args_end(1) - urInit(...) -> ur_result_t(0);
 Platform initialized.
-function_with_args_begin(2) - urPlatformGet(unimplemented);
-function_with_args_end(2) - urPlatformGet(...) -> ur_result_t(0);
-function_with_args_begin(3) - urPlatformGet(unimplemented);
-function_with_args_end(3) - urPlatformGet(...) -> ur_result_t(0);
-function_with_args_begin(4) - urPlatformGetApiVersion(unimplemented);
-function_with_args_end(4) - urPlatformGetApiVersion(...) -> ur_result_t(0);
+function_with_args_begin(2) - urAdapterGet(unimplemented);
+function_with_args_end(2) - urAdapterGet(...) -> ur_result_t(0);
+function_with_args_begin(3) - urAdapterGet(unimplemented);
+function_with_args_end(3) - urAdapterGet(...) -> ur_result_t(0);
+function_with_args_begin(4) - urPlatformGet(unimplemented);
+function_with_args_end(4) - urPlatformGet(...) -> ur_result_t(0);
+function_with_args_begin(5) - urPlatformGet(unimplemented);
+function_with_args_end(5) - urPlatformGet(...) -> ur_result_t(0);
+function_with_args_begin(6) - urPlatformGetApiVersion(unimplemented);
+function_with_args_end(6) - urPlatformGetApiVersion(...) -> ur_result_t(0);
 API version: {{0\.[0-9]+}}
-function_with_args_begin(5) - urDeviceGet(unimplemented);
-function_with_args_end(5) - urDeviceGet(...) -> ur_result_t(0);
-function_with_args_begin(6) - urDeviceGet(unimplemented);
-function_with_args_end(6) - urDeviceGet(...) -> ur_result_t(0);
-function_with_args_begin(7) - urDeviceGetInfo(unimplemented);
-function_with_args_end(7) - urDeviceGetInfo(...) -> ur_result_t(0);
-function_with_args_begin(8) - urDeviceGetInfo(unimplemented);
-function_with_args_end(8) - urDeviceGetInfo(...) -> ur_result_t(0);
+function_with_args_begin(7) - urDeviceGet(unimplemented);
+function_with_args_end(7) - urDeviceGet(...) -> ur_result_t(0);
+function_with_args_begin(8) - urDeviceGet(unimplemented);
+function_with_args_end(8) - urDeviceGet(...) -> ur_result_t(0);
+function_with_args_begin(9) - urDeviceGetInfo(unimplemented);
+function_with_args_end(9) - urDeviceGetInfo(...) -> ur_result_t(0);
+function_with_args_begin(10) - urDeviceGetInfo(unimplemented);
+function_with_args_end(10) - urDeviceGetInfo(...) -> ur_result_t(0);
 Found a Null Device gpu.
-function_with_args_begin(9) - urTearDown(unimplemented);
-function_with_args_end(9) - urTearDown(...) -> ur_result_t(0);
+function_with_args_begin(11) - urAdapterRelease(unimplemented);
+function_with_args_end(11) - urAdapterRelease(...) -> ur_result_t(0);
+function_with_args_begin(12) - urTearDown(unimplemented);
+function_with_args_end(12) - urTearDown(...) -> ur_result_t(0);

--- a/test/layers/validation/fixtures.hpp
+++ b/test/layers/validation/fixtures.hpp
@@ -36,14 +36,27 @@ struct valPlatformsTest : urTest {
 
     void SetUp() override {
         urTest::SetUp();
+
+        uint32_t adapter_count;
+        ASSERT_EQ(urAdapterGet(0, nullptr, &adapter_count), UR_RESULT_SUCCESS);
+        adapters.resize(adapter_count);
+        ASSERT_EQ(urAdapterGet(adapter_count, adapters.data(), nullptr),
+                  UR_RESULT_SUCCESS);
+
         uint32_t count;
-        ASSERT_EQ(urPlatformGet(0, nullptr, &count), UR_RESULT_SUCCESS);
+        ASSERT_EQ(
+            urPlatformGet(adapters.data(), adapter_count, 0, nullptr, &count),
+            UR_RESULT_SUCCESS);
         ASSERT_NE(count, 0);
         platforms.resize(count);
-        ASSERT_EQ(urPlatformGet(count, platforms.data(), nullptr),
+        ASSERT_EQ(urPlatformGet(adapters.data(), adapter_count, count,
+                                platforms.data(), nullptr),
                   UR_RESULT_SUCCESS);
     }
 
+    void TearDown() override { urTest::TearDown(); }
+
+    std::vector<ur_adapter_handle_t> adapters;
     std::vector<ur_platform_handle_t> platforms;
 };
 

--- a/test/loader/platforms/platforms.cpp
+++ b/test/loader/platforms/platforms.cpp
@@ -31,10 +31,26 @@ int main(int argc, char *argv[]) {
     }
     info("urInit succeeded.");
 
+    uint32_t adapterCount = 0;
+    std::vector<ur_adapter_handle_t> adapters;
+    status = urAdapterGet(0, nullptr, &adapterCount);
+    if (status != UR_RESULT_SUCCESS) {
+        error("urAdapterGet failed with return code: {}", status);
+        return 1;
+    }
+
+    adapters.resize(adapterCount);
+    status = urAdapterGet(adapterCount, adapters.data(), nullptr);
+    if (status != UR_RESULT_SUCCESS) {
+        error("urAdapterGet failed with return code: {}", status);
+        return 1;
+    }
+
     uint32_t platformCount = 0;
     std::vector<ur_platform_handle_t> platforms;
 
-    status = urPlatformGet(1, nullptr, &platformCount);
+    status = urPlatformGet(adapters.data(), adapterCount, 1, nullptr,
+                           &platformCount);
     if (status != UR_RESULT_SUCCESS) {
         error("urPlatformGet failed with return code: {}", status);
         goto out;
@@ -42,7 +58,8 @@ int main(int argc, char *argv[]) {
     info("urPlatformGet found {} platforms", platformCount);
 
     platforms.resize(platformCount);
-    status = urPlatformGet(platformCount, platforms.data(), nullptr);
+    status = urPlatformGet(adapters.data(), adapterCount, platformCount,
+                           platforms.data(), nullptr);
     if (status != UR_RESULT_SUCCESS) {
         error("urPlatformGet failed with return code: {}", status);
         goto out;

--- a/test/tools/urtrace/null_hello.match
+++ b/test/tools/urtrace/null_hello.match
@@ -1,7 +1,9 @@
 urInit(.device_flags = 0, .hLoaderConfig = nullptr) -> UR_RESULT_SUCCESS;
 Platform initialized.
-urPlatformGet(.NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS;
-urPlatformGet(.NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS;
+urAdapterGet(.NumEntries = 0, .phAdapters = {}, .pNumAdapters = {{.*}} (1)) -> UR_RESULT_SUCCESS;
+urAdapterGet(.NumEntries = 1, .phAdapters = {{{.*}}}, .pNumAdapters = nullptr) -> UR_RESULT_SUCCESS;
+urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS;
+urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS;
 urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} ({{.*}})) -> UR_RESULT_SUCCESS;
 API version: {{.*}}
 urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS;
@@ -9,4 +11,5 @@ urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries =
 urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = {{.*}}, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS;
 urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = {{.*}}, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS;
 Found a Null Device gpu.
+urAdapterRelease(.hAdapter = {{.*}}) -> UR_RESULT_SUCCESS;
 urTearDown(.pParams = nullptr) -> UR_RESULT_SUCCESS;

--- a/test/tools/urtrace/null_hello_begin.match
+++ b/test/tools/urtrace/null_hello_begin.match
@@ -1,21 +1,27 @@
 begin(1) - urInit(.device_flags = 0, .hLoaderConfig = nullptr);
 end(1) - urInit(.device_flags = 0, .hLoaderConfig = nullptr) -> UR_RESULT_SUCCESS;
 Platform initialized.
-begin(2) - urPlatformGet(.NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (0));
-end(2) - urPlatformGet(.NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS;
-begin(3) - urPlatformGet(.NumEntries = 1, .phPlatforms = {nullptr}, .pNumPlatforms = nullptr);
-end(3) - urPlatformGet(.NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS;
-begin(4) - urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.0));
-end(4) - urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.6)) -> UR_RESULT_SUCCESS;
+begin(2) - urAdapterGet(.NumEntries = 0, .phAdapters = {}, .pNumAdapters = {{.*}} (0));
+end(2) - urAdapterGet(.NumEntries = 0, .phAdapters = {}, .pNumAdapters = {{.*}} (1)) -> UR_RESULT_SUCCESS;
+begin(3) - urAdapterGet(.NumEntries = 1, .phAdapters = {{{.*}}}, .pNumAdapters = nullptr);
+end(3) - urAdapterGet(.NumEntries = 1, .phAdapters = {{{.*}}}, .pNumAdapters = nullptr) -> UR_RESULT_SUCCESS;
+begin(4) - urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (0));
+end(4) - urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS;
+begin(5) - urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {nullptr}, .pNumPlatforms = nullptr);
+end(5) - urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS;
+begin(6) - urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.0));
+end(6) - urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.6)) -> UR_RESULT_SUCCESS;
 API version: {{.*}}
-begin(5) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (0));
-end(5) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS;
-begin(6) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = {nullptr}, .pNumDevices = nullptr);
-end(6) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = {{{.*}}}, .pNumDevices = nullptr) -> UR_RESULT_SUCCESS;
-begin(7) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = 4, .pPropValue = {{.*}}, .pPropSizeRet = nullptr);
-end(7) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = 4, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS;
-begin(8) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = 1023, .pPropValue = {{.*}}, .pPropSizeRet = nullptr);
-end(8) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = 1023, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS;
+begin(7) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (0));
+end(7) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS;
+begin(8) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = {nullptr}, .pNumDevices = nullptr);
+end(8) - urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 1, .phDevices = {{{.*}}}, .pNumDevices = nullptr) -> UR_RESULT_SUCCESS;
+begin(9) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = 4, .pPropValue = {{.*}}, .pPropSizeRet = nullptr);
+end(9) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = 4, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS;
+begin(10) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = 1023, .pPropValue = {{.*}}, .pPropSizeRet = nullptr);
+end(10) - urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = 1023, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS;
 Found a Null Device gpu.
-begin(9) - urTearDown(.pParams = nullptr);
-end(9) - urTearDown(.pParams = nullptr) -> UR_RESULT_SUCCESS;
+begin(11) - urAdapterRelease(.hAdapter = {{.*}});
+end(11) - urAdapterRelease(.hAdapter = {{.*}}) -> UR_RESULT_SUCCESS;
+begin(12) - urTearDown(.pParams = nullptr);
+end(12) - urTearDown(.pParams = nullptr) -> UR_RESULT_SUCCESS;

--- a/test/tools/urtrace/null_hello_json.match
+++ b/test/tools/urtrace/null_hello_json.match
@@ -2,8 +2,10 @@
  "traceEvents": [
 {            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urInit",            "args": "(.device_flags = 0, .hLoaderConfig = nullptr)"        },
 Platform initialized.
-{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGet",            "args": "(.NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1))"        },
-{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGet",            "args": "(.NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr)"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urAdapterGet",            "args": "(.NumEntries = 0, .phAdapters = {}, .pNumAdapters = {{.*}} (1))"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urAdapterGet",            "args": "(.NumEntries = 1, .phAdapters = {{{.*}}}, .pNumAdapters = nullptr)"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGet",            "args": "(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1))"        },
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGet",            "args": "(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr)"        },
 {            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urPlatformGetApiVersion",            "args": "(.hPlatform = {{.*}}, .pVersion = {{.*}} (0.6))"        },
 API version: 0.6
 {            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGet",            "args": "(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (1))"        },
@@ -11,6 +13,7 @@ API version: 0.6
 {            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGetInfo",            "args": "(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = 4, .pPropValue = {{.*}} (UR_DEVICE_TYPE_GPU), .pPropSizeRet = nullptr)"        },
 {            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urDeviceGetInfo",            "args": "(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = 1023, .pPropValue = {{.*}} (Null Device), .pPropSizeRet = nullptr)"        },
 Found a Null Device gpu.
+{            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urAdapterRelease",            "args": "(.hAdapter = {{.*}})"        },
 {            "cat": "UR",             "ph": "X",            "pid": {{.*}},            "tid": {{.*}},            "ts": {{.*}},            "dur": {{.*}},            "name": "urTearDown",            "args": "(.pParams = nullptr)"        },
 {"name": "", "cat": "", "ph": "", "pid": "", "tid": "", "ts": ""}
 ]

--- a/test/tools/urtrace/null_hello_no_args.match
+++ b/test/tools/urtrace/null_hello_no_args.match
@@ -1,5 +1,7 @@
 urInit(...) -> UR_RESULT_SUCCESS;
 Platform initialized.
+urAdapterGet(...) -> UR_RESULT_SUCCESS;
+urAdapterGet(...) -> UR_RESULT_SUCCESS;
 urPlatformGet(...) -> UR_RESULT_SUCCESS;
 urPlatformGet(...) -> UR_RESULT_SUCCESS;
 urPlatformGetApiVersion(...) -> UR_RESULT_SUCCESS;
@@ -9,4 +11,5 @@ urDeviceGet(...) -> UR_RESULT_SUCCESS;
 urDeviceGetInfo(...) -> UR_RESULT_SUCCESS;
 urDeviceGetInfo(...) -> UR_RESULT_SUCCESS;
 Found a Null Device gpu.
+urAdapterRelease(...) -> UR_RESULT_SUCCESS;
 urTearDown(...) -> UR_RESULT_SUCCESS;

--- a/test/tools/urtrace/null_hello_profiling.match
+++ b/test/tools/urtrace/null_hello_profiling.match
@@ -1,7 +1,9 @@
 urInit(.device_flags = 0, .hLoaderConfig = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 Platform initialized.
-urPlatformGet(.NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
-urPlatformGet(.NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
+urAdapterGet(.NumEntries = 0, .phAdapters = {}, .pNumAdapters = {{.*}} (1)) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
+urAdapterGet(.NumEntries = 1, .phAdapters = {{{.*}}}, .pNumAdapters = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
+urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {}, .pNumPlatforms = {{.*}} (1)) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
+urPlatformGet(.phAdapters = {{{.*}}}, .NumAdapters = 1, .NumEntries = 1, .phPlatforms = {{{.*}}}, .pNumPlatforms = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 urPlatformGetApiVersion(.hPlatform = {{.*}}, .pVersion = {{.*}} ({{.*}})) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 API version: {{.*}}
 urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries = 0, .phDevices = {}, .pNumDevices = {{.*}} (1)) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
@@ -9,4 +11,5 @@ urDeviceGet(.hPlatform = {{.*}}, .DeviceType = UR_DEVICE_TYPE_GPU, .NumEntries =
 urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_TYPE, .propSize = {{.*}}, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 urDeviceGetInfo(.hDevice = {{.*}}, .propName = UR_DEVICE_INFO_NAME, .propSize = {{.*}}, .pPropValue = {{.*}}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 Found a Null Device gpu.
+urAdapterRelease(.hAdapter = {{.*}}) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)
 urTearDown(.pParams = nullptr) -> UR_RESULT_SUCCESS; ({{[0-9]+}}ns)

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -51,13 +51,19 @@ struct UrInitParamsInvalidFlags : UrInitParams {
 
 struct UrPlatformGet {
     ur_platform_get_params_t params;
+    uint32_t num_adapters;
+    ur_adapter_handle_t *phAdapters;
     uint32_t num_entries;
     uint32_t *pNumPlatforms;
     ur_platform_handle_t *pPlatforms;
     UrPlatformGet() {
+        num_adapters = 0;
+        phAdapters = nullptr;
         num_entries = 0;
         pPlatforms = nullptr;
         pNumPlatforms = nullptr;
+        params.pNumAdapters = &num_adapters;
+        params.pphAdapters = &phAdapters;
         params.pNumEntries = &num_entries;
         params.pphPlatforms = &pPlatforms;
         params.ppNumPlatforms = &pNumPlatforms;
@@ -69,7 +75,8 @@ struct UrPlatformGet {
 struct UrPlatformGetEmptyArray : UrPlatformGet {
     UrPlatformGetEmptyArray() : UrPlatformGet() {}
     const char *get_expected() {
-        return ".NumEntries = 0, .phPlatforms = \\{\\}, .pNumPlatforms = "
+        return ".phAdapters = \\{\\}, .NumAdapters = 0, .NumEntries = 0, "
+               ".phPlatforms = \\{\\}, .pNumPlatforms = "
                "nullptr";
     };
 };
@@ -85,7 +92,8 @@ struct UrPlatformGetTwoPlatforms : UrPlatformGet {
         pNumPlatforms = &num_platforms;
     }
     const char *get_expected() {
-        return ".NumEntries = 2, .phPlatforms = \\{.+, .+\\}, "
+        return ".phAdapters = \\{\\}, .NumAdapters = 0, .NumEntries = 2, "
+               ".phPlatforms = \\{.+, .+\\}, "
                ".pNumPlatforms = .+ \\(2\\)";
     };
 };


### PR DESCRIPTION
Corresponding changes to the adapters, pi2ur, etc are in https://github.com/intel/llvm/pull/10349/

Summary of new/changed entry points:

- **urInit** Adapters no longer perform global state setup in urInit. The loader may still perform setup (layer config etc), so the entry point is still needed, but it might be possible to combine it with the below.
- **urAdapterGet** Individual adapters return exactly 1 adapter handle, the loader returns however many adapters are known. Each returned adapter increments the reference count of the adapter by 1. When the reference count goes from 0 to 1, adapters may perform setup of global state (which previously happened in urInit). The underlying object pointed to by the `ur_adapter_handle_t` should be a single static object in the adapter.
- **urPlatformGet** Now explicitly takes the adapters to use as arguments. Multiple adapters can be used in the same call. This allows all platforms available to be queried as before, or more fine selection of platforms from certain adapters.
- **urAdapterRetain/Release** Increment or decrement the adapter reference count. When the reference count drops to 0, adapters may perform teardown of global state (which previously happened in urTearDown).
- **urTearDown** Adapters no longer perform global state teardown in urTearDown. This entry point may be kept if useful for the loader, otherwise it could be removed.
- **urAdapterGetLastError** Previously urPlatformGetLastError. No changes other than it takes an adapter handle rather than platform handle, removing the need to always have a platform handle when a UR entry point is called to be able to process an adapter-specific error.
- **urAdapterGetInfo** Can be used to query the backend of the adapter (which is just a duplicate of `UR_PLATFORM_BACKEND`).

Addresses #714 by allowing better sharing of UR adapters when multiple modules in an application share the UR libraries. They may independently call `urAdapterGet` safely, or may explicitly pass adapter handles around (retaining/releasing as necessary).

Provides some more programmatic control over which adapters are used by allowing users to query which backend is supported by each adapter, and only fetching platforms from certain adapters.

Fixes https://github.com/intel/llvm/issues/10066 by allowing `piPluginGetLastError` to be implementable in pi2ur.
