### PR TITLE
[UR] Verify that every source file includes an appropriate license 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -81,6 +81,9 @@ jobs:
     - name: Generate source from spec, check for uncommitted diff
       if: matrix.os == 'ubuntu-22.04'
       run: cmake --build ${{github.workspace}}/build --target check-generated
+    
+    - name: Verify that each source file contains a license
+      run: cmake --build ${{github.workspace}}/build --target verify-licenses
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ endif()
 
 # Obtain files for clang-format
 set(format_glob)
+set(license_glob)
 foreach(dir examples include source test tools)
     list(APPEND format_glob
         "${dir}/*.h"
@@ -167,11 +168,26 @@ foreach(dir examples include source test tools)
         "${dir}/**/*.hpp"
         "${dir}/**/*.c"
         "${dir}/**/*.cpp")
+    list(APPEND license_glob
+        "${dir}/*.yml"
+        "${dir}/**/*.yml"
+        "${dir}/*.py"
+        "${dir}/**/*.py"
+        "${dir}/**/CMakeLists.txt"
+        "${dir}/CMakeLists.txt"
+    )
 endforeach()
 file(GLOB_RECURSE format_src ${format_glob})
+file(GLOB_RECURSE license_src ${license_glob})
 
 # check for licence
-VerifyLicence(${format_src})
+list(FILTER license_src EXCLUDE REGEX "registry.yml")
+add_custom_target(verify-licenses
+    COMMAND ${Python3_EXECUTABLE}
+        "${PROJECT_SOURCE_DIR}/scripts/verify_license.py"
+        "--files" ${format_src} ${license_src}
+    COMMENT "Verify all files contain a license."
+)
 
 # Add code formatter target
 add_custom_target(cppformat)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -146,14 +146,3 @@ function(FetchContentSparse_Declare name GIT_REPOSITORY GIT_TAG GIT_DIR)
         WORKING_DIRECTORY ${content-build-dir})
     FetchContent_Declare(${name} SOURCE_DIR ${content-build-dir}/${GIT_DIR})
 endfunction()
-
-
-# Checks that every input file includes an appropriate license notice.
-function(VerifyLicence)
-    foreach(file ${ARGN})
-        file(READ ${file} file_contents LIMIT 300)
-        if(NOT "${file_contents}" MATCHES "SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception")
-            message(FATAL_ERROR "${file} does not contain an appropriate license comment.")
-        endif()
-    endforeach()
-endfunction()

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2023 Intel Corporation
+#
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# See YaML.md for syntax definition
+#
 --- #--------------------------------------------------------------------------
 type: header
 desc: "Bindless Images Extension APIs"

--- a/scripts/core/exp-usm-import-release.yml
+++ b/scripts/core/exp-usm-import-release.yml
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2023 Intel Corporation
+#
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# See YaML.md for syntax definition
+#
 --- #--------------------------------------------------------------------------
 type: header
 desc: "Intel $OneApi USM Import/Release Extension APIs"

--- a/scripts/templates/__init__.py
+++ b/scripts/templates/__init__.py
@@ -1,0 +1,8 @@
+"""
+ Copyright (C) 2023 Intel Corporation
+
+ Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ See LICENSE.TXT
+ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""

--- a/scripts/verify_license.py
+++ b/scripts/verify_license.py
@@ -1,0 +1,28 @@
+"""
+ Copyright (C) 2023 Intel Corporation
+
+ Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ See LICENSE.TXT
+ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+
+import sys
+import argparse
+
+def verify_file_has_license(file):
+    with open(file, 'r') as in_file:
+        contents = in_file.read(300)
+        if "SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception" not in contents:
+            raise Exception(f"{file} does not contain a license!")
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--files', nargs='+', default=[])
+    args = parser.parse_args()
+    for file in args.files:
+        verify_file_has_license(file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR:
* Adds a simple check in CMake to check that every source file includes an appropriate comment listing the copyright and license notice.
* The license should appear at the top of each file, so Cmake only reads the first 300 bytes in which it should find the keyword "SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception"