### PR TITLE
[ur] Update CTS to match native handle nocheck

### DIFF
--- a/test/conformance/context/urContextCreateWithNativeHandle.cpp
+++ b/test/conformance/context/urContextCreateWithNativeHandle.cpp
@@ -5,14 +5,24 @@
 
 #include <uur/fixtures.h>
 
-using urContextCreateWithNativeHandleTest = uur::urDeviceTest;
-
+using urContextCreateWithNativeHandleTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateWithNativeHandleTest);
 
-TEST_P(urContextCreateWithNativeHandleTest, InvalidNullHandleNativeHandle) {
-    ur_context_handle_t context = nullptr;
+TEST_P(urContextCreateWithNativeHandleTest, Success) {
+    ur_native_handle_t native_context = nullptr;
+    ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_context_handle_t ctx = nullptr;
     ur_context_native_properties_t props{};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urContextCreateWithNativeHandle(nullptr, 0u, nullptr,
-                                                     &props, &context));
+    ASSERT_SUCCESS(urContextCreateWithNativeHandle(native_context, 0, nullptr,
+                                                   &props, &ctx));
+    ASSERT_NE(ctx, nullptr);
+
+    uint32_t n_devices = 0;
+    ASSERT_SUCCESS(urContextGetInfo(ctx, UR_CONTEXT_INFO_NUM_DEVICES,
+                                    sizeof(uint32_t), &n_devices, nullptr));
 }

--- a/test/conformance/context/urContextGetNativeHandle.cpp
+++ b/test/conformance/context/urContextGetNativeHandle.cpp
@@ -6,26 +6,11 @@
 #include <uur/fixtures.h>
 
 using urContextGetNativeHandleTest = uur::urContextTest;
-
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetNativeHandleTest);
 
 TEST_P(urContextGetNativeHandleTest, Success) {
     ur_native_handle_t native_context = nullptr;
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
-
-    // We cannot assume anything about a native_handle, not even if it's
-    // `nullptr` since this could be a valid representation within a backend.
-    // We can however convert the native_handle back into a unified-runtime handle
-    // and perform some query on it to verify that it works.
-    ur_context_handle_t ctx = nullptr;
-    ur_context_native_properties_t props{};
-    ASSERT_SUCCESS(urContextCreateWithNativeHandle(native_context, 0, nullptr,
-                                                   &props, &ctx));
-    ASSERT_NE(ctx, nullptr);
-
-    uint32_t n_devices = 0;
-    ASSERT_SUCCESS(urContextGetInfo(ctx, UR_CONTEXT_INFO_NUM_DEVICES,
-                                    sizeof(uint32_t), &n_devices, nullptr));
 }
 
 TEST_P(urContextGetNativeHandleTest, InvalidNullHandleContext) {

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -4,11 +4,24 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 
-using urDeviceCreateWithNativeHandleTest = uur::urPlatformTest;
+using urDeviceCreateWithNativeHandleTest = uur::urAllDevicesTest;
 
-TEST_F(urDeviceCreateWithNativeHandleTest, InvalidNullHandleNativeDevice) {
-    ur_device_handle_t device = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urDeviceCreateWithNativeHandle(nullptr, platform, nullptr, &device));
+TEST_F(urDeviceCreateWithNativeHandleTest, Success) {
+    for (auto device : devices) {
+        ur_native_handle_t native_handle = nullptr;
+        ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
+
+        // We cannot assume anything about a native_handle, not even if it's
+        // `nullptr` since this could be a valid representation within a backend.
+        // We can however convert the native_handle back into a unified-runtime handle
+        // and perform some query on it to verify that it works.
+        ur_device_handle_t dev = nullptr;
+        ASSERT_SUCCESS(urDeviceCreateWithNativeHandle(native_handle, platform,
+                                                      nullptr, &dev));
+        ASSERT_NE(dev, nullptr);
+
+        uint32_t dev_id = 0;
+        ASSERT_SUCCESS(urDeviceGetInfo(dev, UR_DEVICE_INFO_TYPE,
+                                       sizeof(uint32_t), &dev_id, nullptr));
+    }
 }

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -10,19 +10,6 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
     for (auto device : devices) {
         ur_native_handle_t native_handle = nullptr;
         ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
-
-        // We cannot assume anything about a native_handle, not even if it's
-        // `nullptr` since this could be a valid representation within a backend.
-        // We can however convert the native_handle back into a unified-runtime handle
-        // and perform some query on it to verify that it works.
-        ur_device_handle_t dev = nullptr;
-        ASSERT_SUCCESS(urDeviceCreateWithNativeHandle(native_handle, platform,
-                                                      nullptr, &dev));
-        ASSERT_NE(dev, nullptr);
-
-        uint32_t dev_id = 0;
-        ASSERT_SUCCESS(urDeviceGetInfo(dev, UR_DEVICE_INFO_TYPE,
-                                       sizeof(uint32_t), &dev_id, nullptr));
     }
 }
 

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -3,14 +3,28 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <uur/fixtures.h>
+#include "fixtures.h"
 
-using urEventCreateWithNativeHandleTest = uur::urContextTest;
+using urEventCreateWithNativeHandleTest = uur::event::urEventTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
 
-TEST_P(urEventCreateWithNativeHandleTest, InvalidNullHandleNativeEvent) {
-    ur_event_handle_t event = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urEventCreateWithNativeHandle(nullptr, context, nullptr, &event));
+TEST_P(urEventCreateWithNativeHandleTest, Success) {
+    ur_native_handle_t native_event = nullptr;
+    ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_event_handle_t evt = nullptr;
+    ASSERT_SUCCESS(
+        urEventCreateWithNativeHandle(native_event, context, nullptr, &evt));
+    ASSERT_NE(evt, nullptr);
+
+    ur_execution_info_t exec_info;
+    ASSERT_SUCCESS(urEventGetInfo(evt, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+                                  sizeof(ur_execution_info_t), &exec_info,
+                                  nullptr));
+
+    ASSERT_SUCCESS(urEventRelease(evt));
 }

--- a/test/conformance/event/urEventGetNativeHandle.cpp
+++ b/test/conformance/event/urEventGetNativeHandle.cpp
@@ -11,22 +11,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetNativeHandleTest);
 TEST_P(urEventGetNativeHandleTest, Success) {
     ur_native_handle_t native_event = nullptr;
     ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
-
-    // We cannot assume anything about a native_handle, not even if it's
-    // `nullptr` since this could be a valid representation within a backend.
-    // We can however convert the native_handle back into a unified-runtime handle
-    // and perform some query on it to verify that it works.
-    ur_event_handle_t evt = nullptr;
-    ASSERT_SUCCESS(
-        urEventCreateWithNativeHandle(native_event, context, nullptr, &evt));
-    ASSERT_NE(evt, nullptr);
-
-    ur_execution_info_t exec_info;
-    ASSERT_SUCCESS(urEventGetInfo(evt, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
-                                  sizeof(ur_execution_info_t), &exec_info,
-                                  nullptr));
-
-    ASSERT_SUCCESS(urEventRelease(evt));
 }
 
 TEST_P(urEventGetNativeHandleTest, InvalidNullHandleEvent) {

--- a/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
@@ -54,13 +54,6 @@ TEST_P(urKernelCreateWithNativeHandleTest, InvalidNullHandleProgram) {
                                        &properties, &native_kernel));
 }
 
-TEST_P(urKernelCreateWithNativeHandleTest, InvalidNullHandleNativeKernel) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urKernelCreateWithNativeHandle(nullptr, context, program,
-                                                    &properties,
-                                                    &native_kernel));
-}
-
 TEST_P(urKernelCreateWithNativeHandleTest, InvalidNullPointerProperties) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urKernelCreateWithNativeHandle(native_kernel_handle,

--- a/test/conformance/kernel/urKernelGetNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelGetNativeHandle.cpp
@@ -11,24 +11,6 @@ UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urKernelGetNativeHandleTest);
 TEST_P(urKernelGetNativeHandleTest, Success) {
     ur_native_handle_t native_kernel_handle = nullptr;
     ASSERT_SUCCESS(urKernelGetNativeHandle(kernel, &native_kernel_handle));
-
-    ur_kernel_handle_t native_kernel = nullptr;
-
-    ur_kernel_native_properties_t properties = {
-        UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES, /*sType*/
-        nullptr,                                    /*pNext*/
-        true                                        /*isNativeHandleOwned*/
-    };
-    ASSERT_SUCCESS(urKernelCreateWithNativeHandle(
-        native_kernel_handle, context, program, &properties, &native_kernel));
-
-    uint32_t ref_count = 0;
-    ASSERT_SUCCESS(urKernelGetInfo(native_kernel,
-                                   UR_KERNEL_INFO_REFERENCE_COUNT,
-                                   sizeof(ref_count), &ref_count, nullptr));
-    ASSERT_NE(ref_count, 0);
-
-    ASSERT_SUCCESS(urKernelRelease(native_kernel));
 }
 
 TEST_P(urKernelGetNativeHandleTest, InvalidNullHandleKernel) {

--- a/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
@@ -8,9 +8,27 @@
 using urMemBufferCreateWithNativeHandleTest = uur::urMemBufferTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateWithNativeHandleTest);
 
-TEST_P(urMemBufferCreateWithNativeHandleTest, InvalidNullHandleNativeMem) {
+TEST_P(urMemBufferCreateWithNativeHandleTest, Success) {
+    ur_native_handle_t hNativeMem = nullptr;
+    ASSERT_SUCCESS(urMemGetNativeHandle(buffer, &hNativeMem));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
     ur_mem_handle_t mem = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urMemBufferCreateWithNativeHandle(nullptr, context, nullptr, &mem));
+    ur_mem_native_properties_t props = {
+        /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
+        /*.pNext =*/nullptr,
+        /*.isNativeHandleOwned =*/false,
+    };
+    ASSERT_SUCCESS(
+        urMemBufferCreateWithNativeHandle(hNativeMem, context, &props, &mem));
+    ASSERT_NE(mem, nullptr);
+
+    size_t alloc_size = 0;
+    ASSERT_SUCCESS(urMemGetInfo(mem, UR_MEM_INFO_SIZE, sizeof(size_t),
+                                &alloc_size, nullptr));
+
+    ASSERT_SUCCESS(urMemRelease(mem));
 }

--- a/test/conformance/memory/urMemGetNativeHandle.cpp
+++ b/test/conformance/memory/urMemGetNativeHandle.cpp
@@ -10,26 +10,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetNativeHandleTest);
 TEST_P(urMemGetNativeHandleTest, Success) {
     ur_native_handle_t hNativeMem = nullptr;
     ASSERT_SUCCESS(urMemGetNativeHandle(buffer, &hNativeMem));
-
-    // We cannot assume anything about a native_handle, not even if it's
-    // `nullptr` since this could be a valid representation within a backend.
-    // We can however convert the native_handle back into a unified-runtime handle
-    // and perform some query on it to verify that it works.
-    ur_mem_handle_t mem = nullptr;
-    ur_mem_native_properties_t props = {
-        /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
-        /*.pNext =*/nullptr,
-        /*.isNativeHandleOwned =*/false,
-    };
-    ASSERT_SUCCESS(
-        urMemBufferCreateWithNativeHandle(hNativeMem, context, &props, &mem));
-    ASSERT_NE(mem, nullptr);
-
-    size_t alloc_size = 0;
-    ASSERT_SUCCESS(urMemGetInfo(mem, UR_MEM_INFO_SIZE, sizeof(size_t),
-                                &alloc_size, nullptr));
-
-    ASSERT_SUCCESS(urMemRelease(mem));
 }
 
 TEST_P(urMemGetNativeHandleTest, InvalidNullHandleMem) {

--- a/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
@@ -5,30 +5,23 @@
 
 #include <uur/fixtures.h>
 
-using urMemImageCreateWithNativeHandleTest = uur::urMemBufferTest;
+using urMemImageCreateWithNativeHandleTest = uur::urMemImageTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemImageCreateWithNativeHandleTest);
 
-TEST_P(urMemImageCreateWithNativeHandleTest, InvalidNullHandleNativeMem) {
+TEST_P(urMemImageCreateWithNativeHandleTest, Success) {
+    ur_native_handle_t native_handle = nullptr;
+    ASSERT_SUCCESS(urMemGetNativeHandle(image, &native_handle));
+
     ur_mem_handle_t mem = nullptr;
-    ur_image_format_t imageFormat = {
-        /*.channelOrder =*/UR_IMAGE_CHANNEL_ORDER_ARGB,
-        /*.channelType =*/UR_IMAGE_CHANNEL_TYPE_UNORM_INT8,
-    };
-    ur_image_desc_t imageDesc = {
-        /*.stype =*/UR_STRUCTURE_TYPE_IMAGE_DESC,
-        /*.pNext =*/nullptr,
-        /*.type =*/UR_MEM_TYPE_IMAGE2D,
-        /*.width =*/16,
-        /*.height =*/16,
-        /*.depth =*/1,
-        /*.arraySize =*/1,
-        /*.rowPitch =*/16,
-        /*.slicePitch =*/16 * 16,
-        /*.numMipLevel =*/0,
-        /*.numSamples =*/0,
-    };
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urMemImageCreateWithNativeHandle(nullptr, context,
-                                                      &imageFormat, &imageDesc,
-                                                      nullptr, &mem));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urMemImageCreateWithNativeHandle(native_handle, context, &image_format,
+                                         &image_desc, nullptr, &mem));
+    ASSERT_NE(nullptr, mem);
+
+    ur_context_handle_t mem_context = nullptr;
+    ASSERT_SUCCESS(urMemGetInfo(mem, UR_MEM_INFO_CONTEXT,
+                                sizeof(ur_context_handle_t), &mem_context,
+                                nullptr));
+    ASSERT_EQ(context, mem_context);
 }

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -7,10 +7,33 @@
 
 using urPlatformCreateWithNativeHandleTest = uur::platform::urPlatformTest;
 
+TEST_F(urPlatformCreateWithNativeHandleTest, Success) {
+    for (auto platform : platforms) {
+        ur_native_handle_t native_handle = nullptr;
+        ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
+
+        // We cannot assume anything about a native_handle, not even if it's
+        // `nullptr` since this could be a valid representation within a backend.
+        // We can however convert the native_handle back into a unified-runtime
+        // handle and perform some query on it to verify that it works.
+        ur_platform_handle_t plat = nullptr;
+        ASSERT_SUCCESS(
+            urPlatformCreateWithNativeHandle(native_handle, nullptr, &plat));
+        ASSERT_NE(plat, nullptr);
+
+        ur_platform_backend_t backend;
+        ASSERT_SUCCESS(urPlatformGetInfo(plat, UR_PLATFORM_INFO_BACKEND,
+                                         sizeof(ur_platform_backend_t),
+                                         &backend, nullptr));
+    }
+}
+
 TEST_F(urPlatformCreateWithNativeHandleTest, InvalidNullPointerPlatform) {
-    ur_native_handle_t native_handle = nullptr;
-    ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urPlatformCreateWithNativeHandle(native_handle, nullptr, nullptr));
+    for (auto platform : platforms) {
+        ur_native_handle_t native_handle = nullptr;
+        ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
+        ASSERT_EQ_RESULT(
+            UR_RESULT_ERROR_INVALID_NULL_POINTER,
+            urPlatformCreateWithNativeHandle(native_handle, nullptr, nullptr));
+    }
 }

--- a/test/conformance/platform/urPlatformGetNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformGetNativeHandle.cpp
@@ -11,20 +11,6 @@ TEST_F(urPlatformGetNativeHandleTest, Success) {
     for (auto platform : platforms) {
         ur_native_handle_t native_handle = nullptr;
         ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
-
-        // We cannot assume anything about a native_handle, not even if it's
-        // `nullptr` since this could be a valid representation within a backend.
-        // We can however convert the native_handle back into a unified-runtime
-        // handle and perform some query on it to verify that it works.
-        ur_platform_handle_t plat = nullptr;
-        ASSERT_SUCCESS(
-            urPlatformCreateWithNativeHandle(native_handle, nullptr, &plat));
-        ASSERT_NE(plat, nullptr);
-
-        ur_platform_backend_t backend;
-        ASSERT_SUCCESS(urPlatformGetInfo(plat, UR_PLATFORM_INFO_BACKEND,
-                                         sizeof(ur_platform_backend_t),
-                                         &backend, nullptr));
     }
 }
 

--- a/test/conformance/program/urProgramCreateWithNativeHandle.cpp
+++ b/test/conformance/program/urProgramCreateWithNativeHandle.cpp
@@ -43,12 +43,6 @@ TEST_P(urProgramCreateWithNativeHandleTest, InvalidNullHandleContext) {
                                                      &native_program));
 }
 
-TEST_P(urProgramCreateWithNativeHandleTest, InvalidNullHandleNativeProgram) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urProgramCreateWithNativeHandle(nullptr, context, nullptr,
-                                                     &native_program));
-}
-
 TEST_P(urProgramCreateWithNativeHandleTest, InvalidNullPointerProgram) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urProgramCreateWithNativeHandle(

--- a/test/conformance/program/urProgramGetNativeHandle.cpp
+++ b/test/conformance/program/urProgramGetNativeHandle.cpp
@@ -11,18 +11,6 @@ UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urProgramGetNativeHandleTest);
 TEST_P(urProgramGetNativeHandleTest, Success) {
     ur_native_handle_t native_program_handle = nullptr;
     ASSERT_SUCCESS(urProgramGetNativeHandle(program, &native_program_handle));
-
-    ur_program_handle_t native_program = nullptr;
-    ASSERT_SUCCESS(urProgramCreateWithNativeHandle(
-        native_program_handle, context, nullptr, &native_program));
-
-    uint32_t ref_count = 0;
-    ASSERT_SUCCESS(urProgramGetInfo(native_program,
-                                    UR_PROGRAM_INFO_REFERENCE_COUNT,
-                                    sizeof(ref_count), &ref_count, nullptr));
-    ASSERT_NE(ref_count, 0);
-
-    ASSERT_SUCCESS(urProgramRelease(native_program));
 }
 
 TEST_P(urProgramGetNativeHandleTest, InvalidNullHandleProgram) {

--- a/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -4,13 +4,26 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 
-using urQueueCreateWithNativeHandleTest = uur::urContextTest;
+using urQueueCreateWithNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueCreateWithNativeHandleTest);
 
-TEST_P(urQueueCreateWithNativeHandleTest, InvalidNullHandleNativeQueue) {
-    ur_queue_handle_t queue = nullptr;
+TEST_P(urQueueCreateWithNativeHandleTest, Success) {
+    ur_native_handle_t native_handle = nullptr;
+    ASSERT_SUCCESS(urQueueGetNativeHandle(queue, nullptr, &native_handle));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_queue_handle_t q = nullptr;
     ur_queue_native_properties_t properties{};
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urQueueCreateWithNativeHandle(nullptr, context, device,
-                                                   &properties, &queue));
+    ASSERT_SUCCESS(urQueueCreateWithNativeHandle(native_handle, context, device,
+                                                 &properties, &q));
+    ASSERT_NE(q, nullptr);
+
+    uint32_t q_size = 0;
+    ASSERT_SUCCESS(urQueueGetInfo(q, UR_QUEUE_INFO_SIZE, sizeof(uint32_t),
+                                  &q_size, nullptr));
+
+    ASSERT_SUCCESS(urQueueRelease(q));
 }

--- a/test/conformance/queue/urQueueGetNativeHandle.cpp
+++ b/test/conformance/queue/urQueueGetNativeHandle.cpp
@@ -10,22 +10,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetNativeHandleTest);
 TEST_P(urQueueGetNativeHandleTest, Success) {
     ur_native_handle_t native_handle = nullptr;
     ASSERT_SUCCESS(urQueueGetNativeHandle(queue, nullptr, &native_handle));
-
-    // We cannot assume anything about a native_handle, not even if it's
-    // `nullptr` since this could be a valid representation within a backend.
-    // We can however convert the native_handle back into a unified-runtime handle
-    // and perform some query on it to verify that it works.
-    ur_queue_handle_t q = nullptr;
-    ur_queue_native_properties_t properties{};
-    ASSERT_SUCCESS(urQueueCreateWithNativeHandle(native_handle, context, device,
-                                                 &properties, &q));
-    ASSERT_NE(q, nullptr);
-
-    uint32_t q_size = 0;
-    ASSERT_SUCCESS(urQueueGetInfo(q, UR_QUEUE_INFO_SIZE, sizeof(uint32_t),
-                                  &q_size, nullptr));
-
-    ASSERT_SUCCESS(urQueueRelease(q));
 }
 
 TEST_P(urQueueGetNativeHandleTest, InvalidNullHandleQueue) {

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -5,14 +5,26 @@
 
 #include <uur/fixtures.h>
 
-using urSamplerCreateWithNativeHandleTest = uur::urContextTest;
+using urSamplerCreateWithNativeHandleTest = uur::urSamplerTest;
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerCreateWithNativeHandleTest);
 
-TEST_P(urSamplerCreateWithNativeHandleTest, InvalidNullHandleNativeHandle) {
-    ur_sampler_handle_t sampler = nullptr;
+TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
+    ur_native_handle_t native_sampler = nullptr;
+    ASSERT_SUCCESS(urSamplerGetNativeHandle(sampler, &native_sampler));
+
+    // We cannot assume anything about a native_handle, not even if it's
+    // `nullptr` since this could be a valid representation within a backend.
+    // We can however convert the native_handle back into a unified-runtime handle
+    // and perform some query on it to verify that it works.
+    ur_sampler_handle_t hSampler = nullptr;
     ur_sampler_native_properties_t props{};
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urSamplerCreateWithNativeHandle(nullptr, context, &props, &sampler));
+    ASSERT_SUCCESS(urSamplerCreateWithNativeHandle(native_sampler, context,
+                                                   &props, &hSampler));
+    ASSERT_NE(hSampler, nullptr);
+
+    ur_sampler_addressing_mode_t addr_mode;
+    ASSERT_SUCCESS(urSamplerGetInfo(hSampler, UR_SAMPLER_INFO_ADDRESSING_MODE,
+                                    sizeof(addr_mode), &addr_mode, nullptr));
+    ASSERT_EQ(addr_mode, sampler_desc.addressingMode);
 }

--- a/test/conformance/sampler/urSamplerGetNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerGetNativeHandle.cpp
@@ -12,21 +12,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerGetNativeHandleTest);
 TEST_P(urSamplerGetNativeHandleTest, Success) {
     ur_native_handle_t native_sampler = nullptr;
     ASSERT_SUCCESS(urSamplerGetNativeHandle(sampler, &native_sampler));
-
-    // We cannot assume anything about a native_handle, not even if it's
-    // `nullptr` since this could be a valid representation within a backend.
-    // We can however convert the native_handle back into a unified-runtime handle
-    // and perform some query on it to verify that it works.
-    ur_sampler_handle_t hSampler = nullptr;
-    ur_sampler_native_properties_t props{};
-    ASSERT_SUCCESS(urSamplerCreateWithNativeHandle(native_sampler, context,
-                                                   &props, &hSampler));
-    ASSERT_NE(hSampler, nullptr);
-
-    ur_sampler_addressing_mode_t addr_mode;
-    ASSERT_SUCCESS(urSamplerGetInfo(hSampler, UR_SAMPLER_INFO_ADDRESSING_MODE,
-                                    sizeof(addr_mode), &addr_mode, nullptr));
-    ASSERT_EQ(addr_mode, sampler_desc.addressingMode);
 }
 
 TEST_P(urSamplerGetNativeHandleTest, InvalidNullHandleSampler) {

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -175,6 +175,38 @@ struct urMemBufferTest : urContextTest {
     ur_mem_handle_t buffer = nullptr;
 };
 
+struct urMemImageTest : urContextTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
+    }
+
+    void TearDown() override {
+        if (image) {
+            EXPECT_SUCCESS(urMemRelease(image));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTest::TearDown());
+    }
+
+    ur_image_format_t image_format = {
+        /*.channelOrder =*/UR_IMAGE_CHANNEL_ORDER_ARGB,
+        /*.channelType =*/UR_IMAGE_CHANNEL_TYPE_UNORM_INT8,
+    };
+    ur_image_desc_t image_desc = {
+        /*.stype =*/UR_STRUCTURE_TYPE_IMAGE_DESC,
+        /*.pNext =*/nullptr,
+        /*.type =*/UR_MEM_TYPE_IMAGE2D,
+        /*.width =*/16,
+        /*.height =*/16,
+        /*.depth =*/1,
+        /*.arraySize =*/1,
+        /*.rowPitch =*/16 * sizeof(char[4]),
+        /*.slicePitch =*/16 * 16 * sizeof(char[4]),
+        /*.numMipLevel =*/0,
+        /*.numSamples =*/0,
+    };
+    ur_mem_handle_t image = nullptr;
+};
+
 } // namespace uur
 
 #define UUR_TEST_SUITE_P(FIXTURE, VALUES, PRINTER)                             \


### PR DESCRIPTION
Follow up from #720 where the `nocheck` option was added to the
`ur_native_handle_t` arguments of `ur<Object>CreateWithNativeHandle`.
This patch removes tests which assumed that `ur_native_handle_t` must
not be `nullptr` which is an incorrect assumption.
