### PR TITLE
[umf] return umf_result_t from umfPoolFree

### DIFF
--- a/source/common/umf_helpers.hpp
+++ b/source/common/umf_helpers.hpp
@@ -92,7 +92,7 @@ umf_memory_pool_ops_t poolMakeUniqueOps() {
     UMF_ASSIGN_OP(ops, T, aligned_malloc, ((void *)nullptr));
     UMF_ASSIGN_OP(ops, T, realloc, ((void *)nullptr));
     UMF_ASSIGN_OP(ops, T, malloc_usable_size, ((size_t)0));
-    UMF_ASSIGN_OP_NORETURN(ops, T, free);
+    UMF_ASSIGN_OP(ops, T, free, UMF_RESULT_SUCCESS);
     UMF_ASSIGN_OP(ops, T, get_last_allocation_error, UMF_RESULT_ERROR_UNKNOWN);
 
     return ops;

--- a/source/common/umf_pools/disjoint_pool.hpp
+++ b/source/common/umf_pools/disjoint_pool.hpp
@@ -68,7 +68,7 @@ class DisjointPool {
     void *realloc(void *, size_t);
     void *aligned_malloc(size_t size, size_t alignment);
     size_t malloc_usable_size(void *);
-    void free(void *ptr);
+    enum umf_result_t free(void *ptr);
     enum umf_result_t get_last_allocation_error();
 
     DisjointPool();

--- a/source/common/unified_malloc_framework/include/umf/memory_pool.h
+++ b/source/common/unified_malloc_framework/include/umf/memory_pool.h
@@ -94,14 +94,20 @@ size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool, void *ptr);
 /// \brief Frees the memory space of the specified hPool pointed by ptr.
 /// \param hPool specified memory hPool
 /// \param ptr pointer to the allocated memory
+/// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         Whether any status other than UMF_RESULT_SUCCESS can be returned
+///         depends on the memory provider used by the pool.
 ///
-void umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr);
+enum umf_result_t umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr);
 
 ///
 /// \brief Frees the memory space pointed by ptr if it belongs to UMF pool, does nothing otherwise.
 /// \param ptr pointer to the allocated memory
+/// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         Whether any status other than UMF_RESULT_SUCCESS can be returned
+///         depends on the memory provider used by the pool.
 ///
-void umfFree(void *ptr);
+enum umf_result_t umfFree(void *ptr);
 
 ///
 /// \brief Retrieve umf_result_t representing the error of the last failed allocation

--- a/source/common/unified_malloc_framework/include/umf/memory_pool_ops.h
+++ b/source/common/unified_malloc_framework/include/umf/memory_pool_ops.h
@@ -49,7 +49,7 @@ struct umf_memory_pool_ops_t {
     void *(*realloc)(void *pool, void *ptr, size_t size);
     void *(*aligned_malloc)(void *pool, size_t size, size_t alignment);
     size_t (*malloc_usable_size)(void *pool, void *ptr);
-    void (*free)(void *pool, void *);
+    enum umf_result_t (*free)(void *pool, void *);
     enum umf_result_t (*get_last_allocation_error)(void *pool);
 };
 

--- a/source/common/unified_malloc_framework/src/memory_pool.c
+++ b/source/common/unified_malloc_framework/src/memory_pool.c
@@ -119,15 +119,16 @@ size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool, void *ptr) {
     return hPool->ops.malloc_usable_size(hPool->pool_priv, ptr);
 }
 
-void umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr) {
-    hPool->ops.free(hPool->pool_priv, ptr);
+enum umf_result_t umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr) {
+    return hPool->ops.free(hPool->pool_priv, ptr);
 }
 
-void umfFree(void *ptr) {
+enum umf_result_t umfFree(void *ptr) {
     umf_memory_pool_handle_t hPool = umfPoolByPtr(ptr);
     if (hPool) {
-        umfPoolFree(hPool, ptr);
+        return umfPoolFree(hPool, ptr);
     }
+    return UMF_RESULT_SUCCESS;
 }
 
 enum umf_result_t

--- a/test/unified_malloc_framework/common/pool.c
+++ b/test/unified_malloc_framework/common/pool.c
@@ -57,9 +57,10 @@ static size_t nullMallocUsableSize(void *pool, void *ptr) {
     return 0;
 }
 
-static void nullFree(void *pool, void *ptr) {
+static enum umf_result_t nullFree(void *pool, void *ptr) {
     (void)pool;
     (void)ptr;
+    return UMF_RESULT_SUCCESS;
 }
 
 enum umf_result_t nullGetLastStatus(void *pool) {
@@ -151,11 +152,11 @@ static size_t traceMallocUsableSize(void *pool, void *ptr) {
     return umfPoolMallocUsableSize(tracePool->params.hUpstreamPool, ptr);
 }
 
-static void traceFree(void *pool, void *ptr) {
+static enum umf_result_t traceFree(void *pool, void *ptr) {
     struct tracePool *tracePool = (struct tracePool *)pool;
 
     tracePool->params.trace("free");
-    umfPoolFree(tracePool->params.hUpstreamPool, ptr);
+    return umfPoolFree(tracePool->params.hUpstreamPool, ptr);
 }
 
 enum umf_result_t traceGetLastStatus(void *pool) {

--- a/test/unified_malloc_framework/common/pool.hpp
+++ b/test/unified_malloc_framework/common/pool.hpp
@@ -40,7 +40,7 @@ struct pool_base {
     void *realloc(void *, size_t) noexcept { return nullptr; }
     void *aligned_malloc(size_t, size_t) noexcept { return nullptr; }
     size_t malloc_usable_size(void *) noexcept { return 0; }
-    void free(void *) noexcept {}
+    enum umf_result_t free(void *) noexcept { return UMF_RESULT_SUCCESS; }
     enum umf_result_t get_last_allocation_error() noexcept {
         return UMF_RESULT_SUCCESS;
     }
@@ -71,7 +71,10 @@ struct malloc_pool : public pool_base {
         return ::malloc_usable_size(ptr);
 #endif
     }
-    void free(void *ptr) noexcept { return ::free(ptr); }
+    enum umf_result_t free(void *ptr) noexcept {
+        ::free(ptr);
+        return UMF_RESULT_SUCCESS;
+    }
 };
 
 struct proxy_pool : public pool_base {
@@ -108,9 +111,10 @@ struct proxy_pool : public pool_base {
         // TODO: not supported
         return 0;
     }
-    void free(void *ptr) noexcept {
+    enum umf_result_t free(void *ptr) noexcept {
         auto ret = umfMemoryProviderFree(provider, ptr, 0);
         EXPECT_EQ_NOEXCEPT(ret, UMF_RESULT_SUCCESS);
+        return ret;
     }
     umf_memory_provider_handle_t provider;
 };


### PR DESCRIPTION
This is needed in implementation of urUSMFree.

For most cases, the expectation is that the return value from umfPoolFree will be ingnored.