### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*                               @oneapi-src/unified-runtime-maintain


### PR DESCRIPTION
Adapter implementations are being moved into the repo we should mirror the code ownership of those implementations. This patch adds a CODEOWNERS file which matches the pre adapter move ownership to be used as a baseline for future changes for each individual adapter.

