### PR TITLE
[L0] Add missing loader interfaces to L0 adapter

### DIFF
--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -390,3 +390,41 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
   pDdiTable->pfnPitchedAllocExp = urUSMPitchedAllocExp;
   return UR_RESULT_SUCCESS;
 }
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_virtual_mem_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+  auto retVal = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != retVal) {
+    return retVal;
+  }
+
+  pDdiTable->pfnFree = nullptr;
+  pDdiTable->pfnGetInfo = nullptr;
+  pDdiTable->pfnGranularityGetInfo = nullptr;
+  pDdiTable->pfnMap = nullptr;
+  pDdiTable->pfnReserve = nullptr;
+  pDdiTable->pfnSetAccess = nullptr;
+  pDdiTable->pfnUnmap = nullptr;
+
+  return retVal;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetPhysicalMemProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_physical_mem_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+  auto retVal = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != retVal) {
+    return retVal;
+  }
+
+  pDdiTable->pfnCreate = nullptr;
+  pDdiTable->pfnRelease = nullptr;
+  pDdiTable->pfnRetain = nullptr;
+
+  return retVal;
+}


### PR DESCRIPTION
These symbols are required to be exported by the .def file on Windows