### PR TITLE
[Bindless][Exp] Add bindless images interop resource handles

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -232,6 +232,10 @@ class ur_structure_type_v(IntEnum):
     KERNEL_ARG_LOCAL_PROPERTIES = 33                ## ::ur_kernel_arg_local_properties_t
     EXP_COMMAND_BUFFER_DESC = 0x1000                ## ::ur_exp_command_buffer_desc_t
     EXP_SAMPLER_MIP_PROPERTIES = 0x2000             ## ::ur_exp_sampler_mip_properties_t
+    EXP_INTEROP_MEMORY_DESC = 0x2001                ## ::ur_exp_interop_memory_desc_t
+    EXP_INTEROP_SEMAPHORE_DESC = 0x2002             ## ::ur_exp_interop_semaphore_desc_t
+    EXP_FILE_DESCRIPTOR = 0x2003                    ## ::ur_exp_file_descriptor_t
+    EXP_WIN32_HANDLE = 0x2004                       ## ::ur_exp_win32_handle_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -2098,6 +2102,26 @@ class ur_exp_image_copy_flags_t(c_int):
 
 
 ###############################################################################
+## @brief File descriptor
+class ur_exp_file_descriptor_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("fd", c_int)                                                   ## [in] A file descriptor used for Linux and & MacOS operating systems.
+    ]
+
+###############################################################################
+## @brief Windows specific file handle
+class ur_exp_win32_handle_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("handle", c_void_p)                                            ## [in] A win32 file handle.
+    ]
+
+###############################################################################
 ## @brief Describes mipmap sampler properties
 ## 
 ## @details
@@ -2115,6 +2139,24 @@ class ur_exp_sampler_mip_properties_t(Structure):
         ("maxAnisotropy", c_float),                                     ## [in] anisotropic ratio used when samplling the mipmap with anisotropic
                                                                         ## filtering
         ("mipFilterMode", ur_sampler_filter_mode_t)                     ## [in] mipmap filter mode used for filtering between mipmap levels
+    ]
+
+###############################################################################
+## @brief Describes an interop memory resource descriptor
+class ur_exp_interop_memory_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC
+        ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
+    ]
+
+###############################################################################
+## @brief Describes an interop semaphore resource descriptor
+class ur_exp_interop_semaphore_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
+        ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
     ]
 
 ###############################################################################
@@ -3117,9 +3159,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesImportOpaqueFDExp
 if __use_win_types:
-    _urBindlessImagesImportOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, c_ulong, POINTER(ur_exp_interop_mem_handle_t) )
+    _urBindlessImagesImportOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, POINTER(ur_exp_interop_memory_desc_t), POINTER(ur_exp_interop_mem_handle_t) )
 else:
-    _urBindlessImagesImportOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, c_ulong, POINTER(ur_exp_interop_mem_handle_t) )
+    _urBindlessImagesImportOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_size_t, POINTER(ur_exp_interop_memory_desc_t), POINTER(ur_exp_interop_mem_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesMapExternalArrayExp
@@ -3138,9 +3180,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
 if __use_win_types:
-    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(ur_exp_interop_semaphore_handle_t) )
+    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_exp_interop_semaphore_desc_t), POINTER(ur_exp_interop_semaphore_handle_t) )
 else:
-    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, c_ulong, POINTER(ur_exp_interop_semaphore_handle_t) )
+    _urBindlessImagesImportExternalSemaphoreOpaqueFDExp_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, ur_device_handle_t, POINTER(ur_exp_interop_semaphore_desc_t), POINTER(ur_exp_interop_semaphore_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urBindlessImagesDestroyExternalSemaphoreExp

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -241,6 +241,10 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES = 33,     ///< ::ur_kernel_arg_local_properties_t
     UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC = 0x1000,     ///< ::ur_exp_command_buffer_desc_t
     UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES = 0x2000,  ///< ::ur_exp_sampler_mip_properties_t
+    UR_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC = 0x2001,     ///< ::ur_exp_interop_memory_desc_t
+    UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC = 0x2002,  ///< ::ur_exp_interop_semaphore_desc_t
+    UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR = 0x2003,         ///< ::ur_exp_file_descriptor_t
+    UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE = 0x2004,            ///< ::ur_exp_win32_handle_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -6617,6 +6621,26 @@ typedef enum ur_exp_image_copy_flag_t {
 #define UR_EXP_IMAGE_COPY_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief File descriptor
+typedef struct ur_exp_file_descriptor_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    int fd;                    ///< [in] A file descriptor used for Linux and & MacOS operating systems.
+
+} ur_exp_file_descriptor_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Windows specific file handle
+typedef struct ur_exp_win32_handle_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    void *handle;              ///< [in] A win32 file handle.
+
+} ur_exp_win32_handle_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Describes mipmap sampler properties
 ///
 /// @details
@@ -6635,6 +6659,24 @@ typedef struct ur_exp_sampler_mip_properties_t {
     ur_sampler_filter_mode_t mipFilterMode; ///< [in] mipmap filter mode used for filtering between mipmap levels
 
 } ur_exp_sampler_mip_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Describes an interop memory resource descriptor
+typedef struct ur_exp_interop_memory_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+
+} ur_exp_interop_memory_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Describes an interop semaphore resource descriptor
+typedef struct ur_exp_interop_semaphore_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+
+} ur_exp_interop_semaphore_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocate pitched memory
@@ -7034,17 +7076,18 @@ urBindlessImagesMipmapFreeExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == interopMemDesc`
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImportOpaqueFDExp(
-    ur_context_handle_t hContext,             ///< [in] handle of the context object
-    ur_device_handle_t hDevice,               ///< [in] handle of the device object
-    size_t size,                              ///< [in] size of the external memory
-    uint32_t fileDescriptor,                  ///< [in] the file descriptor
-    ur_exp_interop_mem_handle_t *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_context_handle_t hContext,                 ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                   ///< [in] handle of the device object
+    size_t size,                                  ///< [in] size of the external memory
+    ur_exp_interop_memory_desc_t *interopMemDesc, ///< [in] the interop memory descriptor
+    ur_exp_interop_mem_handle_t *phInteropMem     ///< [out] interop memory handle to the external memory
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7121,15 +7164,16 @@ urBindlessImagesReleaseInteropExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phInteropSemaphoreHandle`
+///         + `NULL == interopSemaphoreDesc`
+///         + `NULL == phInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
-    ur_context_handle_t hContext,                               ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                                 ///< [in] handle of the device object
-    uint32_t fileDescriptor,                                    ///< [in] the file descriptor
-    ur_exp_interop_semaphore_handle_t *phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+    ur_context_handle_t hContext,                          ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                            ///< [in] handle of the device object
+    ur_exp_interop_semaphore_desc_t *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
+    ur_exp_interop_semaphore_handle_t *phInteropSemaphore  ///< [out] interop semaphore handle to the external semaphore
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9199,7 +9243,7 @@ typedef struct ur_bindless_images_import_opaque_fd_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
     size_t *psize;
-    uint32_t *pfileDescriptor;
+    ur_exp_interop_memory_desc_t **pinteropMemDesc;
     ur_exp_interop_mem_handle_t **pphInteropMem;
 } ur_bindless_images_import_opaque_fd_exp_params_t;
 
@@ -9233,8 +9277,8 @@ typedef struct ur_bindless_images_release_interop_exp_params_t {
 typedef struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    uint32_t *pfileDescriptor;
-    ur_exp_interop_semaphore_handle_t **pphInteropSemaphoreHandle;
+    ur_exp_interop_semaphore_desc_t **pinteropSemaphoreDesc;
+    ur_exp_interop_semaphore_handle_t **pphInteropSemaphore;
 } ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1375,7 +1375,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportOpaqueFDExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
     size_t,
-    uint32_t,
+    ur_exp_interop_memory_desc_t *,
     ur_exp_interop_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1400,7 +1400,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseInteropExp_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreOpaqueFDExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    uint32_t,
+    ur_exp_interop_semaphore_desc_t *,
     ur_exp_interop_semaphore_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -64,6 +64,10 @@ Enums
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * ${x}_structure_type_t
     ${X}_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES
+    ${X}_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC
+    ${X}_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
+    ${X}_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
+    ${X}_STRUCTURE_TYPE_EXP_WIN32_HANDLE
 
 * ${x}_device_info_t
     * ${X}_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP
@@ -119,6 +123,10 @@ Types
 * ${x}_exp_image_mem_handle_t
 * ${x}_exp_interop_mem_handle_t
 * ${x}_exp_interop_semaphore_handle_t
+* ${x}_exp_interop_memory_desc_t
+* ${x}_exp_interop_semaphore_desc_t
+* ${x}_exp_file_descriptor_t
+* ${x}_exp_win32_handle_t
 
 Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,8 +167,11 @@ Changelog
 |          || Removed 3D USM capabilities.                            |
 |          || Added mip filter mode.                                  |
 +----------+----------------------------------------------------------+
-| 3.0      | Added device query for bindless images on shared USM    |
-+----------+---------------------------------------------------------+
+| 3.0      | Added device query for bindless images on shared USM     |
++----------+-------------------------------------------------------------+
+| 4.0      || Added platform specific interop resource handles.          |
+|          || Added and updated to use new interop resource descriptors. |
++----------+-------------------------------------------------------------+
 
 Contributors
 --------------------------------------------------------------------------------

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -86,6 +86,18 @@ etors:
     - name: EXP_SAMPLER_MIP_PROPERTIES
       desc: $x_exp_sampler_mip_properties_t
       value: "0x2000"
+    - name: EXP_INTEROP_MEMORY_DESC
+      desc: $x_exp_interop_memory_desc_t
+      value: "0x2001"
+    - name: EXP_INTEROP_SEMAPHORE_DESC
+      desc: $x_exp_interop_semaphore_desc_t
+      value: "0x2002"
+    - name: EXP_FILE_DESCRIPTOR
+      desc: $x_exp_file_descriptor_t
+      value: "0x2003"
+    - name: EXP_WIN32_HANDLE
+      desc: $x_exp_win32_handle_t
+      value: "0x2004"
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true
@@ -112,6 +124,24 @@ etors:
     desc: "Device to device"
 --- #--------------------------------------------------------------------------
 type: struct
+desc: "File descriptor"
+name: $x_exp_file_descriptor_t
+base: $x_base_desc_t
+members:
+    - type: int
+      name: fd
+      desc: "[in] A file descriptor used for Linux and & MacOS operating systems."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Windows specific file handle"
+name: $x_exp_win32_handle_t
+base: $x_base_desc_t
+members:
+    - type: void*
+      name: handle
+      desc: "[in] A win32 file handle."
+--- #--------------------------------------------------------------------------
+type: struct
 desc: "Describes mipmap sampler properties"
 details:
     - Specify these properties in $xSamplerCreate via $x_sampler_desc_t as part
@@ -132,6 +162,20 @@ members:
     - type: $x_sampler_filter_mode_t
       name: mipFilterMode
       desc: "[in] mipmap filter mode used for filtering between mipmap levels"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Describes an interop memory resource descriptor"
+class: $xBindlessImages
+name: $x_exp_interop_memory_desc_t
+base: $x_base_desc_t
+members: []
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Describes an interop semaphore resource descriptor"
+class: $xBindlessImages
+name: $x_exp_interop_semaphore_desc_t
+base: $x_base_desc_t
+members: []
 --- #--------------------------------------------------------------------------
 type: function
 desc: "USM allocate pitched memory"
@@ -518,9 +562,9 @@ params:
     - type: size_t
       name: size
       desc: "[in] size of the external memory"
-    - type: uint32_t
-      name: fileDescriptor
-      desc: "[in] the file descriptor"
+    - type: $x_exp_interop_memory_desc_t*
+      name: interopMemDesc
+      desc: "[in] the interop memory descriptor"
     - type: $x_exp_interop_mem_handle_t*
       name: phInteropMem
       desc: "[out] interop memory handle to the external memory"
@@ -597,11 +641,11 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: uint32_t
-      name: fileDescriptor
-      desc: "[in] the file descriptor"
+    - type: $x_exp_interop_semaphore_desc_t*
+      name: interopSemaphoreDesc
+      desc: "[in] the interop semaphore descriptor"
     - type: $x_exp_interop_semaphore_handle_t*
-      name: phInteropSemaphoreHandle
+      name: phInteropSemaphore
       desc: "[out] interop semaphore handle to the external semaphore"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -4128,7 +4128,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_memory_desc_t
+        *interopMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
     ) try {
@@ -4138,7 +4139,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     auto pfnImportOpaqueFDExp =
         d_context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
     if (nullptr != pfnImportOpaqueFDExp) {
-        result = pfnImportOpaqueFDExp(hContext, hDevice, size, fileDescriptor,
+        result = pfnImportOpaqueFDExp(hContext, hDevice, size, interopMemDesc,
                                       phInteropMem);
     } else {
         // generic implementation
@@ -4213,9 +4214,10 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_desc_t
+        *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4225,10 +4227,10 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
             .pfnImportExternalSemaphoreOpaqueFDExp;
     if (nullptr != pfnImportExternalSemaphoreOpaqueFDExp) {
         result = pfnImportExternalSemaphoreOpaqueFDExp(
-            hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+            hContext, hDevice, interopSemaphoreDesc, phInteropSemaphore);
     } else {
         // generic implementation
-        *phInteropSemaphoreHandle =
+        *phInteropSemaphore =
             reinterpret_cast<ur_exp_interop_semaphore_handle_t>(
                 d_context.get());
     }

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -389,9 +389,18 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_migration_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_exp_image_copy_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_exp_file_descriptor_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_exp_win32_handle_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_exp_sampler_mip_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_exp_interop_memory_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_exp_interop_semaphore_desc_t params);
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
@@ -1213,6 +1222,22 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES";
         break;
+
+    case UR_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC:
+        os << "UR_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC:
+        os << "UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR:
+        os << "UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR";
+        break;
+
+    case UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE:
+        os << "UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -1434,6 +1459,30 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES: {
         const ur_exp_sampler_mip_properties_t *pstruct =
             (const ur_exp_sampler_mip_properties_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_INTEROP_MEMORY_DESC: {
+        const ur_exp_interop_memory_desc_t *pstruct =
+            (const ur_exp_interop_memory_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC: {
+        const ur_exp_interop_semaphore_desc_t *pstruct =
+            (const ur_exp_interop_semaphore_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR: {
+        const ur_exp_file_descriptor_t *pstruct =
+            (const ur_exp_file_descriptor_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE: {
+        const ur_exp_win32_handle_t *pstruct =
+            (const ur_exp_win32_handle_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -9462,6 +9511,48 @@ inline void serializeFlag<ur_exp_image_copy_flag_t>(std::ostream &os,
     }
 }
 } // namespace ur_params
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_exp_file_descriptor_t params) {
+    os << "(struct ur_exp_file_descriptor_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".fd = ";
+
+    os << (params.fd);
+
+    os << "}";
+    return os;
+}
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_exp_win32_handle_t params) {
+    os << "(struct ur_exp_win32_handle_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".handle = ";
+
+    ur_params::serializePtr(os, (params.handle));
+
+    os << "}";
+    return os;
+}
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_exp_sampler_mip_properties_t params) {
@@ -9495,6 +9586,39 @@ operator<<(std::ostream &os,
     os << ".mipFilterMode = ";
 
     os << (params.mipFilterMode);
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os, const struct ur_exp_interop_memory_desc_t params) {
+    os << "(struct ur_exp_interop_memory_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << "}";
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_exp_interop_semaphore_desc_t params) {
+    os << "(struct ur_exp_interop_semaphore_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
 
     os << "}";
     return os;
@@ -9959,9 +10083,9 @@ inline std::ostream &operator<<(
     os << *(params->psize);
 
     os << ", ";
-    os << ".fileDescriptor = ";
+    os << ".interopMemDesc = ";
 
-    os << *(params->pfileDescriptor);
+    ur_params::serializePtr(os, *(params->pinteropMemDesc));
 
     os << ", ";
     os << ".phInteropMem = ";
@@ -10043,14 +10167,14 @@ operator<<(std::ostream &os, const struct
     ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
-    os << ".fileDescriptor = ";
+    os << ".interopSemaphoreDesc = ";
 
-    os << *(params->pfileDescriptor);
+    ur_params::serializePtr(os, *(params->pinteropSemaphoreDesc));
 
     os << ", ";
-    os << ".phInteropSemaphoreHandle = ";
+    os << ".phInteropSemaphore = ";
 
-    ur_params::serializePtr(os, *(params->pphInteropSemaphoreHandle));
+    ur_params::serializePtr(os, *(params->pphInteropSemaphore));
 
     return os;
 }

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -4700,7 +4700,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_memory_desc_t
+        *interopMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -4712,13 +4713,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     }
 
     ur_bindless_images_import_opaque_fd_exp_params_t params = {
-        &hContext, &hDevice, &size, &fileDescriptor, &phInteropMem};
+        &hContext, &hDevice, &size, &interopMemDesc, &phInteropMem};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
                              "urBindlessImagesImportOpaqueFDExp", &params);
 
     ur_result_t result = pfnImportOpaqueFDExp(hContext, hDevice, size,
-                                              fileDescriptor, phInteropMem);
+                                              interopMemDesc, phInteropMem);
 
     context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
                        "urBindlessImagesImportOpaqueFDExp", &params, &result,
@@ -4800,9 +4801,10 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_desc_t
+        *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
 ) {
     auto pfnImportExternalSemaphoreOpaqueFDExp =
         context.urDdiTable.BindlessImagesExp
@@ -4813,13 +4815,13 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     }
 
     ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t params =
-        {&hContext, &hDevice, &fileDescriptor, &phInteropSemaphoreHandle};
+        {&hContext, &hDevice, &interopSemaphoreDesc, &phInteropSemaphore};
     uint64_t instance = context.notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
         "urBindlessImagesImportExternalSemaphoreOpaqueFDExp", &params);
 
     ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, interopSemaphoreDesc, phInteropSemaphore);
 
     context.notify_end(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -5955,7 +5955,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_memory_desc_t
+        *interopMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -5975,13 +5976,17 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
+        if (NULL == interopMemDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
         if (NULL == phInteropMem) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
     }
 
     ur_result_t result = pfnImportOpaqueFDExp(hContext, hDevice, size,
-                                              fileDescriptor, phInteropMem);
+                                              interopMemDesc, phInteropMem);
 
     return result;
 }
@@ -6086,9 +6091,10 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_desc_t
+        *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
 ) {
     auto pfnImportExternalSemaphoreOpaqueFDExp =
         context.urDdiTable.BindlessImagesExp
@@ -6107,13 +6113,17 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == phInteropSemaphoreHandle) {
+        if (NULL == interopSemaphoreDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == phInteropSemaphore) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
     }
 
     ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, interopSemaphoreDesc, phInteropSemaphore);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -5725,7 +5725,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_memory_desc_t
+        *interopMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -5746,7 +5747,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnImportOpaqueFDExp(hContext, hDevice, size, fileDescriptor,
+    result = pfnImportOpaqueFDExp(hContext, hDevice, size, interopMemDesc,
                                   phInteropMem);
 
     if (UR_RESULT_SUCCESS != result) {
@@ -5856,9 +5857,10 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_desc_t
+        *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5878,7 +5880,7 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
 
     // forward to device-platform
     result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, interopSemaphoreDesc, phInteropSemaphore);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -5886,10 +5888,10 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
 
     try {
         // convert platform handle to loader handle
-        *phInteropSemaphoreHandle =
+        *phInteropSemaphore =
             reinterpret_cast<ur_exp_interop_semaphore_handle_t>(
                 ur_exp_interop_semaphore_factory.getInstance(
-                    *phInteropSemaphoreHandle, dditable));
+                    *phInteropSemaphore, dditable));
     } catch (std::bad_alloc &) {
         result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6304,6 +6304,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == interopMemDesc`
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -6312,7 +6313,8 @@ ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_memory_desc_t
+        *interopMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
     ) try {
@@ -6322,7 +6324,7 @@ ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImportOpaqueFDExp(hContext, hDevice, size, fileDescriptor,
+    return pfnImportOpaqueFDExp(hContext, hDevice, size, interopMemDesc,
                                 phInteropMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
@@ -6425,15 +6427,17 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phInteropSemaphoreHandle`
+///         + `NULL == interopSemaphoreDesc`
+///         + `NULL == phInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_desc_t
+        *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
     ) try {
     auto pfnImportExternalSemaphoreOpaqueFDExp =
         ur_lib::context->urDdiTable.BindlessImagesExp
@@ -6443,7 +6447,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     }
 
     return pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, fileDescriptor, phInteropSemaphoreHandle);
+        hContext, hDevice, interopSemaphoreDesc, phInteropSemaphore);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5326,6 +5326,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == interopMemDesc`
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
@@ -5334,7 +5335,8 @@ ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_memory_desc_t
+        *interopMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
@@ -5424,15 +5426,17 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phInteropSemaphoreHandle`
+///         + `NULL == interopSemaphoreDesc`
+///         + `NULL == phInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    uint32_t fileDescriptor,      ///< [in] the file descriptor
+    ur_exp_interop_semaphore_desc_t
+        *interopSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphoreHandle ///< [out] interop semaphore handle to the external semaphore
+        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
- Added new structs `ur_exp_interop_memory_desc_t` and `ur_exp_interop_semaphore_desc_t`.
- Updated `urBindlessImagesImportOpaqueFDExp` and `urBindlessImagesImportExternalSemaphoreOpaqueFDExp` to use the new structs.