### PR TITLE
Add validation layer support for nullptr events

### DIFF
--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -1328,3 +1328,14 @@ def get_create_retain_release_functions(specs, namespace, tags):
     )
 
     return {"create": create_funcs, "retain": retain_funcs, "release": release_funcs}
+
+
+def get_event_wait_list_functions(specs, namespace, tags):
+    funcs = []
+    for s in specs:
+        for obj in s['objects']:
+            if re.match(r"function", obj['type']):
+                if any(x['name'] == 'phEventWaitList' for x in obj['params']) and any(
+                        x['name'] == 'numEventsInWaitList' for x in obj['params']):
+                    funcs.append(make_func_name(namespace, tags, obj))
+    return funcs

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -63,7 +63,7 @@ namespace ur_validation_layer
             %if func_name in th.get_event_wait_list_functions(specs, n, tags):
             if (phEventWaitList != NULL && numEventsInWaitList > 0) {
                 for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                    if (*(phEventWaitList + i) == NULL) {
+                    if (phEventWaitList[i] == NULL) {
                         return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                     }
                 }

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -60,6 +60,16 @@ namespace ur_validation_layer
 
             %endfor
             %endfor
+            %if func_name in th.get_event_wait_list_functions(specs, n, tags):
+            if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+                for (uint i = 0; i < numEventsInWaitList; ++i) {
+                    if (*(phEventWaitList + i) == NULL) {
+                        return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                    }
+                }
+            }
+            %endif
+
         }
 
         ${x}_result_t result = ${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -62,7 +62,7 @@ namespace ur_validation_layer
             %endfor
             %if func_name in th.get_event_wait_list_functions(specs, n, tags):
             if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-                for (uint i = 0; i < numEventsInWaitList; ++i) {
+                for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                     if (*(phEventWaitList + i) == NULL) {
                         return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                     }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3967,7 +3967,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4017,7 +4017,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4067,7 +4067,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4128,7 +4128,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4192,7 +4192,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4306,7 +4306,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4425,7 +4425,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4488,7 +4488,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4595,7 +4595,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4678,7 +4678,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4749,7 +4749,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4821,7 +4821,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4893,7 +4893,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -4961,7 +4961,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5021,7 +5021,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5102,7 +5102,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5167,7 +5167,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5231,7 +5231,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5372,7 +5372,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5458,7 +5458,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5529,7 +5529,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5600,7 +5600,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5674,7 +5674,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -5748,7 +5748,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -6177,7 +6177,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -6551,7 +6551,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -6599,7 +6599,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -7471,7 +7471,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }
@@ -7549,7 +7549,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (*(phEventWaitList + i) == NULL) {
+                if (phEventWaitList[i] == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
             }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3964,6 +3964,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnKernelLaunch(
@@ -4006,6 +4014,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -4047,6 +4063,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4100,6 +4124,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4156,6 +4188,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4262,6 +4302,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
                     (hostRowPitch != 0 ? hostRowPitch : region.width) !=
                 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4374,6 +4422,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
                 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnMemBufferWriteRect(
@@ -4428,6 +4484,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4528,6 +4592,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnMemBufferCopyRect(
@@ -4603,6 +4675,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
         if (offset % patternSize != 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -4665,6 +4745,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
         if (region.width == 0 || region.height == 0 || region.depth == 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4730,6 +4818,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
         if (region.width == 0 || region.height == 0 || region.depth == 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnMemImageWrite(
@@ -4794,6 +4890,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
         if (region.width == 0 || region.height == 0 || region.depth == 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -4854,6 +4958,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags,
@@ -4905,6 +5017,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -4979,6 +5099,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -5036,6 +5164,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -5091,6 +5227,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -5225,6 +5369,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -5303,6 +5455,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -5366,6 +5526,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnDeviceGlobalVariableWrite(
@@ -5428,6 +5596,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -5495,6 +5671,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result =
@@ -5560,6 +5744,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -5982,6 +6174,14 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
         if (pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnImageCopyExp(
@@ -6348,6 +6548,14 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
         if (NULL == hSemaphore) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnWaitExternalSemaphoreExp(
@@ -6387,6 +6595,14 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
         if (NULL == hSemaphore) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 
@@ -7252,6 +7468,14 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
         }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
     }
 
     ur_result_t result = pfnEnqueueExp(
@@ -7321,6 +7545,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
         if (phEventWaitList != NULL && numEventsInWaitList == 0) {
             return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint i = 0; i < numEventsInWaitList; ++i) {
+                if (*(phEventWaitList + i) == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
         }
     }
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3966,7 +3966,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4016,7 +4016,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4066,7 +4066,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4127,7 +4127,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4191,7 +4191,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4305,7 +4305,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4424,7 +4424,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4487,7 +4487,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4594,7 +4594,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4677,7 +4677,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4748,7 +4748,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4820,7 +4820,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4892,7 +4892,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -4960,7 +4960,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5020,7 +5020,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5101,7 +5101,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5166,7 +5166,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5230,7 +5230,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5371,7 +5371,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5457,7 +5457,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5528,7 +5528,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5599,7 +5599,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5673,7 +5673,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -5747,7 +5747,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -6176,7 +6176,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -6550,7 +6550,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -6598,7 +6598,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -7470,7 +7470,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }
@@ -7548,7 +7548,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
         }
 
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint i = 0; i < numEventsInWaitList; ++i) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (*(phEventWaitList + i) == NULL) {
                     return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
                 }

--- a/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -80,4 +80,8 @@ TEST_P(urEnqueueEventsWaitTest, InvalidNullPtrEventWaitList) {
 
     ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 0, &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -89,4 +89,9 @@ TEST_P(urEnqueueEventsWaitWithBarrierTest, InvalidNullPtrEventWaitList) {
     ASSERT_EQ_RESULT(
         urEnqueueEventsWaitWithBarrier(queue1, 0, &validEvent, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(
+        urEnqueueEventsWaitWithBarrier(queue1, 1, &inv_evt, nullptr),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -56,6 +56,12 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidNullPtrEventWaitList) {
                                            &global_offset, &global_size,
                                            nullptr, 0, &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
+                                           &global_offset, &global_size,
+                                           nullptr, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueKernelLaunchTest, InvalidWorkDimension) {

--- a/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -74,6 +74,11 @@ TEST_P(urEnqueueMemBufferCopyTest, InvalidNullPtrEventWaitList) {
     ASSERT_EQ_RESULT(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
                                             size, 0, &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
+                                            size, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -219,6 +219,13 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
                                                 src_region, size, size, size,
                                                 size, 0, &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemBufferCopyRect(queue, src_buffer, dst_buffer,
+                                                src_origin, dst_origin,
+                                                src_region, size, size, size,
+                                                size, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 using urEnqueueMemBufferCopyRectMultiDeviceTest =

--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -183,6 +183,12 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullPtrEventWaitList) {
                                             sizeof(uint32_t), 0, size, 0,
                                             &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemBufferFill(queue, buffer, &pattern,
+                                            sizeof(uint32_t), 0, size, 1,
+                                            &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -187,6 +187,12 @@ TEST_P(urEnqueueMemBufferMapTest, InvalidNullPtrEventWaitList) {
                                            0, size, 0, &validEvent, nullptr,
                                            &map),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemBufferMap(queue, buffer, true,
+                                           UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
+                                           0, size, 1, &inv_evt, nullptr, &map),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -49,6 +49,12 @@ TEST_P(urEnqueueMemBufferReadTest, InvalidNullPtrEventWaitList) {
                                             output.data(), 0, &validEvent,
                                             nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemBufferRead(queue, buffer, true, 0, size,
+                                            output.data(), 1, &inv_evt,
+                                            nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -176,6 +176,13 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
                                    host_offset, region, size, size, size, size,
                                    dst.data(), 0, &validEvent, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(
+        urEnqueueMemBufferReadRect(queue, buffer, true, buffer_offset,
+                                   host_offset, region, size, size, size, size,
+                                   dst.data(), 1, &inv_evt, nullptr),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 using urEnqueueMemBufferReadRectMultiDeviceTest =

--- a/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -61,6 +61,12 @@ TEST_P(urEnqueueMemBufferWriteTest, InvalidNullPtrEventWaitList) {
                                              input.data(), 0, &validEvent,
                                              nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemBufferWrite(queue, buffer, true, 0, size,
+                                             input.data(), 1, &inv_evt,
+                                             nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -183,6 +183,13 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {
                                     host_offset, region, size, size, size, size,
                                     src.data(), 0, &validEvent, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(
+        urEnqueueMemBufferWriteRect(queue, buffer, true, buffer_offset,
+                                    host_offset, region, size, size, size, size,
+                                    src.data(), 1, &inv_evt, nullptr),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -233,6 +233,12 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidNullPtrEventWaitList) {
                                            {0, 0, 0}, size, 0, &validEvent,
                                            nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemImageCopy(queue, srcImage, dstImage, {0, 0, 0},
+                                           {0, 0, 0}, size, 1, &inv_evt,
+                                           nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemImageCopyTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemImageRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageRead.cpp
@@ -69,6 +69,12 @@ TEST_P(urEnqueueMemImageReadTest, InvalidNullPtrEventWaitList) {
                                            region1D, 0, 0, output.data(), 0,
                                            &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemImageRead(queue, image1D, true, origin,
+                                           region1D, 0, 0, output.data(), 1,
+                                           &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemImageReadTest, InvalidOrigin1D) {

--- a/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
@@ -66,6 +66,12 @@ TEST_P(urEnqueueMemImageWriteTest, InvalidNullPtrEventWaitList) {
                                             region1D, 0, 0, input.data(), 0,
                                             &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueMemImageWrite(queue, image1D, true, origin,
+                                            region1D, 0, 0, input.data(), 1,
+                                            &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 TEST_P(urEnqueueMemImageWriteTest, InvalidOrigin1D) {

--- a/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -50,4 +50,9 @@ TEST_P(urEnqueueMemUnmapTest, InvalidNullPtrEventWaitList) {
     ASSERT_EQ_RESULT(
         urEnqueueMemUnmap(queue, buffer, map, 0, &validEvent, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(
+        urEnqueueMemUnmap(queue, buffer, map, 1, &inv_evt, nullptr),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
+++ b/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
@@ -76,4 +76,10 @@ TEST_P(urEnqueueReadHostPipeTest, InvalidEventWaitList) {
                      urEnqueueReadHostPipe(queue, program, pipe_symbol,
                                            /*blocking*/ true, &buffer, size, 0,
                                            &validEvent, nullptr));
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueReadHostPipe(queue, program, pipe_symbol,
+                                           /*blocking*/ true, &buffer, size, 1,
+                                           &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -203,4 +203,9 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidEventWaitList) {
     ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
                                       size, 0, &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
+                                      size, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -273,4 +273,10 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtrEventWaitList) {
                                         pattern.data(), width, 1, 0,
                                         &validEvent, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, pattern_size,
+                                        pattern.data(), width, 1, 1, &inv_evt,
+                                        nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -158,6 +158,11 @@ TEST_P(urEnqueueUSMMemcpyTest, InvalidNullPtrEventWaitList) {
                                         allocation_size, 0, &memset_event,
                                         nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy(queue, true, device_dst, device_src,
+                                        allocation_size, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMMemcpyTest);

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -183,5 +183,10 @@ TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidEventWaitList) {
                      urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
                                           width, height, 0, &event, nullptr));
 
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
+                                          width, height, 1, &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
     ASSERT_SUCCESS(urEventRelease(event));
 }

--- a/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -122,4 +122,10 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
                      urEnqueueUSMPrefetch(queue, ptr, allocation_size,
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 0,
                                           &validEvent, nullptr));
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueUSMPrefetch(queue, ptr, allocation_size,
+                                          UR_USM_MIGRATION_FLAG_DEFAULT, 1,
+                                          &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }

--- a/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
+++ b/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
@@ -76,4 +76,10 @@ TEST_P(urEnqueueWriteHostPipeTest, InvalidEventWaitList) {
                      urEnqueueWriteHostPipe(queue, program, pipe_symbol,
                                             /*blocking*/ true, &buffer, size, 0,
                                             &validEvent, nullptr));
+
+    ur_event_handle_t inv_evt = nullptr;
+    ASSERT_EQ_RESULT(urEnqueueWriteHostPipe(queue, program, pipe_symbol,
+                                            /*blocking*/ true, &buffer, size, 1,
+                                            &inv_evt, nullptr),
+                     UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }


### PR DESCRIPTION
Adds checks in the validation layer for the case where the event wait list parameter in urEnqueue entrypoints contains a nullptr event.

- Also adds more tests because this behaviour was only being checked for urEnqueueDeviceGetGlobalVariableRead and urEnqueueDeviceGetGlobalVariableWrite