### PR TITLE
Add testing for memory management across multi-device contexts

### DIFF
--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -216,3 +216,49 @@ TEST_P(urEnqueueKernelLaunchWithVirtualMemory, Success) {
         ASSERT_EQ(fill_val, data.at(i));
     }
 }
+
+struct urEnqueueKernelLaunchMultiDeviceTest : public urEnqueueKernelLaunchTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urEnqueueKernelLaunchTest::SetUp());
+        queues.reserve(uur::DevicesEnvironment::instance->devices.size());
+        for (const auto &device : uur::DevicesEnvironment::instance->devices) {
+            ur_queue_handle_t queue = nullptr;
+            ASSERT_SUCCESS(urQueueCreate(this->context, device, 0, &queue));
+            queues.push_back(queue);
+        }
+    }
+
+    void TearDown() override {
+        for (const auto &queue : queues) {
+            EXPECT_SUCCESS(urQueueRelease(queue));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(urEnqueueKernelLaunchTest::TearDown());
+    }
+
+    std::vector<ur_queue_handle_t> queues;
+};
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchMultiDeviceTest);
+
+TEST_P(urEnqueueKernelLaunchMultiDeviceTest, KernelLaunchReadDifferentQueues) {
+    ur_mem_handle_t buffer = nullptr;
+    AddBuffer1DArg(sizeof(val) * global_size, &buffer);
+    AddPodArg(val);
+    ASSERT_SUCCESS(urEnqueueKernelLaunch(queues[0], kernel, n_dimensions,
+                                         &global_offset, &global_size, nullptr,
+                                         0, nullptr, nullptr));
+
+    // Wait for the queue to finish executing.
+    EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
+
+    // Then the remaining queues do blocking reads from the buffer. Since the
+    // queues target different devices this checks that any devices memory has
+    // been synchronized.
+    for (unsigned i = 1; i < queues.size(); ++i) {
+        const auto queue = queues[i];
+        uint32_t output = 0;
+        ASSERT_SUCCESS(urEnqueueMemBufferRead(queue, buffer, true, 0,
+                                              sizeof(output), &output, 0,
+                                              nullptr, nullptr));
+        ASSERT_EQ(val, output) << "Result on queue " << i << " did not match!";
+    }
+}

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -188,7 +188,8 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
 using urEnqueueMemBufferReadRectMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
 
-TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest, WriteReadDifferentQueues) {
+TEST_F(urEnqueueMemBufferReadRectMultiDeviceTest,
+       WriteRectReadDifferentQueues) {
     // First queue does a blocking write of 42 into the buffer.
     // Then a rectangular write the buffer as 1024x1x1 1D.
     std::vector<uint32_t> input(count, 42);

--- a/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -251,3 +251,63 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidSize) {
                                            {1, 0, 0}, size, 0, nullptr,
                                            nullptr));
 }
+
+using urEnqueueMemImageCopyMultiDeviceTest =
+    uur::urMultiDeviceMemImageWriteTest;
+
+TEST_F(urEnqueueMemImageCopyMultiDeviceTest, CopyReadDifferentQueues) {
+    ur_mem_handle_t dstImage1D = nullptr;
+    ASSERT_SUCCESS(urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE, &format,
+                                    &desc1D, nullptr, &dstImage1D));
+    ASSERT_SUCCESS(urEnqueueMemImageCopy(queues[0], image1D, dstImage1D, origin,
+                                         origin, region1D, 0, nullptr,
+                                         nullptr));
+
+    ur_mem_handle_t dstImage2D = nullptr;
+    ASSERT_SUCCESS(urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE, &format,
+                                    &desc2D, nullptr, &dstImage2D));
+    ASSERT_SUCCESS(urEnqueueMemImageCopy(queues[0], image2D, dstImage2D, origin,
+                                         origin, region2D, 0, nullptr,
+                                         nullptr));
+
+    ur_mem_handle_t dstImage3D = nullptr;
+    ASSERT_SUCCESS(urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE, &format,
+                                    &desc3D, nullptr, &dstImage3D));
+    ASSERT_SUCCESS(urEnqueueMemImageCopy(queues[0], image3D, dstImage3D, origin,
+                                         origin, region3D, 0, nullptr,
+                                         nullptr));
+
+    // Wait for the queue to finish executing.
+    EXPECT_SUCCESS(urEnqueueEventsWait(queues[0], 0, nullptr, nullptr));
+
+    // The remaining queues do blocking reads from the image1D/2D/3D. Since the
+    // queues target different devices this checks that any devices memory has
+    // been synchronized.
+    for (unsigned i = 1; i < queues.size(); ++i) {
+        const auto queue = queues[i];
+
+        std::vector<uint32_t> output1D(width * 4, 42);
+        ASSERT_SUCCESS(urEnqueueMemImageRead(queue, image1D, true, origin,
+                                             region1D, 0, 0, output1D.data(), 0,
+                                             nullptr, nullptr));
+
+        std::vector<uint32_t> output2D(width * height * 4, 42);
+        ASSERT_SUCCESS(urEnqueueMemImageRead(queue, image2D, true, origin,
+                                             region2D, 0, 0, output2D.data(), 0,
+                                             nullptr, nullptr));
+
+        std::vector<uint32_t> output3D(width * height * depth * 4, 42);
+        ASSERT_SUCCESS(urEnqueueMemImageRead(queue, image3D, true, origin,
+                                             region3D, 0, 0, output3D.data(), 0,
+                                             nullptr, nullptr));
+
+        ASSERT_EQ(input1D, output1D)
+            << "Result on queue " << i << " for 1D image did not match!";
+
+        ASSERT_EQ(input2D, output2D)
+            << "Result on queue " << i << " for 2D image did not match!";
+
+        ASSERT_EQ(input3D, output3D)
+            << "Result on queue " << i << " for 3D image did not match!";
+    }
+}


### PR DESCRIPTION
Fixes [862](https://github.com/oneapi-src/unified-runtime/issues/862)