### PR TITLE
[umf] fix erors reported by ASAN

### DIFF
--- a/source/common/unified_malloc_framework/src/memory_pool_default.c
+++ b/source/common/unified_malloc_framework/src/memory_pool_default.c
@@ -56,6 +56,7 @@ enum umf_result_t umfPoolCreate(const struct umf_memory_pool_ops_t *ops,
     return UMF_RESULT_SUCCESS;
 
 err_pool_init:
+    free(pool->providers);
 err_providers_alloc:
     free(pool);
 
@@ -64,6 +65,7 @@ err_providers_alloc:
 
 void umfPoolDestroy(umf_memory_pool_handle_t hPool) {
     hPool->ops.finalize(hPool->pool_priv);
+    free(hPool->providers);
     free(hPool);
 }
 

--- a/test/unified_malloc_framework/common/pool.hpp
+++ b/test/unified_malloc_framework/common/pool.hpp
@@ -32,41 +32,42 @@ auto wrapPoolUnique(umf_memory_pool_handle_t hPool) {
 }
 
 bool isReallocSupported(umf_memory_pool_handle_t hPool) {
-    static constexpr size_t allocSize = 1;
+    static constexpr size_t allocSize = 8;
     bool supported;
     auto *ptr = umfPoolMalloc(hPool, allocSize);
     auto *new_ptr = umfPoolRealloc(hPool, ptr, allocSize * 2);
 
     if (new_ptr) {
         supported = true;
+        umfPoolFree(hPool, new_ptr);
     } else if (umfPoolGetLastAllocationError(hPool) ==
                UMF_RESULT_ERROR_NOT_SUPPORTED) {
+        umfPoolFree(hPool, ptr);
         supported = false;
     } else {
+        umfPoolFree(hPool, new_ptr);
         throw std::runtime_error("realloc failed with unexpected error");
     }
-
-    umfPoolFree(hPool, new_ptr);
 
     return supported;
 }
 
 bool isCallocSupported(umf_memory_pool_handle_t hPool) {
-    static constexpr size_t num = 1;
+    static constexpr size_t num = 8;
     static constexpr size_t size = sizeof(int);
     bool supported;
     auto *ptr = umfPoolCalloc(hPool, num, size);
 
     if (ptr) {
         supported = true;
+        umfPoolFree(hPool, ptr);
     } else if (umfPoolGetLastAllocationError(hPool) ==
                UMF_RESULT_ERROR_NOT_SUPPORTED) {
         supported = false;
     } else {
+        umfPoolFree(hPool, ptr);
         throw std::runtime_error("calloc failed with unexpected error");
     }
-
-    umfPoolFree(hPool, ptr);
 
     return supported;
 }

--- a/test/unified_malloc_framework/memoryPool.hpp
+++ b/test/unified_malloc_framework/memoryPool.hpp
@@ -243,7 +243,7 @@ TEST_P(umfPoolTest, multiThreadedMallocFreeRandomSizes) {
 
     std::vector<std::thread> threads;
     for (int i = 0; i < NTHREADS; i++) {
-        threads.emplace_back(poolMalloc, rand() % 64 + 1, pool.get());
+        threads.emplace_back(poolMalloc, (rand() % 16) * 8, pool.get());
     }
 
     for (auto &thread : threads) {

--- a/test/unified_malloc_framework/memoryPoolAPI.cpp
+++ b/test/unified_malloc_framework/memoryPoolAPI.cpp
@@ -258,6 +258,7 @@ TEST_F(test, getLastFailedMemoryProvider) {
     auto ptr = umfPoolMalloc(pool.get(), allocSize);
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(umfGetLastFailedMemoryProvider(), nullptr);
+    umfPoolFree(pool.get(), ptr);
 
     // make provider return an error during allocation
     allocResult = UMF_RESULT_ERROR_UNKNOWN;
@@ -280,6 +281,7 @@ TEST_F(test, getLastFailedMemoryProvider) {
     ASSERT_EQ(std::string_view(
                   umfMemoryProviderGetName(umfGetLastFailedMemoryProvider())),
               "provider2");
+    umfPoolFree(pool.get(), ptr);
 
     // error in another thread should not impact umfGetLastFailedMemoryProvider on this thread
     allocResult = UMF_RESULT_ERROR_UNKNOWN;


### PR DESCRIPTION
- memory leak in memory_pool_default.c and tests
- allocating memory with alignemnt=8 and size%8 != 0