### PR TITLE
[umf] fix a function declaration without a prototype

### DIFF
--- a/source/common/unified_malloc_framework/src/memory_provider_get_last_failed.cpp
+++ b/source/common/unified_malloc_framework/src/memory_provider_get_last_failed.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 static thread_local umf_memory_provider_handle_t lastFailedProvider = nullptr;
 
-umf_memory_provider_handle_t *umfGetLastFailedMemoryProviderPtr() {
+umf_memory_provider_handle_t *umfGetLastFailedMemoryProviderPtr(void) {
     return &lastFailedProvider;
 }
 }

--- a/source/common/unified_malloc_framework/src/memory_provider_internal.h
+++ b/source/common/unified_malloc_framework/src/memory_provider_internal.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 void *umfMemoryProviderGetPriv(umf_memory_provider_handle_t hProvider);
-umf_memory_provider_handle_t *umfGetLastFailedMemoryProviderPtr();
+umf_memory_provider_handle_t *umfGetLastFailedMemoryProviderPtr(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
For some reason this isn't being caught by default cmake build...