### PR TITLE
[ur] Add missing event wait list to urEnqueueUSMAdvise

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -3101,9 +3101,9 @@ else:
 ###############################################################################
 ## @brief Function-pointer for urEnqueueUSMAdvise
 if __use_win_types:
-    _urEnqueueUSMAdvise_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_advice_flags_t, POINTER(ur_event_handle_t) )
+    _urEnqueueUSMAdvise_t = WINFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_advice_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 else:
-    _urEnqueueUSMAdvise_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_advice_flags_t, POINTER(ur_event_handle_t) )
+    _urEnqueueUSMAdvise_t = CFUNCTYPE( ur_result_t, ur_queue_handle_t, c_void_p, c_size_t, ur_usm_advice_flags_t, c_ulong, POINTER(ur_event_handle_t), POINTER(ur_event_handle_t) )
 
 ###############################################################################
 ## @brief Function-pointer for urEnqueueUSMFill2D

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -6707,12 +6707,17 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueUSMAdvise(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    const void *pMem,             ///< [in] pointer to the USM memory object
-    size_t size,                  ///< [in] size in bytes to be advised
-    ur_usm_advice_flags_t advice, ///< [in] USM memory advice
-    ur_event_handle_t *phEvent    ///< [out][optional] return an event object that identifies this particular
-                                  ///< command instance.
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    const void *pMem,                         ///< [in] pointer to the USM memory object
+    size_t size,                              ///< [in] size in bytes to be advised
+    ur_usm_advice_flags_t advice,             ///< [in] USM memory advice
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before this command can be executed.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+                                              ///< command does not wait on any event to complete.
+    ur_event_handle_t *phEvent                ///< [out][optional] return an event object that identifies this particular
+                                              ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9596,6 +9601,8 @@ typedef struct ur_enqueue_usm_advise_params_t {
     const void **ppMem;
     size_t *psize;
     ur_usm_advice_flags_t *padvice;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
     ur_event_handle_t **pphEvent;
 } ur_enqueue_usm_advise_params_t;
 

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1143,6 +1143,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnEnqueueUSMAdvise_t)(
     const void *,
     size_t,
     ur_usm_advice_flags_t,
+    uint32_t,
+    const ur_event_handle_t *,
     ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -1151,6 +1151,14 @@ params:
     - type: $x_usm_advice_flags_t
       name: advice
       desc: "[in] USM memory advice"
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before this command can be executed.
+            If nullptr, the numEventsInWaitList must be 0, indicating that this command does not wait on any event to complete.
     - type: $x_event_handle_t*
       name: phEvent
       desc: |

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -3562,6 +3562,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     const void *pMem,             ///< [in] pointer to the USM memory object
     size_t size,                  ///< [in] size in bytes to be advised
     ur_usm_advice_flags_t advice, ///< [in] USM memory advice
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
     ur_event_handle_t *
         phEvent ///< [out][optional] return an event object that identifies this particular
                 ///< command instance.
@@ -3571,7 +3577,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     // if the driver has created a custom function, then call it instead of using the generic path
     auto pfnUSMAdvise = d_context.urDdiTable.Enqueue.pfnUSMAdvise;
     if (nullptr != pfnUSMAdvise) {
-        result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
+        result = pfnUSMAdvise(hQueue, pMem, size, advice, numEventsInWaitList,
+                              phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -12657,6 +12657,24 @@ inline std::ostream &operator<<(
     ur_params::serializeFlag<ur_usm_advice_flag_t>(os, *(params->padvice));
 
     os << ", ";
+    os << ".numEventsInWaitList = ";
+
+    os << *(params->pnumEventsInWaitList);
+
+    os << ", ";
+    os << ".phEventWaitList = {";
+    for (size_t i = 0; *(params->pphEventWaitList) != NULL &&
+                       i < *params->pnumEventsInWaitList;
+         ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur_params::serializePtr(os, (*(params->pphEventWaitList))[i]);
+    }
+    os << "}";
+
+    os << ", ";
     os << ".phEvent = ";
 
     ur_params::serializePtr(os, *(params->pphEvent));

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -4047,6 +4047,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     const void *pMem,             ///< [in] pointer to the USM memory object
     size_t size,                  ///< [in] size in bytes to be advised
     ur_usm_advice_flags_t advice, ///< [in] USM memory advice
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
     ur_event_handle_t *
         phEvent ///< [out][optional] return an event object that identifies this particular
                 ///< command instance.
@@ -4057,12 +4063,15 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_enqueue_usm_advise_params_t params = {&hQueue, &pMem, &size, &advice,
-                                             &phEvent};
+    ur_enqueue_usm_advise_params_t params = {
+        &hQueue,          &pMem,   &size, &advice, &numEventsInWaitList,
+        &phEventWaitList, &phEvent};
     uint64_t instance = context.notify_begin(UR_FUNCTION_ENQUEUE_USM_ADVISE,
                                              "urEnqueueUSMAdvise", &params);
 
-    ur_result_t result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
+    ur_result_t result =
+        pfnUSMAdvise(hQueue, pMem, size, advice, numEventsInWaitList,
+                     phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_ENQUEUE_USM_ADVISE, "urEnqueueUSMAdvise",
                        &params, &result, instance);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -5104,6 +5104,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     const void *pMem,             ///< [in] pointer to the USM memory object
     size_t size,                  ///< [in] size in bytes to be advised
     ur_usm_advice_flags_t advice, ///< [in] USM memory advice
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
     ur_event_handle_t *
         phEvent ///< [out][optional] return an event object that identifies this particular
                 ///< command instance.
@@ -5132,7 +5138,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
         }
     }
 
-    ur_result_t result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
+    ur_result_t result =
+        pfnUSMAdvise(hQueue, pMem, size, advice, numEventsInWaitList,
+                     phEventWaitList, phEvent);
 
     return result;
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -5776,6 +5776,12 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
     const void *pMem,             ///< [in] pointer to the USM memory object
     size_t size,                  ///< [in] size in bytes to be advised
     ur_usm_advice_flags_t advice, ///< [in] USM memory advice
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
     ur_event_handle_t *
         phEvent ///< [out][optional] return an event object that identifies this particular
                 ///< command instance.
@@ -5785,7 +5791,8 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
+    return pfnUSMAdvise(hQueue, pMem, size, advice, numEventsInWaitList,
+                        phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -4914,6 +4914,12 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
     const void *pMem,             ///< [in] pointer to the USM memory object
     size_t size,                  ///< [in] size in bytes to be advised
     ur_usm_advice_flags_t advice, ///< [in] USM memory advice
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before this command can be executed.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that this
+    ///< command does not wait on any event to complete.
     ur_event_handle_t *
         phEvent ///< [out][optional] return an event object that identifies this particular
                 ///< command instance.

--- a/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
@@ -14,7 +14,7 @@ UUR_TEST_SUITE_P(urEnqueueUSMAdviseWithParamTest,
 TEST_P(urEnqueueUSMAdviseWithParamTest, Success) {
     ur_event_handle_t advise_event = nullptr;
     ASSERT_SUCCESS(urEnqueueUSMAdvise(queue, ptr, allocation_size, getParam(),
-                                      &advise_event));
+                                      0, nullptr, &advise_event));
 
     ASSERT_NE(advise_event, nullptr);
     ASSERT_SUCCESS(urQueueFlush(queue));
@@ -35,36 +35,42 @@ TEST_P(urEnqueueUSMAdviseTest, MultipleParamsSuccess) {
     ASSERT_SUCCESS(urEnqueueUSMAdvise(queue, ptr, allocation_size,
                                       UR_USM_ADVICE_FLAG_SET_READ_MOSTLY |
                                           UR_USM_ADVICE_FLAG_BIAS_CACHED,
-                                      nullptr));
+                                      0, nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMAdviseTest, InvalidNullHandleQueue) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urEnqueueUSMAdvise(nullptr, ptr, allocation_size,
-                                        UR_USM_ADVICE_FLAG_DEFAULT, nullptr));
+                                        UR_USM_ADVICE_FLAG_DEFAULT, 0, nullptr,
+                                        nullptr));
 }
 
 TEST_P(urEnqueueUSMAdviseTest, InvalidNullPointerMem) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                      urEnqueueUSMAdvise(queue, nullptr, allocation_size,
-                                        UR_USM_ADVICE_FLAG_DEFAULT, nullptr));
+                                        UR_USM_ADVICE_FLAG_DEFAULT, 0, nullptr,
+                                        nullptr));
 }
 
 TEST_P(urEnqueueUSMAdviseTest, InvalidEnumeration) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urEnqueueUSMAdvise(queue, ptr, allocation_size,
-                                        UR_USM_ADVICE_FLAG_FORCE_UINT32,
-                                        nullptr));
+                                        UR_USM_ADVICE_FLAG_FORCE_UINT32, 0,
+                                        nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMAdviseTest, InvalidSizeZero) {
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_SIZE,
-        urEnqueueUSMAdvise(queue, ptr, 0, UR_USM_ADVICE_FLAG_DEFAULT, nullptr));
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                     urEnqueueUSMAdvise(queue, ptr, 0,
+                                        UR_USM_ADVICE_FLAG_DEFAULT, 0, nullptr,
+                                        nullptr));
 }
 
 TEST_P(urEnqueueUSMAdviseTest, InvalidSizeTooLarge) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urEnqueueUSMAdvise(queue, ptr, allocation_size * 2,
-                                        UR_USM_ADVICE_FLAG_DEFAULT, nullptr));
+                                        UR_USM_ADVICE_FLAG_DEFAULT, 0, nullptr,
+                                        nullptr));
 }
+
+// TODO: Add tests for numEventsInWaitList/phEventWaitList.


### PR DESCRIPTION
The `urEnqueueUSMAdvise` entry-point was missing the `numEventsInWaitList`/`phEventWaitList` arguments which all enqueue entry-points *must* have in order to properly define dependencies between enqueued commands, fixed in this patch.
