### PR TITLE
[ur] refactor more hardcoded loader-specific templates

### DIFF
--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -238,12 +238,13 @@ std::function<void(void*)> ur_callback_t;
 * A handle requires the following scalar fields: {`desc`, `name`}
   - `desc` will be used as the handles's description comment
   - `name` must be a unique ISO-C standard identifier, start with `$` tag, be snake_case and end with `_handle_t`
-* A handle may take the following optional scalar fields: {`class`, `alias`, `condition`, `ordinal`, `version`}
+* A handle may take the following optional scalar fields: {`class`, `alias`, `condition`, `ordinal`, `version`, `loader_only`}
   - `class` will be used to scope the handles declaration within the specified C++ class
   - `alias` will be used to declare the handle as an alias of another handle; specifically, aliases in another namespace
   - `condition` will be used as a C/C++ preprocessor `#if` conditional expression
   - `ordinal` will be used to override the default order (in which they appear) the handles appears within its section; `default="1000"`
   - `version` will be used to define the minimum API version in which the handles will appear; `default="1.0"` This will also affect the order in which the handles appears within its section.
+  - `loader_only` will be used to decide whether the handle can be instantiated and managed only by the loader.
 * A handle may take the following optional field which can be a scalar, a sequence of scalars or scalars to sequences: {`details`}
   - `details` will be used as the handle's detailed comment
 

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -62,6 +62,7 @@ value: uint8_t
 type: handle
 desc: "Handle of a loader config object"
 class: $xLoaderConfig
+loader_only: True
 name: "$x_loader_config_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle

--- a/scripts/json2src.py
+++ b/scripts/json2src.py
@@ -23,33 +23,6 @@ def add_argument(parser, name, help, default=False):
     group.add_argument("--skip-" + name, dest=name, help="Skip "+help, action="store_false")
     parser.set_defaults(**{name:default})
 
-"""
-    helpers to strip loader only api constructs from the json
-"""
-def strip_specs_class(specs, strip_class):
-    for spec in specs:
-        remove_obj = []
-        for obj in spec["objects"]:
-            if "class" in obj and strip_class in obj["class"]:
-                remove_obj.append(obj)
-        for obj in remove_obj:
-            spec["objects"].remove(obj)
-
-def strip_meta_entry(meta, entry_name, pattern):
-    loader_entries = []
-    for entry in meta[entry_name]:
-        if pattern in entry:
-            loader_entries.append(entry)
-
-    for entry in loader_entries:
-        del meta[entry_name][entry]
-
-def strip_loader_meta(meta):
-    strip_meta_entry(meta, "class", "Loader")
-    strip_meta_entry(meta, "function", "Loader")
-    strip_meta_entry(meta, "enum", "loader")
-    strip_meta_entry(meta, "handle", "loader")
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     add_argument(parser, "lib", "generation of lib files.", True)
@@ -75,9 +48,6 @@ if __name__ == '__main__':
         if args.sections == None or config['name'] in args.sections:
             if args.lib:
                 generate_code.generate_lib(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
-            # From here only generate code for functions adapters can implement.
-            strip_specs_class(specs, "Loader")
-            strip_loader_meta(input['meta'])
             if args.loader:
                 generate_code.generate_loader(srcpath, config['name'], config['namespace'], config['tags'], args.ver, specs, input['meta'])
             if args.layers:

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -33,6 +33,13 @@ class obj_traits:
             return False
 
     @staticmethod
+    def is_handle(obj):
+        try:
+            return True if re.match(r"handle", obj['type']) else False
+        except:
+            return False
+
+    @staticmethod
     def is_experimental(obj):
         try:
             return True if re.search("Exp$", obj['name']) else False
@@ -46,7 +53,12 @@ class obj_traits:
         except:
             return None
 
-
+    @staticmethod
+    def is_loader_only(obj):
+        try:
+            return obj['loader_only']
+        except:
+            return False
 
 
 """
@@ -440,13 +452,6 @@ class function_traits:
         except:
             return False
 
-    @staticmethod
-    def is_loader_only(item):
-        try:
-            return item['loader_only']
-        except:
-            return False
-
 
 """
 Public:
@@ -553,6 +558,31 @@ def extract_objs(specs, value):
         for obj in s['objects']:
             if re.match(value, obj['type']):
                 objs.append(obj)
+    return objs
+
+"""
+Public:
+    returns a list of all adapter functions
+"""
+def get_adapter_functions(specs):
+    objs = []
+    for s in specs:
+        for obj in s['objects']:
+            if obj_traits.is_function(obj) and not obj_traits.is_loader_only(obj):
+                objs.append(obj)
+    return objs
+
+"""
+Public:
+    returns a list of all adapter handles
+"""
+def get_adapter_handles(specs):
+    objs = []
+    for s in specs:
+        for obj in s['objects']:
+            if obj_traits.is_handle(obj) and not obj_traits.is_loader_only(obj):
+                objs.append(obj)
+
     return objs
 
 """
@@ -1055,8 +1085,8 @@ def get_pfntables(specs, meta, namespace, tags):
     tables = []
     for cname in sorted(meta['class'], key=lambda x: meta['class'][x]['ordinal']):
         objs, exp_objs = get_class_function_objs_exp(specs, cname)
-        objs = list(filter(lambda obj: not function_traits.is_loader_only(obj), objs))
-        exp_objs = list(filter(lambda obj: not function_traits.is_loader_only(obj), exp_objs))
+        objs = list(filter(lambda obj: not obj_traits.is_loader_only(obj), objs))
+        exp_objs = list(filter(lambda obj: not obj_traits.is_loader_only(obj), exp_objs))
 
         if len(objs) > 0:
             name = get_table_name(namespace, tags, objs[0])

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -24,7 +24,7 @@ from templates import helper as th
 namespace ur_loader
 {
     ///////////////////////////////////////////////////////////////////////////////
-    %for obj in th.extract_objs(specs, r"handle"):
+    %for obj in th.get_adapter_handles(specs):
     %if 'class' in obj:
     <%
         _handle_t = th.subt(n, tags, obj['name'])
@@ -34,7 +34,7 @@ namespace ur_loader
     %endif
     %endfor
 
-    %for obj in th.extract_objs(specs, r"function"):
+    %for obj in th.get_adapter_functions(specs):
     ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for ${th.make_func_name(n, tags, obj)}
     %if 'condition' in obj:

--- a/scripts/templates/ldrddi.hpp.mako
+++ b/scripts/templates/ldrddi.hpp.mako
@@ -27,7 +27,7 @@ from templates import helper as th
 namespace ur_loader
 {
     ///////////////////////////////////////////////////////////////////////////////
-    %for obj in th.extract_objs(specs, r"handle"):
+    %for obj in th.get_adapter_handles(specs):
     %if 'class' in obj:
     <%
         _handle_t = th.subt(n, tags, obj['name'])

--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -56,7 +56,7 @@ ${th.make_func_name(n, tags, obj)}(
     %endfor
     )
 try {
-%if th.function_traits.is_loader_only(obj):
+%if th.obj_traits.is_loader_only(obj):
     return ur_lib::${th.make_func_name(n, tags, obj)}(${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
 %else:
 %if re.match("Init", obj['name']):

--- a/scripts/templates/nullddi.cpp.mako
+++ b/scripts/templates/nullddi.cpp.mako
@@ -22,7 +22,7 @@ from templates import helper as th
 
 namespace driver
 {
-    %for obj in th.extract_objs(specs, r"function"):
+    %for obj in th.get_adapter_functions(specs):
     ///////////////////////////////////////////////////////////////////////////////
     <%
         fname = th.make_func_name(n, tags, obj)

--- a/scripts/templates/trcddi.cpp.mako
+++ b/scripts/templates/trcddi.cpp.mako
@@ -24,7 +24,7 @@ from templates import helper as th
 
 namespace ur_tracing_layer
 {
-    %for obj in th.extract_objs(specs, r"function"):
+    %for obj in th.get_adapter_functions(specs):
     ///////////////////////////////////////////////////////////////////////////////
     /// @brief Intercept function for ${th.make_func_name(n, tags, obj)}
     %if 'condition' in obj:

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -24,7 +24,7 @@ from templates import helper as th
 
 namespace ur_validation_layer
 {
-    %for obj in th.extract_objs(specs, r"function"):
+    %for obj in th.get_adapter_functions(specs):
     <%
         func_name=th.make_func_name(n, tags, obj)
         object_param=th.make_param_lines(n, tags, obj, format=["name"])[-1]

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -32,6 +32,10 @@ inline void serializeFlag<ur_device_init_flag_t>(std::ostream &os,
 
 template <>
 inline void serializeTagged(std::ostream &os, const void *ptr,
+                            ur_loader_config_info_t value, size_t size);
+
+template <>
+inline void serializeTagged(std::ostream &os, const void *ptr,
                             ur_adapter_info_t value, size_t size);
 
 template <>
@@ -207,6 +211,8 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_rect_region_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_init_flag_t value);
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_loader_config_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_adapter_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_adapter_backend_t value);
@@ -2003,6 +2009,59 @@ inline void serializeFlag<ur_device_init_flag_t>(std::ostream &os,
         os << "unknown bit flags " << bits;
     } else if (first) {
         os << "0";
+    }
+}
+} // namespace ur_params
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_loader_config_info_t value) {
+    switch (value) {
+
+    case UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS:
+        os << "UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS";
+        break;
+
+    case UR_LOADER_CONFIG_INFO_REFERENCE_COUNT:
+        os << "UR_LOADER_CONFIG_INFO_REFERENCE_COUNT";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+namespace ur_params {
+template <>
+inline void serializeTagged(std::ostream &os, const void *ptr,
+                            ur_loader_config_info_t value, size_t size) {
+    if (ptr == NULL) {
+        serializePtr(os, ptr);
+        return;
+    }
+
+    switch (value) {
+
+    case UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS: {
+
+        const char *tptr = (const char *)ptr;
+        serializePtr(os, tptr);
+    } break;
+
+    case UR_LOADER_CONFIG_INFO_REFERENCE_COUNT: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size
+               << ", expected: >=" << sizeof(uint32_t) << ")";
+            return;
+        }
+        os << (void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    default:
+        os << "unknown enumerator";
+        break;
     }
 }
 } // namespace ur_params
@@ -13283,6 +13342,86 @@ inline std::ostream &operator<<(
 
 inline std::ostream &
 operator<<(std::ostream &os,
+           const struct ur_loader_config_create_params_t *params) {
+
+    os << ".phLoaderConfig = ";
+
+    ur_params::serializePtr(os, *(params->pphLoaderConfig));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_loader_config_retain_params_t *params) {
+
+    os << ".hLoaderConfig = ";
+
+    ur_params::serializePtr(os, *(params->phLoaderConfig));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_loader_config_release_params_t *params) {
+
+    os << ".hLoaderConfig = ";
+
+    ur_params::serializePtr(os, *(params->phLoaderConfig));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_loader_config_get_info_params_t *params) {
+
+    os << ".hLoaderConfig = ";
+
+    ur_params::serializePtr(os, *(params->phLoaderConfig));
+
+    os << ", ";
+    os << ".propName = ";
+
+    os << *(params->ppropName);
+
+    os << ", ";
+    os << ".propSize = ";
+
+    os << *(params->ppropSize);
+
+    os << ", ";
+    os << ".pPropValue = ";
+    ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
+                               *(params->ppropSize));
+
+    os << ", ";
+    os << ".pPropSizeRet = ";
+
+    ur_params::serializePtr(os, *(params->ppPropSizeRet));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_loader_config_enable_layer_params_t *params) {
+
+    os << ".hLoaderConfig = ";
+
+    ur_params::serializePtr(os, *(params->phLoaderConfig));
+
+    os << ", ";
+    os << ".pLayerName = ";
+
+    ur_params::serializePtr(os, *(params->ppLayerName));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
            const struct ur_mem_image_create_params_t *params) {
 
     os << ".hContext = ";
@@ -15470,6 +15609,21 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     case UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS: {
         os << (const struct ur_kernel_set_specialization_constants_params_t *)
                 params;
+    } break;
+    case UR_FUNCTION_LOADER_CONFIG_CREATE: {
+        os << (const struct ur_loader_config_create_params_t *)params;
+    } break;
+    case UR_FUNCTION_LOADER_CONFIG_RETAIN: {
+        os << (const struct ur_loader_config_retain_params_t *)params;
+    } break;
+    case UR_FUNCTION_LOADER_CONFIG_RELEASE: {
+        os << (const struct ur_loader_config_release_params_t *)params;
+    } break;
+    case UR_FUNCTION_LOADER_CONFIG_GET_INFO: {
+        os << (const struct ur_loader_config_get_info_params_t *)params;
+    } break;
+    case UR_FUNCTION_LOADER_CONFIG_ENABLE_LAYER: {
+        os << (const struct ur_loader_config_enable_layer_params_t *)params;
     } break;
     case UR_FUNCTION_MEM_IMAGE_CREATE: {
         os << (const struct ur_mem_image_create_params_t *)params;


### PR DESCRIPTION
Missed some things in #770...

Came up during a discussion in #776. This change might also help with `urinfo`: https://github.com/oneapi-src/unified-runtime/blob/7a69e10e5f0fdde1b5afbb8e76b685648dc1aa25/tools/urinfo/urinfo.cpp#L135.
