### PR TITLE
Another small batch of CTS fixes

### DIFF
--- a/test/conformance/event/fixtures.h
+++ b/test/conformance/event/fixtures.h
@@ -65,6 +65,7 @@ struct urEventReferenceTest : uur::urProfilingQueueTest {
         input.assign(count, 42);
         ASSERT_SUCCESS(urEnqueueMemBufferWrite(
             queue, buffer, false, 0, size, input.data(), 0, nullptr, &event));
+        ASSERT_SUCCESS(urEventWait(1, &event));
     }
 
     void TearDown() override {

--- a/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
@@ -25,7 +25,7 @@ struct urKernelCreateWithNativeHandleTest : uur::urKernelTest {
     ur_kernel_native_properties_t properties = {
         UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES, /*sType*/
         nullptr,                                    /*pNext*/
-        true                                        /*isNativeHandleOwned*/
+        false                                       /*isNativeHandleOwned*/
     };
 };
 UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urKernelCreateWithNativeHandleTest);

--- a/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -23,9 +23,9 @@ TEST_P(urQueueCreateWithNativeHandleTest, Success) {
                                                  &properties, &q));
     ASSERT_NE(q, nullptr);
 
-    uint32_t q_size = 0;
-    ASSERT_SUCCESS(urQueueGetInfo(q, UR_QUEUE_INFO_SIZE, sizeof(uint32_t),
-                                  &q_size, nullptr));
-
+    ur_context_handle_t q_context = nullptr;
+    ASSERT_SUCCESS(urQueueGetInfo(q, UR_QUEUE_INFO_CONTEXT, sizeof(q_context),
+                                  &q_context, nullptr));
+    ASSERT_EQ(q_context, context);
     ASSERT_SUCCESS(urQueueRelease(q));
 }

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -29,17 +29,22 @@ UUR_TEST_SUITE_P(urQueueGetInfoTestWithInfoParam,
 TEST_P(urQueueGetInfoTestWithInfoParam, Success) {
     ur_queue_info_t info_type = getParam();
     size_t size = 0;
-    ASSERT_SUCCESS(urQueueGetInfo(queue, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
+    auto result = urQueueGetInfo(queue, info_type, 0, nullptr, &size);
 
-    if (const auto expected_size = queue_info_size_map.find(info_type);
-        expected_size != queue_info_size_map.end()) {
-        ASSERT_EQ(expected_size->second, size);
+    if (result == UR_RESULT_SUCCESS) {
+        ASSERT_NE(size, 0);
+
+        if (const auto expected_size = queue_info_size_map.find(info_type);
+            expected_size != queue_info_size_map.end()) {
+            ASSERT_EQ(expected_size->second, size);
+        }
+
+        std::vector<uint8_t> data(size);
+        ASSERT_SUCCESS(
+            urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
+    } else {
+        ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
     }
-
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(
-        urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
 }
 
 using urQueueGetInfoTest = uur::urQueueTest;


### PR DESCRIPTION
Mostly these are consistency related:

* Add missing EventWait to event fixture
* Set isNativeHandleOwned to false in KernelCreateWithNativeHandleTest
* Use more commonly supported UR_QUEUE_INFO_CONTEXT query in QueueCreateWithNativeHandleTest
* Add UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION path to QueueGetInfo test