### PR TITLE
[ADAPTERS] HIP specific CTS

### DIFF
--- a/test/conformance/adapters/CMakeLists.txt
+++ b/test/conformance/adapters/CMakeLists.txt
@@ -6,3 +6,7 @@
 if(UR_BUILD_ADAPTER_CUDA)
     add_subdirectory(cuda)
 endif()
+
+if(UR_BUILD_ADAPTER_HIP)
+    add_subdirectory(hip)
+endif()

--- a/test/conformance/adapters/hip/CMakeLists.txt
+++ b/test/conformance/adapters/hip/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (C) 2023 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_conformance_test_with_devices_environment(adapter-hip 
+    hip_fixtures.h
+    hip_urContextGetNativeHandle.cpp
+    hip_urDeviceGetNativeHandle.cpp
+    hip_urEventGetNativeHandle.cpp
+)
+target_link_libraries(test-adapter-hip PRIVATE rocmdrv)
+
+if(UR_HIP_PLATFORM STREQUAL "AMD")
+    target_compile_definitions(test-adapter-hip PRIVATE __HIP_PLATFORM_AMD__)
+else()
+    target_compile_definitions(test-adapter-hip PRIVATE __HIP_PLATFORM_NVIDIA__)
+endif()
+
+set_tests_properties(adapter-hip PROPERTIES
+    LABELS "conformance:hip"
+    ENVIRONMENT "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_hip>\""
+)

--- a/test/conformance/adapters/hip/hip_fixtures.h
+++ b/test/conformance/adapters/hip/hip_fixtures.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef UR_TEST_CONFORMANCE_ADAPTERS_HIP_FIXTURES_H_INCLUDED
+#define UR_TEST_CONFORMANCE_ADAPTERS_HIP_FIXTURES_H_INCLUDED
+#include <hip/hip_runtime.h>
+#include <uur/fixtures.h>
+
+namespace uur {
+
+struct ResultHip {
+    constexpr ResultHip(hipError_t result) noexcept : value(result) {}
+
+    inline bool operator==(const ResultHip &rhs) const noexcept {
+        return rhs.value == value;
+    }
+
+    hipError_t value;
+};
+
+} // namespace uur
+
+#ifndef ASSERT_EQ_RESULT_HIP
+#define ASSERT_EQ_RESULT_HIP(EXPECTED, ACTUAL)                                 \
+    ASSERT_EQ(uur::ResultHip(EXPECTED), uur::ResultHip(ACTUAL))
+#endif // ASSERT_EQ_RESULT_HIP
+
+#ifndef ASSERT_SUCCESS_HIP
+#define ASSERT_SUCCESS_HIP(ACTUAL) ASSERT_EQ_RESULT_HIP(hipSuccess, ACTUAL)
+#endif // ASSERT_SUCCESS_HIP
+
+#ifndef EXPECT_EQ_RESULT_HIP
+#define EXPECT_EQ_RESULT_HIP(EXPECTED, ACTUAL)                                 \
+    EXPECT_EQ_RESULT_HIP(uur::ResultHip(EXPECTED), uur::ResultHip(ACTUAL))
+#endif // EXPECT_EQ_RESULT_HIP
+
+#ifndef EXPECT_SUCCESS_HIP
+#define EXPECT_SUCCESS_HIP(ACTUAL)                                             \
+    EXPECT_EQ_RESULT_HIP(UR_RESULT_SUCCESS, ACTUAL)
+#endif // EXPECT_EQ_RESULT_HIP
+
+#endif // UR_TEST_CONFORMANCE_ADAPTERS_HIP_FIXTURES_H_INCLUDED

--- a/test/conformance/adapters/hip/hip_urContextGetNativeHandle.cpp
+++ b/test/conformance/adapters/hip/hip_urContextGetNativeHandle.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "hip_fixtures.h"
+
+using urHipContextGetNativeHandleTest = uur::urContextTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipContextGetNativeHandleTest);
+
+TEST_P(urHipContextGetNativeHandleTest, Success) {
+    ur_native_handle_t native_context = nullptr;
+    ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
+    hipCtx_t hip_context = reinterpret_cast<hipCtx_t>(native_context);
+    std::ignore = hip_context;
+}

--- a/test/conformance/adapters/hip/hip_urDeviceGetNativeHandle.cpp
+++ b/test/conformance/adapters/hip/hip_urDeviceGetNativeHandle.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "hip_fixtures.h"
+
+using urHipGetDeviceNativeHandle = uur::urDeviceTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipGetDeviceNativeHandle);
+
+TEST_P(urHipGetDeviceNativeHandle, Success) {
+    ur_native_handle_t native_handle;
+    ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
+
+    hipDevice_t hip_device = *reinterpret_cast<hipDevice_t *>(&native_handle);
+
+    char hip_device_name[256];
+    ASSERT_SUCCESS_HIP(
+        hipDeviceGetName(hip_device_name, sizeof(hip_device_name), hip_device));
+}

--- a/test/conformance/adapters/hip/hip_urEventGetNativeHandle.cpp
+++ b/test/conformance/adapters/hip/hip_urEventGetNativeHandle.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "hip_fixtures.h"
+
+using urHipEventGetNativeHandleTest = uur::urQueueTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipEventGetNativeHandleTest);
+
+TEST_P(urHipEventGetNativeHandleTest, Success) {
+    constexpr size_t buffer_size = 1024;
+    ur_mem_handle_t mem = nullptr;
+    ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                     buffer_size, nullptr, &mem));
+
+    ur_event_handle_t event = nullptr;
+    uint8_t pattern = 6;
+    ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, mem, &pattern, sizeof(pattern),
+                                          0, buffer_size, 0, nullptr, &event));
+
+    ur_native_handle_t native_event = nullptr;
+    ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
+    hipEvent_t hip_event = reinterpret_cast<hipEvent_t>(native_event);
+
+    ASSERT_SUCCESS_HIP(hipEventSynchronize(hip_event));
+
+    ASSERT_SUCCESS(urEventRelease(event));
+    ASSERT_SUCCESS(urMemRelease(mem));
+}


### PR DESCRIPTION
Adds HIP specific CTS for native handle entry-points

1. urContextGetNativehandle
2. urDevicGetNativeHandle
3. urEventGetNativeHandle