### PR TITLE
CI: Cancel stale workflows when new commits are added to a PR

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -3,6 +3,10 @@ name: Bandit
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     name: Bandit

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,10 @@ name: Build and test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu-build:
     name: Build - Ubuntu

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,10 @@ name: "CodeQL"
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze-ubuntu:
     name: Analyze on Ubuntu


### PR DESCRIPTION
We have a limited number of runners for the adapter testing jobs, so this helps avoid congestion