### PR TITLE
[adapters] only export get proc table symbols in adapters

### DIFF
--- a/source/adapters/CMakeLists.txt
+++ b/source/adapters/CMakeLists.txt
@@ -3,8 +3,30 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_subdirectory(null)
+function(add_ur_adapter name)
+    add_library(${name} ${ARGN})
+    if(MSVC)
+        set(TARGET_LIBNAME ${name})
+        string(TOUPPER ${TARGET_LIBNAME} TARGET_LIBNAME)
 
+        set(ADAPTER_VERSION_SCRIPT ${name}.def)
+
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../adapter.def.in ${ADAPTER_VERSION_SCRIPT} @ONLY)
+        set_target_properties(${name} PROPERTIES
+            LINK_FLAGS "/DEF:${ADAPTER_VERSION_SCRIPT}"
+        )
+    else()
+        set(TARGET_LIBNAME lib${name}_${PROJECT_VERSION_MAJOR}.0)
+        string(TOUPPER ${TARGET_LIBNAME} TARGET_LIBNAME)
+
+        set(ADAPTER_VERSION_SCRIPT ${name}.map)
+
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../adapter.map.in ${ADAPTER_VERSION_SCRIPT} @ONLY)
+        target_link_options(${name} PRIVATE "-Wl,--version-script=${ADAPTER_VERSION_SCRIPT}")
+    endif()
+endfunction()
+
+add_subdirectory(null)
 
 if(UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_CUDA OR UR_BUILD_ADAPTER_HIP)
     # fetch adapter sources from SYCL

--- a/source/adapters/adapter.def.in
+++ b/source/adapters/adapter.def.in
@@ -1,0 +1,20 @@
+LIBRARY @TARGET_LIBNAME@
+EXPORTS
+	urGetBindlessImagesExpProcAddrTable
+	urGetCommandBufferExpProcAddrTable
+	urGetContextProcAddrTable
+	urGetDeviceProcAddrTable
+	urGetEnqueueProcAddrTable
+	urGetEventProcAddrTable
+	urGetGlobalProcAddrTable
+	urGetKernelProcAddrTable
+	urGetMemProcAddrTable
+	urGetPhysicalMemProcAddrTable
+	urGetPlatformProcAddrTable
+	urGetProgramProcAddrTable
+	urGetQueueProcAddrTable
+	urGetSamplerProcAddrTable
+	urGetUSMExpProcAddrTable
+	urGetUsmP2PExpProcAddrTable
+	urGetUSMProcAddrTable
+	urGetVirtualMemProcAddrTable

--- a/source/adapters/adapter.map.in
+++ b/source/adapters/adapter.map.in
@@ -1,0 +1,23 @@
+@TARGET_LIBNAME@ {
+	global:
+		urGetBindlessImagesExpProcAddrTable;
+		urGetCommandBufferExpProcAddrTable;
+		urGetContextProcAddrTable;
+		urGetDeviceProcAddrTable;
+		urGetEnqueueProcAddrTable;
+		urGetEventProcAddrTable;
+		urGetGlobalProcAddrTable;
+		urGetKernelProcAddrTable;
+		urGetMemProcAddrTable;
+		urGetPhysicalMemProcAddrTable;
+		urGetPlatformProcAddrTable;
+		urGetProgramProcAddrTable;
+		urGetQueueProcAddrTable;
+		urGetSamplerProcAddrTable;
+		urGetUSMExpProcAddrTable;
+		urGetUsmP2PExpProcAddrTable;
+		urGetUSMProcAddrTable;
+		urGetVirtualMemProcAddrTable;
+	local:
+		*;
+};

--- a/source/adapters/cuda/CMakeLists.txt
+++ b/source/adapters/cuda/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CUDA_DIR "${SYCL_ADAPTER_DIR}/sycl/plugins/unified_runtime/ur/adapters/cuda"
 
 set(TARGET_NAME ur_adapter_cuda)
 
-add_library(${TARGET_NAME}
+add_ur_adapter(${TARGET_NAME}
     SHARED
     ${CUDA_DIR}/ur_interface_loader.cpp
     ${CUDA_DIR}/common.hpp

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 # Set includes used in added library (rocmdrv)
 set(HIP_HEADERS "${UR_HIP_INCLUDE_DIR};${UR_HIP_HSA_INCLUDE_DIR}")
 
-add_library(${TARGET_NAME}
+add_ur_adapter(${TARGET_NAME}
     SHARED
     ${HIP_DIR}/ur_interface_loader.cpp
     ${HIP_DIR}/common.hpp
@@ -75,7 +75,7 @@ add_library(${TARGET_NAME}
     ${HIP_DIR}/../../usm_allocator_config.hpp
 )
 
-if (NOT MSVC)
+if(NOT MSVC)
     target_compile_options(${TARGET_NAME} PRIVATE
         -Wno-deprecated-declarations
     )

--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -71,7 +71,7 @@ target_include_directories(LevelZeroLoader-Headers
     INTERFACE "${LEVEL_ZERO_INCLUDE_DIR}"
 )
 
-add_library(${TARGET_NAME}
+add_ur_adapter(${TARGET_NAME}
     SHARED
     ${L0_DIR}/ur_interface_loader.cpp
     ${L0_DIR}/common.hpp
@@ -120,9 +120,3 @@ target_include_directories(${TARGET_NAME} PRIVATE
     ${L0_DIR}/../../../
     LevelZeroLoader-Headers
 )
-
-if(UNIX)
-    set(GCC_COVERAGE_COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -fno-strict-aliasing")
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
-endif()
-

--- a/source/adapters/null/CMakeLists.txt
+++ b/source/adapters/null/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(TARGET_NAME ur_adapter_null)
 
-add_library(${TARGET_NAME}
+add_ur_adapter(${TARGET_NAME}
     SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_null.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_null.cpp
@@ -21,8 +21,3 @@ target_link_libraries(${TARGET_NAME} PRIVATE
     ${PROJECT_NAME}::headers
     ${PROJECT_NAME}::common
 )
-
-if(UNIX)
-    set(GCC_COVERAGE_COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -fno-strict-aliasing")
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
-endif()


### PR DESCRIPTION
This adds a version script to restrict visiblity of symbols in adapters. This is so that adapters don't use loader ur functions when populating proc tables...

Before:
```sh
piotrekpc :: unified-runtime/build/bin ‹adapters-ci*› » UR_ADAPTERS_FORCE_LOAD=../lib/libur_adapter_hip.so ./hello_world
AddressSanitizer:DEADLYSIGNAL
=================================================================
==84218==ERROR: AddressSanitizer: stack-overflow on address 0x7ffe394fefc0 (pc 0x7f843eac49b1 bp 0x7ffe394ff0d0 sp 0x7ffe394fefc0 T0)
    #0 0x7f843eac49b1 in void std::call_once<urInit::$_0>(std::once_flag&, urInit::$_0&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.1.1/../../../../include/c++/13.1.1/mutex:897
    #1 0x7f843eac44d2 in urInit /home/piotrek/work/unified-runtime/source/loader/ur_libapi.cpp:48:5
    #2 0x7f843eac472e in urInit /home/piotrek/work/unified-runtime/source/loader/ur_libapi.cpp:61:12
    ...
    #245 0x7f843eac472e in urInit /home/piotrek/work/unified-runtime/source/loader/ur_libapi.cpp:61:12
    #246 0x7f843eac472e in urInit /home/piotrek/work/unified-runtime/source/loader/ur_libapi.cpp:61:12

SUMMARY: AddressSanitizer: stack-overflow /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.1.1/../../../../include/c++/13.1.1/mutex:897 in void std::call_once<urInit::$_0>(std::once_flag&, urInit::$_0&&)
==84218==ABORTING
```
```sh
piotrekpc :: unified-runtime/build/lib ‹adapters-ci*› » nm libur_adapter_hip.so
...
000000000011b5c0 T urGetUsmP2PExpProcAddrTable
0000000000119ee0 T urGetUSMProcAddrTable
00000000001a6c40 T urInit
0000000000185bc0 T urKernelCreate
000000000018a540 T urKernelCreateWithNativeHandle
...
```

After:
```sh
piotrekpc :: unified-runtime/build/bin ‹adapters-ci*› » UR_ADAPTERS_FORCE_LOAD=../lib/libur_adapter_hip.so ./hello_world
Platform initialized.
API version: 0.6
Found a AMD Radeon RX 7900 XT gpu.

=================================================================
==85366==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 144 byte(s) in 2 object(s) allocated from:
    #0 0x5625a26c0202 in operator new(unsigned long) (/home/piotrek/work/unified-runtime/build/bin/hello_world+0x126202) (BuildId: bf43e9d3666a60ce9d2a785e91b9c26426eabfd0)
    #1 0x7f5095457651  (/opt/rocm/lib/libhsa-runtime64.so.1+0x57651) (BuildId: f7f526d06338fb02490caa9445ee3ad876fcab4f)

    ...

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x5625a26c0202 in operator new(unsigned long) (/home/piotrek/work/unified-runtime/build/bin/hello_world+0x126202) (BuildId: bf43e9d3666a60ce9d2a785e91b9c26426eabfd0)
    #1 0x7f5095aa0722  (/opt/rocm/hip/lib/libamdhip64.so.5+0x2a0722) (BuildId: fb16c579f66b7bf10313de1f62a8fd7f64a0f860)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x5625a26c0202 in operator new(unsigned long) (/home/piotrek/work/unified-runtime/build/bin/hello_world+0x126202) (BuildId: bf43e9d3666a60ce9d2a785e91b9c26426eabfd0)
    #1 0x7f4f89da9dab  (/opt/rocm/lib/libamd_comgr.so.2+0x9a9dab) (BuildId: 80900645c6c6d589df59db110a00d470d77ab376)

SUMMARY: AddressSanitizer: 3495 byte(s) leaked in 55 allocation(s).
```
```sh
piotrekpc :: unified-runtime/build/lib ‹adapters-ci*› » nm libur_adapter_hip.so
...
00000000000a76b0 T urGetUsmP2PExpProcAddrTable
00000000000a5fd0 T urGetUSMProcAddrTable
0000000000132d30 t urInit
0000000000111cb0 t urKernelCreate
0000000000116630 t urKernelCreateWithNativeHandle
...
```