### PR TITLE
[cmake] Ensure code is compiled with -Werror in dev mode

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -3,28 +3,25 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_library(ur_common INTERFACE)
+add_subdirectory(unified_malloc_framework)
+add_subdirectory(umf_pools)
+
+add_ur_library(ur_common STATIC
+    umf_helpers.hpp
+    ur_pool_manager.hpp
+    $<$<PLATFORM_ID:Windows>:windows/ur_lib_loader.cpp>
+    $<$<PLATFORM_ID:Linux,Darwin>:linux/ur_lib_loader.cpp>
+)
 add_library(${PROJECT_NAME}::common ALIAS ur_common)
 
-target_include_directories(ur_common INTERFACE
+target_include_directories(ur_common PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/include
 )
 
-add_subdirectory(unified_malloc_framework)
-add_subdirectory(umf_pools)
-target_link_libraries(ur_common INTERFACE unified_malloc_framework disjoint_pool ${CMAKE_DL_LIBS} ${PROJECT_NAME}::headers)
-
-if(WIN32)
-    target_sources(ur_common
-        INTERFACE
-            ${CMAKE_CURRENT_SOURCE_DIR}/windows/ur_lib_loader.cpp
-            umf_helpers.hpp ur_pool_manager.hpp
-    )
-else()
-    target_sources(ur_common
-        INTERFACE
-            ${CMAKE_CURRENT_SOURCE_DIR}/linux/ur_lib_loader.cpp
-            umf_helpers.hpp ur_pool_manager.hpp
-    )
-endif()
+target_link_libraries(ur_common PUBLIC
+    unified_malloc_framework
+    disjoint_pool
+    ${CMAKE_DL_LIBS}
+    ${PROJECT_NAME}::headers
+)

--- a/test/loader/loader_config/CMakeLists.txt
+++ b/test/loader/loader_config/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_executable(test-loader-config
+add_ur_executable(test-loader-config
     urLoaderConfigCreate.cpp
     urLoaderConfigGetInfo.cpp
     urLoaderConfigEnableLayer.cpp


### PR DESCRIPTION
The recent hotfix in #800 requiring the v0.7.1 tag was fixing an instance of code not compiling when `-Werror` is specified. We do already specify `-Werror` with `UR_DEVELOPER_MODE=ON` in the GitHub Actions, however the `ur_common` library was not being compiled explicitly with this flag.

As setup prior to this patch `ur_common` was an interface library. This means the source files are not compiled into their own static library but instead included in any targets which "link" it.

This patch changes the `ur_common` into a static library that is always compiled into a static library avoiding recompiling the source files in each target which makes use of it. Adapters will now link with the static library instead of including its source files into their own targets build steps. Additionally, the test suite `test-loader-config` was also updated to use `add_ur_exectuable` and thus respect the flags set when `UR_DEVELOPER_MODE=ON`.
