### PR TITLE
[UR] Check for unused parameters

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -64,6 +64,7 @@ function(add_ur_target_compile_options name)
             -Wall
             -Wpedantic
             -Wempty-body
+            -Wunused-parameter
             $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
             $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
         )

--- a/examples/collector/collector.cpp
+++ b/examples/collector/collector.cpp
@@ -82,10 +82,10 @@ static std::unordered_map<
  * On begin, it prints the function declaration with the call arguments specified,
  * and on end it prints the function name with the result of the call.
  */
-XPTI_CALLBACK_API void trace_cb(uint16_t trace_type,
-                                xpti::trace_event_data_t *parent,
-                                xpti::trace_event_data_t *event,
-                                uint64_t instance, const void *user_data) {
+XPTI_CALLBACK_API void
+trace_cb(uint16_t trace_type, [[maybe_unused]] xpti::trace_event_data_t *parent,
+         [[maybe_unused]] xpti::trace_event_data_t *event, uint64_t instance,
+         const void *user_data) {
     auto *args = static_cast<const xpti::function_with_args_t *>(user_data);
     std::ostringstream out;
     if (trace_type == TRACE_FN_BEGIN) {
@@ -120,7 +120,7 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type,
  */
 XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
                                      unsigned int minor_version,
-                                     const char *version_str,
+                                     [[maybe_unused]] const char *version_str,
                                      const char *stream_name) {
     if (stream_name == nullptr) {
         std::cout << "Stream name not provided. Aborting." << std::endl;
@@ -158,5 +158,6 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
  *
  * Can be used to cleanup state or resources.
  */
-XPTI_CALLBACK_API void xptiTraceFinish(const char *stream_name) { /* noop */
+XPTI_CALLBACK_API void
+xptiTraceFinish([[maybe_unused]] const char *stream_name) { /* noop */
 }

--- a/examples/collector/collector.cpp
+++ b/examples/collector/collector.cpp
@@ -82,10 +82,9 @@ static std::unordered_map<
  * On begin, it prints the function declaration with the call arguments specified,
  * and on end it prints the function name with the result of the call.
  */
-XPTI_CALLBACK_API void
-trace_cb(uint16_t trace_type, [[maybe_unused]] xpti::trace_event_data_t *parent,
-         [[maybe_unused]] xpti::trace_event_data_t *event, uint64_t instance,
-         const void *user_data) {
+XPTI_CALLBACK_API void trace_cb(uint16_t trace_type, xpti::trace_event_data_t *,
+                                xpti::trace_event_data_t *, uint64_t instance,
+                                const void *user_data) {
     auto *args = static_cast<const xpti::function_with_args_t *>(user_data);
     std::ostringstream out;
     if (trace_type == TRACE_FN_BEGIN) {
@@ -119,8 +118,7 @@ trace_cb(uint16_t trace_type, [[maybe_unused]] xpti::trace_event_data_t *parent,
  * selected trace types.
  */
 XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
-                                     unsigned int minor_version,
-                                     [[maybe_unused]] const char *version_str,
+                                     unsigned int minor_version, const char *,
                                      const char *stream_name) {
     if (stream_name == nullptr) {
         std::cout << "Stream name not provided. Aborting." << std::endl;
@@ -158,6 +156,5 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
  *
  * Can be used to cleanup state or resources.
  */
-XPTI_CALLBACK_API void
-xptiTraceFinish([[maybe_unused]] const char *stream_name) { /* noop */
+XPTI_CALLBACK_API void xptiTraceFinish(const char *) { /* noop */
 }

--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -15,7 +15,7 @@
 #include "ur_api.h"
 
 //////////////////////////////////////////////////////////////////////////
-int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
+int main(int, char *[]) {
     ur_result_t status;
 
     // Initialize the platform

--- a/examples/hello_world/hello_world.cpp
+++ b/examples/hello_world/hello_world.cpp
@@ -15,7 +15,7 @@
 #include "ur_api.h"
 
 //////////////////////////////////////////////////////////////////////////
-int main(int argc, char *argv[]) {
+int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
     ur_result_t status;
 
     // Initialize the platform

--- a/scripts/templates/params.hpp.mako
+++ b/scripts/templates/params.hpp.mako
@@ -144,7 +144,7 @@ template <typename T> inline void serializeTagged(std::ostream &os, const void *
 %if re.match(r"enum", obj['type']):
     inline std::ostream &operator<<(std::ostream &os, enum ${th.make_enum_name(n, tags, obj)} value);
 %elif re.match(r"struct", obj['type']):
-    inline std::ostream &operator<<(std::ostream &os, const ${obj['type']} ${th.make_type_name(n, tags, obj)} params);
+    inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const ${obj['type']} ${th.make_type_name(n, tags, obj)} params);
 %endif
 %endfor # obj in spec['objects']
 %endfor
@@ -353,7 +353,7 @@ for item in obj['members']:
 %for tbl in th.get_pfncbtables(specs, meta, n, tags):
 %for obj in tbl['functions']:
 
-inline std::ostream &operator<<(std::ostream &os, const struct ${th.make_pfncb_param_type(n, tags, obj)} *params) {
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ${th.make_pfncb_param_type(n, tags, obj)} *params) {
     <%
         params_dict = dict()
         for item in obj['params']:

--- a/source/adapters/null/ur_null.cpp
+++ b/source/adapters/null/ur_null.cpp
@@ -38,21 +38,21 @@ context_t::context_t() {
         return UR_RESULT_SUCCESS;
     };
     //////////////////////////////////////////////////////////////////////////
-    urDdiTable.Platform.pfnGet = [](ur_adapter_handle_t *phAdapters,
-                                    uint32_t NumAdapters, uint32_t NumEntries,
-                                    ur_platform_handle_t *phPlatforms,
-                                    uint32_t *pNumPlatforms) {
-        if (phPlatforms != nullptr && NumEntries != 1) {
-            return UR_RESULT_ERROR_INVALID_SIZE;
-        }
-        if (pNumPlatforms != nullptr) {
-            *pNumPlatforms = 1;
-        }
-        if (nullptr != phPlatforms) {
-            *reinterpret_cast<void **>(phPlatforms) = d_context.get();
-        }
-        return UR_RESULT_SUCCESS;
-    };
+    urDdiTable.Platform.pfnGet =
+        []([[maybe_unused]] ur_adapter_handle_t *phAdapters,
+           [[maybe_unused]] uint32_t NumAdapters, uint32_t NumEntries,
+           ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
+            if (phPlatforms != nullptr && NumEntries != 1) {
+                return UR_RESULT_ERROR_INVALID_SIZE;
+            }
+            if (pNumPlatforms != nullptr) {
+                *pNumPlatforms = 1;
+            }
+            if (nullptr != phPlatforms) {
+                *reinterpret_cast<void **>(phPlatforms) = d_context.get();
+            }
+            return UR_RESULT_SUCCESS;
+        };
 
     //////////////////////////////////////////////////////////////////////////
     urDdiTable.Platform.pfnGetApiVersion = [](ur_platform_handle_t,
@@ -122,8 +122,9 @@ context_t::context_t() {
 
     //////////////////////////////////////////////////////////////////////////
     urDdiTable.Device.pfnGetInfo =
-        [](ur_device_handle_t hDevice, ur_device_info_t infoType,
-           size_t propSize, void *pDeviceInfo, size_t *pPropSizeRet) {
+        []([[maybe_unused]] ur_device_handle_t hDevice,
+           ur_device_info_t infoType, size_t propSize, void *pDeviceInfo,
+           size_t *pPropSizeRet) {
             switch (infoType) {
             case UR_DEVICE_INFO_TYPE:
                 if (pDeviceInfo && propSize != sizeof(ur_device_type_t)) {

--- a/source/adapters/null/ur_null.cpp
+++ b/source/adapters/null/ur_null.cpp
@@ -39,8 +39,7 @@ context_t::context_t() {
     };
     //////////////////////////////////////////////////////////////////////////
     urDdiTable.Platform.pfnGet =
-        []([[maybe_unused]] ur_adapter_handle_t *phAdapters,
-           [[maybe_unused]] uint32_t NumAdapters, uint32_t NumEntries,
+        [](ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
            ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
             if (phPlatforms != nullptr && NumEntries != 1) {
                 return UR_RESULT_ERROR_INVALID_SIZE;
@@ -122,9 +121,8 @@ context_t::context_t() {
 
     //////////////////////////////////////////////////////////////////////////
     urDdiTable.Device.pfnGetInfo =
-        []([[maybe_unused]] ur_device_handle_t hDevice,
-           ur_device_info_t infoType, size_t propSize, void *pDeviceInfo,
-           size_t *pPropSizeRet) {
+        [](ur_device_handle_t, ur_device_info_t infoType, size_t propSize,
+           void *pDeviceInfo, size_t *pPropSizeRet) {
             switch (infoType) {
             case UR_DEVICE_INFO_TYPE:
                 if (pDeviceInfo && propSize != sizeof(ur_device_type_t)) {

--- a/source/common/unified_malloc_framework/src/memory_pool_default.c
+++ b/source/common/unified_malloc_framework/src/memory_pool_default.c
@@ -69,9 +69,15 @@ void umfPoolDestroy(umf_memory_pool_handle_t hPool) {
     free(hPool);
 }
 
-enum umf_result_t umfFree(void *ptr) { return UMF_RESULT_ERROR_NOT_SUPPORTED; }
+enum umf_result_t umfFree(void *ptr) {
+    (void)ptr;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
 
-umf_memory_pool_handle_t umfPoolByPtr(const void *ptr) { return NULL; }
+umf_memory_pool_handle_t umfPoolByPtr(const void *ptr) {
+    (void)ptr;
+    return NULL;
+}
 
 enum umf_result_t
 umfPoolGetMemoryProviders(umf_memory_pool_handle_t hPool, size_t numProviders,

--- a/source/common/unified_malloc_framework/src/memory_tracker_windows.cpp
+++ b/source/common/unified_malloc_framework/src/memory_tracker_windows.cpp
@@ -15,7 +15,8 @@
 
 #if defined(UMF_SHARED_LIBRARY)
 critnib *TRACKER = NULL;
-BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+BOOL APIENTRY DllMain([[maybe_unused]] HINSTANCE hinstDLL, DWORD fdwReason,
+                      LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_DETACH) {
         critnib_delete(TRACKER);
     } else if (fdwReason == DLL_PROCESS_ATTACH) {

--- a/source/common/unified_malloc_framework/src/memory_tracker_windows.cpp
+++ b/source/common/unified_malloc_framework/src/memory_tracker_windows.cpp
@@ -12,11 +12,9 @@
 #include "memory_tracker.h"
 
 #include <windows.h>
-
 #if defined(UMF_SHARED_LIBRARY)
 critnib *TRACKER = NULL;
-BOOL APIENTRY DllMain([[maybe_unused]] HINSTANCE hinstDLL, DWORD fdwReason,
-                      LPVOID lpvReserved) {
+BOOL APIENTRY DllMain(HINSTANCE, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_DETACH) {
         critnib_delete(TRACKER);
     } else if (fdwReason == DLL_PROCESS_ATTACH) {

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -224,14 +224,18 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_structure_type_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_base_properties_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_base_desc_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_rect_offset_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_rect_region_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_base_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_base_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_rect_offset_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_rect_region_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_init_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -242,13 +246,14 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_platform_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_platform_native_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_platform_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_platform_backend_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_device_binary_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_device_binary_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_device_type_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -257,10 +262,10 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_partition_t value);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_device_partition_property_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_device_partition_properties_t params);
+           [[maybe_unused]] const struct ur_device_partition_property_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_device_partition_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_fp_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -270,7 +275,8 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_exec_capability_flag_t value);
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_device_native_properties_t params);
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_device_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_memory_order_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -278,12 +284,13 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &
 operator<<(std::ostream &os, enum ur_device_usm_access_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_context_flag_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_context_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_context_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_context_info_t value);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_context_native_properties_t params);
+           [[maybe_unused]] const struct ur_context_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_mem_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_mem_type_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_mem_info_t value);
@@ -292,34 +299,40 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_image_channel_type_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_image_info_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_image_format_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_image_desc_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_buffer_properties_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_buffer_channel_properties_t params);
+           [[maybe_unused]] const struct ur_image_format_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_buffer_alloc_location_properties_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_buffer_region_t params);
+           [[maybe_unused]] const struct ur_image_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_buffer_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_buffer_channel_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_buffer_alloc_location_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_buffer_region_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_buffer_create_type_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_mem_native_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_mem_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_sampler_filter_mode_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_sampler_addressing_mode_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_sampler_info_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_sampler_desc_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_sampler_native_properties_t params);
+           [[maybe_unused]] const struct ur_sampler_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_sampler_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_host_mem_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -331,16 +344,21 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_alloc_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_advice_flag_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_desc_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_host_desc_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_device_desc_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_pool_desc_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_pool_limits_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_host_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_device_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_pool_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_pool_limits_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_pool_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
@@ -352,13 +370,16 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_physical_mem_flag_t value);
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_physical_mem_properties_t params);
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_physical_mem_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_program_metadata_type_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_program_metadata_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_program_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_program_metadata_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_program_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_program_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_program_build_status_t value);
@@ -366,18 +387,18 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_program_binary_type_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_program_build_info_t value);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_specialization_constant_info_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_specialization_constant_info_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_program_native_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_arg_value_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_arg_local_properties_t params);
+           [[maybe_unused]] const struct ur_program_native_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_arg_value_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_arg_local_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_kernel_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_group_info_t value);
@@ -387,37 +408,43 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_cache_config_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_kernel_exec_info_t value);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_arg_pointer_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_exec_info_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_arg_sampler_properties_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_arg_mem_obj_properties_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_kernel_arg_pointer_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_exec_info_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_arg_sampler_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_arg_mem_obj_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_kernel_native_properties_t params);
+           [[maybe_unused]] const struct ur_kernel_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_queue_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_queue_flag_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_queue_properties_t params);
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_queue_index_properties_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_queue_native_desc_t params);
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_properties_t params);
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_queue_native_properties_t params);
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_index_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_native_desc_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_event_status_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_event_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_profiling_info_t value);
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_event_native_properties_t params);
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_event_native_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_execution_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_map_flag_t value);
@@ -425,10 +452,6 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_usm_migration_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_exp_image_copy_flag_t value);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_exp_file_descriptor_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_exp_win32_handle_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_exp_sampler_mip_properties_t params);
@@ -438,12 +461,22 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_exp_interop_mem_desc_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_exp_interop_semaphore_desc_t params);
+           [[maybe_unused]] const struct ur_exp_win32_handle_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_exp_sampler_mip_properties_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_exp_layered_image_properties_t params);
+           [[maybe_unused]] const struct ur_exp_interop_mem_desc_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_exp_interop_semaphore_desc_t params);
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_exp_layered_image_properties_t params);
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_exp_command_buffer_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_exp_peer_info_t value);
 
@@ -10055,8 +10088,9 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
 }
 } // namespace ur_params
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_adapter_get_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_get_params_t *params) {
 
     os << ".NumEntries = ";
 
@@ -10083,17 +10117,8 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_adapter_release_params_t *params) {
-
-    os << ".hAdapter = ";
-
-    ur_params::serializePtr(os, *(params->phAdapter));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_adapter_retain_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_release_params_t *params) {
 
     os << ".hAdapter = ";
 
@@ -10104,7 +10129,18 @@ operator<<(std::ostream &os, const struct ur_adapter_retain_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_adapter_get_last_error_params_t *params) {
+           [[maybe_unused]] const struct ur_adapter_retain_params_t *params) {
+
+    os << ".hAdapter = ";
+
+    ur_params::serializePtr(os, *(params->phAdapter));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_adapter_get_last_error_params_t *params) {
 
     os << ".hAdapter = ";
 
@@ -10125,7 +10161,7 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_adapter_get_info_params_t *params) {
+           [[maybe_unused]] const struct ur_adapter_get_info_params_t *params) {
 
     os << ".hAdapter = ";
 
@@ -10155,9 +10191,29 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t
-        *params) {
+    std::ostream &os, [[maybe_unused]] const struct
+    ur_bindless_images_unsampled_image_handle_destroy_exp_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur_params::serializePtr(os, *(params->phDevice));
+
+    os << ", ";
+    os << ".hImage = ";
+
+    ur_params::serializePtr(os, *(params->phImage));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os, [[maybe_unused]] const struct
+    ur_bindless_images_sampled_image_handle_destroy_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10178,29 +10234,8 @@ inline std::ostream &operator<<(
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_bindless_images_sampled_image_handle_destroy_exp_params_t
+    [[maybe_unused]] const struct ur_bindless_images_image_allocate_exp_params_t
         *params) {
-
-    os << ".hContext = ";
-
-    ur_params::serializePtr(os, *(params->phContext));
-
-    os << ", ";
-    os << ".hDevice = ";
-
-    ur_params::serializePtr(os, *(params->phDevice));
-
-    os << ", ";
-    os << ".hImage = ";
-
-    ur_params::serializePtr(os, *(params->phImage));
-
-    return os;
-}
-
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_image_allocate_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10229,9 +10264,10 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_bindless_images_image_free_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_bindless_images_image_free_exp_params_t
+        *params) {
 
     os << ".hContext = ";
 
@@ -10251,9 +10287,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_bindless_images_unsampled_image_create_exp_params_t
-               *params) {
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_unsampled_image_create_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10292,9 +10327,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_sampled_image_create_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_sampled_image_create_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10338,9 +10373,10 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_bindless_images_image_copy_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_bindless_images_image_copy_exp_params_t
+        *params) {
 
     os << ".hQueue = ";
 
@@ -10420,7 +10456,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_bindless_images_image_get_info_exp_params_t *params) {
+    [[maybe_unused]] const struct ur_bindless_images_image_get_info_exp_params_t
+        *params) {
 
     os << ".hImageMem = ";
 
@@ -10444,9 +10481,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_mipmap_get_level_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_mipmap_get_level_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10475,9 +10512,10 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_bindless_images_mipmap_free_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_bindless_images_mipmap_free_exp_params_t
+        *params) {
 
     os << ".hContext = ";
 
@@ -10496,9 +10534,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_import_opaque_fd_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_import_opaque_fd_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10527,9 +10565,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_map_external_array_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_map_external_array_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10563,9 +10601,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_release_interop_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_release_interop_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10585,7 +10623,7 @@ inline std::ostream &operator<<(
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct
+operator<<(std::ostream &os, [[maybe_unused]] const struct
            ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t
                *params) {
 
@@ -10611,10 +10649,9 @@ operator<<(std::ostream &os, const struct
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_destroy_external_semaphore_exp_params_t
-        *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_destroy_external_semaphore_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -10634,9 +10671,8 @@ inline std::ostream &operator<<(
 }
 
 inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_bindless_images_wait_external_semaphore_exp_params_t
-               *params) {
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_wait_external_semaphore_exp_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -10673,10 +10709,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_bindless_images_signal_external_semaphore_exp_params_t
-        *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_bindless_images_signal_external_semaphore_exp_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -10715,7 +10750,8 @@ inline std::ostream &operator<<(
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_command_buffer_create_exp_params_t *params) {
+           [[maybe_unused]] const struct ur_command_buffer_create_exp_params_t
+               *params) {
 
     os << ".hContext = ";
 
@@ -10741,7 +10777,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_command_buffer_retain_exp_params_t *params) {
+           [[maybe_unused]] const struct ur_command_buffer_retain_exp_params_t
+               *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10752,7 +10789,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_command_buffer_release_exp_params_t *params) {
+           [[maybe_unused]] const struct ur_command_buffer_release_exp_params_t
+               *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10763,7 +10801,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_command_buffer_finalize_exp_params_t *params) {
+           [[maybe_unused]] const struct ur_command_buffer_finalize_exp_params_t
+               *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10772,9 +10811,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_command_buffer_append_kernel_launch_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_kernel_launch_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10823,9 +10862,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_command_buffer_append_usm_memcpy_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_usm_memcpy_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10866,7 +10905,8 @@ inline std::ostream &operator<<(
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_command_buffer_append_usm_fill_exp_params_t *params) {
+    [[maybe_unused]] const struct ur_command_buffer_append_usm_fill_exp_params_t
+        *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10911,9 +10951,8 @@ inline std::ostream &operator<<(
 }
 
 inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_append_mem_buffer_copy_exp_params_t
-               *params) {
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_mem_buffer_copy_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -10963,9 +11002,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_append_mem_buffer_write_exp_params_t
-               *params) {
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_mem_buffer_write_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11010,9 +11048,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_append_mem_buffer_read_exp_params_t
-               *params) {
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_mem_buffer_read_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11056,10 +11093,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_command_buffer_append_mem_buffer_copy_rect_exp_params_t
-        *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_mem_buffer_copy_rect_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11129,9 +11165,8 @@ inline std::ostream &operator<<(
 }
 
 inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_command_buffer_append_mem_buffer_write_rect_exp_params_t
-        *params) {
+    std::ostream &os, [[maybe_unused]] const struct
+    ur_command_buffer_append_mem_buffer_write_rect_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11200,10 +11235,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_command_buffer_append_mem_buffer_read_rect_exp_params_t
-        *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_mem_buffer_read_rect_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11273,9 +11307,8 @@ inline std::ostream &operator<<(
 }
 
 inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_command_buffer_append_mem_buffer_fill_exp_params_t
-               *params) {
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_command_buffer_append_mem_buffer_fill_exp_params_t *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11326,7 +11359,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_command_buffer_enqueue_exp_params_t *params) {
+           [[maybe_unused]] const struct ur_command_buffer_enqueue_exp_params_t
+               *params) {
 
     os << ".hCommandBuffer = ";
 
@@ -11364,7 +11398,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_context_create_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_context_create_params_t *params) {
 
     os << ".DeviceCount = ";
 
@@ -11396,17 +11431,8 @@ operator<<(std::ostream &os, const struct ur_context_create_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_context_retain_params_t *params) {
-
-    os << ".hContext = ";
-
-    ur_params::serializePtr(os, *(params->phContext));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_context_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_context_retain_params_t *params) {
 
     os << ".hContext = ";
 
@@ -11417,7 +11443,18 @@ operator<<(std::ostream &os, const struct ur_context_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_context_get_info_params_t *params) {
+           [[maybe_unused]] const struct ur_context_release_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur_params::serializePtr(os, *(params->phContext));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_context_get_info_params_t *params) {
 
     os << ".hContext = ";
 
@@ -11448,7 +11485,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_context_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_context_get_native_handle_params_t
+               *params) {
 
     os << ".hContext = ";
 
@@ -11462,9 +11500,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_context_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_context_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeContext = ";
 
@@ -11500,9 +11539,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_context_set_extended_deleter_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_context_set_extended_deleter_params_t
+        *params) {
 
     os << ".hContext = ";
 
@@ -11521,9 +11561,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_kernel_launch_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_kernel_launch_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -11580,9 +11620,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_events_wait_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_events_wait_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -11614,9 +11654,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_events_wait_with_barrier_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_events_wait_with_barrier_params_t
+        *params) {
 
     os << ".hQueue = ";
 
@@ -11648,9 +11689,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_read_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_read_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -11709,7 +11750,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_write_params_t *params) {
+           [[maybe_unused]] const struct ur_enqueue_mem_buffer_write_params_t
+               *params) {
 
     os << ".hQueue = ";
 
@@ -11766,9 +11808,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_read_rect_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_read_rect_params_t
+        *params) {
 
     os << ".hQueue = ";
 
@@ -11850,9 +11893,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_write_rect_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_write_rect_params_t
+        *params) {
 
     os << ".hQueue = ";
 
@@ -11934,9 +11978,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_copy_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_copy_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -11993,9 +12037,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_copy_rect_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_copy_rect_params_t
+        *params) {
 
     os << ".hQueue = ";
 
@@ -12072,9 +12117,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_fill_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_fill_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12131,9 +12176,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_image_read_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_image_read_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12200,9 +12245,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_image_write_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_image_write_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12269,9 +12314,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_image_copy_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_image_copy_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12328,9 +12373,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_buffer_map_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_buffer_map_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12392,9 +12437,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_mem_unmap_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_mem_unmap_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12438,7 +12483,7 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_enqueue_usm_fill_params_t *params) {
+           [[maybe_unused]] const struct ur_enqueue_usm_fill_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12490,9 +12535,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_usm_memcpy_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_usm_memcpy_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12544,9 +12589,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_usm_prefetch_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_usm_prefetch_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12593,9 +12638,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_usm_advise_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_usm_advise_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12624,9 +12669,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_usm_fill_2d_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_usm_fill_2d_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12688,9 +12733,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_usm_memcpy_2d_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_usm_memcpy_2d_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12757,9 +12802,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_enqueue_device_global_variable_write_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_enqueue_device_global_variable_write_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12821,9 +12866,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_enqueue_device_global_variable_read_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_enqueue_device_global_variable_read_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12885,9 +12930,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_read_host_pipe_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_read_host_pipe_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -12944,9 +12989,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_enqueue_write_host_pipe_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_enqueue_write_host_pipe_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -13063,7 +13108,8 @@ inline std::ostream &operator<<(
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_event_get_info_params_t *params) {
 
     os << ".hEvent = ";
 
@@ -13094,7 +13140,8 @@ operator<<(std::ostream &os, const struct ur_event_get_info_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_event_get_profiling_info_params_t *params) {
+           [[maybe_unused]] const struct ur_event_get_profiling_info_params_t
+               *params) {
 
     os << ".hEvent = ";
 
@@ -13123,8 +13170,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_event_wait_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_event_wait_params_t *params) {
 
     os << ".numEvents = ";
 
@@ -13145,18 +13193,9 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_event_retain_params_t *params) {
-
-    os << ".hEvent = ";
-
-    ur_params::serializePtr(os, *(params->phEvent));
-
-    return os;
-}
-
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_event_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_event_retain_params_t *params) {
 
     os << ".hEvent = ";
 
@@ -13167,7 +13206,18 @@ operator<<(std::ostream &os, const struct ur_event_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_event_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_event_release_params_t *params) {
+
+    os << ".hEvent = ";
+
+    ur_params::serializePtr(os, *(params->phEvent));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_event_get_native_handle_params_t *params) {
 
     os << ".hEvent = ";
 
@@ -13181,9 +13231,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_event_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_event_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeEvent = ";
 
@@ -13207,9 +13258,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_event_set_callback_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_event_set_callback_params_t *params) {
 
     os << ".hEvent = ";
 
@@ -13234,7 +13285,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_kernel_create_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_kernel_create_params_t *params) {
 
     os << ".hProgram = ";
 
@@ -13254,7 +13306,8 @@ operator<<(std::ostream &os, const struct ur_kernel_create_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_kernel_get_info_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_kernel_get_info_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13283,9 +13336,9 @@ operator<<(std::ostream &os, const struct ur_kernel_get_info_params_t *params) {
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_get_group_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_get_group_info_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13321,7 +13374,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_kernel_get_sub_group_info_params_t *params) {
+           [[maybe_unused]] const struct ur_kernel_get_sub_group_info_params_t
+               *params) {
 
     os << ".hKernel = ";
 
@@ -13356,17 +13410,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_kernel_retain_params_t *params) {
-
-    os << ".hKernel = ";
-
-    ur_params::serializePtr(os, *(params->phKernel));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_kernel_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_kernel_retain_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13377,7 +13422,19 @@ operator<<(std::ostream &os, const struct ur_kernel_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_kernel_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_kernel_release_params_t *params) {
+
+    os << ".hKernel = ";
+
+    ur_params::serializePtr(os, *(params->phKernel));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_kernel_get_native_handle_params_t
+               *params) {
 
     os << ".hKernel = ";
 
@@ -13391,9 +13448,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeKernel = ";
 
@@ -13422,9 +13480,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_set_arg_value_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_set_arg_value_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13453,9 +13511,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_set_arg_local_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_set_arg_local_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13479,9 +13537,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_set_arg_pointer_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_set_arg_pointer_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13505,9 +13563,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_set_exec_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_set_exec_info_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13536,35 +13594,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_set_arg_sampler_params_t *params) {
-
-    os << ".hKernel = ";
-
-    ur_params::serializePtr(os, *(params->phKernel));
-
-    os << ", ";
-    os << ".argIndex = ";
-
-    os << *(params->pargIndex);
-
-    os << ", ";
-    os << ".pProperties = ";
-
-    ur_params::serializePtr(os, *(params->ppProperties));
-
-    os << ", ";
-    os << ".hArgValue = ";
-
-    ur_params::serializePtr(os, *(params->phArgValue));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_kernel_set_arg_mem_obj_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_kernel_set_arg_sampler_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13590,7 +13622,33 @@ operator<<(std::ostream &os,
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_kernel_set_specialization_constants_params_t *params) {
+    [[maybe_unused]] const struct ur_kernel_set_arg_mem_obj_params_t *params) {
+
+    os << ".hKernel = ";
+
+    ur_params::serializePtr(os, *(params->phKernel));
+
+    os << ", ";
+    os << ".argIndex = ";
+
+    os << *(params->pargIndex);
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur_params::serializePtr(os, *(params->ppProperties));
+
+    os << ", ";
+    os << ".hArgValue = ";
+
+    ur_params::serializePtr(os, *(params->phArgValue));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_kernel_set_specialization_constants_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13644,14 +13702,14 @@ inline std::ostream &operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_loader_tear_down_params_t *params) {
+           [[maybe_unused]] const struct ur_loader_tear_down_params_t *params) {
 
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_loader_config_create_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_loader_config_create_params_t *params) {
 
     os << ".phLoaderConfig = ";
 
@@ -13660,9 +13718,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_loader_config_retain_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_loader_config_retain_params_t *params) {
 
     os << ".hLoaderConfig = ";
 
@@ -13671,9 +13729,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_loader_config_release_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_loader_config_release_params_t *params) {
 
     os << ".hLoaderConfig = ";
 
@@ -13682,9 +13740,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_loader_config_get_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_loader_config_get_info_params_t *params) {
 
     os << ".hLoaderConfig = ";
 
@@ -13715,7 +13773,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_loader_config_enable_layer_params_t *params) {
+           [[maybe_unused]] const struct ur_loader_config_enable_layer_params_t
+               *params) {
 
     os << ".hLoaderConfig = ";
 
@@ -13731,7 +13790,7 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_mem_image_create_params_t *params) {
+           [[maybe_unused]] const struct ur_mem_image_create_params_t *params) {
 
     os << ".hContext = ";
 
@@ -13765,9 +13824,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_mem_buffer_create_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_mem_buffer_create_params_t *params) {
 
     os << ".hContext = ";
 
@@ -13796,18 +13855,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_mem_retain_params_t *params) {
-
-    os << ".hMem = ";
-
-    ur_params::serializePtr(os, *(params->phMem));
-
-    return os;
-}
-
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_mem_release_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_mem_retain_params_t *params) {
 
     os << ".hMem = ";
 
@@ -13818,7 +13868,18 @@ inline std::ostream &operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_mem_buffer_partition_params_t *params) {
+           [[maybe_unused]] const struct ur_mem_release_params_t *params) {
+
+    os << ".hMem = ";
+
+    ur_params::serializePtr(os, *(params->phMem));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_mem_buffer_partition_params_t *params) {
 
     os << ".hBuffer = ";
 
@@ -13847,9 +13908,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_mem_get_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_mem_get_native_handle_params_t *params) {
 
     os << ".hMem = ";
 
@@ -13863,9 +13924,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_mem_buffer_create_with_native_handle_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_mem_buffer_create_with_native_handle_params_t *params) {
 
     os << ".hNativeMem = ";
 
@@ -13889,9 +13950,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_mem_image_create_with_native_handle_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_mem_image_create_with_native_handle_params_t *params) {
 
     os << ".hNativeMem = ";
 
@@ -13925,8 +13986,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_mem_get_info_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_mem_get_info_params_t *params) {
 
     os << ".hMemory = ";
 
@@ -13955,9 +14017,9 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_mem_image_get_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_mem_image_get_info_params_t *params) {
 
     os << ".hMemory = ";
 
@@ -13986,9 +14048,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_physical_mem_create_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_physical_mem_create_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14017,9 +14079,20 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_physical_mem_retain_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_physical_mem_retain_params_t *params) {
+
+    os << ".hPhysicalMem = ";
+
+    ur_params::serializePtr(os, *(params->phPhysicalMem));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_physical_mem_release_params_t *params) {
 
     os << ".hPhysicalMem = ";
 
@@ -14030,17 +14103,7 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_physical_mem_release_params_t *params) {
-
-    os << ".hPhysicalMem = ";
-
-    ur_params::serializePtr(os, *(params->phPhysicalMem));
-
-    return os;
-}
-
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_platform_get_params_t *params) {
+           [[maybe_unused]] const struct ur_platform_get_params_t *params) {
 
     os << ".phAdapters = {";
     for (size_t i = 0;
@@ -14083,9 +14146,9 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_platform_get_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_platform_get_info_params_t *params) {
 
     os << ".hPlatform = ";
 
@@ -14116,7 +14179,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_platform_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_platform_get_native_handle_params_t
+               *params) {
 
     os << ".hPlatform = ";
 
@@ -14132,7 +14196,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_platform_create_with_native_handle_params_t *params) {
+    [[maybe_unused]] const struct ur_platform_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativePlatform = ";
 
@@ -14153,7 +14218,8 @@ inline std::ostream &operator<<(
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_platform_get_api_version_params_t *params) {
+           [[maybe_unused]] const struct ur_platform_get_api_version_params_t
+               *params) {
 
     os << ".hPlatform = ";
 
@@ -14169,7 +14235,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_platform_get_backend_option_params_t *params) {
+           [[maybe_unused]] const struct ur_platform_get_backend_option_params_t
+               *params) {
 
     os << ".hPlatform = ";
 
@@ -14188,9 +14255,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_program_create_with_il_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_program_create_with_il_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14221,7 +14288,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_program_create_with_binary_params_t *params) {
+           [[maybe_unused]] const struct ur_program_create_with_binary_params_t
+               *params) {
 
     os << ".hContext = ";
 
@@ -14256,7 +14324,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_program_build_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_program_build_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14276,7 +14345,8 @@ operator<<(std::ostream &os, const struct ur_program_build_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_program_compile_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_program_compile_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14295,8 +14365,9 @@ operator<<(std::ostream &os, const struct ur_program_compile_params_t *params) {
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_program_link_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_program_link_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14333,17 +14404,8 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_program_retain_params_t *params) {
-
-    os << ".hProgram = ";
-
-    ur_params::serializePtr(os, *(params->phProgram));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_program_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_program_retain_params_t *params) {
 
     os << ".hProgram = ";
 
@@ -14354,7 +14416,19 @@ operator<<(std::ostream &os, const struct ur_program_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_program_get_function_pointer_params_t *params) {
+           [[maybe_unused]] const struct ur_program_release_params_t *params) {
+
+    os << ".hProgram = ";
+
+    ur_params::serializePtr(os, *(params->phProgram));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_program_get_function_pointer_params_t
+        *params) {
 
     os << ".hDevice = ";
 
@@ -14380,47 +14454,11 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_program_get_info_params_t *params) {
+           [[maybe_unused]] const struct ur_program_get_info_params_t *params) {
 
     os << ".hProgram = ";
 
     ur_params::serializePtr(os, *(params->phProgram));
-
-    os << ", ";
-    os << ".propName = ";
-
-    os << *(params->ppropName);
-
-    os << ", ";
-    os << ".propSize = ";
-
-    os << *(params->ppropSize);
-
-    os << ", ";
-    os << ".pPropValue = ";
-    ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
-                               *(params->ppropSize));
-
-    os << ", ";
-    os << ".pPropSizeRet = ";
-
-    ur_params::serializePtr(os, *(params->ppPropSizeRet));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_program_get_build_info_params_t *params) {
-
-    os << ".hProgram = ";
-
-    ur_params::serializePtr(os, *(params->phProgram));
-
-    os << ", ";
-    os << ".hDevice = ";
-
-    ur_params::serializePtr(os, *(params->phDevice));
 
     os << ", ";
     os << ".propName = ";
@@ -14447,7 +14485,43 @@ operator<<(std::ostream &os,
 
 inline std::ostream &operator<<(
     std::ostream &os,
-    const struct ur_program_set_specialization_constants_params_t *params) {
+    [[maybe_unused]] const struct ur_program_get_build_info_params_t *params) {
+
+    os << ".hProgram = ";
+
+    ur_params::serializePtr(os, *(params->phProgram));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur_params::serializePtr(os, *(params->phDevice));
+
+    os << ", ";
+    os << ".propName = ";
+
+    os << *(params->ppropName);
+
+    os << ", ";
+    os << ".propSize = ";
+
+    os << *(params->ppropSize);
+
+    os << ", ";
+    os << ".pPropValue = ";
+    ur_params::serializeTagged(os, *(params->ppPropValue), *(params->ppropName),
+                               *(params->ppropSize));
+
+    os << ", ";
+    os << ".pPropSizeRet = ";
+
+    ur_params::serializePtr(os, *(params->ppPropSizeRet));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_program_set_specialization_constants_params_t *params) {
 
     os << ".hProgram = ";
 
@@ -14475,7 +14549,8 @@ inline std::ostream &operator<<(
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_program_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_program_get_native_handle_params_t
+               *params) {
 
     os << ".hProgram = ";
 
@@ -14489,9 +14564,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_program_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_program_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeProgram = ";
 
@@ -14516,7 +14592,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_queue_get_info_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_get_info_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -14545,8 +14622,9 @@ operator<<(std::ostream &os, const struct ur_queue_get_info_params_t *params) {
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_queue_create_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_create_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14570,18 +14648,9 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_queue_retain_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur_params::serializePtr(os, *(params->phQueue));
-
-    return os;
-}
-
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_queue_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_retain_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -14592,7 +14661,18 @@ operator<<(std::ostream &os, const struct ur_queue_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_queue_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_queue_release_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur_params::serializePtr(os, *(params->phQueue));
+
+    return os;
+}
+
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_queue_get_native_handle_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -14611,9 +14691,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_queue_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_queue_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeQueue = ";
 
@@ -14642,18 +14723,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_queue_finish_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur_params::serializePtr(os, *(params->phQueue));
-
-    return os;
-}
-
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_queue_flush_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_finish_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -14663,7 +14735,19 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_sampler_create_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_queue_flush_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur_params::serializePtr(os, *(params->phQueue));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_sampler_create_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14683,17 +14767,8 @@ operator<<(std::ostream &os, const struct ur_sampler_create_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_sampler_retain_params_t *params) {
-
-    os << ".hSampler = ";
-
-    ur_params::serializePtr(os, *(params->phSampler));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_sampler_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_sampler_retain_params_t *params) {
 
     os << ".hSampler = ";
 
@@ -14704,7 +14779,18 @@ operator<<(std::ostream &os, const struct ur_sampler_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_sampler_get_info_params_t *params) {
+           [[maybe_unused]] const struct ur_sampler_release_params_t *params) {
+
+    os << ".hSampler = ";
+
+    ur_params::serializePtr(os, *(params->phSampler));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_sampler_get_info_params_t *params) {
 
     os << ".hSampler = ";
 
@@ -14735,7 +14821,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_sampler_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_sampler_get_native_handle_params_t
+               *params) {
 
     os << ".hSampler = ";
 
@@ -14749,9 +14836,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_sampler_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_sampler_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeSampler = ";
 
@@ -14776,7 +14864,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_usm_host_alloc_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_host_alloc_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14807,7 +14896,7 @@ operator<<(std::ostream &os, const struct ur_usm_host_alloc_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_usm_device_alloc_params_t *params) {
+           [[maybe_unused]] const struct ur_usm_device_alloc_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14843,7 +14932,7 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_usm_shared_alloc_params_t *params) {
+           [[maybe_unused]] const struct ur_usm_shared_alloc_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14877,8 +14966,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_usm_free_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_free_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14892,9 +14982,9 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_usm_get_mem_alloc_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_usm_get_mem_alloc_info_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14929,7 +15019,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_usm_pool_create_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_pool_create_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14949,7 +15040,8 @@ operator<<(std::ostream &os, const struct ur_usm_pool_create_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_usm_pool_retain_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_pool_retain_params_t *params) {
 
     os << ".pPool = ";
 
@@ -14960,7 +15052,7 @@ operator<<(std::ostream &os, const struct ur_usm_pool_retain_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_usm_pool_release_params_t *params) {
+           [[maybe_unused]] const struct ur_usm_pool_release_params_t *params) {
 
     os << ".pPool = ";
 
@@ -14969,9 +15061,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_usm_pool_get_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_usm_pool_get_info_params_t *params) {
 
     os << ".hPool = ";
 
@@ -15000,9 +15092,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_usm_pitched_alloc_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_usm_pitched_alloc_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15052,7 +15144,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_usm_import_exp_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_import_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15072,7 +15165,8 @@ operator<<(std::ostream &os, const struct ur_usm_import_exp_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_usm_release_exp_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_usm_release_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15086,9 +15180,10 @@ operator<<(std::ostream &os, const struct ur_usm_release_exp_params_t *params) {
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_usm_p2p_enable_peer_access_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_usm_p2p_enable_peer_access_exp_params_t
+        *params) {
 
     os << ".commandDevice = ";
 
@@ -15102,9 +15197,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_usm_p2p_disable_peer_access_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_usm_p2p_disable_peer_access_exp_params_t
+        *params) {
 
     os << ".commandDevice = ";
 
@@ -15118,9 +15214,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_usm_p2p_peer_access_get_info_exp_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_usm_p2p_peer_access_get_info_exp_params_t
+        *params) {
 
     os << ".commandDevice = ";
 
@@ -15154,9 +15251,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_virtual_mem_granularity_get_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_virtual_mem_granularity_get_info_params_t
+        *params) {
 
     os << ".hContext = ";
 
@@ -15190,9 +15288,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_virtual_mem_reserve_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_virtual_mem_reserve_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15218,7 +15316,7 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_virtual_mem_free_params_t *params) {
+           [[maybe_unused]] const struct ur_virtual_mem_free_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15238,7 +15336,8 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_virtual_mem_map_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_virtual_mem_map_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15273,9 +15372,9 @@ operator<<(std::ostream &os, const struct ur_virtual_mem_map_params_t *params) {
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_virtual_mem_unmap_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_virtual_mem_unmap_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15294,9 +15393,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_virtual_mem_set_access_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_virtual_mem_set_access_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15321,9 +15420,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_virtual_mem_get_info_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_virtual_mem_get_info_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15362,8 +15461,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_device_get_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_device_get_params_t *params) {
 
     os << ".hPlatform = ";
 
@@ -15400,7 +15500,8 @@ inline std::ostream &operator<<(std::ostream &os,
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_device_get_info_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_device_get_info_params_t *params) {
 
     os << ".hDevice = ";
 
@@ -15430,17 +15531,8 @@ operator<<(std::ostream &os, const struct ur_device_get_info_params_t *params) {
 }
 
 inline std::ostream &
-operator<<(std::ostream &os, const struct ur_device_retain_params_t *params) {
-
-    os << ".hDevice = ";
-
-    ur_params::serializePtr(os, *(params->phDevice));
-
-    return os;
-}
-
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_device_release_params_t *params) {
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_device_retain_params_t *params) {
 
     os << ".hDevice = ";
 
@@ -15451,7 +15543,18 @@ operator<<(std::ostream &os, const struct ur_device_release_params_t *params) {
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_device_partition_params_t *params) {
+           [[maybe_unused]] const struct ur_device_release_params_t *params) {
+
+    os << ".hDevice = ";
+
+    ur_params::serializePtr(os, *(params->phDevice));
+
+    return os;
+}
+
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_device_partition_params_t *params) {
 
     os << ".hDevice = ";
 
@@ -15487,9 +15590,9 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_device_select_binary_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_device_select_binary_params_t *params) {
 
     os << ".hDevice = ";
 
@@ -15515,7 +15618,8 @@ operator<<(std::ostream &os,
 
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_device_get_native_handle_params_t *params) {
+           [[maybe_unused]] const struct ur_device_get_native_handle_params_t
+               *params) {
 
     os << ".hDevice = ";
 
@@ -15529,9 +15633,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_device_create_with_native_handle_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_device_create_with_native_handle_params_t
+        *params) {
 
     os << ".hNativeDevice = ";
 
@@ -15555,9 +15660,10 @@ operator<<(std::ostream &os,
     return os;
 }
 
-inline std::ostream &
-operator<<(std::ostream &os,
-           const struct ur_device_get_global_timestamps_params_t *params) {
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_device_get_global_timestamps_params_t
+        *params) {
 
     os << ".hDevice = ";
 

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -454,17 +454,16 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_exp_image_copy_flag_t value);
 inline std::ostream &
 operator<<(std::ostream &os,
-           const struct ur_exp_sampler_mip_properties_t params);
-inline std::ostream &
-operator<<(std::ostream &os, const struct ur_exp_sampler_addr_modes_t params);
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_exp_interop_mem_desc_t params);
+           [[maybe_unused]] const struct ur_exp_file_descriptor_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            [[maybe_unused]] const struct ur_exp_win32_handle_t params);
 inline std::ostream &operator<<(
     std::ostream &os,
     [[maybe_unused]] const struct ur_exp_sampler_mip_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_exp_sampler_addr_modes_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            [[maybe_unused]] const struct ur_exp_interop_mem_desc_t params);
@@ -13048,9 +13047,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_enqueue_cooperative_kernel_launch_exp_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_enqueue_cooperative_kernel_launch_exp_params_t *params) {
 
     os << ".hQueue = ";
 
@@ -13667,10 +13666,9 @@ operator<<(std::ostream &os, [[maybe_unused]] const struct
     return os;
 }
 
-inline std::ostream &operator<<(
-    std::ostream &os,
-    const struct ur_kernel_suggest_max_cooperative_group_count_exp_params_t
-        *params) {
+inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_kernel_suggest_max_cooperative_group_count_exp_params_t *params) {
 
     os << ".hKernel = ";
 
@@ -13684,8 +13682,9 @@ inline std::ostream &operator<<(
     return os;
 }
 
-inline std::ostream &operator<<(std::ostream &os,
-                                const struct ur_loader_init_params_t *params) {
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_loader_init_params_t *params) {
 
     os << ".device_flags = ";
 

--- a/source/common/ur_singleton.hpp
+++ b/source/common/ur_singleton.hpp
@@ -31,7 +31,8 @@ template <typename singleton_tn, typename key_tn> class singleton_factory_t {
 
     //////////////////////////////////////////////////////////////////////////
     /// extract the key from parameter list and if necessary, convert type
-    template <typename... Ts> key_t getKey(key_tn key, Ts &&...params) {
+    template <typename... Ts>
+    key_t getKey(key_tn key, [[maybe_unused]] Ts &&...params) {
         return reinterpret_cast<key_t>(key);
     }
 

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -70,7 +70,7 @@ void context_t::tearDownLayers() const {
 
 //////////////////////////////////////////////////////////////////////////
 __urdlllocal ur_result_t
-context_t::Init(ur_device_init_flags_t device_flags,
+context_t::Init([[maybe_unused]] ur_device_init_flags_t device_flags,
                 ur_loader_config_handle_t hLoaderConfig) {
     ur_result_t result;
     const char *logger_name = "loader";

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -69,9 +69,8 @@ void context_t::tearDownLayers() const {
 }
 
 //////////////////////////////////////////////////////////////////////////
-__urdlllocal ur_result_t
-context_t::Init([[maybe_unused]] ur_device_init_flags_t device_flags,
-                ur_loader_config_handle_t hLoaderConfig) {
+__urdlllocal ur_result_t context_t::Init(
+    ur_device_init_flags_t, ur_loader_config_handle_t hLoaderConfig) {
     ur_result_t result;
     const char *logger_name = "loader";
     logger::init(logger_name);

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -167,9 +167,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventSetCallbackTest);
 /* Negative tests */
 using urEventSetCallbackNegativeTest = uur::event::urEventTest;
 
-void emptyCallback([[maybe_unused]] ur_event_handle_t hEvent,
-                   [[maybe_unused]] ur_execution_info_t execStatus,
-                   [[maybe_unused]] void *pUserData) {}
+void emptyCallback(ur_event_handle_t, ur_execution_info_t, void *) {}
 
 TEST_P(urEventSetCallbackNegativeTest, InvalidNullHandleEvent) {
     ASSERT_EQ_RESULT(

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -14,8 +14,9 @@ using urEventSetCallbackTest = uur::event::urEventReferenceTest;
 TEST_P(urEventSetCallbackTest, Success) {
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
-                             ur_execution_info_t execStatus, void *pUserData) {
+        static void callback([[maybe_unused]] ur_event_handle_t hEvent,
+                             [[maybe_unused]] ur_execution_info_t execStatus,
+                             void *pUserData) {
 
             auto status = reinterpret_cast<bool *>(pUserData);
             *status = true;
@@ -78,7 +79,7 @@ TEST_P(urEventSetCallbackTest, AllStates) {
     };
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
+        static void callback([[maybe_unused]] ur_event_handle_t hEvent,
                              ur_execution_info_t execStatus, void *pUserData) {
 
             auto status = reinterpret_cast<CallbackStatus *>(pUserData);
@@ -142,8 +143,9 @@ TEST_P(urEventSetCallbackTest, EventAlreadyCompleted) {
     ASSERT_SUCCESS(urEventWait(1, &event));
 
     struct Callback {
-        static void callback(ur_event_handle_t hEvent,
-                             ur_execution_info_t execStatus, void *pUserData) {
+        static void callback([[maybe_unused]] ur_event_handle_t hEvent,
+                             [[maybe_unused]] ur_execution_info_t execStatus,
+                             void *pUserData) {
 
             auto status = reinterpret_cast<bool *>(pUserData);
             *status = true;
@@ -165,8 +167,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventSetCallbackTest);
 /* Negative tests */
 using urEventSetCallbackNegativeTest = uur::event::urEventTest;
 
-void emptyCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
-                   void *pUserData) {}
+void emptyCallback([[maybe_unused]] ur_event_handle_t hEvent,
+                   [[maybe_unused]] ur_execution_info_t execStatus,
+                   [[maybe_unused]] void *pUserData) {}
 
 TEST_P(urEventSetCallbackNegativeTest, InvalidNullHandleEvent) {
     ASSERT_EQ_RESULT(

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -356,8 +356,8 @@ void KernelsEnvironment::LoadSource(
     binary_out = binary_ptr;
 }
 
-std::vector<std::string>
-KernelsEnvironment::GetEntryPointNames(std::string program_name) {
+std::vector<std::string> KernelsEnvironment::GetEntryPointNames(
+    [[maybe_unused]] std::string program_name) {
     std::vector<std::string> entry_points;
 #ifdef KERNELS_ENVIRONMENT
     entry_points = uur::device_binaries::program_kernel_map[program_name];

--- a/test/loader/platforms/platforms.cpp
+++ b/test/loader/platforms/platforms.cpp
@@ -18,7 +18,7 @@
 using namespace logger;
 
 //////////////////////////////////////////////////////////////////////////
-int main(int argc, char *argv[]) {
+int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
     logger::init("TEST");
 
     ur_result_t status;

--- a/test/loader/platforms/platforms.cpp
+++ b/test/loader/platforms/platforms.cpp
@@ -18,7 +18,7 @@
 using namespace logger;
 
 //////////////////////////////////////////////////////////////////////////
-int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
+int main(int, char *[]) {
     logger::init("TEST");
 
     ur_result_t status;

--- a/test/unified_malloc_framework/common/pool.hpp
+++ b/test/unified_malloc_framework/common/pool.hpp
@@ -76,7 +76,7 @@ struct pool_base {
     umf_result_t initialize(umf_memory_provider_handle_t *, size_t) noexcept {
         return UMF_RESULT_SUCCESS;
     };
-    void *malloc(size_t size) noexcept { return nullptr; }
+    void *malloc([[maybe_unused]] size_t size) noexcept { return nullptr; }
     void *calloc(size_t, size_t) noexcept { return nullptr; }
     void *realloc(void *, size_t) noexcept { return nullptr; }
     void *aligned_malloc(size_t, size_t) noexcept { return nullptr; }
@@ -120,7 +120,7 @@ struct malloc_pool : public pool_base {
 
 struct proxy_pool : public pool_base {
     umf_result_t initialize(umf_memory_provider_handle_t *providers,
-                            size_t numProviders) noexcept {
+                            [[maybe_unused]] size_t numProviders) noexcept {
         this->provider = providers[0];
         return UMF_RESULT_SUCCESS;
     }
@@ -136,7 +136,8 @@ struct proxy_pool : public pool_base {
         }
         return ptr;
     }
-    void *realloc(void *ptr, size_t size) noexcept {
+    void *realloc([[maybe_unused]] void *ptr,
+                  [[maybe_unused]] size_t size) noexcept {
         // TODO: not supported
         umf::getPoolLastStatusRef<proxy_pool>() =
             UMF_RESULT_ERROR_NOT_SUPPORTED;
@@ -150,7 +151,7 @@ struct proxy_pool : public pool_base {
         }
         return ptr;
     }
-    size_t malloc_usable_size(void *ptr) noexcept {
+    size_t malloc_usable_size([[maybe_unused]] void *ptr) noexcept {
         // TODO: not supported
         return 0;
     }

--- a/test/unified_malloc_framework/common/provider.hpp
+++ b/test/unified_malloc_framework/common/provider.hpp
@@ -30,21 +30,27 @@ struct provider_base {
     enum umf_result_t alloc(size_t, size_t, void **) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
-    enum umf_result_t free(void *ptr, size_t size) noexcept {
+    enum umf_result_t free([[maybe_unused]] void *ptr,
+                           [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
     void get_last_native_error(const char **, int32_t *) noexcept {}
-    enum umf_result_t get_recommended_page_size(size_t size,
-                                                size_t *pageSize) noexcept {
+    enum umf_result_t
+    get_recommended_page_size([[maybe_unused]] size_t size,
+                              [[maybe_unused]] size_t *pageSize) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
-    enum umf_result_t get_min_page_size(void *ptr, size_t *pageSize) noexcept {
+    enum umf_result_t
+    get_min_page_size([[maybe_unused]] void *ptr,
+                      [[maybe_unused]] size_t *pageSize) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
-    enum umf_result_t purge_lazy(void *ptr, size_t size) noexcept {
+    enum umf_result_t purge_lazy([[maybe_unused]] void *ptr,
+                                 [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
-    enum umf_result_t purge_force(void *ptr, size_t size) noexcept {
+    enum umf_result_t purge_force([[maybe_unused]] void *ptr,
+                                  [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
     const char *get_name() noexcept { return "base"; }

--- a/test/unified_malloc_framework/memoryPoolAPI.cpp
+++ b/test/unified_malloc_framework/memoryPoolAPI.cpp
@@ -187,9 +187,10 @@ TEST_P(poolInitializeTest, errorPropagation) {
     umf_memory_provider_handle_t providers[] = {nullProvider.get()};
 
     struct pool : public umf_test::pool_base {
-        umf_result_t initialize(umf_memory_provider_handle_t *providers,
-                                size_t numProviders,
-                                umf_result_t errorToReturn) noexcept {
+        umf_result_t
+        initialize([[maybe_unused]] umf_memory_provider_handle_t *providers,
+                   [[maybe_unused]] size_t numProviders,
+                   umf_result_t errorToReturn) noexcept {
             return errorToReturn;
         }
     };
@@ -233,6 +234,7 @@ TEST_F(test, getLastFailedMemoryProvider) {
         }
 
         enum umf_result_t free(void *ptr, size_t size) noexcept {
+            (void)size;
             ::free(ptr);
             return UMF_RESULT_SUCCESS;
         }

--- a/test/unified_malloc_framework/memoryPoolAPI.cpp
+++ b/test/unified_malloc_framework/memoryPoolAPI.cpp
@@ -233,8 +233,8 @@ TEST_F(test, getLastFailedMemoryProvider) {
             return allocResult;
         }
 
-        enum umf_result_t free(void *ptr, size_t size) noexcept {
-            (void)size;
+        enum umf_result_t free(void *ptr,
+                               [[maybe_unused]] size_t size) noexcept {
             ::free(ptr);
             return UMF_RESULT_SUCCESS;
         }

--- a/test/unified_malloc_framework/umf_pools/disjoint_pool.cpp
+++ b/test/unified_malloc_framework/umf_pools/disjoint_pool.cpp
@@ -42,7 +42,8 @@ TEST_F(test, freeErrorPropagation) {
             *ptr = malloc(size);
             return UMF_RESULT_SUCCESS;
         }
-        enum umf_result_t free(void *ptr, size_t size) noexcept {
+        enum umf_result_t free(void *ptr,
+                               [[maybe_unused]] size_t size) noexcept {
             ::free(ptr);
             return freeReturn;
         }

--- a/tools/urtrace/collector.cpp
+++ b/tools/urtrace/collector.cpp
@@ -245,12 +245,10 @@ class JsonWriter : public TraceWriter {
             "\"tid\": \"\", \"ts\": \"\"}}");
         out.info("]\n}}");
     }
-    void begin([[maybe_unused]] uint64_t id, [[maybe_unused]] const char *fname,
-               [[maybe_unused]] std::string args) override {}
+    void begin(uint64_t, const char *, std::string) override {}
 
-    void end([[maybe_unused]] uint64_t id, const char *fname, std::string args,
-             Timepoint tp, Timepoint start_tp,
-             [[maybe_unused]] const ur_result_t *resultp) override {
+    void end(uint64_t, const char *fname, std::string args, Timepoint tp,
+             Timepoint start_tp, const ur_result_t *) override {
         auto dur = tp - start_tp;
         auto ts_us = std::chrono::duration_cast<std::chrono::microseconds>(
                          tp.time_since_epoch())
@@ -316,10 +314,9 @@ std::optional<fn_context> pop_instance_data(uint64_t instance) {
     return data;
 }
 
-XPTI_CALLBACK_API void
-trace_cb(uint16_t trace_type, [[maybe_unused]] xpti::trace_event_data_t *parent,
-         [[maybe_unused]] xpti::trace_event_data_t *event, uint64_t instance,
-         const void *user_data) {
+XPTI_CALLBACK_API void trace_cb(uint16_t trace_type, xpti::trace_event_data_t *,
+                                xpti::trace_event_data_t *, uint64_t instance,
+                                const void *user_data) {
     // stop the the clock as the very first thing, only used for TRACE_FN_END
     auto time_for_end = Clock::now();
     auto *args = static_cast<const xpti::function_with_args_t *>(user_data);
@@ -368,8 +365,7 @@ trace_cb(uint16_t trace_type, [[maybe_unused]] xpti::trace_event_data_t *parent,
  * Called for every stream.
  */
 XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
-                                     unsigned int minor_version,
-                                     [[maybe_unused]] const char *version_str,
+                                     unsigned int minor_version, const char *,
                                      const char *stream_name) {
     if (stream_name == nullptr) {
         out.debug("Found stream with null name. Skipping...");

--- a/tools/urtrace/collector.cpp
+++ b/tools/urtrace/collector.cpp
@@ -245,10 +245,12 @@ class JsonWriter : public TraceWriter {
             "\"tid\": \"\", \"ts\": \"\"}}");
         out.info("]\n}}");
     }
-    void begin(uint64_t id, const char *fname, std::string args) override {}
+    void begin([[maybe_unused]] uint64_t id, [[maybe_unused]] const char *fname,
+               [[maybe_unused]] std::string args) override {}
 
-    void end(uint64_t id, const char *fname, std::string args, Timepoint tp,
-             Timepoint start_tp, const ur_result_t *resultp) override {
+    void end([[maybe_unused]] uint64_t id, const char *fname, std::string args,
+             Timepoint tp, Timepoint start_tp,
+             [[maybe_unused]] const ur_result_t *resultp) override {
         auto dur = tp - start_tp;
         auto ts_us = std::chrono::duration_cast<std::chrono::microseconds>(
                          tp.time_since_epoch())
@@ -314,10 +316,10 @@ std::optional<fn_context> pop_instance_data(uint64_t instance) {
     return data;
 }
 
-XPTI_CALLBACK_API void trace_cb(uint16_t trace_type,
-                                xpti::trace_event_data_t *parent,
-                                xpti::trace_event_data_t *event,
-                                uint64_t instance, const void *user_data) {
+XPTI_CALLBACK_API void
+trace_cb(uint16_t trace_type, [[maybe_unused]] xpti::trace_event_data_t *parent,
+         [[maybe_unused]] xpti::trace_event_data_t *event, uint64_t instance,
+         const void *user_data) {
     // stop the the clock as the very first thing, only used for TRACE_FN_END
     auto time_for_end = Clock::now();
     auto *args = static_cast<const xpti::function_with_args_t *>(user_data);
@@ -367,7 +369,7 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type,
  */
 XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
                                      unsigned int minor_version,
-                                     const char *version_str,
+                                     [[maybe_unused]] const char *version_str,
                                      const char *stream_name) {
     if (stream_name == nullptr) {
         out.debug("Found stream with null name. Skipping...");


### PR DESCRIPTION
Since UR is imported as a library to different project, we should make sure we don't cause warnings with their compiler. A common warning is for unused parameters so we should ensure we don't raise this warning when compiling the code.