### PR TITLE
[ur][loader] add code location callback for tracing layer

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -202,6 +202,7 @@ class ur_function_v(IntEnum):
     KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP = 194## Enumerator for ::urKernelSuggestMaxCooperativeGroupCountExp
     COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP = 195    ## Enumerator for ::urCommandBufferAppendUSMPrefetchExp
     COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 196      ## Enumerator for ::urCommandBufferAppendUSMAdviseExp
+    LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK = 197  ## Enumerator for ::urLoaderConfigSetCodeLocationCallback
 
 class ur_function_t(c_int):
     def __str__(self):
@@ -517,6 +518,24 @@ class ur_loader_config_info_t(c_int):
     def __str__(self):
         return str(ur_loader_config_info_v(self.value))
 
+
+###############################################################################
+## @brief Code location data
+class ur_code_location_t(Structure):
+    _fields_ = [
+        ("functionName", c_char_p),                                     ## [in][out] Function name.
+        ("sourceFile", c_char_p),                                       ## [in][out] Source code file.
+        ("lineNumber", c_ulong),                                        ## [in][out] Source code line number.
+        ("columnNumber", c_ulong)                                       ## [in][out] Source code column number.
+    ]
+
+###############################################################################
+## @brief Code location callback with user data.
+def ur_code_location_callback_t(user_defined_callback):
+    @CFUNCTYPE(ur_code_location_t, c_void_p)
+    def ur_code_location_callback_t_wrapper(pUserData):
+        return user_defined_callback(pUserData)
+    return ur_code_location_callback_t_wrapper
 
 ###############################################################################
 ## @brief Supported adapter info

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -211,6 +211,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP = 194,          ///< Enumerator for ::urKernelSuggestMaxCooperativeGroupCountExp
     UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP = 195,                  ///< Enumerator for ::urCommandBufferAppendUSMPrefetchExp
     UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 196,                    ///< Enumerator for ::urCommandBufferAppendUSMAdviseExp
+    UR_FUNCTION_LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK = 197,                ///< Enumerator for ::urLoaderConfigSetCodeLocationCallback
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -673,6 +674,49 @@ urLoaderConfigEnableLayer(
     ur_loader_config_handle_t hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
     const char *pLayerName                   ///< [in] Null terminated string containing the name of the layer to
                                              ///< enable.
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Code location data
+typedef struct ur_code_location_t {
+    const char *functionName; ///< [in][out] Function name.
+    const char *sourceFile;   ///< [in][out] Source code file.
+    uint32_t lineNumber;      ///< [in][out] Source code line number.
+    uint32_t columnNumber;    ///< [in][out] Source code column number.
+
+} ur_code_location_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Code location callback with user data.
+typedef ur_code_location_t (*ur_code_location_callback_t)(
+    void *pUserData ///< [in][out] pointer to data to be passed to callback
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a function callback for use by the loader to retrieve code
+///        location information.
+///
+/// @details
+///     - The code location callback is optional and provides additional
+///       information to the tracing layer about the entry point of the current
+///       execution flow.
+///     - This functionality can be used to match traced unified runtime
+///       function calls with higher-level user calls.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hLoaderConfig`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnCodeloc`
+UR_APIEXPORT ur_result_t UR_APICALL
+urLoaderConfigSetCodeLocationCallback(
+    ur_loader_config_handle_t hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
+    ur_code_location_callback_t pfnCodeloc,  ///< [in] Function pointer to code location callback.
+    void *pUserData                          ///< [in][out][optional] pointer to data to be passed to callback.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8617,6 +8661,16 @@ typedef struct ur_loader_config_enable_layer_params_t {
     ur_loader_config_handle_t *phLoaderConfig;
     const char **ppLayerName;
 } ur_loader_config_enable_layer_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urLoaderConfigSetCodeLocationCallback
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_loader_config_set_code_location_callback_params_t {
+    ur_loader_config_handle_t *phLoaderConfig;
+    ur_code_location_callback_t *ppfnCodeloc;
+    void **ppUserData;
+} ur_loader_config_set_code_location_callback_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urPlatformGet

--- a/scripts/core/loader.yml
+++ b/scripts/core/loader.yml
@@ -140,6 +140,53 @@ returns:
     - $X_RESULT_ERROR_LAYER_NOT_PRESENT:
         - "If layer specified with `pLayerName` can't be found by the loader."
 --- #--------------------------------------------------------------------------
+type: struct
+desc: "Code location data"
+class: $xLoaderConfig
+name: $x_code_location_t
+members:
+    - type: const char*
+      name: functionName
+      desc: "[in][out] Function name."
+    - type: const char*
+      name: sourceFile
+      desc: "[in][out] Source code file."
+    - type: uint32_t
+      name: lineNumber
+      desc: "[in][out] Source code line number."
+    - type: uint32_t
+      name: columnNumber
+      desc: "[in][out] Source code column number."
+--- #--------------------------------------------------------------------------
+type: fptr_typedef
+desc: "Code location callback with user data."
+name: $x_code_location_callback_t
+return: $x_code_location_t
+params:
+    - type: void*
+      name: pUserData
+      desc: "[in][out] pointer to data to be passed to callback"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Set a function callback for use by the loader to retrieve code location information."
+details:
+    - "The code location callback is optional and provides additional information to the tracing layer about the entry point of the current execution flow."
+    - "This functionality can be used to match traced unified runtime function calls with higher-level user calls."
+class: $xLoaderConfig
+loader_only: True
+name: SetCodeLocationCallback
+decl: static
+params:
+    - type: $x_loader_config_handle_t
+      name: hLoaderConfig
+      desc: "[in] Handle to config object the layer will be enabled for."
+    - type: $x_code_location_callback_t
+      name: pfnCodeloc
+      desc: "[in] Function pointer to code location callback."
+    - type: void*
+      name: pUserData
+      desc: "[in][out][optional] pointer to data to be passed to callback."
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Initialize the $OneApi loader"
 class: $xLoader

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -547,6 +547,9 @@ etors:
 - name: COMMAND_BUFFER_APPEND_USM_ADVISE_EXP
   desc: Enumerator for $xCommandBufferAppendUSMAdviseExp
   value: '196'
+- name: LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK
+  desc: Enumerator for $xLoaderConfigSetCodeLocationCallback
+  value: '197'
 ---
 type: enum
 desc: Defines structure types

--- a/scripts/templates/trcddi.cpp.mako
+++ b/scripts/templates/trcddi.cpp.mako
@@ -104,12 +104,15 @@ namespace ur_tracing_layer
 
     ${x}_result_t
     context_t::init(ur_dditable_t *dditable,
-                    const std::set<std::string> &enabledLayerNames) {
+                    const std::set<std::string> &enabledLayerNames,
+                    codeloc_data codelocData) {
         ${x}_result_t result = ${X}_RESULT_SUCCESS;
         
         if(!enabledLayerNames.count(name)) {
             return result;
         }
+
+        ur_tracing_layer::context.codelocData = codelocData;
 
     %for tbl in th.get_pfntables(specs, meta, n, tags):
         if( ${X}_RESULT_SUCCESS == result )

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -160,9 +160,10 @@ namespace ur_validation_layer
     %endfor
     ${x}_result_t
     context_t::init(ur_dditable_t *dditable,
-                    const std::set<std::string> &enabledLayerNames) {
+                    const std::set<std::string> &enabledLayerNames,
+                    codeloc_data) {
         ${x}_result_t result = ${X}_RESULT_SUCCESS;
-        
+
         if (enabledLayerNames.count(nameFullValidation)) {
             enableParameterValidation = true;
             enableLeakChecking = true;

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -240,6 +240,9 @@ inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_device_init_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_loader_config_info_t value);
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_code_location_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_adapter_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_adapter_backend_t value);
@@ -1201,6 +1204,10 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
 
     case UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP";
+        break;
+
+    case UR_FUNCTION_LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK:
+        os << "UR_FUNCTION_LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK";
         break;
     default:
         os << "unknown enumerator";
@@ -2170,6 +2177,32 @@ inline void serializeTagged(std::ostream &os, const void *ptr,
     }
 }
 } // namespace ur_params
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_code_location_t params) {
+    os << "(struct ur_code_location_t){";
+
+    os << ".functionName = ";
+
+    ur_params::serializePtr(os, (params.functionName));
+
+    os << ", ";
+    os << ".sourceFile = ";
+
+    ur_params::serializePtr(os, (params.sourceFile));
+
+    os << ", ";
+    os << ".lineNumber = ";
+
+    os << (params.lineNumber);
+
+    os << ", ";
+    os << ".columnNumber = ";
+
+    os << (params.columnNumber);
+
+    os << "}";
+    return os;
+}
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_adapter_info_t value) {
     switch (value) {
@@ -13874,6 +13907,27 @@ operator<<(std::ostream &os,
 }
 
 inline std::ostream &
+operator<<(std::ostream &os, [[maybe_unused]] const struct
+           ur_loader_config_set_code_location_callback_params_t *params) {
+
+    os << ".hLoaderConfig = ";
+
+    ur_params::serializePtr(os, *(params->phLoaderConfig));
+
+    os << ", ";
+    os << ".pfnCodeloc = ";
+
+    os << reinterpret_cast<void *>(*(params->ppfnCodeloc));
+
+    os << ", ";
+    os << ".pUserData = ";
+
+    ur_params::serializePtr(os, *(params->ppUserData));
+
+    return os;
+}
+
+inline std::ostream &
 operator<<(std::ostream &os,
            [[maybe_unused]] const struct ur_mem_image_create_params_t *params) {
 
@@ -16145,6 +16199,10 @@ inline int serializeFunctionParams(std::ostream &os, uint32_t function,
     } break;
     case UR_FUNCTION_LOADER_CONFIG_ENABLE_LAYER: {
         os << (const struct ur_loader_config_enable_layer_params_t *)params;
+    } break;
+    case UR_FUNCTION_LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK: {
+        os << (const struct ur_loader_config_set_code_location_callback_params_t
+                   *)params;
     } break;
     case UR_FUNCTION_MEM_IMAGE_CREATE: {
         os << (const struct ur_mem_image_create_params_t *)params;

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(ur_loader
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_libddi.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_lib.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_lib.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ur_codeloc.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/ur_valddi.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/layers/validation/ur_validation_layer.cpp
 )

--- a/source/loader/layers/tracing/ur_tracing_layer.cpp
+++ b/source/loader/layers/tracing/ur_tracing_layer.cpp
@@ -14,6 +14,7 @@
 #include "ur_util.hpp"
 #include "xpti/xpti_data_types.h"
 #include "xpti/xpti_trace_framework.h"
+#include <optional>
 #include <sstream>
 
 namespace ur_tracing_layer {
@@ -22,6 +23,8 @@ context_t context;
 constexpr auto CALL_STREAM_NAME = "ur";
 constexpr auto STREAM_VER_MAJOR = UR_MAJOR_VERSION(UR_API_VERSION_CURRENT);
 constexpr auto STREAM_VER_MINOR = UR_MINOR_VERSION(UR_API_VERSION_CURRENT);
+
+static thread_local xpti_td *activeEvent;
 
 ///////////////////////////////////////////////////////////////////////////////
 context_t::context_t() {
@@ -39,11 +42,21 @@ bool context_t::isAvailable() const { return xptiTraceEnabled(); }
 void context_t::notify(uint16_t trace_type, uint32_t id, const char *name,
                        void *args, ur_result_t *resultp, uint64_t instance) {
     xpti::function_with_args_t payload{id, name, args, resultp, nullptr};
-    xptiNotifySubscribers(call_stream_id, trace_type, nullptr, nullptr,
+    xptiNotifySubscribers(call_stream_id, trace_type, nullptr, activeEvent,
                           instance, &payload);
 }
 
 uint64_t context_t::notify_begin(uint32_t id, const char *name, void *args) {
+    if (auto loc = codelocData.get_codeloc()) {
+        xpti::payload_t payload =
+            xpti::payload_t(loc->functionName, loc->sourceFile, loc->lineNumber,
+                            loc->columnNumber, nullptr);
+        uint64_t InstanceNumber{};
+        activeEvent = xptiMakeEvent("Unified Runtime call", &payload,
+                                    xpti::trace_graph_event, xpti_at::active,
+                                    &InstanceNumber);
+    }
+
     uint64_t instance = xptiGetUniqueId();
     notify((uint16_t)xpti::trace_point_type_t::function_with_args_begin, id,
            name, args, nullptr, instance);

--- a/source/loader/layers/tracing/ur_tracing_layer.hpp
+++ b/source/loader/layers/tracing/ur_tracing_layer.hpp
@@ -24,6 +24,7 @@ namespace ur_tracing_layer {
 class __urdlllocal context_t : public proxy_layer_context_t {
   public:
     ur_dditable_t urDdiTable = {};
+    codeloc_data codelocData;
 
     context_t();
     ~context_t();
@@ -32,7 +33,8 @@ class __urdlllocal context_t : public proxy_layer_context_t {
 
     std::vector<std::string> getNames() const override { return {name}; }
     ur_result_t init(ur_dditable_t *dditable,
-                     const std::set<std::string> &enabledLayerNames) override;
+                     const std::set<std::string> &enabledLayerNames,
+                     codeloc_data codelocData) override;
     ur_result_t tearDown() override { return UR_RESULT_SUCCESS; }
     uint64_t notify_begin(uint32_t id, const char *name, void *args);
     void notify_end(uint32_t id, const char *name, void *args,

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -7222,12 +7222,15 @@ __urdlllocal ur_result_t UR_APICALL urGetDeviceProcAddrTable(
 }
 
 ur_result_t context_t::init(ur_dditable_t *dditable,
-                            const std::set<std::string> &enabledLayerNames) {
+                            const std::set<std::string> &enabledLayerNames,
+                            codeloc_data codelocData) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (!enabledLayerNames.count(name)) {
         return result;
     }
+
+    ur_tracing_layer::context.codelocData = codelocData;
 
     if (UR_RESULT_SUCCESS == result) {
         result = ur_tracing_layer::urGetGlobalProcAddrTable(

--- a/source/loader/layers/ur_proxy_layer.hpp
+++ b/source/loader/layers/ur_proxy_layer.hpp
@@ -12,6 +12,7 @@
 #ifndef UR_PROXY_LAYER_H
 #define UR_PROXY_LAYER_H 1
 
+#include "ur_codeloc.hpp"
 #include "ur_ddi.h"
 #include "ur_util.hpp"
 
@@ -24,9 +25,9 @@ class __urdlllocal proxy_layer_context_t {
 
     virtual std::vector<std::string> getNames() const = 0;
     virtual bool isAvailable() const = 0;
-    virtual ur_result_t
-    init(ur_dditable_t *dditable,
-         const std::set<std::string> &enabledLayerNames) = 0;
+    virtual ur_result_t init(ur_dditable_t *dditable,
+                             const std::set<std::string> &enabledLayerNames,
+                             codeloc_data codelocData) = 0;
     virtual ur_result_t tearDown() = 0;
 };
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -8991,7 +8991,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
 }
 
 ur_result_t context_t::init(ur_dditable_t *dditable,
-                            const std::set<std::string> &enabledLayerNames) {
+                            const std::set<std::string> &enabledLayerNames,
+                            codeloc_data) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (enabledLayerNames.count(nameFullValidation)) {

--- a/source/loader/layers/validation/ur_validation_layer.hpp
+++ b/source/loader/layers/validation/ur_validation_layer.hpp
@@ -34,7 +34,8 @@ class __urdlllocal context_t : public proxy_layer_context_t {
         return {nameFullValidation, nameParameterValidation, nameLeakChecking};
     }
     ur_result_t init(ur_dditable_t *dditable,
-                     const std::set<std::string> &enabledLayerNames) override;
+                     const std::set<std::string> &enabledLayerNames,
+                     codeloc_data codelocData) override;
     ur_result_t tearDown() override;
 
   private:

--- a/source/loader/ur_codeloc.hpp
+++ b/source/loader/ur_codeloc.hpp
@@ -1,0 +1,35 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file ur_codeloc.hpp
+ *
+ */
+
+#ifndef UR_CODELOC_HPP
+#define UR_CODELOC_HPP 1
+
+#include "ur_api.h"
+#include <optional>
+
+struct codeloc_data {
+    codeloc_data() {
+        codelocCb = nullptr;
+        codelocUserdata = nullptr;
+    }
+    ur_code_location_callback_t codelocCb;
+    void *codelocUserdata;
+
+    std::optional<ur_code_location_t> get_codeloc() {
+        if (!codelocCb) {
+            return std::nullopt;
+        }
+        return codelocCb(codelocUserdata);
+    }
+};
+
+#endif /* UR_CODELOC_HPP */

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -55,7 +55,7 @@ void context_t::parseEnvEnabledLayers() {
 void context_t::initLayers() const {
     for (auto &l : layers) {
         if (l->isAvailable()) {
-            l->init(&context->urDdiTable, enabledLayerNames);
+            l->init(&context->urDdiTable, enabledLayerNames, codelocData);
         }
     }
 }
@@ -83,6 +83,7 @@ __urdlllocal ur_result_t context_t::Init(
     }
 
     if (hLoaderConfig) {
+        codelocData = hLoaderConfig->codelocData;
         enabledLayerNames.merge(hLoaderConfig->getEnabledLayerNames());
     }
 
@@ -187,4 +188,22 @@ ur_result_t urLoaderTearDown() {
 
     return UR_RESULT_SUCCESS;
 }
+
+ur_result_t
+urLoaderConfigSetCodeLocationCallback(ur_loader_config_handle_t hLoaderConfig,
+                                      ur_code_location_callback_t pfnCodeloc,
+                                      void *pUserData) {
+    if (!hLoaderConfig) {
+        return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+    }
+    if (!pfnCodeloc) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    hLoaderConfig->codelocData.codelocCb = pfnCodeloc;
+    hLoaderConfig->codelocData.codelocUserdata = pUserData;
+
+    return UR_RESULT_SUCCESS;
+}
+
 } // namespace ur_lib

--- a/source/loader/ur_lib.hpp
+++ b/source/loader/ur_lib.hpp
@@ -14,6 +14,7 @@
 #define UR_LOADER_LIB_H 1
 
 #include "ur_api.h"
+#include "ur_codeloc.hpp"
 #include "ur_ddi.h"
 #include "ur_proxy_layer.hpp"
 #include "ur_util.hpp"
@@ -42,6 +43,8 @@ struct ur_loader_config_handle_t_ {
         return refCount.load(std::memory_order_acquire);
     }
     std::set<std::string> &getEnabledLayerNames() { return enabledLayers; }
+
+    codeloc_data codelocData;
 };
 
 namespace ur_lib {
@@ -72,6 +75,8 @@ class __urdlllocal context_t {
     std::string availableLayers;
     std::set<std::string> enabledLayerNames;
 
+    codeloc_data codelocData;
+
     bool layerExists(const std::string &layerName) const;
     void parseEnvEnabledLayers();
     void initLayers() const;
@@ -89,5 +94,10 @@ ur_result_t urLoaderConfigGetInfo(ur_loader_config_handle_t hLoaderConfig,
 ur_result_t urLoaderConfigEnableLayer(ur_loader_config_handle_t hLoaderConfig,
                                       const char *pLayerName);
 ur_result_t urLoaderTearDown();
+ur_result_t
+urLoaderConfigSetCodeLocationCallback(ur_loader_config_handle_t hLoaderConfig,
+                                      ur_code_location_callback_t pfnCodeloc,
+                                      void *pUserData);
+
 } // namespace ur_lib
 #endif /* UR_LOADER_LIB_H */

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -158,6 +158,40 @@ ur_result_t UR_APICALL urLoaderConfigEnableLayer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a function callback for use by the loader to retrieve code
+///        location information.
+///
+/// @details
+///     - The code location callback is optional and provides additional
+///       information to the tracing layer about the entry point of the current
+///       execution flow.
+///     - This functionality can be used to match traced unified runtime
+///       function calls with higher-level user calls.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hLoaderConfig`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnCodeloc`
+ur_result_t UR_APICALL urLoaderConfigSetCodeLocationCallback(
+    ur_loader_config_handle_t
+        hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
+    ur_code_location_callback_t
+        pfnCodeloc, ///< [in] Function pointer to code location callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+    ) try {
+    return ur_lib::urLoaderConfigSetCodeLocationCallback(hLoaderConfig,
+                                                         pfnCodeloc, pUserData);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' loader
 ///
 /// @details

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -149,6 +149,38 @@ ur_result_t UR_APICALL urLoaderConfigEnableLayer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a function callback for use by the loader to retrieve code
+///        location information.
+///
+/// @details
+///     - The code location callback is optional and provides additional
+///       information to the tracing layer about the entry point of the current
+///       execution flow.
+///     - This functionality can be used to match traced unified runtime
+///       function calls with higher-level user calls.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hLoaderConfig`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnCodeloc`
+ur_result_t UR_APICALL urLoaderConfigSetCodeLocationCallback(
+    ur_loader_config_handle_t
+        hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
+    ur_code_location_callback_t
+        pfnCodeloc, ///< [in] Function pointer to code location callback.
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to callback.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Initialize the 'oneAPI' loader
 ///
 /// @details

--- a/test/layers/tracing/CMakeLists.txt
+++ b/test/layers/tracing/CMakeLists.txt
@@ -3,9 +3,36 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(TEST_NAME example-collected-hello-world)
+add_ur_library(test_collector SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_collector.cpp
+)
 
-add_test(NAME ${TEST_NAME}
+target_include_directories(test_collector PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(test_collector PRIVATE ${TARGET_XPTI})
+target_include_directories(test_collector PRIVATE ${xpti_SOURCE_DIR}/include)
+
+if(MSVC)
+    target_compile_definitions(test_collector PRIVATE
+        XPTI_STATIC_LIBRARY XPTI_CALLBACK_API_EXPORTS)
+endif()
+
+function(set_tracing_test_props target_name collector_name)
+    set_tests_properties(${target_name} PROPERTIES
+        LABELS "tracing"
+    )
+
+    set_property(TEST ${target_name} PROPERTY ENVIRONMENT
+        "XPTI_TRACE_ENABLE=1"
+        "XPTI_FRAMEWORK_DISPATCHER=$<TARGET_FILE:xptifw>"
+        "XPTI_SUBSCRIBERS=$<TARGET_FILE:${collector_name}>"
+        "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_null>\""
+        "UR_ENABLE_LAYERS=UR_LAYER_TRACING")
+endfunction()
+
+add_test(NAME example-collected-hello-world
     COMMAND ${CMAKE_COMMAND}
     -D MODE=stdout
     -D TEST_FILE=$<TARGET_FILE:hello_world>
@@ -14,13 +41,28 @@ add_test(NAME ${TEST_NAME}
     DEPENDS collector hello_world
 )
 
-set_tests_properties(${TEST_NAME} PROPERTIES
-    LABELS "tracing"
-)
+set_tracing_test_props(example-collected-hello-world collector)
 
-set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT
-    "XPTI_TRACE_ENABLE=1"
-    "XPTI_FRAMEWORK_DISPATCHER=$<TARGET_FILE:xptifw>"
-    "XPTI_SUBSCRIBERS=$<TARGET_FILE:collector>"
-    "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_null>\""
-    "UR_ENABLE_LAYERS=UR_LAYER_TRACING")
+function(add_tracing_test name)
+    set(TEST_TARGET_NAME tracing-test-${name})
+    add_ur_executable(${TEST_TARGET_NAME}
+        ${ARGN})
+    target_link_libraries(${TEST_TARGET_NAME}
+        PRIVATE
+        ${PROJECT_NAME}::loader
+        ${PROJECT_NAME}::headers
+        ${PROJECT_NAME}::testing
+        GTest::gtest_main)
+    add_test(NAME ${name}
+        COMMAND ${CMAKE_COMMAND}
+        -D MODE=stderr
+        -D TEST_FILE=$<TARGET_FILE:${TEST_TARGET_NAME}>
+        -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}.out.match
+        -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
+        DEPENDS test_collector
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tracing_test_props(${name} test_collector)
+endfunction()
+
+add_tracing_test(codeloc codeloc.cpp)

--- a/test/layers/tracing/codeloc.cpp
+++ b/test/layers/tracing/codeloc.cpp
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file codeloc.cpp
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <ur_api.h>
+
+struct ur_code_location_t test_callback(void *userdata) {
+    (void)userdata;
+
+    ur_code_location_t codeloc;
+    codeloc.columnNumber = 1;
+    codeloc.lineNumber = 2;
+    codeloc.functionName = "fname";
+    codeloc.sourceFile = "sfile";
+
+    return codeloc;
+}
+
+TEST(LoaderCodeloc, NullCallback) {
+    ur_loader_config_handle_t loader_config;
+    ASSERT_EQ(urLoaderConfigCreate(&loader_config), UR_RESULT_SUCCESS);
+    ASSERT_EQ(
+        urLoaderConfigSetCodeLocationCallback(loader_config, nullptr, nullptr),
+        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+    urLoaderConfigRelease(loader_config);
+}
+
+TEST(LoaderCodeloc, NullHandle) {
+    ASSERT_EQ(
+        urLoaderConfigSetCodeLocationCallback(nullptr, test_callback, nullptr),
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST(LoaderCodeloc, Success) {
+    ur_loader_config_handle_t loader_config;
+    ASSERT_EQ(urLoaderConfigCreate(&loader_config), UR_RESULT_SUCCESS);
+    ASSERT_EQ(urLoaderConfigSetCodeLocationCallback(loader_config,
+                                                    test_callback, nullptr),
+              UR_RESULT_SUCCESS);
+    urLoaderInit(0, loader_config);
+    uint32_t nadapters;
+    urAdapterGet(0, nullptr, &nadapters);
+    urLoaderConfigRelease(loader_config);
+}

--- a/test/layers/tracing/codeloc.out.match
+++ b/test/layers/tracing/codeloc.out.match
@@ -1,0 +1,2 @@
+begin urAdapterGet 178 fname sfile 2 1
+end urAdapterGet 178 fname sfile 2 1

--- a/test/layers/tracing/test_collector.cpp
+++ b/test/layers/tracing/test_collector.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * @file test_collector.cpp
+ *
+ */
+
+#include <cassert>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string_view>
+
+#include "ur_api.h"
+#include "xpti/xpti_trace_framework.h"
+
+constexpr uint16_t TRACE_FN_BEGIN =
+    static_cast<uint16_t>(xpti::trace_point_type_t::function_with_args_begin);
+constexpr uint16_t TRACE_FN_END =
+    static_cast<uint16_t>(xpti::trace_point_type_t::function_with_args_end);
+constexpr std::string_view UR_STREAM_NAME = "ur";
+
+XPTI_CALLBACK_API void trace_cb(uint16_t trace_type, xpti::trace_event_data_t *,
+                                xpti::trace_event_data_t *child, uint64_t,
+                                const void *user_data) {
+    auto *args = static_cast<const xpti::function_with_args_t *>(user_data);
+    auto *payload = xptiQueryPayload(child);
+    std::cerr << (trace_type == TRACE_FN_BEGIN ? "begin" : "end");
+    std::cerr << " " << args->function_name << " " << args->function_id;
+    if (payload) {
+        std::cerr << " " << payload->name << " " << payload->source_file << " "
+                  << payload->line_no << " " << payload->column_no;
+    }
+    std::cerr << std::endl;
+}
+
+XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
+                                     unsigned int minor_version, const char *,
+                                     const char *stream_name) {
+    if (stream_name == nullptr) {
+        std::cout << "Stream name not provided. Aborting." << std::endl;
+        return;
+    }
+    if (std::string_view(stream_name) != UR_STREAM_NAME) {
+        std::cout << "Invalid stream name: " << stream_name << ". Expected "
+                  << UR_STREAM_NAME << ". Aborting." << std::endl;
+        return;
+    }
+
+    if (UR_MAKE_VERSION(major_version, minor_version) !=
+        UR_API_VERSION_CURRENT) {
+        std::cout << "Invalid stream version: " << major_version << "."
+                  << minor_version << ". Expected "
+                  << UR_MAJOR_VERSION(UR_API_VERSION_CURRENT) << "."
+                  << UR_MINOR_VERSION(UR_API_VERSION_CURRENT) << ". Aborting."
+                  << std::endl;
+        return;
+    }
+
+    uint8_t stream_id = xptiRegisterStream(stream_name);
+
+    xptiRegisterCallback(stream_id, TRACE_FN_BEGIN, trace_cb);
+    xptiRegisterCallback(stream_id, TRACE_FN_END, trace_cb);
+}
+
+XPTI_CALLBACK_API void xptiTraceFinish(const char *) { /* noop */
+}


### PR DESCRIPTION
This addresses the gap between XPTI support in PI and UR, where UR implementation was unable to provide code location information in traces, by adding an optional callback that, when set, allows language runtimes to provide this information.