### PR TITLE
[umf] use alloc sizes that are multiples of 8 in tests

### DIFF
--- a/test/unified_malloc_framework/memoryPool.hpp
+++ b/test/unified_malloc_framework/memoryPool.hpp
@@ -255,8 +255,7 @@ TEST_P(umfPoolTest, multiThreadedMallocFreeRandomSizes) {
 // TODO: add similar tests for realloc/aligned_alloc, etc.
 // TODO: add multithreaded tests
 TEST_P(umfMultiPoolTest, memoryTracking) {
-    static constexpr int allocSizes[] = {1,  2,  4,  8,   16,   20,
-                                         32, 40, 64, 128, 1024, 4096};
+    static constexpr int allocSizes[] = {8, 16, 32, 40, 64, 128, 1024, 4096};
     static constexpr auto nAllocs = 256;
 
     std::mt19937_64 g(0);


### PR DESCRIPTION
to make ASAN happy. By default we are using alignment == 8 and size needs to be a multiple of that.

We might consider adding extra tests, specifically for different sizes.