### PR TITLE
[umf] extend umf_helpers so we can expose ops in C

### DIFF
--- a/test/unified_malloc_framework/common/pool.hpp
+++ b/test/unified_malloc_framework/common/pool.hpp
@@ -73,9 +73,6 @@ bool isCallocSupported(umf_memory_pool_handle_t hPool) {
 }
 
 struct pool_base {
-    umf_result_t initialize(umf_memory_provider_handle_t *, size_t) noexcept {
-        return UMF_RESULT_SUCCESS;
-    };
     void *malloc(size_t size) noexcept { return nullptr; }
     void *calloc(size_t, size_t) noexcept { return nullptr; }
     void *realloc(void *, size_t) noexcept { return nullptr; }
@@ -88,6 +85,9 @@ struct pool_base {
 };
 
 struct malloc_pool : public pool_base {
+    umf_result_t initialize(umf_memory_provider_handle_t *, size_t) noexcept {
+        return UMF_RESULT_SUCCESS;
+    };
     void *malloc(size_t size) noexcept { return ::malloc(size); }
     void *calloc(size_t num, size_t size) noexcept {
         return ::calloc(num, size);

--- a/test/unified_malloc_framework/umf_pools/disjoint_pool.cpp
+++ b/test/unified_malloc_framework/umf_pools/disjoint_pool.cpp
@@ -15,7 +15,7 @@
 #include "provider.hpp"
 
 static usm::DisjointPool::Config poolConfig() {
-    usm::DisjointPool::Config config{};
+    usm::DisjointPool::Config config;
     config.SlabMinSize = 4096;
     config.MaxPoolableSize = 4096;
     config.Capacity = 4;


### PR DESCRIPTION
Translate void* into appropriate type expected by
pool/provider::initialize() functions. Also, add
support to a case where `params == NULL`.