### PR TITLE
Add parameterization to USM alloc tests for testing pools.

### DIFF
--- a/test/conformance/testing/CMakeLists.txt
+++ b/test/conformance/testing/CMakeLists.txt
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_ur_library(ur_testing STATIC 
-    source/utils.cpp)
+    source/utils.cpp
+    source/fixtures.cpp)
 target_include_directories(ur_testing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(ur_testing PRIVATE gtest_main unified-runtime::headers)
+target_link_libraries(ur_testing PRIVATE
+    gtest_main
+    ${PROJECT_NAME}::common
+    ${PROJECT_NAME}::headers)
 add_library(${PROJECT_NAME}::testing ALIAS ur_testing)

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -653,7 +653,6 @@ template <class T> struct urUSMPoolTestWithParam : urContextTestWithParam<T> {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
         ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr,
                                      UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK};
-        ur_usm_pool_handle_t pool = nullptr;
         ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
     }
 
@@ -823,8 +822,12 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
         if (!device_usm) {
             GTEST_SKIP() << "Device USM in not supported";
         }
+        if (use_pool) {
+            ur_usm_pool_desc_t pool_desc = {};
+            ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
+        }
         ASSERT_SUCCESS(urUSMDeviceAlloc(this->context, this->device, nullptr,
-                                        nullptr, allocation_size, &ptr));
+                                        pool, allocation_size, &ptr));
         ur_event_handle_t event = nullptr;
 
         uint8_t fillPattern = 0;
@@ -839,11 +842,17 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
 
     void TearDown() override {
         ASSERT_SUCCESS(urUSMFree(this->context, ptr));
+        if (pool) {
+            ASSERT_TRUE(use_pool);
+            ASSERT_SUCCESS(urUSMPoolRelease(pool));
+        }
         uur::urQueueTestWithParam<T>::TearDown();
     }
 
     size_t allocation_size = sizeof(int);
     void *ptr = nullptr;
+    bool use_pool = false;
+    ur_usm_pool_handle_t pool = nullptr;
 };
 
 /// @brief
@@ -860,6 +869,22 @@ std::string deviceTestWithParamPrinter(
     ss << param;
     return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
 }
+
+// Helper struct to allow bool param tests with meaningful names.
+struct BoolTestParam {
+    std::string name;
+    bool value;
+
+    // For use with testing::ValuesIn to generate the param values.
+    static std::vector<BoolTestParam> makeBoolParam(std::string name) {
+        return std::vector<BoolTestParam>({{name, true}, {name, false}});
+    }
+};
+
+template <>
+std::string deviceTestWithParamPrinter<BoolTestParam>(
+    const ::testing::TestParamInfo<
+        std::tuple<ur_device_handle_t, BoolTestParam>> &info);
 
 struct urProgramTest : urQueueTest {
     void SetUp() override {

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -634,7 +634,7 @@ struct urUSMPoolTest : urContextTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
         ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr,
-                                     UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK};
+                                     0};
         ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
     }
 
@@ -645,14 +645,14 @@ struct urUSMPoolTest : urContextTest {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTest::TearDown());
     }
 
-    ur_usm_pool_handle_t pool;
+    ur_usm_pool_handle_t pool = nullptr;
 };
 
 template <class T> struct urUSMPoolTestWithParam : urContextTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
         ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr,
-                                     UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK};
+                                     0};
         ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
     }
 
@@ -663,7 +663,7 @@ template <class T> struct urUSMPoolTestWithParam : urContextTestWithParam<T> {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::TearDown());
     }
 
-    ur_usm_pool_handle_t pool;
+    ur_usm_pool_handle_t pool = nullptr;
 };
 
 struct urVirtualMemGranularityTest : urContextTest {

--- a/test/conformance/testing/source/fixtures.cpp
+++ b/test/conformance/testing/source/fixtures.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "uur/fixtures.h"
+
+namespace uur {
+template <>
+std::string deviceTestWithParamPrinter<BoolTestParam>(
+    const ::testing::TestParamInfo<
+        std::tuple<ur_device_handle_t, BoolTestParam>> &info) {
+    auto device = std::get<0>(info.param);
+    auto param = std::get<1>(info.param);
+
+    std::stringstream ss;
+    ss << param.name << (param.value ? "Enabled" : "Disabled");
+    return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
+}
+} // namespace uur

--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -5,23 +5,43 @@
 
 #include <uur/fixtures.h>
 
-struct urUSMDeviceAllocTest : uur::urQueueTest {
+struct urUSMDeviceAllocTest : uur::urQueueTestWithParam<uur::BoolTestParam> {
     void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
+        UUR_RETURN_ON_FATAL_FAILURE(
+            uur::urQueueTestWithParam<uur::BoolTestParam>::SetUp());
         ur_device_usm_access_capability_flags_t deviceUSMSupport = 0;
         ASSERT_SUCCESS(
             uur::GetDeviceUSMDeviceSupport(device, deviceUSMSupport));
         if (!deviceUSMSupport) {
             GTEST_SKIP() << "Device USM is not supported.";
         }
+
+        if (getParam().value) {
+            ur_usm_pool_desc_t pool_desc = {};
+            ASSERT_SUCCESS(urUSMPoolCreate(context, &pool_desc, &pool));
+        }
     }
+
+    void TearDown() override {
+        if (pool) {
+            ASSERT_SUCCESS(urUSMPoolRelease(pool));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(
+            uur::urQueueTestWithParam<uur::BoolTestParam>::TearDown());
+    }
+
+    ur_usm_pool_handle_t pool = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMDeviceAllocTest);
+
+UUR_TEST_SUITE_P(
+    urUSMDeviceAllocTest,
+    testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
+    uur::deviceTestWithParamPrinter<uur::BoolTestParam>);
 
 TEST_P(urUSMDeviceAllocTest, Success) {
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
-    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, nullptr,
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, nullptr, pool,
                                     allocation_size, &ptr));
     ASSERT_NE(ptr, nullptr);
 
@@ -47,7 +67,7 @@ TEST_P(urUSMDeviceAllocTest, SuccessWithDescriptors) {
                            /* alignment */ 0};
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
-    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &usm_desc, nullptr,
+    ASSERT_SUCCESS(urUSMDeviceAlloc(context, device, &usm_desc, pool,
                                     allocation_size, &ptr));
 
     ur_event_handle_t event = nullptr;
@@ -64,27 +84,27 @@ TEST_P(urUSMDeviceAllocTest, InvalidNullHandleContext) {
     void *ptr = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urUSMDeviceAlloc(nullptr, device, nullptr, nullptr, sizeof(int), &ptr));
+        urUSMDeviceAlloc(nullptr, device, nullptr, pool, sizeof(int), &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullHandleDevice) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urUSMDeviceAlloc(context, nullptr, nullptr, nullptr,
-                                      sizeof(int), &ptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urUSMDeviceAlloc(context, nullptr, nullptr, pool, sizeof(int), &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidNullPtrResult) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urUSMDeviceAlloc(context, device, nullptr, nullptr,
-                                      sizeof(int), nullptr));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urUSMDeviceAlloc(context, device, nullptr, pool, sizeof(int), nullptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_USM_SIZE,
-        urUSMDeviceAlloc(context, device, nullptr, nullptr, -1, &ptr));
+        urUSMDeviceAlloc(context, device, nullptr, pool, -1, &ptr));
 }
 
 TEST_P(urUSMDeviceAllocTest, InvalidValueAlignPowerOfTwo) {
@@ -94,5 +114,5 @@ TEST_P(urUSMDeviceAllocTest, InvalidValueAlignPowerOfTwo) {
     desc.align = 5;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_VALUE,
-        urUSMDeviceAlloc(context, device, &desc, nullptr, sizeof(int), &ptr));
+        urUSMDeviceAlloc(context, device, &desc, pool, sizeof(int), &ptr));
 }

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -6,8 +6,14 @@
 #include <map>
 #include <uur/fixtures.h>
 
-using urUSMAllocInfoTest =
-    uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t>;
+struct urUSMAllocInfoTest
+    : uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t> {
+    void SetUp() override {
+        use_pool = getParam() == UR_USM_ALLOC_INFO_POOL;
+        UUR_RETURN_ON_FATAL_FAILURE(
+            uur::urUSMDeviceAllocTestWithParam<ur_usm_alloc_info_t>::SetUp());
+    }
+};
 
 UUR_TEST_SUITE_P(urUSMAllocInfoTest,
                  ::testing::Values(UR_USM_ALLOC_INFO_TYPE,
@@ -71,7 +77,7 @@ TEST_P(urUSMGetMemAllocInfoTest, InvalidEnumeration) {
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidValuePropSize) {
     ur_usm_type_t USMType;
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_TYPE,
                                           sizeof(ur_usm_type_t) - 1, &USMType,
                                           nullptr));

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -6,17 +6,36 @@
 #include <cstring>
 #include <uur/fixtures.h>
 
-struct urUSMHostAllocTest : uur::urQueueTest {
+struct urUSMHostAllocTest : uur::urQueueTestWithParam<uur::BoolTestParam> {
     void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
+        UUR_RETURN_ON_FATAL_FAILURE(
+            uur::urQueueTestWithParam<uur::BoolTestParam>::SetUp());
         ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
         ASSERT_SUCCESS(uur::GetDeviceUSMHostSupport(device, hostUSMSupport));
         if (!hostUSMSupport) {
             GTEST_SKIP() << "Device USM is not supported.";
         }
+        if (getParam().value) {
+            ur_usm_pool_desc_t pool_desc = {};
+            ASSERT_SUCCESS(urUSMPoolCreate(context, &pool_desc, &pool));
+        }
     }
+
+    void TearDown() override {
+        if (pool) {
+            ASSERT_SUCCESS(urUSMPoolRelease(pool));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(
+            uur::urQueueTestWithParam<uur::BoolTestParam>::TearDown());
+    }
+
+    ur_usm_pool_handle_t pool = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMHostAllocTest);
+
+UUR_TEST_SUITE_P(
+    urUSMHostAllocTest,
+    testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
+    uur::deviceTestWithParamPrinter<uur::BoolTestParam>);
 
 TEST_P(urUSMHostAllocTest, Success) {
     ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
@@ -27,7 +46,7 @@ TEST_P(urUSMHostAllocTest, Success) {
 
     size_t allocation_size = sizeof(int);
     int *ptr = nullptr;
-    ASSERT_SUCCESS(urUSMHostAlloc(context, nullptr, nullptr, sizeof(int),
+    ASSERT_SUCCESS(urUSMHostAlloc(context, nullptr, pool, sizeof(int),
                                   reinterpret_cast<void **>(&ptr)));
     ASSERT_NE(ptr, nullptr);
 
@@ -68,7 +87,7 @@ TEST_P(urUSMHostAllocTest, SuccessWithDescriptors) {
     void *ptr = nullptr;
     size_t allocation_size = sizeof(int);
     ASSERT_SUCCESS(
-        urUSMHostAlloc(context, &usm_desc, nullptr, allocation_size, &ptr));
+        urUSMHostAlloc(context, &usm_desc, pool, allocation_size, &ptr));
 
     ur_event_handle_t event = nullptr;
     uint8_t pattern = 0;
@@ -82,21 +101,20 @@ TEST_P(urUSMHostAllocTest, SuccessWithDescriptors) {
 
 TEST_P(urUSMHostAllocTest, InvalidNullHandleContext) {
     void *ptr = nullptr;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urUSMHostAlloc(nullptr, nullptr, nullptr, sizeof(int), &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urUSMHostAlloc(nullptr, nullptr, pool, sizeof(int), &ptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidNullPtrMem) {
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_NULL_POINTER,
-        urUSMHostAlloc(context, nullptr, nullptr, sizeof(int), nullptr));
+        urUSMHostAlloc(context, nullptr, pool, sizeof(int), nullptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidUSMSize) {
     void *ptr = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_USM_SIZE,
-                     urUSMHostAlloc(context, nullptr, nullptr, -1, &ptr));
+                     urUSMHostAlloc(context, nullptr, pool, -1, &ptr));
 }
 
 TEST_P(urUSMHostAllocTest, InvalidValueAlignPowerOfTwo) {
@@ -104,7 +122,6 @@ TEST_P(urUSMHostAllocTest, InvalidValueAlignPowerOfTwo) {
     ur_usm_desc_t desc = {};
     desc.stype = UR_STRUCTURE_TYPE_USM_DESC;
     desc.align = 5;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_VALUE,
-        urUSMHostAlloc(context, &desc, nullptr, sizeof(int), &ptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+                     urUSMHostAlloc(context, &desc, pool, sizeof(int), &ptr));
 }

--- a/test/conformance/usm/urUSMPoolCreate.cpp
+++ b/test/conformance/usm/urUSMPoolCreate.cpp
@@ -9,6 +9,14 @@ using urUSMPoolCreateTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMPoolCreateTest);
 
 TEST_P(urUSMPoolCreateTest, Success) {
+    ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr, 0};
+    ur_usm_pool_handle_t pool = nullptr;
+    ASSERT_SUCCESS(urUSMPoolCreate(context, &pool_desc, &pool));
+    ASSERT_NE(pool, nullptr);
+    EXPECT_SUCCESS(urUSMPoolRelease(pool));
+}
+
+TEST_P(urUSMPoolCreateTest, SuccessWithFlag) {
     ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr,
                                  UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK};
     ur_usm_pool_handle_t pool = nullptr;


### PR DESCRIPTION
Also fix a couple of minor issues in tests:
* check correct code for invalid size in GetMemAllocInfo test
* fix shadowing in urUSMPoolTestWithParam fixture
* ensure we allocate with a pool for UR_USM_ALLOC_INFO_POOL GetMemAllocInfo test

Addresses #738 