### PR TITLE
[ur] Add missing virtual memory support query

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -826,6 +826,7 @@ class ur_device_info_v(IntEnum):
     IP_VERSION = 113                                ## [uint32_t] The device IP version. The meaning of the device IP version
                                                     ## is implementation-defined, but newer devices should have a higher
                                                     ## version than older devices.
+    VIRTUAL_MEMORY_SUPPORT = 114                    ## [::ur_bool_t] return true if the device supports virtual memory.
     BINDLESS_IMAGES_SUPPORT_EXP = 0x2000            ## [::ur_bool_t] returns true if the device supports the creation of
                                                     ## bindless images
     BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP = 0x2001 ## [::ur_bool_t] returns true if the device supports the creation of

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1453,6 +1453,7 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_IP_VERSION = 113,                                ///< [uint32_t] The device IP version. The meaning of the device IP version
                                                                     ///< is implementation-defined, but newer devices should have a higher
                                                                     ///< version than older devices.
+    UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT = 114,                    ///< [::ur_bool_t] return true if the device supports virtual memory.
     UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP = 0x2000,            ///< [::ur_bool_t] returns true if the device supports the creation of
                                                                     ///< bindless images
     UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP = 0x2001, ///< [::ur_bool_t] returns true if the device supports the creation of

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -383,6 +383,8 @@ etors:
       desc: "[uint32_t] The maximum number of registers available per block."
     - name: IP_VERSION
       desc: "[uint32_t] The device IP version. The meaning of the device IP version is implementation-defined, but newer devices should have a higher version than older devices."
+    - name: VIRTUAL_MEMORY_SUPPORT
+      desc: "[$x_bool_t] return true if the device supports virtual memory."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -2768,6 +2768,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
         os << "UR_DEVICE_INFO_IP_VERSION";
         break;
 
+    case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT:
+        os << "UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT";
+        break;
+
     case UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP";
         break;
@@ -4383,6 +4387,20 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
         if (sizeof(uint32_t) > size) {
             os << "invalid size (is: " << size
                << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+
+    case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(ur_bool_t) << ")";
             return;
         }
         os << (void *)(tptr) << " (";

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -231,7 +231,8 @@ INSTANTIATE_TEST_SUITE_P(
         UR_DEVICE_INFO_ASYNC_BARRIER,                          //
         UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT,                    //
         UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED,         //
-        UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP            //
+        UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP,           //
+        UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT                  //
         ),
     [](const ::testing::TestParamInfo<ur_device_info_t> &info) {
         std::stringstream ss;


### PR DESCRIPTION
Introduce the missing `UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT`
enumeration for use with `urDeviceGetInfo` to determine if the device
supports the virtual memory interfaces.
