### PR TITLE
[ur] Introduce urinfo tool

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -298,6 +298,25 @@ def _mako_params_hpp(path, namespace, tags, version, specs, meta):
 
 """
 Entry-point:
+    generates tools code
+"""
+def _mako_info_hpp(path, namespace, tags, version, specs, meta):
+    fin = os.path.join(templates_dir, "tools-info.hpp.mako")
+    name = f"{namespace}info"
+    filename = f"{name}.hpp"
+    fout = os.path.join(path, filename)
+    print("Generating %s..." % fout)
+    return util.makoWrite(
+        fin, fout,
+        name=name,
+        ver=version,
+        namespace=namespace,
+        tags=tags,
+        specs=specs,
+        meta=meta)
+
+"""
+Entry-point:
     generates lib code
 """
 def generate_lib(path, section, namespace, tags, version, specs, meta):
@@ -364,3 +383,15 @@ def generate_common(path, section, namespace, tags, version, specs, meta):
     loc += _mako_params_hpp(layer_dstpath, namespace, tags, version, specs, meta)
     print("COMMON Generated %s lines of code.\n"%loc)
 
+"""
+Entry-point:
+    generates tools for unified_runtime
+"""
+def generate_tools(path, section, namespace, tags, version, specs, meta):
+    loc = 0
+
+    infodir = os.path.join(path, f"{namespace}info")
+    os.makedirs(infodir, exist_ok=True)
+    loc += _mako_info_hpp(infodir, namespace, tags, version, specs, meta)
+
+    print("TOOLS Generated %s lines of code.\n" % loc)

--- a/scripts/json2src.py
+++ b/scripts/json2src.py
@@ -30,6 +30,7 @@ if __name__ == '__main__':
     add_argument(parser, "layers", "generation of layer files.", True)
     add_argument(parser, "adapters", "generation of null adapter files.", True)
     add_argument(parser, "common", "generation of common files.", True)
+    add_argument(parser, "tools", "generation of common files.", True)
     parser.add_argument("--debug", action='store_true', help="dump intermediate data to disk.")
     parser.add_argument("--sections", type=list, default=None, help="Optional list of sections for which to generate source, default is all")
     parser.add_argument("--ver", type=str, default="1.0", help="specification version to generate.")
@@ -42,6 +43,7 @@ if __name__ == '__main__':
     start = time.time()
 
     srcpath = os.path.join(args.out_dir, "source")
+    toolspath = os.path.join(args.out_dir, "tools")
 
     for idx, specs in enumerate(input['specs']):
         config = input['configs'][idx]
@@ -56,6 +58,8 @@ if __name__ == '__main__':
                 generate_code.generate_adapters(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
             if args.common:
                 generate_code.generate_common(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
+            if args.tools:
+                generate_code.generate_tools(toolspath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
 
     if args.debug:
         util.makoFileListWrite("generated.json")

--- a/scripts/templates/tools-info.hpp.mako
+++ b/scripts/templates/tools-info.hpp.mako
@@ -1,0 +1,70 @@
+<%!
+import re
+from templates import helper as th
+%><%
+    n=namespace
+    N=n.upper()
+
+    x=tags['$x']
+    X=x.upper()
+%>/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file ${name}.cpp
+ *
+ */
+
+#pragma once
+
+#include <ur_api.h>
+#include "utils.hpp"
+#include <cstdlib>
+#include <string_view>
+
+namespace urinfo {
+%for obj in th.extract_objs(specs, r"enum"):
+%if obj["name"] == '$x_loader_config_info_t':
+inline void printLoaderConfigInfos(${x}_loader_config_handle_t hLoaderConfig, std::string_view prefix = "  ") {
+%for etor in obj['etors']:
+%if 'REFERENCE_COUNT' not in etor['name']:
+    std::cout << prefix;
+    printLoaderConfigInfo<${etor['desc'][1:etor['desc'].find(' ')-1].replace('$x', x)}>(hLoaderConfig, ${etor['name'].replace('$X', X)});
+%endif
+%endfor
+}
+%endif
+%if obj["name"] == '$x_adapter_info_t':
+inline void printAdapterInfos(${x}_adapter_handle_t hAdapter, std::string_view prefix = "  ") {
+%for etor in obj['etors']:
+%if 'REFERENCE_COUNT' not in etor['name']:
+    std::cout << prefix;
+    printAdapterInfo<${etor['desc'][1:etor['desc'].find(' ')-1].replace('$x', x)}>(hAdapter, ${etor['name'].replace('$X', X)});
+%endif
+%endfor
+}
+
+%endif
+%if obj["name"] == '$x_platform_info_t':
+inline void printPlatformInfos(${x}_platform_handle_t hPlatform, std::string_view prefix = "    ") {
+%for etor in obj['etors']:
+    std::cout << prefix;
+    printPlatformInfo<${etor['desc'][1:etor['desc'].find(' ')-1].replace('$x', x)}>(hPlatform, ${etor['name'].replace('$X', X)});
+%endfor
+}
+
+%endif
+%if obj['name'] == '$x_device_info_t':
+inline void printDeviceInfos(${x}_device_handle_t hDevice, std::string_view prefix = "      ") {
+%for etor in obj['etors']:
+    std::cout << prefix;
+    printDeviceInfo<${etor['desc'][1:etor['desc'].find(' ')-1].replace('$x', x)}>(hDevice, ${etor['name'].replace('$X', X)});
+%endfor
+}
+%endif
+%endfor
+}  // namespace urinfo

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,8 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
+add_subdirectory(urinfo)
 if(UR_ENABLE_TRACING)
     add_subdirectory(urtrace)
 endif()

--- a/tools/urinfo/CMakeLists.txt
+++ b/tools/urinfo/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (C) 2023 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_ur_executable(urinfo
+    urinfo.hpp
+    utils.hpp
+    urinfo.cpp
+)
+target_compile_definitions(urinfo PRIVATE
+    UR_VERSION="${PROJECT_VERSION}"
+)
+target_include_directories(urinfo PRIVATE
+    ${PROJECT_SOURCE_DIR}/source/common
+)
+target_link_libraries(urinfo PRIVATE
+    ${PROJECT_NAME}::headers
+    ${PROJECT_NAME}::loader
+)

--- a/tools/urinfo/urinfo.cpp
+++ b/tools/urinfo/urinfo.cpp
@@ -1,0 +1,189 @@
+// Copyright (C) 2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "urinfo.hpp"
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace urinfo {
+struct app {
+    bool verbose = false;
+    ur_loader_config_handle_t loaderConfig = nullptr;
+    std::vector<ur_adapter_handle_t> adapters;
+    std::unordered_map<ur_adapter_handle_t, std::vector<ur_platform_handle_t>>
+        adapterPlatformsMap;
+    std::unordered_map<ur_platform_handle_t, std::vector<ur_device_handle_t>>
+        platformDevicesMap;
+
+    app(int argc, const char **argv) {
+        parseArgs(argc, argv);
+        UR_CHECK(urLoaderConfigCreate(&loaderConfig));
+        UR_CHECK(urLoaderConfigEnableLayer(loaderConfig,
+                                           "UR_LAYER_FULL_VALIDATION"));
+        UR_CHECK(urInit(0, loaderConfig));
+        enumerateDevices();
+    }
+
+    void parseArgs(int argc, const char **argv) {
+        static const char *usage = R"(usage: %s [-h] [-v] [-V]
+
+This tool enumerates Unified Runtime layers, adapters, platforms, and
+devices which are currently visible in the local execution environment.
+
+options:
+  -h, --help            show this help message and exit
+  --version             show version number and exit
+  -v, --verbose         print additional information
+)";
+        for (int argi = 1; argi < argc; argi++) {
+            std::string_view arg{argv[argi]};
+            if (arg == "-h" || arg == "--help") {
+                std::printf(usage, argv[0]);
+                std::exit(0);
+            } else if (arg == "--version") {
+                std::printf("%s v%s\n", argv[0], UR_VERSION);
+                std::exit(0);
+            } else if (arg == "-v" || arg == "--verbose") {
+                verbose = true;
+            } else {
+                std::fprintf(stderr, "error: invalid argument: %s\n",
+                             argv[argi]);
+                std::fprintf(stderr, usage, argv[0]);
+                std::exit(1);
+            }
+        }
+    }
+
+    void enumerateDevices() {
+        // Enumerate adapters.
+        uint32_t numAdapters = 0;
+        UR_CHECK(urAdapterGet(0, nullptr, &numAdapters));
+        if (numAdapters == 0) {
+            std::cout << "No adapters found.\n";
+            std::exit(0);
+        }
+        adapters.resize(numAdapters);
+        UR_CHECK(urAdapterGet(numAdapters, adapters.data(), nullptr));
+
+        for (size_t adapterIndex = 0; adapterIndex < adapters.size();
+             adapterIndex++) {
+            auto adapter = adapters[adapterIndex];
+            // Enumerate platforms
+            uint32_t numPlatforms = 0;
+            UR_CHECK(urPlatformGet(&adapter, 1, 0, nullptr, &numPlatforms));
+            if (numPlatforms == 0) {
+                std::cout << "No platforms found in adapter " << adapterIndex
+                          << ".\n";
+                continue;
+            }
+            adapterPlatformsMap[adapter].resize(numPlatforms);
+            UR_CHECK(urPlatformGet(&adapter, 1, numPlatforms,
+                                   adapterPlatformsMap[adapter].data(),
+                                   nullptr));
+
+            for (size_t platformIndex = 0; platformIndex < numPlatforms;
+                 platformIndex++) {
+                auto platform = adapterPlatformsMap[adapter][platformIndex];
+                // Enumerate devices
+                uint32_t numDevices = 0;
+                UR_CHECK(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr,
+                                     &numDevices));
+                if (numDevices == 0) {
+                    std::cout << "No devices found platform " << platformIndex
+                              << ".\n";
+                    continue;
+                }
+                platformDevicesMap[platform].resize(numDevices);
+                UR_CHECK(urDeviceGet(platform, UR_DEVICE_TYPE_ALL, numDevices,
+                                     platformDevicesMap[platform].data(),
+                                     nullptr));
+            }
+        }
+    }
+
+    void printSummary() {
+        for (size_t adapterIndex = 0; adapterIndex < adapters.size();
+             adapterIndex++) {
+            auto adapter = adapters[adapterIndex];
+            auto &platforms = adapterPlatformsMap[adapter];
+            for (size_t platformIndex = 0; platformIndex < platforms.size();
+                 platformIndex++) {
+                auto platform = platforms[platformIndex];
+                auto &devices = platformDevicesMap[platform];
+                for (size_t deviceIndex = 0; deviceIndex < devices.size();
+                     deviceIndex++) {
+                    auto device = devices[deviceIndex];
+                    std::cout << "[adapter(" << adapterIndex << ","
+                              << urinfo::getAdapterBackend(adapter) << "):"
+                              << "platform(" << platformIndex << "):"
+                              << "device(" << deviceIndex << ","
+                              << urinfo::getDeviceType(device) << ")] "
+                              << urinfo::getPlatformName(platform) << ", "
+                              << urinfo::getDeviceName(device) << " "
+                              << urinfo::getDeviceVersion(device) << " "
+                              << "[" << urinfo::getDeviceDriverVersion(device)
+                              << "]\n";
+                }
+            }
+        }
+    }
+
+    void printDetail() {
+        std::cout << "\n"
+                  << "[loader]:"
+                  << "\n";
+        urinfo::printLoaderConfigInfos(loaderConfig);
+
+        for (size_t adapterIndex = 0; adapterIndex < adapters.size();
+             adapterIndex++) {
+            auto adapter = adapters[adapterIndex];
+            std::cout << "\n"
+                      << "[adapter(" << adapterIndex << ")]:"
+                      << "\n";
+            urinfo::printAdapterInfos(adapter);
+
+            size_t numPlatforms = adapterPlatformsMap[adapter].size();
+            for (size_t platformIndex = 0; platformIndex < numPlatforms;
+                 platformIndex++) {
+                auto platform = adapterPlatformsMap[adapter][platformIndex];
+                std::cout << "\n"
+                          << "[adapter(" << adapterIndex << "),"
+                          << "platform(" << platformIndex << ")]:"
+                          << "\n";
+                urinfo::printPlatformInfos(platform);
+
+                size_t numDevices = platformDevicesMap[platform].size();
+                for (size_t deviceI = 0; deviceI < numDevices; deviceI++) {
+                    auto device = platformDevicesMap[platform][deviceI];
+                    std::cout << "\n"
+                              << "[adapter(" << adapterIndex << "),"
+                              << "platform(" << platformIndex << "),"
+                              << "device(" << deviceI << ")]:"
+                              << "\n";
+                    urinfo::printDeviceInfos(device);
+                }
+            }
+        }
+    }
+
+    ~app() {
+        urLoaderConfigRelease(loaderConfig);
+        urTearDown(nullptr);
+    }
+};
+} // namespace urinfo
+
+int main(int argc, const char **argv) {
+    auto app = urinfo::app{argc, argv};
+    app.printSummary();
+    if (app.verbose) {
+        app.printDetail();
+    }
+    return 0;
+}

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -1,0 +1,368 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file urinfo.cpp
+ *
+ */
+
+#pragma once
+
+#include "utils.hpp"
+#include <cstdlib>
+#include <string_view>
+#include <ur_api.h>
+
+namespace urinfo {
+inline void printLoaderConfigInfos(ur_loader_config_handle_t hLoaderConfig,
+                                   std::string_view prefix = "  ") {
+    std::cout << prefix;
+    printLoaderConfigInfo<char[]>(hLoaderConfig,
+                                  UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS);
+}
+inline void printAdapterInfos(ur_adapter_handle_t hAdapter,
+                              std::string_view prefix = "  ") {
+    std::cout << prefix;
+    printAdapterInfo<ur_adapter_backend_t>(hAdapter, UR_ADAPTER_INFO_BACKEND);
+}
+
+inline void printPlatformInfos(ur_platform_handle_t hPlatform,
+                               std::string_view prefix = "    ") {
+    std::cout << prefix;
+    printPlatformInfo<char[]>(hPlatform, UR_PLATFORM_INFO_NAME);
+    std::cout << prefix;
+    printPlatformInfo<char[]>(hPlatform, UR_PLATFORM_INFO_VENDOR_NAME);
+    std::cout << prefix;
+    printPlatformInfo<char[]>(hPlatform, UR_PLATFORM_INFO_VERSION);
+    std::cout << prefix;
+    printPlatformInfo<char[]>(hPlatform, UR_PLATFORM_INFO_EXTENSIONS);
+    std::cout << prefix;
+    printPlatformInfo<char[]>(hPlatform, UR_PLATFORM_INFO_PROFILE);
+    std::cout << prefix;
+    printPlatformInfo<ur_platform_backend_t>(hPlatform,
+                                             UR_PLATFORM_INFO_BACKEND);
+}
+
+inline void printDeviceInfos(ur_device_handle_t hDevice,
+                             std::string_view prefix = "      ") {
+    std::cout << prefix;
+    printDeviceInfo<ur_device_type_t>(hDevice, UR_DEVICE_INFO_TYPE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_VENDOR_ID);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_DEVICE_ID);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_COMPUTE_UNITS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS);
+    std::cout << prefix;
+    printDeviceInfo<size_t[]>(hDevice, UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_fp_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_SINGLE_FP_CONFIG);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_fp_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_HALF_FP_CONFIG);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_fp_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_DOUBLE_FP_CONFIG);
+    std::cout << prefix;
+    printDeviceInfo<ur_queue_flags_t>(hDevice, UR_DEVICE_INFO_QUEUE_PROPERTIES);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MEMORY_CLOCK_RATE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_ADDRESS_BITS);
+    std::cout << prefix;
+    printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_IMAGE_SUPPORTED);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_SAMPLERS);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_MAX_PARAMETER_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_mem_cache_type_t>(
+        hDevice, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_GLOBAL_MEM_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_GLOBAL_MEM_FREE);
+    std::cout << prefix;
+    printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_CONSTANT_ARGS);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_local_mem_type_t>(hDevice,
+                                                UR_DEVICE_INFO_LOCAL_MEM_TYPE);
+    std::cout << prefix;
+    printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_LOCAL_MEM_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice,
+                               UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_HOST_UNIFIED_MEMORY);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_ENDIAN_LITTLE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_AVAILABLE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_COMPILER_AVAILABLE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_LINKER_AVAILABLE);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_exec_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_EXECUTION_CAPABILITIES);
+    std::cout << prefix;
+    printDeviceInfo<ur_queue_flags_t>(
+        hDevice, UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES);
+    std::cout << prefix;
+    printDeviceInfo<ur_queue_flags_t>(hDevice,
+                                      UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_BUILT_IN_KERNELS);
+    std::cout << prefix;
+    printDeviceInfo<ur_platform_handle_t>(hDevice, UR_DEVICE_INFO_PLATFORM);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_REFERENCE_COUNT);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_IL_VERSION);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_NAME);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_VENDOR);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_DRIVER_VERSION);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_PROFILE);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_VERSION);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_EXTENSIONS);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_PRINTF_BUFFER_SIZE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice,
+                               UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_handle_t>(hDevice, UR_DEVICE_INFO_PARENT_DEVICE);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_partition_t[]>(
+        hDevice, UR_DEVICE_INFO_SUPPORTED_PARTITIONS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_affinity_domain_flags_t>(
+        hDevice, UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_partition_property_t[]>(
+        hDevice, UR_DEVICE_INFO_PARTITION_TYPE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t[]>(hDevice, UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_USM_HOST_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_USM_DEVICE_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_device_usm_access_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_UUID);
+    std::cout << prefix;
+    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_PCI_ADDRESS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_EU_COUNT);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_EU_SLICES);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_IMAGE_SRGB);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_BUILD_ON_SUBDEVICE);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_ATOMIC_64);
+    std::cout << prefix;
+    printDeviceInfo<ur_memory_order_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES);
+    std::cout << prefix;
+    printDeviceInfo<ur_memory_scope_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES);
+    std::cout << prefix;
+    printDeviceInfo<ur_memory_order_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES);
+    std::cout << prefix;
+    printDeviceInfo<ur_memory_scope_capability_flags_t>(
+        hDevice, UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_BFLOAT16);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MEMORY_BUS_WIDTH);
+    std::cout << prefix;
+    printDeviceInfo<size_t[3]>(hDevice, UR_DEVICE_INFO_MAX_WORK_GROUPS_3D);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_ASYNC_BARRIER);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice,
+                               UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_IP_VERSION);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice,
+                               UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice,
+                            UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<size_t>(hDevice, UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice,
+                               UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<uint32_t>(hDevice,
+                              UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_INTEROP_MEMORY_EXPORT_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP);
+}
+} // namespace urinfo

--- a/tools/urinfo/utils.hpp
+++ b/tools/urinfo/utils.hpp
@@ -1,0 +1,240 @@
+// Copyright (C) 2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "ur_api.h"
+#include "ur_params.hpp"
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#define UR_CHECK(ACTION)                                                       \
+    if (auto error = ACTION) {                                                 \
+        std::cerr << "error: " #ACTION " failed: " << error << "\n";           \
+        std::exit(1);                                                          \
+    }                                                                          \
+    (void)0
+
+#define UR_CHECK_WEAK(ACTION)                                                  \
+    if (auto error = ACTION) {                                                 \
+        std::cout << error << "\n";                                            \
+        return;                                                                \
+    }                                                                          \
+    (void)0
+
+namespace urinfo {
+inline std::string stripPrefix(std::string_view value,
+                               std::string_view prefix) {
+    if (std::equal(prefix.begin(), prefix.end(), value.begin(),
+                   value.begin() + std::min(value.size(), prefix.size()))) {
+        value.remove_prefix(prefix.size());
+    }
+    return std::string(value);
+}
+
+inline std::string getAdapterBackend(ur_adapter_handle_t adapter) {
+    ur_adapter_backend_t adapterBackend;
+    UR_CHECK(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND,
+                              sizeof(ur_adapter_backend_t), &adapterBackend,
+                              nullptr));
+    std::stringstream adapterBackendStream;
+    adapterBackendStream << adapterBackend;
+    std::string adapterBackendStr =
+        stripPrefix(adapterBackendStream.str(), "UR_ADAPTER_BACKEND_");
+    std::transform(adapterBackendStr.begin(), adapterBackendStr.end(),
+                   adapterBackendStr.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return adapterBackendStr;
+}
+
+inline std::string getDeviceType(ur_device_handle_t device) {
+    ur_device_type_t deviceType;
+    UR_CHECK(urDeviceGetInfo(device, UR_DEVICE_INFO_TYPE,
+                             sizeof(ur_device_type_t), &deviceType, nullptr));
+    std::stringstream deviceTypeStream;
+    deviceTypeStream << deviceType;
+    std::string deviceTypeStr =
+        stripPrefix(deviceTypeStream.str(), "UR_DEVICE_TYPE_");
+    std::transform(deviceTypeStr.begin(), deviceTypeStr.end(),
+                   deviceTypeStr.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return deviceTypeStr;
+}
+
+inline std::string getPlatformName(ur_platform_handle_t platform) {
+    size_t nameSize = 0;
+    UR_CHECK(urPlatformGetInfo(platform, UR_PLATFORM_INFO_NAME, 0, nullptr,
+                               &nameSize));
+    std::string name(nameSize, '\0');
+    UR_CHECK(urPlatformGetInfo(platform, UR_PLATFORM_INFO_NAME, nameSize,
+                               name.data(), &nameSize));
+    return name;
+}
+
+inline std::string getDeviceName(ur_device_handle_t device) {
+    size_t nameSize = 0;
+    UR_CHECK(
+        urDeviceGetInfo(device, UR_DEVICE_INFO_NAME, 0, nullptr, &nameSize));
+    std::string name(nameSize, '\0');
+    UR_CHECK(urDeviceGetInfo(device, UR_DEVICE_INFO_NAME, nameSize, name.data(),
+                             &nameSize));
+    return name;
+}
+
+inline std::string getDeviceVersion(ur_device_handle_t device) {
+    size_t versionSize = 0;
+    UR_CHECK(urDeviceGetInfo(device, UR_DEVICE_INFO_VERSION, 0, nullptr,
+                             &versionSize));
+    std::string name(versionSize, '\0');
+    UR_CHECK(urDeviceGetInfo(device, UR_DEVICE_INFO_VERSION, versionSize,
+                             name.data(), &versionSize));
+    return name;
+}
+
+inline std::string getDeviceDriverVersion(ur_device_handle_t device) {
+    size_t driverVersionSize = 0;
+    UR_CHECK(urDeviceGetInfo(device, UR_DEVICE_INFO_DRIVER_VERSION, 0, nullptr,
+                             &driverVersionSize));
+    std::string name(driverVersionSize, '\0');
+    UR_CHECK(urDeviceGetInfo(device, UR_DEVICE_INFO_DRIVER_VERSION,
+                             driverVersionSize, name.data(),
+                             &driverVersionSize));
+    return name;
+}
+
+inline std::string getLoaderConfigInfoName(ur_loader_config_info_t info) {
+    std::stringstream stream;
+    stream << info;
+    return stripPrefix(stream.str(), "UR_LOADER_CONFIG_INFO_");
+}
+
+template <class T>
+inline void printLoaderConfigInfo(ur_loader_config_handle_t loaderConfig,
+                                  ur_loader_config_info_t info) {
+    std::cout << getLoaderConfigInfoName(info) << ": ";
+    T value;
+    UR_CHECK(urLoaderConfigGetInfo(
+        loaderConfig, info, sizeof(ur_adapter_backend_t), &value, nullptr));
+    std::cout << value << "\n";
+}
+
+template <>
+inline void
+printLoaderConfigInfo<char[]>(ur_loader_config_handle_t loaderConfig,
+                              ur_loader_config_info_t info) {
+    std::cout << getLoaderConfigInfoName(info) << ": ";
+    size_t size = 0;
+    UR_CHECK_WEAK(urLoaderConfigGetInfo(loaderConfig, info, 0, nullptr, &size));
+    std::string str(size, '\0');
+    UR_CHECK_WEAK(
+        urLoaderConfigGetInfo(loaderConfig, info, size, str.data(), nullptr));
+    std::cout << str << "\n";
+}
+
+inline std::string getAdapterInfoName(ur_adapter_info_t info) {
+    std::stringstream stream;
+    stream << info;
+    return stripPrefix(stream.str(), "UR_ADAPTER_INFO_");
+}
+
+template <class T>
+inline void printAdapterInfo(ur_adapter_handle_t adapter,
+                             ur_adapter_info_t info) {
+    std::cout << getAdapterInfoName(info) << ": ";
+    T value;
+    UR_CHECK(urAdapterGetInfo(adapter, info, sizeof(ur_adapter_backend_t),
+                              &value, nullptr));
+    std::cout << value << "\n";
+}
+
+inline std::string getPlatformInfoName(ur_platform_info_t info) {
+    std::stringstream stream;
+    stream << info;
+    return stripPrefix(stream.str(), "UR_PLATFORM_INFO_");
+}
+
+template <class T>
+inline void printPlatformInfo(ur_platform_handle_t platform,
+                              ur_platform_info_t info) {
+    std::cout << getPlatformInfoName(info) << ": ";
+    T value;
+    UR_CHECK_WEAK(
+        urPlatformGetInfo(platform, info, sizeof(T), &value, nullptr));
+    std::cout << value << "\n";
+}
+
+template <>
+inline void printPlatformInfo<char[]>(ur_platform_handle_t platform,
+                                      ur_platform_info_t info) {
+    std::cout << getPlatformInfoName(info) << ": ";
+    size_t size = 0;
+    UR_CHECK_WEAK(urPlatformGetInfo(platform, info, 0, nullptr, &size));
+    std::string str(size, '\0');
+    UR_CHECK_WEAK(urPlatformGetInfo(platform, info, size, str.data(), nullptr));
+    std::cout << str << "\n";
+}
+
+inline std::string getDeviceInfoName(ur_device_info_t info) {
+    std::stringstream stream;
+    stream << info;
+    return stripPrefix(stream.str(), "UR_DEVICE_INFO_");
+}
+
+template <class T>
+inline std::enable_if_t<!std::is_array_v<T>>
+printDeviceInfo(ur_device_handle_t device, ur_device_info_t info) {
+    std::cout << getDeviceInfoName(info) << ": ";
+    T value;
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, sizeof(T), &value, nullptr));
+    std::cout << value << "\n";
+}
+
+template <>
+inline void printDeviceInfo<ur_bool_t>(ur_device_handle_t device,
+                                       ur_device_info_t info) {
+    std::cout << getDeviceInfoName(info) << ": ";
+    ur_bool_t value;
+    UR_CHECK_WEAK(
+        urDeviceGetInfo(device, info, sizeof(ur_bool_t), &value, nullptr));
+    std::string result = value ? "true" : "false";
+    std::cout << result << "\n";
+}
+
+template <class T>
+inline std::enable_if_t<std::is_array_v<T>>
+printDeviceInfo(ur_device_handle_t device, ur_device_info_t info) {
+    std::cout << getDeviceInfoName(info) << ": ";
+    using value_t = std::remove_reference_t<decltype(std::declval<T>()[0])>;
+    size_t size;
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, 0, nullptr, &size));
+    std::vector<value_t> values(size / sizeof(value_t));
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, size, values.data(), nullptr));
+    std::cout << "{ ";
+    for (size_t i = 0; i < values.size(); i++) {
+        if (i > 0) {
+            std::cout << ", ";
+        }
+        std::cout << values[i];
+    }
+    std::cout << " }\n";
+}
+
+template <>
+inline void printDeviceInfo<char[]>(ur_device_handle_t device,
+                                    ur_device_info_t info) {
+    std::cout << getDeviceInfoName(info) << ": ";
+    size_t size = 0;
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, 0, nullptr, &size));
+    std::string str(size, 0);
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, size, str.data(), nullptr));
+    std::cout << str << "\n";
+}
+} // namespace urinfo


### PR DESCRIPTION
`urinfo` is a command-line tool for inspecting the current execution
environment:

```console
$ build/bin/urinfo --help
usage: build/bin/urinfo [-h] [-v] [-V]

This tool enumerates Unified Runtime layers, adapters, platforms, and
devices which are currently visible in the local execution environment.

options:
  -h, --help            show this help message and exit
  --version             show version number and exit
  -v, --verbose         print additional information
```
