### PR TITLE
[ur] Add support for clang-cl.exe on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -98,6 +98,7 @@ jobs:
       matrix:
         os: ['windows-2019', 'windows-2022']
         build_type: [Debug, Release]
+        compiler: [{c: cl.exe, cxx: cl.exe}, {c: clang-cl.exe, cxx: clang-cl.exe}]
     runs-on: ${{matrix.os}}
 
     steps:
@@ -114,6 +115,8 @@ jobs:
       run: >
         cmake
         -B${{github.workspace}}/build
+        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
         -DUR_ENABLE_TRACING=ON
         -DUR_DEVELOPER_MODE=ON

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -78,7 +78,7 @@ function(add_ur_target_compile_options name)
         endif()
     elseif(MSVC)
         target_compile_options(${name} PRIVATE
-            /MP
+            $<$<CXX_COMPILER_ID:MSVC>:/MP>  # clang-cl.exe does not support /MP
             /W3
             /MD$<$<CONFIG:Debug>:d>
             /GS

--- a/scripts/templates/params.hpp.mako
+++ b/scripts/templates/params.hpp.mako
@@ -36,6 +36,8 @@ from templates import helper as th
         ${x}_params::serializePtr(os, ${caller.body()});
     %elif th.type_traits.is_handle(itype):
         ${x}_params::serializePtr(os, ${caller.body()});
+    %elif iname and iname.startswith("pfn"):
+        os << reinterpret_cast<void*>(${caller.body()});
     %else:
         os << ${caller.body()};
     %endif

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -11342,7 +11342,7 @@ operator<<(std::ostream &os,
     os << ", ";
     os << ".pfnDeleter = ";
 
-    os << *(params->ppfnDeleter);
+    os << reinterpret_cast<void *>(*(params->ppfnDeleter));
 
     os << ", ";
     os << ".pUserData = ";
@@ -12995,7 +12995,7 @@ operator<<(std::ostream &os,
     os << ", ";
     os << ".pfnNotify = ";
 
-    os << *(params->ppfnNotify);
+    os << reinterpret_cast<void *>(*(params->ppfnNotify));
 
     os << ", ";
     os << ".pUserData = ";


### PR DESCRIPTION
Fix compilation of passing function pointers to `std::ostream`s when compiling with `clang-cl.exe` on Windows. Extend the GitHub Actions matrix on Windows to test both the `cl.exe` and `clang-cl.exe` compiler frontends.

Following on from #814.
