### PR TITLE
[UR] bump libxml requirement version

### DIFF
--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -12,7 +12,7 @@ exhale==0.3.0
 idna==2.8
 imagesize==1.1.0
 Jinja2==2.11.3
-lxml==4.9.1
+lxml==4.9.3
 Mako==1.1.0
 MarkupSafe==1.1.1
 packaging==19.2


### PR DESCRIPTION
It cannot be found on a (bare metal) machine with Win Server 2022.