### PR TITLE
[UR] Add validation check to urDeviceGet

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1304,6 +1304,8 @@ typedef enum ur_device_type_t {
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `NumEntries == 0 && phDevices != NULL`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NumEntries > 0 && phDevices == NULL`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urDeviceGet(

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -146,6 +146,8 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`NumEntries == 0 && phDevices != NULL`"
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER:
+        - "`NumEntries > 0 && phDevices == NULL`"
     - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: enum

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -419,6 +419,10 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
+        if (NumEntries > 0 && phDevices == NULL) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
         if (UR_DEVICE_TYPE_VPU < DeviceType) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -714,6 +714,8 @@ ur_result_t UR_APICALL urPlatformGetBackendOption(
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `NumEntries == 0 && phDevices != NULL`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NumEntries > 0 && phDevices == NULL`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -618,6 +618,8 @@ ur_result_t UR_APICALL urPlatformGetBackendOption(
 ///         + `::UR_DEVICE_TYPE_VPU < DeviceType`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `NumEntries == 0 && phDevices != NULL`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NumEntries > 0 && phDevices == NULL`
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance

--- a/test/conformance/device/urDeviceGet.cpp
+++ b/test/conformance/device/urDeviceGet.cpp
@@ -49,7 +49,7 @@ TEST_F(urDeviceGetTest, InvalidEnumerationDevicesType) {
         urDeviceGet(platform, UR_DEVICE_TYPE_FORCE_UINT32, 0, nullptr, &count));
 }
 
-TEST_F(urDeviceGetTest, InvalidValueNumEntries) {
+TEST_F(urDeviceGetTest, InvalidSizeNumEntries) {
     uint32_t count = 0;
     ASSERT_SUCCESS(
         urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
@@ -58,4 +58,14 @@ TEST_F(urDeviceGetTest, InvalidValueNumEntries) {
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_SIZE,
         urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, devices.data(), nullptr));
+}
+
+TEST_F(urDeviceGetTest, InvalidNullPointerDevices) {
+    uint32_t count = 0;
+    ASSERT_SUCCESS(
+        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &count));
+    ASSERT_NE(count, 0);
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urDeviceGet(platform, UR_DEVICE_TYPE_ALL, count, nullptr, nullptr));
 }


### PR DESCRIPTION
It should be invalid to pass a positive number for the number of devices and a null pointer for the device handle pointer. If this situation occurs we should return an invalid null pointer. Invalid size might also be a valid return code, but decided to use null pointer error to indicate that likely the device handle pointer is incorrect.