### PR TITLE
[UR] [CUDA] Changed the output of querying localMemSize

### DIFF
--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -501,12 +501,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       return ReturnValue(
           static_cast<uint64_t>(hDevice->getMaxChosenLocalMem()));
     } else {
-      int LocalMemSize = 0;
-      UR_CHECK_ERROR(cuDeviceGetAttribute(
-          &LocalMemSize, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
-          hDevice->get()));
-      detail::ur::assertion(LocalMemSize >= 0);
-      return ReturnValue(static_cast<uint64_t>(LocalMemSize));
+      return ReturnValue(
+          static_cast<uint64_t>(hDevice->getMaxCapacityLocalMem()));
     }
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {

--- a/source/adapters/cuda/device.hpp
+++ b/source/adapters/cuda/device.hpp
@@ -45,6 +45,9 @@ public:
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxRegsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
         cuDevice));
+    UR_CHECK_ERROR(cuDeviceGetAttribute(
+        &MaxCapacityLocalMem,
+        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, cuDevice));
 
     // Set local mem max size if env var is present
     static const char *LocalMemSizePtrUR =
@@ -56,9 +59,6 @@ public:
                           : (LocalMemSizePtrPI ? LocalMemSizePtrPI : nullptr);
 
     if (LocalMemSizePtr) {
-      cuDeviceGetAttribute(
-          &MaxCapacityLocalMem,
-          CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, cuDevice);
       MaxChosenLocalMem = std::atoi(LocalMemSizePtr);
       MaxLocalMemSizeChosen = true;
     }

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -295,7 +295,7 @@ setKernelParams(const ur_context_handle_t Context,
       // Set up local memory requirements for kernel.
       if (Device->getMaxChosenLocalMem() < 0) {
         bool EnvVarHasURPrefix =
-            (std::getenv("UR_CUDA_MAX_LOCAL_MEM_SIZE") != nullptr);
+            std::getenv("UR_CUDA_MAX_LOCAL_MEM_SIZE") != nullptr;
         setErrorMessage(EnvVarHasURPrefix ? "Invalid value specified for "
                                             "UR_CUDA_MAX_LOCAL_MEM_SIZE"
                                           : "Invalid value specified for "
@@ -305,7 +305,7 @@ setKernelParams(const ur_context_handle_t Context,
       }
       if (LocalSize > static_cast<uint32_t>(Device->getMaxChosenLocalMem())) {
         bool EnvVarHasURPrefix =
-            (std::getenv("UR_CUDA_MAX_LOCAL_MEM_SIZE") != nullptr);
+            std::getenv("UR_CUDA_MAX_LOCAL_MEM_SIZE") != nullptr;
         setErrorMessage(
             EnvVarHasURPrefix
                 ? "Local memory for kernel exceeds the amount requested using "

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -286,7 +286,7 @@ setKernelParams(const ur_context_handle_t Context,
 
     auto Device = Context->getDevice();
     if (LocalSize > static_cast<uint32_t>(Device->getMaxCapacityLocalMem())) {
-      setErrorMessage("Too much local memory allocated for device",
+      setErrorMessage("Excessive allocation of local memory on the device",
                       UR_RESULT_ERROR_ADAPTER_SPECIFIC);
       return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }


### PR DESCRIPTION
With this patch when the user asks for the amount of `localMemSize`, they receive the maximum amount available on the SM. Setting the maximum limit with the env variable still remains an option. 