### PR TITLE
[UR][L0][CMake] Disable warning for ICX on Windows

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -56,7 +56,8 @@ target_link_libraries(LevelZeroLoader
     INTERFACE "${LEVEL_ZERO_LIB_NAME}"
 )
 
-if (NOT MSVC)
+# Windows build might have warnings (both MSVC and ICX), disable Werror etc.
+if (NOT WIN32)
     target_compile_options(${LEVEL_ZERO_LIB_NAME} PUBLIC
         -Wno-unused-but-set-variable
         -Wno-pedantic


### PR DESCRIPTION
On Windows we may build L0 using ICX , this is to revert changes to
check WIN32 instead of MSVC, to fix build failures with ICX on Windows.
