### PR TITLE
Temporarily disable running check-generated target in windows CI.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -123,9 +123,10 @@ jobs:
         -DUR_BUILD_TESTS=ON
         -DUR_FORMAT_CPP_STYLE=ON
 
-    - name: Generate source from spec, check for uncommitted diff
-      if: matrix.os == 'windows-2022'
-      run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{matrix.build_type}}
+    # TODO: re-enable when check-generated is fixed for windows runners see #888
+    # - name: Generate source from spec, check for uncommitted diff
+    #   if: matrix.os == 'windows-2022'
+    #   run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{matrix.build_type}}
 
     - name: Build all
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j 2


### PR DESCRIPTION
See issue #888 