### PR TITLE
[L0] fix windows cmake scripts

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -266,7 +266,16 @@ jobs:
     strategy:
       matrix:
         os: ['windows-2019', 'windows-2022']
+        adapter: [
+          {name: None, var: ''}, {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
+        ]
+
+        # TODO: building level zero loader on windows-2019 is currently broken
+        exclude:
+         - os: 'windows-2019'
+           adapter: {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
         build_type: [Debug, Release]
+        compiler: [{c: cl.exe, cxx: cl.exe}, {c: clang-cl.exe, cxx: clang-cl.exe}]
     runs-on: ${{matrix.os}}
 
     steps:
@@ -283,11 +292,14 @@ jobs:
       run: >
         cmake
         -B${{github.workspace}}/build
+        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
         -DUR_ENABLE_TRACING=ON
         -DUR_DEVELOPER_MODE=ON
         -DUR_BUILD_TESTS=ON
         -DUR_FORMAT_CPP_STYLE=ON
+        ${{matrix.adapter.var}}
 
     # TODO: re-enable when check-generated is fixed for windows runners see #888
     # - name: Generate source from spec, check for uncommitted diff

--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -23,20 +23,16 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         GIT_REPOSITORY    ${LEVEL_ZERO_LOADER_REPO}
         GIT_TAG           ${LEVEL_ZERO_LOADER_TAG}
     )
-    set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
     if(MSVC)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX-")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX-")
-      # FIXME: Unified runtime build fails with /DUNICODE
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /UUNICODE")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /UUNICODE")
-      # USE_Z7 forces use of /Z7 instead of /Zi which is broken with sccache
-      set(USE_Z7 ON)
+        set(USE_Z7 ON)
     endif()
     FetchContent_MakeAvailable(level-zero-loader)
     FetchContent_GetProperties(level-zero-loader)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BAK}")
+    target_compile_options(ze_loader PRIVATE
+        $<$<IN_LIST:$<CXX_COMPILER_ID>,GNU;Clang;Intel;IntelLLVM>:-Wno-error>
+        $<$<CXX_COMPILER_ID:MSVC>:/WX- /UUNICODE>
+    )
 
     set(LEVEL_ZERO_LIBRARY ze_loader)
     set(LEVEL_ZERO_INCLUDE_DIR
@@ -55,16 +51,6 @@ target_link_directories(LevelZeroLoader
 target_link_libraries(LevelZeroLoader
     INTERFACE "${LEVEL_ZERO_LIB_NAME}"
 )
-
-# Windows build might have warnings (both MSVC and ICX), disable Werror etc.
-if (NOT WIN32)
-    target_compile_options(${LEVEL_ZERO_LIB_NAME} PUBLIC
-        -Wno-unused-but-set-variable
-        -Wno-pedantic
-        -Wno-unused-parameter
-        -Wno-error
-    )
-endif()
 
 add_library (LevelZeroLoader-Headers INTERFACE)
 target_include_directories(LevelZeroLoader-Headers
@@ -104,6 +90,11 @@ add_ur_adapter(${TARGET_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/sampler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/image.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../ur/ur.cpp
+)
+
+# TODO: fix level_zero adapter conversion warnings
+target_compile_options(${TARGET_NAME} PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/wd4267 /wd4805 /wd4244 /D_CRT_SECURE_NO_WARNINGS>
 )
 
 set_target_properties(${TARGET_NAME} PROPERTIES


### PR DESCRIPTION
This patch addresses the portability of L0 cmake scripts and adds building L0 adapter in CI on Windows. There were a lot of conversion warnings in the L0 adapter itself, so I disabled these for now. I've also had to exclude windows 2019 from building the adapter because of these errors from level-zero loader:

```
2023-10-03T10:10:14.5073647Z   Building Custom Rule D:/a/unified-runtime/unified-runtime/source/adapters/null/CMakeLists.txt
2023-10-03T10:10:15.0383355Z D:\a\unified-runtime\unified-runtime\build\_deps\level-zero-loader-src\source\loader\windows\driver_discovery_win.cpp(37,69): error C2065: 'GUID_DEVCLASS_COMPUTEACCELERATOR': undeclared identifier [D:\a\unified-runtime\unified-runtime\build\_deps\level-zero-loader-build\source\ze_loader.vcxproj]
2023-10-03T10:10:15.0662878Z D:\a\unified-runtime\unified-runtime\build\_deps\level-zero-loader-src\source\loader\windows\driver_discovery_win.cpp(39,67): error C3536: 'computeDrivers': cannot be used before it is initialized [D:\a\unified-runtime\unified-runtime\build\_deps\level-zero-loader-build\source\ze_loader.vcxproj]
2023-10-03T10:10:15.1634971Z   ur_null.cpp
2023-10-03T10:10:15.2915021Z   ur_nullddi.cpp
2023-10-03T10:10:15.5559593Z D:\a\unified-runtime\unified-runtime\build\_deps\level-zero-loader-src\source\loader\windows\driver_discovery_win.cpp(39,97): error C2661: 'std::vector<loader::DriverLibraryPath,std::allocator<loader::DriverLibraryPath>>::insert': no overloaded function takes 1 arguments [D:\a\unified-runtime\unified-runtime\build\_deps\level-zero-loader-build\source\ze_loader.vcxproj]
```

I tried looking into this (maybe some windows component is missing?), but to no avail unfortunately.