### PR TITLE
[umf] extend error message for disjoint pool

### DIFF
--- a/source/common/umf_pools/disjoint_pool.cpp
+++ b/source/common/umf_pools/disjoint_pool.cpp
@@ -381,6 +381,15 @@ Slab::~Slab() {
     } catch (MemoryProviderError &e) {
         std::cout << "DisjointPool: error from memory provider: " << e.code
                   << "\n";
+        if (e.code == UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC) {
+            const char *message = "";
+            int error = 0;
+
+            umfMemoryProviderGetLastNativeError(
+                umfGetLastFailedMemoryProvider(), &message, &error);
+            std::cout << "Native error msg: " << message
+                      << ", native error code: " << error << std::endl;
+        }
     }
 }
 


### PR DESCRIPTION
To make debugging easier when `memoryProviderFree` in ~Slab fails.

We should also implement get_last_native_error` for adapters to set the error message correctly.