### PR TITLE
[test] improve match file error output

### DIFF
--- a/cmake/match.cmake
+++ b/cmake/match.cmake
@@ -71,9 +71,7 @@ execute_process(
 )
 
 if(TEST_RESULT)
-    file(READ ${OUT_FILE} OUTPUT)
-    file(READ ${MATCH_FILE} MATCH_STRING)
-    message(FATAL_ERROR "Failed: The output of ${OUT_FILE}:\n  ${OUTPUT}\n does not match ${MATCH_FILE}:\n ${MATCH_STRING} (${TEST_RESULT})")
+    message(FATAL_ERROR "Failed (${TEST_RESULT}): The output of ${OUT_FILE} does not match ${MATCH_FILE}")
 elseif()
     message("Passed: The output ${OUT_FILE} matches ${MATCH_FILE}")
 endif()

--- a/cmake/match.py
+++ b/cmake/match.py
@@ -60,6 +60,11 @@ for i, match_line in enumerate(match_lines):
             print("Line " + str(i+1) + " does not match")
             print("is:       " + input_line)
             print("expected: " + match_line.strip())
+            print("--- Input Lines " + "-" * 64)
+            print("".join(input_lines).strip())
+            print("--- Match Lines " + "-" * 64)
+            print("".join(match_lines).strip())
+            print("-" * 80)
             sys.exit(1)
     else:
         if (input_idx == len(input_lines) - 1):


### PR DESCRIPTION
When a test fails a match, cmakes print both the
input file and the match file, so that it's easy to see why the failure happened and how to fix it. Unfortunately, cmake was inserting 3 newlines between every line of both input and match files, making things hard to read.

This patch fixes this by moving match and input files printing to the python script.