### PR TITLE
Fix GetEnvironmentVariable encoding

### DIFF
--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -92,7 +92,7 @@ inline std::optional<std::string> ur_getenv(const char *name) {
 #if defined(_WIN32)
     constexpr int buffer_size = 1024;
     char buffer[buffer_size];
-    auto rc = GetEnvironmentVariable(name, buffer, buffer_size);
+    auto rc = GetEnvironmentVariableA(name, buffer, buffer_size);
     if (0 != rc && rc < buffer_size) {
         return std::string(buffer);
     } else if (rc >= buffer_size) {


### PR DESCRIPTION
Due to possibly harsher compiler checks, the current usage of `GetEnvironmentVariable` causes a conversion error in the Unified Runtime L0 adapter implementation on the https://github.com/intel/llvm/ repo.
CI: https://github.com/intel/llvm/actions/runs/5577820648/jobs/10191589770?pr=10269

This fixes the following error: `error C2664: 'DWORD GetEnvironmentVariableW(LPCWSTR,LPWSTR,DWORD)': cannot convert argument 1 from 'const char *' to 'LPCWSTR'`.
