### PR TITLE
[ur] Fix leak validation test fixture

### DIFF
--- a/test/layers/validation/fixtures.hpp
+++ b/test/layers/validation/fixtures.hpp
@@ -18,7 +18,6 @@ struct urTest : ::testing::Test {
                   UR_RESULT_SUCCESS);
         ur_device_init_flags_t device_flags = 0;
         ASSERT_EQ(urInit(device_flags, loader_config), UR_RESULT_SUCCESS);
-        ASSERT_EQ(urLoaderConfigRelease(loader_config), UR_RESULT_SUCCESS);
     }
 
     void TearDown() override {


### PR DESCRIPTION
This patch removes a superflous call to `urLoaderConfigRelease` which resulted in attempting to release and already destroyed `ur_loader_config_handle_t`.