### PR TITLE
[loader] make RTLD_DEEPBIND optional when loading adapters

### DIFF
--- a/scripts/core/INTRO.rst
+++ b/scripts/core/INTRO.rst
@@ -296,6 +296,15 @@ Specific environment variables can be set to control the behavior of unified run
 
     This environment variable is ignored when :envvar:`UR_ADAPTERS_FORCE_LOAD` environment variable is used.
 
+.. envvar:: UR_ADAPTERS_DEEP_BIND
+
+   If set, the loader will use `RTLD_DEEPBIND` when opening adapter libraries. This might be useful if an adapter
+   requires a different version of a shared library compared to the rest of the applcation.
+
+   .. note::
+
+    This environment variable is Linux-only.
+
 .. envvar:: UR_ENABLE_LAYERS
 
     Holds a comma-separated list of layers to enable in addition to any specified via ``urInit``.

--- a/source/common/linux/ur_lib_loader.cpp
+++ b/source/common/linux/ur_lib_loader.cpp
@@ -12,12 +12,7 @@
 #include "logger/ur_logger.hpp"
 #include "ur_lib_loader.hpp"
 
-#if defined(SANITIZER_ANY) || defined(__APPLE__)
-#define LOAD_DRIVER_LIBRARY(NAME) dlopen(NAME, RTLD_LAZY | RTLD_LOCAL)
-#else
-#define LOAD_DRIVER_LIBRARY(NAME)                                              \
-    dlopen(NAME, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND)
-#endif
+#define DEEP_BIND_ENV "UR_ADAPTERS_DEEP_BIND"
 
 namespace ur_loader {
 
@@ -34,8 +29,21 @@ void LibLoader::freeAdapterLibrary(HMODULE handle) {
 
 std::unique_ptr<HMODULE, LibLoader::lib_dtor>
 LibLoader::loadAdapterLibrary(const char *name) {
-    return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(
-        LOAD_DRIVER_LIBRARY(name));
+    int mode = RTLD_LAZY | RTLD_LOCAL;
+#if !defined(__APPLE__)
+    bool deepbind = getenv_tobool(DEEP_BIND_ENV);
+    if (deepbind) {
+#if defined(SANITIZER_ANY)
+        logger::warning(
+            "Enabling RTLD_DEEPBIND while running under a sanitizer is likely "
+            "to cause issues. Consider disabling {} environment variable.",
+            DEEP_BIND_ENV);
+#endif
+        mode |= RTLD_DEEPBIND;
+    }
+#endif
+
+    return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(dlopen(name, mode));
 }
 
 void *LibLoader::getFunctionPtr(HMODULE handle, const char *func_name) {


### PR DESCRIPTION
RTLD_DEEPBIND can help solve conflicts with shared library versions, but it interferes with overriding functions in shared objects through LD_PRELOAD and similar mechanisms.

Fixes #803