### PR TITLE
Fix a couple of minor issues in the USM fill and memcpy tests

### DIFF
--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -189,6 +189,7 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullPtrEventWaitList) {
                                             sizeof(uint32_t), 0, size, 1,
                                             &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -208,4 +208,5 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidEventWaitList) {
     ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
                                       size, 1, &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -66,8 +66,8 @@ struct urEnqueueUSMFill2DTestWithParam
                                             nullptr, nullptr));
 
         size_t pattern_index = 0;
-        for (size_t w = 0; w < width; ++w) {
-            for (size_t h = 0; h < height; ++h) {
+        for (size_t h = 0; h < height; ++h) {
+            for (size_t w = 0; w < width; ++w) {
                 uint8_t *host_ptr = host_mem.data();
                 size_t index = (pitch * h) + w;
                 ASSERT_TRUE((*(host_ptr + index) == pattern[pattern_index]));
@@ -279,4 +279,5 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullPtrEventWaitList) {
                                         pattern.data(), width, 1, 1, &inv_evt,
                                         nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -115,6 +115,7 @@ TEST_P(urEnqueueUSMMemcpyTest, NonBlocking) {
                                       allocation_size, 0, nullptr,
                                       &memcpy_event));
     ASSERT_SUCCESS(urEventWait(1, &memcpy_event));
+    ASSERT_SUCCESS(urEventRelease(memcpy_event));
 
     ASSERT_NO_FATAL_FAILURE(verifyData());
 }

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -104,6 +104,7 @@ TEST_P(urEnqueueUSMMemcpy2DTestWithParam, SuccessNonBlocking) {
     ASSERT_SUCCESS(uur::GetEventInfo<ur_event_status_t>(
         memcpy_event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS, event_status));
     ASSERT_EQ(event_status, UR_EVENT_STATUS_COMPLETE);
+    ASSERT_SUCCESS(urEventRelease(memcpy_event));
 
     ASSERT_NO_FATAL_FAILURE(verifyMemcpySucceeded());
 }
@@ -169,7 +170,7 @@ TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidSize) {
 TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidEventWaitList) {
     // enqueue something to get an event
     ur_event_handle_t event = nullptr;
-    int fill_pattern = 14;
+    uint8_t fill_pattern = 14;
     ASSERT_SUCCESS(urEnqueueUSMFill2D(queue, pDst, pitch, sizeof(fill_pattern),
                                       &fill_pattern, width, height, 0, nullptr,
                                       &event));


### PR DESCRIPTION
* Release a couple of events
* Check the output buffer for Fill2D row first instead of column first
* Change size of a pattern to match the size of a fill