### PR TITLE
[UR] Implement CUDA native handle tests

### DIFF
--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -45,6 +45,7 @@ function(add_conformance_test_with_platform_environment name)
 endfunction()
 
 add_subdirectory(testing)
+add_subdirectory(adapters)
 
 add_subdirectory(platform)
 add_subdirectory(device)

--- a/test/conformance/adapters/CMakeLists.txt
+++ b/test/conformance/adapters/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(UR_BUILD_ADAPTER_CUDA)
+    add_subdirectory(cuda)
+endif()

--- a/test/conformance/adapters/cuda/CMakeLists.txt
+++ b/test/conformance/adapters/cuda/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+add_conformance_test_with_devices_environment(adapter-cuda 
+    cuda_fixtures.h
+    cuda_urContextGetNativeHandle.cpp
+    cuda_urDeviceGetNativeHandle.cpp
+    cuda_urDeviceCreateWithNativeHandle.cpp
+    cuda_urEventGetNativeHandle.cpp
+    cuda_urEventCreateWithNativeHandle.cpp
+)
+target_link_libraries(test-adapter-cuda PRIVATE cudadrv)
+
+set_tests_properties(adapter-cuda PROPERTIES
+        LABELS "conformance:cuda"
+        ENVIRONMENT "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_cuda>\""
+    )

--- a/test/conformance/adapters/cuda/cuda_fixtures.h
+++ b/test/conformance/adapters/cuda/cuda_fixtures.h
@@ -1,0 +1,38 @@
+#ifndef UR_TEST_CONFORMANCE_ADAPTERS_CUDA_FIXTURES_H_INCLUDED
+#define UR_TEST_CONFORMANCE_ADAPTERS_CUDA_FIXTURES_H_INCLUDED
+#include <cuda.h>
+#include <uur/fixtures.h>
+
+namespace uur {
+struct ResultCuda {
+
+    constexpr ResultCuda(CUresult result) noexcept : value(result) {}
+
+    inline bool operator==(const ResultCuda &rhs) const noexcept {
+        return rhs.value == value;
+    }
+
+    CUresult value;
+};
+} // namespace uur
+
+#ifndef ASSERT_EQ_RESULT_CUDA
+#define ASSERT_EQ_RESULT_CUDA(EXPECTED, ACTUAL)                                \
+    ASSERT_EQ(uur::ResultCuda(EXPECTED), uur::ResultCuda(ACTUAL))
+#endif // ASSERT_EQ_RESULT_CUDA
+
+#ifndef ASSERT_SUCCESS_CUDA
+#define ASSERT_SUCCESS_CUDA(ACTUAL) ASSERT_EQ_RESULT_CUDA(CUDA_SUCCESS, ACTUAL)
+#endif // ASSERT_SUCCESS_CUDA
+
+#ifndef EXPECT_EQ_RESULT_CUDA
+#define EXPECT_EQ_RESULT_CUDA(EXPECTED, ACTUAL)                                \
+    EXPECT_EQ_RESULT_CUDA(uur::ResultCuda(EXPECTED), uur::ResultCuda(ACTUAL))
+#endif // EXPECT_EQ_RESULT_CUDA
+
+#ifndef EXPECT_SUCCESS_CUDA
+#define EXPECT_SUCCESS_CUDA(ACTUAL)                                            \
+    EXPECT_EQ_RESULT_CUDA(UR_RESULT_SUCCESS, ACTUAL)
+#endif // EXPECT_EQ_RESULT_CUDA
+
+#endif // UR_TEST_CONFORMANCE_ADAPTERS_CUDA_FIXTURES_H_INCLUDED

--- a/test/conformance/adapters/cuda/cuda_urContextGetNativeHandle.cpp
+++ b/test/conformance/adapters/cuda/cuda_urContextGetNativeHandle.cpp
@@ -1,0 +1,13 @@
+#include "cuda_fixtures.h"
+
+using urCudaContextGetNativeHandle = uur::urContextTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaContextGetNativeHandle);
+
+TEST_P(urCudaContextGetNativeHandle, Success) {
+    ur_native_handle_t native_context = nullptr;
+    ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
+    CUcontext cuda_context = reinterpret_cast<CUcontext>(native_context);
+
+    unsigned int cudaVersion;
+    ASSERT_SUCCESS_CUDA(cuCtxGetApiVersion(cuda_context, &cudaVersion));
+}

--- a/test/conformance/adapters/cuda/cuda_urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/adapters/cuda/cuda_urDeviceCreateWithNativeHandle.cpp
@@ -1,0 +1,18 @@
+#include "cuda_fixtures.h"
+
+using urCudaDeviceCreateWithNativeHandle = uur::urPlatformTest;
+
+TEST_F(urCudaDeviceCreateWithNativeHandle, Success) {
+    // get a device from cuda
+    int nCudaDevices;
+    ASSERT_SUCCESS_CUDA(cuDeviceGetCount(&nCudaDevices));
+    ASSERT_GT(nCudaDevices, 0);
+    CUdevice cudaDevice;
+    ASSERT_SUCCESS_CUDA(cuDeviceGet(&cudaDevice, 0));
+
+    ur_native_handle_t nativeCuda =
+        reinterpret_cast<ur_native_handle_t>(cudaDevice);
+    ur_device_handle_t urDevice;
+    ASSERT_SUCCESS(urDeviceCreateWithNativeHandle(nativeCuda, platform, nullptr,
+                                                  &urDevice));
+}

--- a/test/conformance/adapters/cuda/cuda_urDeviceGetNativeHandle.cpp
+++ b/test/conformance/adapters/cuda/cuda_urDeviceGetNativeHandle.cpp
@@ -1,0 +1,15 @@
+#include "cuda_fixtures.h"
+
+using urCudaGetDeviceNativeHandle = uur::urDeviceTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaGetDeviceNativeHandle);
+
+TEST_P(urCudaGetDeviceNativeHandle, Success) {
+    ur_native_handle_t native_handle;
+    ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
+
+    CUdevice cuda_device = *reinterpret_cast<CUdevice *>(&native_handle);
+
+    char cuda_device_name[256];
+    ASSERT_SUCCESS_CUDA(cuDeviceGetName(cuda_device_name,
+                                        sizeof(cuda_device_name), cuda_device));
+}

--- a/test/conformance/adapters/cuda/cuda_urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/adapters/cuda/cuda_urEventCreateWithNativeHandle.cpp
@@ -1,0 +1,19 @@
+#include "cuda_fixtures.h"
+
+using urCudaEventCreateWithNativeHandleTest = uur::urQueueTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventCreateWithNativeHandleTest);
+
+TEST_P(urCudaEventCreateWithNativeHandleTest, Success) {
+
+    CUevent cuda_event;
+    ASSERT_SUCCESS_CUDA(cuEventCreate(&cuda_event, CU_EVENT_DEFAULT));
+
+    ur_native_handle_t native_event =
+        reinterpret_cast<ur_native_handle_t>(cuda_event);
+
+    ur_event_handle_t event = nullptr;
+    ASSERT_SUCCESS(
+        urEventCreateWithNativeHandle(native_event, context, nullptr, &event));
+
+    ASSERT_SUCCESS(urEventRelease(event));
+}

--- a/test/conformance/adapters/cuda/cuda_urEventGetNativeHandle.cpp
+++ b/test/conformance/adapters/cuda/cuda_urEventGetNativeHandle.cpp
@@ -1,0 +1,25 @@
+#include "cuda_fixtures.h"
+
+using urCudaEventGetNativeHandleTest = uur::urQueueTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventGetNativeHandleTest);
+
+TEST_P(urCudaEventGetNativeHandleTest, Success) {
+    constexpr size_t buffer_size = 1024;
+    ur_mem_handle_t mem = nullptr;
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     buffer_size, nullptr, &mem));
+
+    ur_event_handle_t event = nullptr;
+    uint8_t pattern = 6;
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, mem, &pattern, sizeof(pattern),
+                                          0, buffer_size, 0, nullptr, &event));
+
+    ur_native_handle_t native_event = nullptr;
+    ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
+    CUevent cuda_event = reinterpret_cast<CUevent>(native_event);
+
+    ASSERT_SUCCESS_CUDA(cuEventSynchronize(cuda_event));
+
+    ASSERT_SUCCESS(urEventRelease(event));
+    ASSERT_SUCCESS(urMemRelease(mem));
+}


### PR DESCRIPTION
This PR:
- Adds a new conformance target `test-adapter-cuda` which runs adapter specific CTS tests against the CUDA adapter.
- Currently I have only added CTS tests for 'Native Handle' entry-points, but further testing can easily be added.

I'm currently targeting this PR against the `adapters` branch, but perhaps we could have a separate branch in upstream to track changes separately.