### PR TITLE
[umf] Fix macOS build

### DIFF
--- a/source/common/unified_malloc_framework/src/memory_tracker.c
+++ b/source/common/unified_malloc_framework/src/memory_tracker.c
@@ -21,10 +21,12 @@
 
 #if !defined(_WIN32)
 critnib *TRACKER = NULL;
-void __attribute__((constructor)) createLibTracker() {
+void __attribute__((constructor)) createLibTracker(void) {
     TRACKER = critnib_new();
 }
-void __attribute__((destructor)) deleteLibTracker() { critnib_delete(TRACKER); }
+void __attribute__((destructor)) deleteLibTracker(void) {
+    critnib_delete(TRACKER);
+}
 
 umf_memory_tracker_handle_t umfMemoryTrackerGet(void) {
     return (umf_memory_tracker_handle_t)TRACKER;

--- a/source/common/unified_malloc_framework/src/utils/utils_posix.c
+++ b/source/common/unified_malloc_framework/src/utils/utils_posix.c
@@ -13,7 +13,7 @@
 
 #include "utils.h"
 
-struct os_mutex_t *util_mutex_create() {
+struct os_mutex_t *util_mutex_create(void) {
     pthread_mutex_t *mutex = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
     int ret = pthread_mutex_init(mutex, NULL);
     return ret == 0 ? ((struct os_mutex_t *)mutex) : NULL;


### PR DESCRIPTION
The AppleClang compiler emits warnings in C functions with zero arguments that are not specified as `f(void)`.
