### PR TITLE
[CUDA] Fix queue creation with native handle

### DIFF
--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -279,6 +279,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
                              hContext->getDevice(),
                              CuFlags,
                              Flags,
+                             /*priority*/ 0,
                              /*backend_owns*/ pProperties->isNativeHandleOwned};
   (*phQueue)->NumComputeStreams = 1;
 


### PR DESCRIPTION
The new priority parameter hadn't been reflected here so the ownership property was being used as priority and default to `true` which caused crashes.

Testing: https://github.com/intel/llvm/pull/11487