### PR TITLE
[cmake] Respect Python virtualenv on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(helpers)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  set(CMAKE_FIND_FRAMEWORK NEVER)
+    set(Python3_FIND_FRAMEWORK NEVER)
+    set(Python3_FIND_STRATEGY LOCATION)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter REQUIRED)


### PR DESCRIPTION
Fix issue where CMake ignores the Python interpreter specified by a virtual environment by default. This results in the generate targets failing when the Python package requirements are installed in a virtual environment but the system interpreter is found by CMake.

This patch replaces the use of `CMAKE_FIND_FRAMEWORK` with the more precise `Python3_FIND_FRAMEWORK`. It also sets the `Python3_FIND_STRATEGY` to `LOCATION` which stops searching once the first Python interpreter is found, i.e. the interpreter from an activated virtual environment, or the system interpreter otherwise.
