### PR TITLE
[UMF] Fix -Wempty-body warning

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -63,6 +63,7 @@ function(add_ur_target_compile_options name)
             -fPIC
             -Wall
             -Wpedantic
+            -Wempty-body
             $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
             $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
         )

--- a/source/common/unified_malloc_framework/src/utils/utils.h
+++ b/source/common/unified_malloc_framework/src/utils/utils.h
@@ -73,9 +73,8 @@ static inline void *Zalloc(size_t s) {
 }
 
 #define NOFUNCTION                                                             \
-    do                                                                         \
-        ;                                                                      \
-    while (0)
+    do {                                                                       \
+    } while (0)
 #define VALGRIND_ANNOTATE_NEW_MEMORY(p, s) NOFUNCTION
 #define VALGRIND_HG_DRD_DISABLE_CHECKING(p, s) NOFUNCTION
 


### PR DESCRIPTION
When updating the tag of UR in SYCL I got the -Wempty-body warning emitted from UMF. This PR just places braces around the do statement to prevent emitting this warning.