### PR TITLE
[loader] Add use of threads so -lpthread works when building

### DIFF
--- a/source/loader/ur_lib.hpp
+++ b/source/loader/ur_lib.hpp
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <mutex>
 #include <set>
+#include <thread>
 #include <vector>
 
 struct ur_loader_config_handle_t_ {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -7743,4 +7743,8 @@ ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     return exceptionToResult(std::current_exception());
 }
 
+void uselessFunc() {
+    std::thread NullThread([](){});
+}
+
 } // extern "C"


### PR DESCRIPTION
This patch makes `libur_loader.so` force link against `pthreads` by adding some trivial use of threads. Linking against pthreads is necessary for `std::call_once` to work for gcc 9.4, but it doesn't happen automatically, as even when specifying `-lpthread`, the linker doesn't know that pthreads are necessary for `call_once` (pthreads isn't necessary for call_once for other versions of gcc) so it may elide the linking.