### PR TITLE
CTS fixes for ProgramLink and ProgramCreateWithBinary

### DIFF
--- a/test/conformance/program/program_adapter_level_zero.match
+++ b/test/conformance/program/program_adapter_level_zero.match
@@ -1,1 +1,6 @@
-Segmentation fault
+urProgramCreateWithNativeHandleTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+urProgramCreateWithNativeHandleTest.InvalidNullHandleContext/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+urProgramCreateWithNativeHandleTest.InvalidNullPointerProgram/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+urProgramGetBuildInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_UR_PROGRAM_BUILD_INFO_STATUS
+urProgramGetFunctionPointerTest.InvalidFunctionName/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+Aborted

--- a/test/conformance/program/program_adapter_opencl.match
+++ b/test/conformance/program/program_adapter_opencl.match
@@ -1,10 +1,3 @@
-urProgramCreateWithBinaryTest.Success/Intel_R__OpenCL___{{.*}}_
-urProgramCreateWithBinaryTest.InvalidNullHandleContext/Intel_R__OpenCL___{{.*}}_
-urProgramCreateWithBinaryTest.InvalidNullHandleDevice/Intel_R__OpenCL___{{.*}}_
-urProgramCreateWithBinaryTest.InvalidNullPointerBinary/Intel_R__OpenCL___{{.*}}_
-urProgramCreateWithBinaryTest.InvalidNullPointerProgram/Intel_R__OpenCL___{{.*}}_
-urProgramCreateWithBinaryTest.InvalidNullPointerMetadata/Intel_R__OpenCL___{{.*}}_
-urProgramCreateWithBinaryTest.InvalidSizePropertyCount/Intel_R__OpenCL___{{.*}}_
 urProgramGetFunctionPointerTest.InvalidFunctionName/Intel_R__OpenCL___{{.*}}_
 urProgramGetInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_PROGRAM_INFO_SOURCE
 urProgramGetInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_PROGRAM_INFO_BINARIES

--- a/test/conformance/program/urProgramCreateWithBinary.cpp
+++ b/test/conformance/program/urProgramCreateWithBinary.cpp
@@ -9,6 +9,11 @@ struct urProgramCreateWithBinaryTest : uur::urProgramTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::SetUp());
         ASSERT_SUCCESS(urProgramBuild(context, program, nullptr));
+        size_t binary_sizes_len = 0;
+        ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARY_SIZES,
+                                        0, nullptr, &binary_sizes_len));
+        // We're expecting one binary
+        ASSERT_EQ(binary_sizes_len / sizeof(size_t), 1);
         size_t binary_size = 0;
         ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARY_SIZES,
                                         sizeof(binary_size), &binary_size,

--- a/test/conformance/program/urProgramCreateWithBinary.cpp
+++ b/test/conformance/program/urProgramCreateWithBinary.cpp
@@ -10,11 +10,14 @@ struct urProgramCreateWithBinaryTest : uur::urProgramTest {
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::SetUp());
         ASSERT_SUCCESS(urProgramBuild(context, program, nullptr));
         size_t binary_size = 0;
-        ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARIES, 0,
-                                        nullptr, &binary_size));
+        ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARY_SIZES,
+                                        sizeof(binary_size), &binary_size,
+                                        nullptr));
         binary.resize(binary_size);
+        uint8_t *binary_ptr = binary.data();
         ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARIES,
-                                        binary_size, binary.data(), nullptr));
+                                        sizeof(binary_ptr), &binary_ptr,
+                                        nullptr));
     }
 
     void TearDown() override {

--- a/test/conformance/program/urProgramLink.cpp
+++ b/test/conformance/program/urProgramLink.cpp
@@ -9,62 +9,48 @@ struct urProgramLinkTest : uur::urProgramTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::SetUp());
         ASSERT_SUCCESS(urProgramCompile(context, program, nullptr));
-        programs.push_back(program);
-
-        uur::KernelsEnvironment::instance->LoadSource("bar", 0, bar_binary);
-        ASSERT_SUCCESS(urProgramCreateWithIL(context, bar_binary->data(),
-                                             bar_binary->size(), nullptr,
-                                             &bar_program));
-        ASSERT_SUCCESS(urProgramCompile(context, bar_program, nullptr));
-        programs.push_back(bar_program);
     }
 
     void TearDown() override {
-        if (bar_program) {
-            EXPECT_SUCCESS(urProgramRelease(bar_program));
-        }
         if (linked_program) {
             EXPECT_SUCCESS(urProgramRelease(linked_program));
         }
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::TearDown());
     }
 
-    ur_program_handle_t bar_program = nullptr;
     ur_program_handle_t linked_program = nullptr;
-    std::shared_ptr<std::vector<char>> bar_binary;
-    std::vector<ur_program_handle_t> programs;
 };
 UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urProgramLinkTest);
 
 TEST_P(urProgramLinkTest, Success) {
-    ASSERT_SUCCESS(urProgramLink(context, programs.size(), programs.data(),
-                                 nullptr, &linked_program));
+    ASSERT_SUCCESS(
+        urProgramLink(context, 1, &program, nullptr, &linked_program));
     ur_program_binary_type_t binary_type = UR_PROGRAM_BINARY_TYPE_NONE;
     ASSERT_SUCCESS(urProgramGetBuildInfo(
-        program, device, UR_PROGRAM_BUILD_INFO_BINARY_TYPE, sizeof(binary_type),
-        &binary_type, nullptr));
+        linked_program, device, UR_PROGRAM_BUILD_INFO_BINARY_TYPE,
+        sizeof(binary_type), &binary_type, nullptr));
+    ASSERT_EQ(binary_type, UR_PROGRAM_BINARY_TYPE_EXECUTABLE);
 }
 
 TEST_P(urProgramLinkTest, InvalidNullHandleContext) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                     urProgramLink(nullptr, programs.size(), programs.data(),
-                                   nullptr, &linked_program));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+        urProgramLink(nullptr, 1, &program, nullptr, &linked_program));
 }
 
 TEST_P(urProgramLinkTest, InvalidNullPointerProgram) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urProgramLink(context, programs.size(), programs.data(),
-                                   nullptr, nullptr));
+                     urProgramLink(context, 1, &program, nullptr, nullptr));
 }
 
 TEST_P(urProgramLinkTest, InvalidNullPointerInputPrograms) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urProgramLink(context, programs.size(), nullptr, nullptr,
-                                   &linked_program));
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urProgramLink(context, 1, nullptr, nullptr, &linked_program));
 }
 
 TEST_P(urProgramLinkTest, InvalidSizeCount) {
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_SIZE,
-        urProgramLink(context, 0, programs.data(), nullptr, &linked_program));
+        urProgramLink(context, 0, &program, nullptr, &linked_program));
 }


### PR DESCRIPTION
We now no longer attempt to link two programs with duplicate definitions together (the SPIR-V dpc++ generates for us always contains a wrapper function with the same name and function signature)

We also now correctly query program binaries