### PR TITLE
[umf] change default MinBucketSize and ensure buckets are generated from the min size 8

### DIFF
--- a/source/common/umf_pools/disjoint_pool.cpp
+++ b/source/common/umf_pools/disjoint_pool.cpp
@@ -293,6 +293,8 @@ class DisjointPool::AllocImpl {
         // Generate buckets sized such as: 64, 96, 128, 192, ..., CutOff.
         // Powers of 2 and the value halfway between the powers of 2.
         auto Size1 = params.MinBucketSize;
+        // Buckets sized smaller than the bucket default size- 8 aren't needed.
+        Size1 = std::max(Size1, MIN_BUCKET_DEFAULT_SIZE);
         auto Size2 = Size1 + Size1 / 2;
         for (; Size2 < CutOff; Size1 *= 2, Size2 *= 2) {
             Buckets.push_back(std::make_unique<Bucket>(Size1, *this));

--- a/source/common/umf_pools/disjoint_pool.hpp
+++ b/source/common/umf_pools/disjoint_pool.hpp
@@ -17,6 +17,8 @@
 
 namespace usm {
 
+inline constexpr size_t MIN_BUCKET_DEFAULT_SIZE = 8;
+
 // Configuration for specific USM allocator instance
 class DisjointPoolConfig {
   public:
@@ -46,7 +48,7 @@ class DisjointPoolConfig {
 
     // Holds the minimum bucket size valid for allocation of a memory type.
     // This value must be a power of 2.
-    size_t MinBucketSize = 1;
+    size_t MinBucketSize = MIN_BUCKET_DEFAULT_SIZE;
 
     // Holds size of the pool managed by the allocator.
     size_t CurPoolSize = 0;


### PR DESCRIPTION
Currently, for when the MinBucketSize parameter equals 1, sizes were generated with duplicates (such as 1,1,2,2,4,4...). Since such small sized buckets aren't needed anyway this PR changes the minimal value of MinBucketSize to 8.