### PR TITLE
[cmake] Use separate FetchSource's per adapter

### DIFF
--- a/source/adapters/CMakeLists.txt
+++ b/source/adapters/CMakeLists.txt
@@ -30,31 +30,29 @@ endfunction()
 
 add_subdirectory(null)
 
-if(UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_CUDA OR UR_BUILD_ADAPTER_HIP)
-    # fetch adapter sources from SYCL
-    set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external")
-    FetchSource(https://github.com/intel/llvm.git nightly-2023-08-20 "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
-endif()
-
-# Temporarily fetch the opencl adapter from a fork until the PR has been merged.
-if(UR_BUILD_ADAPTER_OPENCL)
-    # fetch adapter sources from SYCL
-    set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external")
-    FetchSource(https://github.com/fabiomestre/llvm.git opencl_adapter_unofficial "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
-endif()
+set(INTEL_LLVM_TAG nightly-2023-08-20)
 
 if(UR_BUILD_ADAPTER_L0)
+    set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/level_zero")
+    FetchSource(https://github.com/intel/llvm.git ${INTEL_LLVM_TAG} "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
     add_subdirectory(level_zero)
 endif()
 
 if(UR_BUILD_ADAPTER_CUDA)
+    set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/cuda")
+    FetchSource(https://github.com/intel/llvm.git ${INTEL_LLVM_TAG} "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
     add_subdirectory(cuda)
 endif()
 
 if(UR_BUILD_ADAPTER_HIP)
+    set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/hip")
+    FetchSource(https://github.com/intel/llvm.git ${INTEL_LLVM_TAG} "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
     add_subdirectory(hip)
 endif()
 
 if(UR_BUILD_ADAPTER_OPENCL)
+    # Temporarily fetch the opencl adapter from a fork until the PR has been merged.
+    set(SYCL_ADAPTER_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/opencl")
+    FetchSource(https://github.com/fabiomestre/llvm.git opencl_adapter_unofficial "sycl/plugins/unified_runtime/ur" ${SYCL_ADAPTER_DIR})
     add_subdirectory(opencl)
 endif()


### PR DESCRIPTION
While attempting to enable the Level-Zero and OpenCL adapters at the same time git will report an error due to the OpenCL tag not existing in the intel/llvm clone use for the Level-Zero adapter. Furthermore, if I wanted to test separate bug fixes for the CUDA and HIP adapters from different sources, this would also not be possible.

This patch uses a separate FetchSource for each adapter to allow each adapters source to be fetched independently of the others and moves those clones into the build directory. This does result in additional git clones when enabling multiple adapters and again in multiple build directories but avoids conflicting remote URL's or multiple build configurations trampling on each others checked out tags.
