### PR TITLE
[umf] extend out of memory test for disjoint pool

### DIFF
--- a/test/unified_malloc_framework/memoryPoolAPI.cpp
+++ b/test/unified_malloc_framework/memoryPoolAPI.cpp
@@ -158,13 +158,12 @@ INSTANTIATE_TEST_SUITE_P(
     }));
 
 INSTANTIATE_TEST_SUITE_P(
-    proxyPoolOOMTest, umfMemTest, ::testing::Values([] {
-        return umf::poolMakeUnique<umf_test::proxy_pool, 1>(
-                   {umf::memoryProviderMakeUnique<
-                        umf_test::provider_mock_out_of_mem>(10)
-                        .second})
-            .second;
-    }));
+    proxyPoolOOMTest, umfMemTest,
+    ::testing::Values(std::tuple(
+        [] {
+            return umf_test::makePoolWithOOMProvider<umf_test::proxy_pool>(10);
+        },
+        0)));
 
 ////////////////// Negative test cases /////////////////
 


### PR DESCRIPTION
It is the continuation of the previous out of memory test. This PR adds check for the disjoint pool if after reaching out of memory error from the provider and then freeing some memory, we are able to allocate again.
Based on #783 