### PR TITLE
Add urUSMPoolFree function to spec

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -196,6 +196,7 @@ class ur_function_v(IntEnum):
     ADAPTER_RETAIN = 179                            ## Enumerator for ::urAdapterRetain
     ADAPTER_GET_LAST_ERROR = 180                    ## Enumerator for ::urAdapterGetLastError
     ADAPTER_GET_INFO = 181                          ## Enumerator for ::urAdapterGetInfo
+    USM_POOL_FREE = 182                             ## Enumerator for ::urUSMPoolFree
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -1548,7 +1549,7 @@ class ur_usm_pool_limits_desc_t(Structure):
 ## @brief Get USM memory pool information
 class ur_usm_pool_info_v(IntEnum):
     REFERENCE_COUNT = 0                             ## [uint32_t] Reference count of the pool object.
-                                                    ## The reference count returned should be considered immediately stale. 
+                                                    ## The reference count returned should be considered immediately stale.
                                                     ## It is unsuitable for general use in applications. This feature is
                                                     ## provided for identifying memory leaks.
     CONTEXT = 1                                     ## [::ur_context_handle_t] USM memory pool context info
@@ -3360,6 +3361,13 @@ else:
     _urUSMFree_t = CFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p )
 
 ###############################################################################
+## @brief Function-pointer for urUSMPoolFree
+if __use_win_types:
+    _urUSMPoolFree_t = WINFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, c_void_p )
+else:
+    _urUSMPoolFree_t = CFUNCTYPE( ur_result_t, ur_usm_pool_handle_t, c_void_p )
+
+###############################################################################
 ## @brief Function-pointer for urUSMGetMemAllocInfo
 if __use_win_types:
     _urUSMGetMemAllocInfo_t = WINFUNCTYPE( ur_result_t, ur_context_handle_t, c_void_p, ur_usm_alloc_info_t, c_size_t, c_void_p, POINTER(c_size_t) )
@@ -3403,6 +3411,7 @@ class ur_usm_dditable_t(Structure):
         ("pfnDeviceAlloc", c_void_p),                                   ## _urUSMDeviceAlloc_t
         ("pfnSharedAlloc", c_void_p),                                   ## _urUSMSharedAlloc_t
         ("pfnFree", c_void_p),                                          ## _urUSMFree_t
+        ("pfnPoolFree", c_void_p),                                      ## _urUSMPoolFree_t
         ("pfnGetMemAllocInfo", c_void_p),                               ## _urUSMGetMemAllocInfo_t
         ("pfnPoolCreate", c_void_p),                                    ## _urUSMPoolCreate_t
         ("pfnPoolRetain", c_void_p),                                    ## _urUSMPoolRetain_t
@@ -4057,6 +4066,7 @@ class UR_DDI:
         self.urUSMDeviceAlloc = _urUSMDeviceAlloc_t(self.__dditable.USM.pfnDeviceAlloc)
         self.urUSMSharedAlloc = _urUSMSharedAlloc_t(self.__dditable.USM.pfnSharedAlloc)
         self.urUSMFree = _urUSMFree_t(self.__dditable.USM.pfnFree)
+        self.urUSMPoolFree = _urUSMPoolFree_t(self.__dditable.USM.pfnPoolFree)
         self.urUSMGetMemAllocInfo = _urUSMGetMemAllocInfo_t(self.__dditable.USM.pfnGetMemAllocInfo)
         self.urUSMPoolCreate = _urUSMPoolCreate_t(self.__dditable.USM.pfnPoolCreate)
         self.urUSMPoolRetain = _urUSMPoolRetain_t(self.__dditable.USM.pfnPoolRetain)

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -205,6 +205,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_ADAPTER_RETAIN = 179,                                          ///< Enumerator for ::urAdapterRetain
     UR_FUNCTION_ADAPTER_GET_LAST_ERROR = 180,                                  ///< Enumerator for ::urAdapterGetLastError
     UR_FUNCTION_ADAPTER_GET_INFO = 181,                                        ///< Enumerator for ::urAdapterGetInfo
+    UR_FUNCTION_USM_POOL_FREE = 182,                                           ///< Enumerator for ::urUSMPoolFree
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -3384,6 +3385,30 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Free the USM memory object from the pool
+///
+/// @details
+///     - Calling this function is equivalent to urUSMFree but without the pool
+///       look-up overhead.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == pool`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMPoolFree(
+    ur_usm_pool_handle_t pool, ///< [in] Pointer to a pool created using urUSMPoolCreate
+    void *pMem                 ///< [in] pointer to USM memory object
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9718,6 +9743,15 @@ typedef struct ur_usm_free_params_t {
     ur_context_handle_t *phContext;
     void **ppMem;
 } ur_usm_free_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urUSMPoolFree
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_usm_pool_free_params_t {
+    ur_usm_pool_handle_t *ppool;
+    void **ppMem;
+} ur_usm_pool_free_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urUSMGetMemAllocInfo

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1501,6 +1501,12 @@ typedef ur_result_t(UR_APICALL *ur_pfnUSMFree_t)(
     void *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urUSMPoolFree
+typedef ur_result_t(UR_APICALL *ur_pfnUSMPoolFree_t)(
+    ur_usm_pool_handle_t,
+    void *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urUSMGetMemAllocInfo
 typedef ur_result_t(UR_APICALL *ur_pfnUSMGetMemAllocInfo_t)(
     ur_context_handle_t,
@@ -1543,6 +1549,7 @@ typedef struct ur_usm_dditable_t {
     ur_pfnUSMDeviceAlloc_t pfnDeviceAlloc;
     ur_pfnUSMSharedAlloc_t pfnSharedAlloc;
     ur_pfnUSMFree_t pfnFree;
+    ur_pfnUSMPoolFree_t pfnPoolFree;
     ur_pfnUSMGetMemAllocInfo_t pfnGetMemAllocInfo;
     ur_pfnUSMPoolCreate_t pfnPoolCreate;
     ur_pfnUSMPoolRetain_t pfnPoolRetain;

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -529,6 +529,9 @@ etors:
 - name: ADAPTER_GET_INFO
   desc: Enumerator for $xAdapterGetInfo
   value: '181'
+- name: USM_POOL_FREE
+  desc: Enumerator for $xUSMPoolFree
+  value: '182'
 ---
 type: enum
 desc: Defines structure types

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -148,7 +148,7 @@ members:
             Must be zero or a power of 2.
             Must be equal to or smaller than the size of the largest data type supported by `hDevice`.
 --- #--------------------------------------------------------------------------
-type: struct 
+type: struct
 desc: "USM host allocation descriptor type."
 details:
   - Specify these properties in $xUSMHostAlloc and $xUSMSharedAlloc via $x_usm_desc_t
@@ -228,10 +228,10 @@ params:
     - type: void**
       name: ppMem
       desc: "[out] pointer to USM host memory object"
-returns:      
+returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_OPERATION:
-      - "If $X_DEVICE_INFO_USM_HOST_SUPPORT is false."    
+      - "If $X_DEVICE_INFO_USM_HOST_SUPPORT is false."
     - $X_RESULT_ERROR_INVALID_VALUE:
       - "`pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`" # alignment must be power of two
       - "If `align` is greater that the size of the largest data type supported by `hDevice`."
@@ -272,7 +272,7 @@ params:
     - type: void**
       name: ppMem
       desc: "[out] pointer to USM device memory object"
-returns:      
+returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_OPERATION:
       - "If $X_DEVICE_INFO_USM_HOST_SUPPORT is false."
@@ -317,7 +317,7 @@ params:
     - type: void**
       name: ppMem
       desc: "[out] pointer to USM shared memory object"
-returns:      
+returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE:
       - "`pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`" # alignment must be power of two
@@ -339,6 +339,24 @@ params:
     - type: $x_context_handle_t
       name: hContext
       desc: "[in] handle of the context object"
+    - type: void*
+      name: pMem
+      desc: "[in] pointer to USM memory object"
+returns:
+    - $X_RESULT_ERROR_INVALID_MEM_OBJECT
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Free the USM memory object from the pool"
+class: $xUSM
+name: PoolFree
+ordinal: "0"
+details:
+  - "Calling this function is equivalent to urUSMFree but without the pool look-up overhead."
+params:
+    - type: $x_usm_pool_handle_t
+      name: pool
+      desc: "[in] Pointer to a pool created using urUSMPoolCreate"
     - type: void*
       name: pMem
       desc: "[in] pointer to USM memory object"
@@ -436,7 +454,7 @@ etors:
     - name: REFERENCE_COUNT
       desc: |
             [uint32_t] Reference count of the pool object.
-            The reference count returned should be considered immediately stale. 
+            The reference count returned should be considered immediately stale.
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: CONTEXT
       desc: "[$x_context_handle_t] USM memory pool context info"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -1112,6 +1112,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_ADAPTER_GET_INFO:
         os << "UR_FUNCTION_ADAPTER_GET_INFO";
         break;
+
+    case UR_FUNCTION_USM_POOL_FREE:
+        os << "UR_FUNCTION_USM_POOL_FREE";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -14445,6 +14449,21 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline std::ostream &
+operator<<(std::ostream &os, const struct ur_usm_pool_free_params_t *params) {
+
+    os << ".pool = ";
+
+    ur_params::serializePtr(os, *(params->ppool));
+
+    os << ", ";
+    os << ".pMem = ";
+
+    ur_params::serializePtr(os, *(params->ppMem));
+
+    return os;
+}
+
+inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_usm_get_mem_alloc_info_params_t *params) {
 
@@ -15627,6 +15646,9 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     } break;
     case UR_FUNCTION_USM_FREE: {
         os << (const struct ur_usm_free_params_t *)params;
+    } break;
+    case UR_FUNCTION_USM_POOL_FREE: {
+        os << (const struct ur_usm_pool_free_params_t *)params;
     } break;
     case UR_FUNCTION_USM_GET_MEM_ALLOC_INFO: {
         os << (const struct ur_usm_get_mem_alloc_info_params_t *)params;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2273,6 +2273,39 @@ ur_result_t UR_APICALL urUSMFree(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Free the USM memory object from the pool
+///
+/// @details
+///     - Calling this function is equivalent to urUSMFree but without the pool
+///       look-up overhead.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == pool`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urUSMPoolFree(
+    ur_usm_pool_handle_t
+        pool,  ///< [in] Pointer to a pool created using urUSMPoolCreate
+    void *pMem ///< [in] pointer to USM memory object
+    ) try {
+    auto pfnPoolFree = ur_lib::context->urDdiTable.USM.pfnPoolFree;
+    if (nullptr == pfnPoolFree) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnPoolFree(pool, pMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Get USM memory object allocation information
 ///
 /// @returns

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1932,6 +1932,33 @@ ur_result_t UR_APICALL urUSMFree(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Free the USM memory object from the pool
+///
+/// @details
+///     - Calling this function is equivalent to urUSMFree but without the pool
+///       look-up overhead.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == pool`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pMem`
+///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
+ur_result_t UR_APICALL urUSMPoolFree(
+    ur_usm_pool_handle_t
+        pool,  ///< [in] Pointer to a pool created using urUSMPoolCreate
+    void *pMem ///< [in] pointer to USM memory object
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Get USM memory object allocation information
 ///
 /// @returns


### PR DESCRIPTION
To free previously allocated USM memory urUSMFree accepts a context handle and pointer. If it's memory from a pool we need to identify the pool from which the memory was allocated. We can avoid this overhead by having a function that accepts pool handle.