### PR TITLE
[UR] Support C style arrays

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -2228,9 +2228,7 @@ class ur_exp_sampler_addr_modes_t(Structure):
         ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
                                                                         ## ::UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
         ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
-        ("addrModeX", ur_sampler_addressing_mode_t),                    ## [in] Specify the addressing mode of the x-dimension.
-        ("addrModeY", ur_sampler_addressing_mode_t),                    ## [in] Specify the addressing mode of the y-dimension.
-        ("addrModeZ", ur_sampler_addressing_mode_t)                     ## [in] Specify the addressing mode of the z-dimension.
+        ("addrModes", ur_sampler_addressing_mode_t * 3)                 ## [in] Specify the address mode of the sampler per dimension
     ]
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7047,12 +7047,10 @@ typedef struct ur_exp_sampler_mip_properties_t {
 ///     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
 ///       as part of a `pNext` chain.
 typedef struct ur_exp_sampler_addr_modes_t {
-    ur_structure_type_t stype;              ///< [in] type of this structure, must be
-                                            ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
-    void *pNext;                            ///< [in,out][optional] pointer to extension-specific structure
-    ur_sampler_addressing_mode_t addrModeX; ///< [in] Specify the addressing mode of the x-dimension.
-    ur_sampler_addressing_mode_t addrModeY; ///< [in] Specify the addressing mode of the y-dimension.
-    ur_sampler_addressing_mode_t addrModeZ; ///< [in] Specify the addressing mode of the z-dimension.
+    ur_structure_type_t stype;                 ///< [in] type of this structure, must be
+                                               ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
+    void *pNext;                               ///< [in,out][optional] pointer to extension-specific structure
+    ur_sampler_addressing_mode_t addrModes[3]; ///< [in] Specify the address mode of the sampler per dimension
 
 } ur_exp_sampler_addr_modes_t;
 

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -187,15 +187,9 @@ class: $xBindlessImages
 name: $x_exp_sampler_addr_modes_t
 base: $x_base_properties_t
 members:
-    - type: $x_sampler_addressing_mode_t
-      name: addrModeX
-      desc: "[in] Specify the addressing mode of the x-dimension."
-    - type: $x_sampler_addressing_mode_t
-      name: addrModeY
-      desc: "[in] Specify the addressing mode of the y-dimension."
-    - type: $x_sampler_addressing_mode_t
-      name: addrModeZ
-      desc: "[in] Specify the addressing mode of the z-dimension."
+    - type: $x_sampler_addressing_mode_t[3]
+      name: addrModes
+      desc: "[in] Specify the address mode of the sampler per dimension"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Describes an interop memory resource descriptor"

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -105,6 +105,7 @@ class type_traits:
     RE_DESC     = r"(.*)desc_t.*"
     RE_PROPS    = r"(.*)properties_t.*"
     RE_FLAGS    = r"(.*)flags_t"
+    RE_ARRAY    = r"(.*)\[([1-9][0-9]*)\]"
 
     @staticmethod
     def base(name):
@@ -216,6 +217,29 @@ class type_traits:
             return None
         except:
             return None
+
+    @classmethod
+    def is_array(cls, name):
+        try:
+            return True if re.match(cls.RE_ARRAY, name) else False
+        except:
+            return False
+        
+    @classmethod
+    def get_array_length(cls, name):
+        if not cls.is_array(name):
+            raise Exception("Cannot find array length of non-array type.")
+
+        match = re.match(cls.RE_ARRAY, name)
+        return match.groups()[1]
+    
+    @classmethod
+    def get_array_element_type(cls, name):
+        if not cls.is_array(name):
+            raise Exception("Cannot find array length of non-array type.")
+
+        match = re.match(cls.RE_ARRAY, name)
+        return match.groups()[0]
 
 """
     Extracts traits from a value name
@@ -729,7 +753,10 @@ Private:
     returns c/c++ name of any type
 """
 def _get_type_name(namespace, tags, obj, item):
-    name = subt(namespace, tags, item['type'],)
+    type = item['type']
+    if type_traits.is_array(type):
+        type = type_traits.get_array_element_type(type)
+    name = subt(namespace, tags, type,)
     return name
 
 """
@@ -763,9 +790,9 @@ def get_ctype_name(namespace, tags, item):
     while type_traits.is_pointer(name):
         name = "POINTER(%s)"%_remove_ptr(name)
 
-    if 'name' in item and value_traits.is_array(item['name']):
-        length = subt(namespace, tags, value_traits.get_array_length(item['name']))
-        name = "%s * %s"%(name, length)
+    if 'name' in item and type_traits.is_array(item['type']):
+        length = subt(namespace, tags, type_traits.get_array_length(item['type'])) 
+        name = "%s * %s"%(type_traits.get_array_element_type(name), length)
 
     return name
 
@@ -804,7 +831,8 @@ def make_member_lines(namespace, tags, obj, prefix="", py=False, meta=None):
             delim = "," if i < (len(obj['members'])-1) else ""
             prologue = "(\"%s\", %s)%s"%(name, tname, delim)
         else:
-            prologue = "%s %s;"%(tname, name)
+            array_suffix = f"[{type_traits.get_array_length(item['type'])}]" if type_traits.is_array(item['type']) else ""
+            prologue = "%s %s %s;"%(tname, name, array_suffix)
 
         comment_style = "##" if py else "///<"
         ws_count = 64 if py else 48

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -236,7 +236,7 @@ class type_traits:
     @classmethod
     def get_array_element_type(cls, name):
         if not cls.is_array(name):
-            raise Exception("Cannot find array length of non-array type.")
+            raise Exception("Cannot find array type of non-array type.")
 
         match = re.match(cls.RE_ARRAY, name)
         return match.groups()[0]

--- a/scripts/templates/params.hpp.mako
+++ b/scripts/templates/params.hpp.mako
@@ -85,14 +85,16 @@ def findMemberType(_item):
         os << ".${iname} = ";
         ${x}_params::serializeUnion(os, ${deref}(params${access}${item['name']}), params${access}${th.param_traits.tagged_member(item)});
     %elif th.type_traits.is_array(item['type']):
-        os << ".${iname} = [";
+        os << ".${iname} = {";
         for(auto i = 0; i < ${th.type_traits.get_array_length(item['type'])}; i++){
             if(i != 0){
                 os << ", ";
             }
-            os << ${deref}(params${access}${item['name']}[i]);
+            <%call expr="member(iname, itype, True)">
+                ${deref}(params${access}${item['name']}[i])
+            </%call>
         }
-        os << "]";
+        os << "}";
     %elif typename is not None:
         os << ".${iname} = ";
         ${x}_params::serializeTagged(os, ${deref}(params${access}${pname}), ${deref}(params${access}${prefix}${typename}), ${deref}(params${access}${prefix}${typename_size}));

--- a/scripts/templates/params.hpp.mako
+++ b/scripts/templates/params.hpp.mako
@@ -84,6 +84,15 @@ def findMemberType(_item):
     %elif findMemberType(item) is not None and findMemberType(item)['type'] == "union":
         os << ".${iname} = ";
         ${x}_params::serializeUnion(os, ${deref}(params${access}${item['name']}), params${access}${th.param_traits.tagged_member(item)});
+    %elif th.type_traits.is_array(item['type']):
+        os << ".${iname} = [";
+        for(auto i = 0; i < ${th.type_traits.get_array_length(item['type'])}; i++){
+            if(i != 0){
+                os << ", ";
+            }
+            os << ${deref}(params${access}${item['name']}[i]);
+        }
+        os << "]";
     %elif typename is not None:
         os << ".${iname} = ";
         ${x}_params::serializeTagged(os, ${deref}(params${access}${pname}), ${deref}(params${access}${prefix}${typename}), ${deref}(params${access}${prefix}${typename_size}));

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -9905,14 +9905,15 @@ operator<<(std::ostream &os, const struct ur_exp_sampler_addr_modes_t params) {
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-    os << ".addrModes = [";
+    os << ".addrModes = {";
     for (auto i = 0; i < 3; i++) {
         if (i != 0) {
             os << ", ";
         }
+
         os << (params.addrModes[i]);
     }
-    os << "]";
+    os << "}";
 
     os << "}";
     return os;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -9905,19 +9905,14 @@ operator<<(std::ostream &os, const struct ur_exp_sampler_addr_modes_t params) {
     ur_params::serializeStruct(os, (params.pNext));
 
     os << ", ";
-    os << ".addrModeX = ";
-
-    os << (params.addrModeX);
-
-    os << ", ";
-    os << ".addrModeY = ";
-
-    os << (params.addrModeY);
-
-    os << ", ";
-    os << ".addrModeZ = ";
-
-    os << (params.addrModeZ);
+    os << ".addrModes = [";
+    for (auto i = 0; i < 3; i++) {
+        if (i != 0) {
+            os << ", ";
+        }
+        os << (params.addrModes[i]);
+    }
+    os << "]";
 
     os << "}";
     return os;

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -367,6 +367,31 @@ struct UrDevicePartitionPropertyTest {
     ur_device_partition_property_t prop;
 };
 
+struct UrSamplerAddressModesTest {
+    UrSamplerAddressModesTest() {
+        prop.addrModes[0] = UR_SAMPLER_ADDRESSING_MODE_CLAMP;
+        prop.addrModes[1] = UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT;
+        prop.addrModes[2] = UR_SAMPLER_ADDRESSING_MODE_REPEAT;
+        prop.pNext = nullptr;
+        prop.stype = UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES;
+    }
+    ur_exp_sampler_addr_modes_t &get_struct() { return prop; }
+    const char *get_expected() {
+        return "\\(struct ur_exp_sampler_addr_modes_t\\)"
+               "\\{"
+               ".stype = UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES, "
+               ".pNext = nullptr, "
+               ".addrModes = \\["
+               "UR_SAMPLER_ADDRESSING_MODE_CLAMP, "
+               "UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT, "
+               "UR_SAMPLER_ADDRESSING_MODE_REPEAT"
+               "\\]"
+               "\\}";
+    }
+
+    ur_exp_sampler_addr_modes_t prop;
+};
+
 using testing::Types;
 typedef Types<UrLoaderInitParamsNoFlags, UrLoaderInitParamsInvalidFlags,
               UrUsmHostAllocParamsEmpty, UrPlatformGetEmptyArray,
@@ -376,7 +401,7 @@ typedef Types<UrLoaderInitParamsNoFlags, UrLoaderInitParamsInvalidFlags,
               UrDeviceGetInfoParamsPartitionArray,
               UrContextGetInfoParamsDevicesArray,
               UrDeviceGetInfoParamsInvalidSize, UrProgramMetadataTest,
-              UrDevicePartitionPropertyTest>
+              UrDevicePartitionPropertyTest, UrSamplerAddressModesTest>
     Implementations;
 
 using ::testing::MatchesRegex;

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -381,11 +381,11 @@ struct UrSamplerAddressModesTest {
                "\\{"
                ".stype = UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES, "
                ".pNext = nullptr, "
-               ".addrModes = \\["
+               ".addrModes = \\{"
                "UR_SAMPLER_ADDRESSING_MODE_CLAMP, "
                "UR_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT, "
                "UR_SAMPLER_ADDRESSING_MODE_REPEAT"
-               "\\]"
+               "\\}"
                "\\}";
     }
 


### PR DESCRIPTION
This PR:
* Adds support to type members of structs as c-style arrays
* Changes `ur_exp_sampler_addr_modes_t` to use array as requested in #863 

Closes #869 