### PR TITLE
[cts] add integer overflow/bounds check tests for rect APIs

### DIFF
--- a/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -261,3 +261,16 @@ TEST_F(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
 
     EXPECT_SUCCESS(urMemRelease(dst_buffer));
 }
+
+TEST_P(urEnqueueMemBufferCopyRectTest, InvalidSize) {
+    // out-of-bounds access with potential overflow
+    ur_rect_region_t src_region{size, 1, 1};
+    ur_rect_offset_t src_origin{std::numeric_limits<uint64_t>::max(), 1, 1};
+    ur_rect_offset_t dst_origin{0, 0, 0};
+
+    ASSERT_EQ_RESULT(urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer,
+                                                src_origin, dst_origin,
+                                                src_region, size, size, size,
+                                                size, 0, nullptr, nullptr),
+                     UR_RESULT_ERROR_INVALID_SIZE);
+}

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -203,3 +203,19 @@ TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest, WriteReadDifferentQueues) {
             << "Result on queue " << i << " did not match!";
     }
 }
+
+TEST_P(urEnqueueMemBufferReadRectTest, InvalidSize) {
+    std::vector<uint32_t> dst(count);
+    // out-of-bounds access with potential overflow
+    ur_rect_region_t region{size, 1, 1};
+    ur_rect_offset_t buffer_offset{std::numeric_limits<uint64_t>::max(), 1, 1};
+    // Creating an overflow in host_offsets leads to a crash because
+    // the function doesn't do bounds checking of host buffers.
+    ur_rect_offset_t host_offset{0, 0, 0};
+
+    ASSERT_EQ_RESULT(
+        urEnqueueMemBufferReadRect(queue, buffer, true, buffer_offset,
+                                   host_offset, region, size, size, size, size,
+                                   dst.data(), 0, nullptr, nullptr),
+        UR_RESULT_ERROR_INVALID_SIZE);
+}

--- a/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -184,3 +184,21 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {
                                     src.data(), 0, &validEvent, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
+
+TEST_P(urEnqueueMemBufferWriteRectTest, InvalidSize) {
+    std::vector<uint32_t> src(count);
+    std::fill(src.begin(), src.end(), 1);
+
+    // out-of-bounds access with potential overflow
+    ur_rect_region_t region{size, 1, 1};
+    ur_rect_offset_t buffer_offset{std::numeric_limits<uint64_t>::max(), 1, 1};
+    // Creating an overflow in host_offsets leads to a crash because
+    // the function doesn't do bounds checking of host buffers.
+    ur_rect_offset_t host_offset{0, 0, 0};
+
+    ASSERT_EQ_RESULT(
+        urEnqueueMemBufferWriteRect(queue, buffer, true, buffer_offset,
+                                    host_offset, region, size, size, size, size,
+                                    src.data(), 0, nullptr, nullptr),
+        UR_RESULT_ERROR_INVALID_SIZE);
+}


### PR DESCRIPTION
Ref: #595

I've looked over all the non-experimental APIs where adapters can potentially do arithmetic to calculate buffer offsets/sizes for copying/allocation, and these three were missing relevant tests for invalid size checks or overflow. The rest of the functions have tests for either overflow or out-of-bounds access.
