### PR TITLE
[UR][HIP] Enable kernel finalization using comgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ List of options provided by CMake:
 | UR_BUILD_ADAPTER_CUDA   | Fetch and use cuda adapter from SYCL                   | ON/OFF     | OFF     |
 | UR_BUILD_ADAPTER_HIP    | Fetch and use hip adapter from SYCL                    | ON/OFF     | OFF     |
 | UR_HIP_PLATFORM         | Build hip adapter for AMD or NVIDIA platform           | AMD/NVIDIA | AMD     |
+| UR_ENABLE_COMGR         | Enable comgr lib usage           | AMD/NVIDIA | AMD     |
 
 ### Additional make targets
 

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -18,7 +18,7 @@ set(UR_HIP_INCLUDE_DIR "${UR_HIP_ROCM_DIR}/include")
 set(UR_HIP_HSA_INCLUDE_DIR "${UR_HIP_ROCM_DIR}/hsa/include")
 
 # Set HIP lib dir
-set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/hip/lib")
+set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib")
 
 # Check if HIP library path exists (AMD platform only)
 if("${UR_HIP_PLATFORM}" STREQUAL "AMD")
@@ -98,6 +98,18 @@ if("${UR_HIP_PLATFORM}" STREQUAL "AMD")
         INTERFACE_INCLUDE_DIRECTORIES        "${HIP_HEADERS}"
         INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_HEADERS}"
     )
+
+    if(UR_ENABLE_COMGR)
+        add_library(amd_comgr SHARED IMPORTED GLOBAL)
+        set_target_properties(
+        amd_comgr PROPERTIES
+            IMPORTED_LOCATION                    "${UR_HIP_LIB_DIR}/libamd_comgr.so"
+            INTERFACE_INCLUDE_DIRECTORIES        "${HIP_HEADERS}"
+            INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_HEADERS}"
+        )
+        target_link_libraries(pi_hip PUBLIC amd_comgr)
+        target_compile_definitions(pi_hip PRIVATE SYCL_ENABLE_KERNEL_FUSION)
+    endif(UR_ENABLE_COMGR)
 
     target_link_libraries(${TARGET_NAME} PRIVATE
     ${PROJECT_NAME}::headers

--- a/source/adapters/hip/common.cpp
+++ b/source/adapters/hip/common.cpp
@@ -11,6 +11,23 @@
 
 #include <sstream>
 
+#ifdef SYCL_ENABLE_KERNEL_FUSION
+ur_result_t mapErrorUR(amd_comgr_status_t Result) {
+  switch (Result) {
+  case AMD_COMGR_STATUS_SUCCESS:
+    return UR_RESULT_SUCCESS;
+  case AMD_COMGR_STATUS_ERROR:
+    return UR_RESULT_ERROR_UNKNOWN;
+  case AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT:
+    return UR_RESULT_ERROR_INVALID_ARGUMENT;
+  case AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES:
+    return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+  default:
+    return UR_RESULT_ERROR_UNKNOWN;
+  }
+}
+#endif
+
 ur_result_t mapErrorUR(hipError_t Result) {
   switch (Result) {
   case hipSuccess:
@@ -29,6 +46,52 @@ ur_result_t mapErrorUR(hipError_t Result) {
     return UR_RESULT_ERROR_UNKNOWN;
   }
 }
+
+#ifdef SYCL_ENABLE_KERNEL_FUSION
+void checkErrorUR(amd_comgr_status_t Result, const char *Function, int Line,
+                  const char *File) {
+  if (Result == AMD_COMGR_STATUS_SUCCESS) {
+    return;
+  }
+
+  if (std::getenv("SYCL_PI_SUPPRESS_ERROR_MESSAGE") == nullptr ||
+      std::getenv("UR_SUPPRESS_ERROR_MESSAGE") == nullptr) {
+    const char *ErrorString = nullptr;
+    const char *ErrorName = nullptr;
+    switch (Result) {
+    case AMD_COMGR_STATUS_ERROR:
+      ErrorName = "AMD_COMGR_STATUS_ERROR";
+      ErrorString = "Generic error";
+      break;
+    case AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT:
+      ErrorName = "AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT";
+      ErrorString =
+          "One of the actual arguments does not meet a precondition stated in "
+          "the documentation of the corresponding formal argument.";
+      break;
+    case AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES:
+      ErrorName = "AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES";
+      ErrorString = "Failed to allocate the necessary resources";
+      break;
+    default:
+      break;
+    }
+    std::cerr << "\nUR HIP ERROR:"
+              << "\n\tValue:           " << Result
+              << "\n\tName:            " << ErrorName
+              << "\n\tDescription:     " << ErrorString
+              << "\n\tFunction:        " << Function
+              << "\n\tSource Location: " << File << ":" << Line << "\n\n";
+  }
+
+  if (std::getenv("PI_HIP_ABORT") != nullptr ||
+      std::getenv("UR_HIP_ABORT") != nullptr) {
+    std::abort();
+  }
+
+  throw mapErrorUR(Result);
+}
+#endif
 
 void checkErrorUR(hipError_t Result, const char *Function, int Line,
                   const char *File) {

--- a/source/adapters/hip/common.hpp
+++ b/source/adapters/hip/common.hpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#ifdef SYCL_ENABLE_KERNEL_FUSION
+#include <amd_comgr/amd_comgr.h>
+#endif
 #include <hip/hip_runtime.h>
 #include <ur/ur.hpp>
 
@@ -69,6 +72,10 @@ typedef hipArray *hipCUarray;
 
 ur_result_t mapErrorUR(hipError_t Result);
 
+#ifdef SYCL_ENABLE_KERNEL_FUSION
+void checkErrorUR(amd_comgr_status_t Result, const char *Function, int Line,
+                  const char *File);
+#endif
 void checkErrorUR(hipError_t Result, const char *Function, int Line,
                   const char *File);
 void checkErrorUR(ur_result_t Result, const char *Function, int Line,

--- a/source/adapters/hip/program.hpp
+++ b/source/adapters/hip/program.hpp
@@ -23,6 +23,10 @@ struct ur_program_handle_t_ {
   size_t BinarySizeInBytes;
   std::atomic_uint32_t RefCount;
   ur_context_handle_t Context;
+  std::string ExecutableCache;
+
+  // Metadata
+  bool IsRelocatable = false;
 
   constexpr static size_t MAX_LOG_SIZE = 8192u;
 
@@ -33,9 +37,12 @@ struct ur_program_handle_t_ {
   ur_program_handle_t_(ur_context_handle_t Ctxt);
   ~ur_program_handle_t_();
 
+  ur_result_t setMetadata(const ur_program_metadata_t *Metadata, size_t Length);
+
   ur_result_t setBinary(const char *Binary, size_t BinarySizeInBytes);
 
   ur_result_t buildProgram(const char *BuildOptions);
+  ur_result_t finalizeRelocatable();
   ur_context_handle_t getContext() const { return Context; };
 
   native_type get() const noexcept { return Module; };

--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -49,6 +49,7 @@ const ur_command_t UR_EXT_COMMAND_TYPE_USER =
 #define __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE                    \
   "@reqd_work_group_size"
 #define __SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING "@global_id_mapping"
+#define __SYCL_UR_PROGRAM_METADATA_TAG_NEED_FINALIZATION "Requires finalization"
 
 // Terminates the process with a catastrophic error message.
 [[noreturn]] inline void die(const char *Message) {


### PR DESCRIPTION
For kernel fusion support for hip, we need to finalize the kernels using comgr. The patch finalizes tagged binaries during buildProgram before handing it over to the hip runtime.

Initial / related PR https://github.com/intel/llvm/pull/11003