### PR TITLE
[umf] add synchronous umf*Memcpy functions

### DIFF
--- a/source/common/umf_helpers.hpp
+++ b/source/common/umf_helpers.hpp
@@ -131,6 +131,8 @@ auto memoryProviderMakeUnique(Args &&...args) {
     UMF_ASSIGN_OP(ops, T, purge_lazy, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops, T, purge_force, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops, T, get_name, "");
+    UMF_ASSIGN_OP(ops, T, memcpy_to, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops, T, memcpy_from, UMF_RESULT_ERROR_UNKNOWN);
 
     umf_memory_provider_handle_t hProvider = nullptr;
     auto ret = umfMemoryProviderCreate(&ops, &argsTuple, &hProvider);

--- a/source/common/unified_malloc_framework/include/umf/base.h
+++ b/source/common/unified_malloc_framework/include/umf/base.h
@@ -18,6 +18,9 @@
 extern "C" {
 #endif
 
+typedef struct umf_memory_pool_t *umf_memory_pool_handle_t;
+typedef struct umf_memory_provider_t *umf_memory_provider_handle_t;
+
 /// \brief Generates generic 'UMF' API versions
 #define UMF_MAKE_VERSION(_major, _minor)                                       \
     ((_major << 16) | (_minor & 0x0000ffff))

--- a/source/common/unified_malloc_framework/include/umf/memory_pool.h
+++ b/source/common/unified_malloc_framework/include/umf/memory_pool.h
@@ -18,8 +18,6 @@
 extern "C" {
 #endif
 
-typedef struct umf_memory_pool_t *umf_memory_pool_handle_t;
-
 struct umf_memory_pool_ops_t;
 
 ///
@@ -146,6 +144,14 @@ enum umf_result_t
 umfPoolGetMemoryProviders(umf_memory_pool_handle_t hPool, size_t numProviders,
                           umf_memory_provider_handle_t *hProviders,
                           size_t *numProvidersRet);
+
+///
+/// \brief Copy size bytes from the location pointed to by src to the location pointer to by dest. Location pointed to by src should reside in srcPool. Location pointer to by dst should reside in dstPool.
+enum umf_result_t umfPoolMemcpy(umf_memory_pool_handle_t dstPool, umf_memory_pool_handle_t srcPool, void *dst, const void *src, size_t size);
+
+///
+/// \brief Copy size bytes from the location pointed to by src to the location pointer to by dest.
+enum umf_result_t umfMemcpy(void *dst, const void *src, size_t size);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_malloc_framework/include/umf/memory_provider.h
+++ b/source/common/unified_malloc_framework/include/umf/memory_provider.h
@@ -18,8 +18,6 @@
 extern "C" {
 #endif
 
-typedef struct umf_memory_provider_t *umf_memory_provider_handle_t;
-
 ///
 /// \brief Creates new memory provider.
 /// \param ops instance of umf_memory_provider_ops_t
@@ -149,6 +147,10 @@ const char *umfMemoryProviderGetName(umf_memory_provider_handle_t hProvider);
 ///
 /// \return Handle to the memory provider
 umf_memory_provider_handle_t umfGetLastFailedMemoryProvider(void);
+
+///
+/// \brief Copy size bytes from the location pointed to by src to the location pointer to by dest. Location pointed to by src should reside in srcProvider. Location pointer to by dst should reside in dstProvider.
+enum umf_result_t umfMemoryProviderMemcpy(umf_memory_provider_handle_t dstProvider, umf_memory_provider_handle_t srcProvider, void *dst, const void *src, size_t size);
 
 #ifdef __cplusplus
 }

--- a/source/common/unified_malloc_framework/include/umf/memory_provider_ops.h
+++ b/source/common/unified_malloc_framework/include/umf/memory_provider_ops.h
@@ -50,6 +50,8 @@ struct umf_memory_provider_ops_t {
     enum umf_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);
     enum umf_result_t (*purge_force)(void *provider, void *ptr, size_t size);
     const char *(*get_name)(void *provider);
+    enum umf_result_t (*memcpy_from)(void *srcProvider, umf_memory_provider_handle_t dstProvider, void *dst, const void *src, size_t size);
+    enum umf_result_t (*memcpy_to)(void *dstProvider, umf_memory_provider_handle_t srcProvider, void *dst, const void *src, size_t size);
 };
 
 #ifdef __cplusplus

--- a/source/common/unified_malloc_framework/src/memory_pool.c
+++ b/source/common/unified_malloc_framework/src/memory_pool.c
@@ -161,3 +161,25 @@ umfPoolGetMemoryProviders(umf_memory_pool_handle_t hPool, size_t numProviders,
 
     return UMF_RESULT_SUCCESS;
 }
+
+enum umf_result_t umfPoolMemcpy(umf_memory_pool_handle_t dstPool, umf_memory_pool_handle_t srcPool, void *dst, const void *src, size_t size) {
+    umf_memory_provider_handle_t srcProvider;
+    umf_memory_provider_handle_t dstProvider;
+
+    // TODO: handle more than 1 provider case
+    enum umf_result_t ret = umfPoolGetMemoryProviders(srcPool, 1, &srcProvider, NULL);
+    if (ret != UMF_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    ret = umfPoolGetMemoryProviders(dstPool, 1, &dstProvider, NULL);
+    if (ret != UMF_RESULT_SUCCESS) {
+        return ret;
+    }
+
+    return umfMemoryProviderMemcpy(srcProvider, dstProvider, dst, src, size);
+}
+
+enum umf_result_t umfMemcpy(void *dst, const void *src, size_t size) {
+    return umfPoolMemcpy(umfPoolByPtr(dst), umfPoolByPtr(src), dst, src, size);
+}

--- a/source/common/unified_malloc_framework/src/memory_provider.c
+++ b/source/common/unified_malloc_framework/src/memory_provider.c
@@ -130,3 +130,13 @@ const char *umfMemoryProviderGetName(umf_memory_provider_handle_t hProvider) {
 umf_memory_provider_handle_t umfGetLastFailedMemoryProvider(void) {
     return *umfGetLastFailedMemoryProviderPtr();
 }
+
+enum umf_result_t umfMemoryProviderMemcpy(umf_memory_provider_handle_t dstProvider, umf_memory_provider_handle_t srcProvider, void *dst, const void *src, size_t size) {
+    enum umf_result_t ret = srcProvider->ops.memcpy_from(srcProvider->provider_priv, dstProvider, dst, src, size);
+    if (ret == UMF_RESULT_SUCCESS) {
+        return ret;
+    }
+    
+    return dstProvider->ops.memcpy_to(dstProvider->provider_priv, srcProvider, dst, src, size);
+    // TODO: if this returns unsupported, we can try copying through the host
+}

--- a/test/unified_malloc_framework/common/provider.hpp
+++ b/test/unified_malloc_framework/common/provider.hpp
@@ -47,6 +47,12 @@ struct provider_base {
     enum umf_result_t purge_force(void *ptr, size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
+    enum umf_result_t memcpy_to(umf_memory_provider_handle_t dstProvider, void *dst, const void *src, size_t size) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+    enum umf_result_t memcpy_from(umf_memory_provider_handle_t srcProvider, void *dst, const void *src, size_t size) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
     const char *get_name() noexcept { return "base"; }
 };
 


### PR DESCRIPTION
which allow to copy memory between different pools/providers.

The idea is to expose `memcpy_from` and `memcpy_to` in provider_ops. When we copy between 2 different memory providers we can try to use `memcpy_from` on the `src provider` and if that fails, try `memcpy_to` on the `dst provider`.  Alternatively, we could have some API to query whether we can perform a copy between 2 providers but that wouldn't change the logic much.

One open question is how `memcpy_to` / `memcpy_from` should be implemented (how to detect whether we can actually copy the memory from/to other provider). The simplest implementation could just call `get_name` and support some predefined set of providers. We could also introduce some kind of type/tag that we could associate with the provider but I'm not sure if it's useful - in most cases I would assume that provider only supports copying between other providers of the same type + USM providers could support copying between host memory and USM.
