### PR TITLE
[HIP][CUDA] Change unions in ur_mem_handle_t_ to stdvariant

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -514,7 +514,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   ur_result_t Result = UR_RESULT_SUCCESS;
-  CUdeviceptr DevPtr = hBuffer->Mem.BufferMem.get();
+  CUdeviceptr DevPtr = std::get<BufferMem>(hBuffer->Mem).get();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -562,7 +562,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   ur_result_t Result = UR_RESULT_SUCCESS;
-  CUdeviceptr DevPtr = hBuffer->Mem.BufferMem.get();
+  CUdeviceptr DevPtr = std::get<BufferMem>(hBuffer->Mem).get();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -606,9 +606,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_mem_handle_t hBufferDst, size_t srcOffset, size_t dstOffset, size_t size,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  UR_ASSERT(size + dstOffset <= hBufferDst->Mem.BufferMem.getSize(),
+  UR_ASSERT(size + dstOffset <= std::get<BufferMem>(hBufferDst->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(size + srcOffset <= hBufferSrc->Mem.BufferMem.getSize(),
+  UR_ASSERT(size + srcOffset <= std::get<BufferMem>(hBufferSrc->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
 
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
@@ -628,8 +628,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    auto Src = hBufferSrc->Mem.BufferMem.get() + srcOffset;
-    auto Dst = hBufferDst->Mem.BufferMem.get() + dstOffset;
+    auto Src = std::get<BufferMem>(hBufferSrc->Mem).get() + srcOffset;
+    auto Dst = std::get<BufferMem>(hBufferDst->Mem).get() + dstOffset;
 
     UR_CHECK_ERROR(cuMemcpyDtoDAsync(Dst, Src, size, Stream));
 
@@ -654,8 +654,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   ur_result_t Result = UR_RESULT_SUCCESS;
-  CUdeviceptr SrcPtr = hBufferSrc->Mem.BufferMem.get();
-  CUdeviceptr DstPtr = hBufferDst->Mem.BufferMem.get();
+  CUdeviceptr SrcPtr = std::get<BufferMem>(hBufferSrc->Mem).get();
+  CUdeviceptr DstPtr = std::get<BufferMem>(hBufferDst->Mem).get();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -726,7 +726,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t patternSize, size_t offset, size_t size,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  UR_ASSERT(size + offset <= hBuffer->Mem.BufferMem.getSize(),
+  UR_ASSERT(size + offset <= std::get<BufferMem>(hBuffer->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
 
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
@@ -745,7 +745,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    auto DstDevice = hBuffer->Mem.BufferMem.get() + offset;
+    auto DstDevice = std::get<BufferMem>(hBuffer->Mem).get() + offset;
     auto N = size / patternSize;
 
     // pattern size in bytes
@@ -892,7 +892,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     Result = enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                phEventWaitList);
 
-    CUarray Array = hImage->Mem.SurfaceMem.getArray();
+    CUarray Array = std::get<SurfaceMem>(hImage->Mem).getArray();
 
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
@@ -902,7 +902,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     size_t ByteOffsetX = origin.x * ElementByteSize * ArrayDesc.NumChannels;
     size_t BytesToCopy = ElementByteSize * ArrayDesc.NumChannels * region.width;
 
-    ur_mem_type_t ImgType = hImage->Mem.SurfaceMem.getImageType();
+    ur_mem_type_t ImgType = std::get<SurfaceMem>(hImage->Mem).getImageType();
 
     std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
     if (phEvent) {
@@ -964,7 +964,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     Result = enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                phEventWaitList);
 
-    CUarray Array = hImage->Mem.SurfaceMem.getArray();
+    CUarray Array = std::get<SurfaceMem>(hImage->Mem).getArray();
 
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
@@ -982,7 +982,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    ur_mem_type_t ImgType = hImage->Mem.SurfaceMem.getImageType();
+    ur_mem_type_t ImgType = std::get<SurfaceMem>(hImage->Mem).getImageType();
     if (ImgType == UR_MEM_TYPE_IMAGE1D) {
       UR_CHECK_ERROR(
           cuMemcpyHtoAAsync(Array, ByteOffsetX, pSrc, BytesToCopy, CuStream));
@@ -1023,8 +1023,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(hImageDst->MemType == ur_mem_handle_t_::Type::Surface,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(hImageSrc->Mem.SurfaceMem.getImageType() ==
-                hImageDst->Mem.SurfaceMem.getImageType(),
+  UR_ASSERT(std::get<SurfaceMem>(hImageSrc->Mem).getImageType() ==
+                std::get<SurfaceMem>(hImageDst->Mem).getImageType(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
@@ -1035,8 +1035,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     Result = enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
                                phEventWaitList);
 
-    CUarray SrcArray = hImageSrc->Mem.SurfaceMem.getArray();
-    CUarray DstArray = hImageDst->Mem.SurfaceMem.getArray();
+    CUarray SrcArray = std::get<SurfaceMem>(hImageSrc->Mem).getArray();
+    CUarray DstArray = std::get<SurfaceMem>(hImageDst->Mem).getArray();
 
     CUDA_ARRAY_DESCRIPTOR SrcArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&SrcArrayDesc, SrcArray));
@@ -1065,7 +1065,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    ur_mem_type_t ImgType = hImageSrc->Mem.SurfaceMem.getImageType();
+    ur_mem_type_t ImgType = std::get<SurfaceMem>(hImageSrc->Mem).getImageType();
     if (ImgType == UR_MEM_TYPE_IMAGE1D) {
       UR_CHECK_ERROR(cuMemcpyAtoA(DstArray, DstByteOffsetX, SrcArray,
                                   SrcByteOffsetX, BytesToCopy));
@@ -1108,22 +1108,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_event_handle_t *phEvent, void **ppRetMap) {
   UR_ASSERT(hBuffer->MemType == ur_mem_handle_t_::Type::Buffer,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(offset + size <= hBuffer->Mem.BufferMem.getSize(),
+  UR_ASSERT(offset + size <= std::get<BufferMem>(hBuffer->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
 
+  auto &BufferImpl = std::get<BufferMem>(hBuffer->Mem);
   ur_result_t Result = UR_RESULT_ERROR_INVALID_MEM_OBJECT;
   const bool IsPinned =
-      hBuffer->Mem.BufferMem.MemAllocMode ==
-      ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr;
+      BufferImpl.MemAllocMode == BufferMem::AllocMode::AllocHostPtr;
 
   // Currently no support for overlapping regions
-  if (hBuffer->Mem.BufferMem.getMapPtr() != nullptr) {
+  if (BufferImpl.getMapPtr() != nullptr) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   // Allocate a pointer in the host to store the mapped information
-  auto HostPtr = hBuffer->Mem.BufferMem.mapToPtr(size, offset, mapFlags);
-  *ppRetMap = hBuffer->Mem.BufferMem.getMapPtr();
+  auto HostPtr = BufferImpl.mapToPtr(size, offset, mapFlags);
+  *ppRetMap = BufferImpl.getMapPtr();
   if (HostPtr) {
     Result = UR_RESULT_SUCCESS;
   }
@@ -1168,21 +1168,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
   ur_result_t Result = UR_RESULT_SUCCESS;
   UR_ASSERT(hMem->MemType == ur_mem_handle_t_::Type::Buffer,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(hMem->Mem.BufferMem.getMapPtr() != nullptr,
+  UR_ASSERT(std::get<BufferMem>(hMem->Mem).getMapPtr() != nullptr,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(hMem->Mem.BufferMem.getMapPtr() == pMappedPtr,
+  UR_ASSERT(std::get<BufferMem>(hMem->Mem).getMapPtr() == pMappedPtr,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-  const bool IsPinned =
-      hMem->Mem.BufferMem.MemAllocMode ==
-      ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr;
+  const bool IsPinned = std::get<BufferMem>(hMem->Mem).MemAllocMode ==
+                        BufferMem::AllocMode::AllocHostPtr;
 
-  if (!IsPinned && (hMem->Mem.BufferMem.getMapFlags() & UR_MAP_FLAG_WRITE)) {
+  if (!IsPinned &&
+      (std::get<BufferMem>(hMem->Mem).getMapFlags() & UR_MAP_FLAG_WRITE)) {
     // Pinned host memory is only on host so it doesn't need to be written to.
     Result = urEnqueueMemBufferWrite(
-        hQueue, hMem, true, hMem->Mem.BufferMem.getMapOffset(),
-        hMem->Mem.BufferMem.getMapSize(), pMappedPtr, numEventsInWaitList,
-        phEventWaitList, phEvent);
+        hQueue, hMem, true, std::get<BufferMem>(hMem->Mem).getMapOffset(),
+        std::get<BufferMem>(hMem->Mem).getMapSize(), pMappedPtr,
+        numEventsInWaitList, phEventWaitList, phEvent);
   } else {
     ScopedContext Active(hQueue->getContext());
 
@@ -1203,7 +1203,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
     }
   }
 
-  hMem->Mem.BufferMem.unmap(pMappedPtr);
+  std::get<BufferMem>(hMem->Mem).unmap(pMappedPtr);
   return Result;
 }
 
@@ -1502,11 +1502,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
     size_t offset, size_t size, void *pDst, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   UR_ASSERT(!hBuffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(offset + size <= hBuffer->Mem.BufferMem.Size,
+  UR_ASSERT(offset + size <= std::get<BufferMem>(hBuffer->Mem).Size,
             UR_RESULT_ERROR_INVALID_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
-  CUdeviceptr DevPtr = hBuffer->Mem.BufferMem.get();
+  CUdeviceptr DevPtr = std::get<BufferMem>(hBuffer->Mem).get();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -1549,11 +1549,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     size_t offset, size_t size, const void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   UR_ASSERT(!hBuffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(offset + size <= hBuffer->Mem.BufferMem.Size,
+  UR_ASSERT(offset + size <= std::get<BufferMem>(hBuffer->Mem).Size,
             UR_RESULT_ERROR_INVALID_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
-  CUdeviceptr DevPtr = hBuffer->Mem.BufferMem.get();
+  CUdeviceptr DevPtr = std::get<BufferMem>(hBuffer->Mem).get();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {

--- a/source/adapters/cuda/kernel.cpp
+++ b/source/adapters/cuda/kernel.cpp
@@ -304,7 +304,7 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
     if (hArgValue->MemType == ur_mem_handle_t_::Type::Surface) {
       CUDA_ARRAY3D_DESCRIPTOR arrayDesc;
       UR_CHECK_ERROR(cuArray3DGetDescriptor(
-          &arrayDesc, hArgValue->Mem.SurfaceMem.getArray()));
+          &arrayDesc, std::get<SurfaceMem>(hArgValue->Mem).getArray()));
       if (arrayDesc.Format != CU_AD_FORMAT_UNSIGNED_INT32 &&
           arrayDesc.Format != CU_AD_FORMAT_SIGNED_INT32 &&
           arrayDesc.Format != CU_AD_FORMAT_HALF &&
@@ -314,10 +314,10 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
                         UR_RESULT_ERROR_ADAPTER_SPECIFIC);
         return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
       }
-      CUsurfObject CuSurf = hArgValue->Mem.SurfaceMem.getSurface();
+      CUsurfObject CuSurf = std::get<SurfaceMem>(hArgValue->Mem).getSurface();
       hKernel->setKernelArg(argIndex, sizeof(CuSurf), (void *)&CuSurf);
     } else {
-      CUdeviceptr CuPtr = hArgValue->Mem.BufferMem.get();
+      CUdeviceptr CuPtr = std::get<BufferMem>(hArgValue->Mem).get();
       hKernel->setKernelArg(argIndex, sizeof(CUdeviceptr), (void *)&CuPtr);
     }
   } catch (ur_result_t Err) {

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -112,9 +112,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    UR_CHECK_ERROR(
-        hipMemcpyHtoDAsync(hBuffer->Mem.BufferMem.getWithOffset(offset),
-                           const_cast<void *>(pSrc), size, HIPStream));
+    UR_CHECK_ERROR(hipMemcpyHtoDAsync(
+        std::get<BufferMem>(hBuffer->Mem).getWithOffset(offset),
+        const_cast<void *>(pSrc), size, HIPStream));
 
     if (phEvent) {
       UR_CHECK_ERROR(RetImplEvent->record());
@@ -159,7 +159,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
     }
 
     UR_CHECK_ERROR(hipMemcpyDtoHAsync(
-        pDst, hBuffer->Mem.BufferMem.getWithOffset(offset), size, HIPStream));
+        pDst, std::get<BufferMem>(hBuffer->Mem).getWithOffset(offset), size,
+        HIPStream));
 
     if (phEvent) {
       UR_CHECK_ERROR(RetImplEvent->record());
@@ -518,7 +519,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
             UR_RESULT_ERROR_INVALID_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
-  void *DevPtr = hBuffer->Mem.BufferMem.getVoid();
+  void *DevPtr = std::get<BufferMem>(hBuffer->Mem).getVoid();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -566,7 +567,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   ur_result_t Result = UR_RESULT_SUCCESS;
-  void *DevPtr = hBuffer->Mem.BufferMem.getVoid();
+  void *DevPtr = std::get<BufferMem>(hBuffer->Mem).getVoid();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -610,9 +611,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_mem_handle_t hBufferDst, size_t srcOffset, size_t dstOffset, size_t size,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  UR_ASSERT(size + srcOffset <= hBufferSrc->Mem.BufferMem.getSize(),
+  UR_ASSERT(size + srcOffset <= std::get<BufferMem>(hBufferSrc->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
-  UR_ASSERT(size + dstOffset <= hBufferDst->Mem.BufferMem.getSize(),
+  UR_ASSERT(size + dstOffset <= std::get<BufferMem>(hBufferDst->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
 
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
@@ -634,8 +635,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    auto Src = hBufferSrc->Mem.BufferMem.getWithOffset(srcOffset);
-    auto Dst = hBufferDst->Mem.BufferMem.getWithOffset(dstOffset);
+    auto Src = std::get<BufferMem>(hBufferSrc->Mem).getWithOffset(srcOffset);
+    auto Dst = std::get<BufferMem>(hBufferDst->Mem).getWithOffset(dstOffset);
 
     UR_CHECK_ERROR(hipMemcpyDtoDAsync(Dst, Src, size, Stream));
 
@@ -660,8 +661,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
   ur_result_t Result = UR_RESULT_SUCCESS;
-  void *SrcPtr = hBufferSrc->Mem.BufferMem.getVoid();
-  void *DstPtr = hBufferDst->Mem.BufferMem.getVoid();
+  void *SrcPtr = std::get<BufferMem>(hBufferSrc->Mem).getVoid();
+  void *DstPtr = std::get<BufferMem>(hBufferDst->Mem).getVoid();
   std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
 
   try {
@@ -733,7 +734,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     size_t patternSize, size_t offset, size_t size,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  UR_ASSERT(size + offset <= hBuffer->Mem.BufferMem.getSize(),
+  UR_ASSERT(size + offset <= std::get<BufferMem>(hBuffer->Mem).getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
   auto ArgsAreMultiplesOfPatternSize =
       (offset % patternSize == 0) || (size % patternSize == 0);
@@ -770,7 +771,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
 
-    auto DstDevice = hBuffer->Mem.BufferMem.getWithOffset(offset);
+    auto DstDevice = std::get<BufferMem>(hBuffer->Mem).getWithOffset(offset);
     auto N = size / patternSize;
 
     // pattern size in bytes
@@ -904,7 +905,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
                                  phEventWaitList);
     }
 
-    hipArray *Array = hImage->Mem.SurfaceMem.getArray();
+    hipArray *Array = std::get<SurfaceMem>(hImage->Mem).getArray();
 
     hipArray_Format Format;
     size_t NumChannels;
@@ -915,7 +916,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     size_t ByteOffsetX = origin.x * ElementByteSize * NumChannels;
     size_t BytesToCopy = ElementByteSize * NumChannels * region.depth;
 
-    auto ImgType = hImage->Mem.SurfaceMem.getImageType();
+    auto ImgType = std::get<SurfaceMem>(hImage->Mem).getImageType();
 
     size_t AdjustedRegion[3] = {BytesToCopy, region.height, region.height};
     size_t SrcOffset[3] = {ByteOffsetX, origin.y, origin.z};
@@ -972,7 +973,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
                                  phEventWaitList);
     }
 
-    hipArray *Array = hImage->Mem.SurfaceMem.getArray();
+    hipArray *Array = std::get<SurfaceMem>(hImage->Mem).getArray();
 
     hipArray_Format Format;
     size_t NumChannels;
@@ -983,7 +984,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     size_t ByteOffsetX = origin.x * ElementByteSize * NumChannels;
     size_t BytesToCopy = ElementByteSize * NumChannels * region.depth;
 
-    auto ImgType = hImage->Mem.SurfaceMem.getImageType();
+    auto ImgType = std::get<SurfaceMem>(hImage->Mem).getImageType();
 
     size_t AdjustedRegion[3] = {BytesToCopy, region.height, region.height};
     size_t DstOffset[3] = {ByteOffsetX, origin.y, origin.z};
@@ -1029,8 +1030,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
   UR_ASSERT(hImageDst->MemType == ur_mem_handle_t_::Type::Surface,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(hImageSrc->Mem.SurfaceMem.getImageType() ==
-                hImageDst->Mem.SurfaceMem.getImageType(),
+  UR_ASSERT(std::get<SurfaceMem>(hImageSrc->Mem).getImageType() ==
+                std::get<SurfaceMem>(hImageDst->Mem).getImageType(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
@@ -1043,12 +1044,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
                                  phEventWaitList);
     }
 
-    hipArray *SrcArray = hImageSrc->Mem.SurfaceMem.getArray();
+    hipArray *SrcArray = std::get<SurfaceMem>(hImageSrc->Mem).getArray();
     hipArray_Format SrcFormat;
     size_t SrcNumChannels;
     getArrayDesc(SrcArray, SrcFormat, SrcNumChannels);
 
-    hipArray *DstArray = hImageDst->Mem.SurfaceMem.getArray();
+    hipArray *DstArray = std::get<SurfaceMem>(hImageDst->Mem).getArray();
     hipArray_Format DstFormat;
     size_t DstNumChannels;
     getArrayDesc(DstArray, DstFormat, DstNumChannels);
@@ -1064,7 +1065,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     size_t SrcByteOffsetX = srcOrigin.x * ElementByteSize * DstNumChannels;
     size_t BytesToCopy = ElementByteSize * SrcNumChannels * region.depth;
 
-    auto ImgType = hImageSrc->Mem.SurfaceMem.getImageType();
+    auto ImgType = std::get<SurfaceMem>(hImageSrc->Mem).getImageType();
 
     size_t AdjustedRegion[3] = {BytesToCopy, region.height, region.width};
     size_t SrcOffset[3] = {SrcByteOffsetX, srcOrigin.y, srcOrigin.z};
@@ -1111,22 +1112,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_event_handle_t *phEvent, void **ppRetMap) {
   UR_ASSERT(hBuffer->MemType == ur_mem_handle_t_::Type::Buffer,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(offset + size <= hBuffer->Mem.BufferMem.getSize(),
+  auto &BufferImpl = std::get<BufferMem>(hBuffer->Mem);
+  UR_ASSERT(offset + size <= BufferImpl.getSize(),
             UR_RESULT_ERROR_INVALID_SIZE);
 
   ur_result_t Result = UR_RESULT_ERROR_INVALID_OPERATION;
   const bool IsPinned =
-      hBuffer->Mem.BufferMem.MemAllocMode ==
-      ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr;
+      BufferImpl.MemAllocMode == BufferMem::AllocMode::AllocHostPtr;
 
   // Currently no support for overlapping regions
-  if (hBuffer->Mem.BufferMem.getMapPtr() != nullptr) {
+  if (BufferImpl.getMapPtr() != nullptr) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   // Allocate a pointer in the host to store the mapped information
-  auto HostPtr = hBuffer->Mem.BufferMem.mapToPtr(size, offset, mapFlags);
-  *ppRetMap = hBuffer->Mem.BufferMem.getMapPtr();
+  auto HostPtr = BufferImpl.mapToPtr(size, offset, mapFlags);
+  *ppRetMap = std::get<BufferMem>(hBuffer->Mem).getMapPtr();
   if (HostPtr) {
     Result = UR_RESULT_SUCCESS;
   }
@@ -1171,23 +1172,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
   ur_result_t Result = UR_RESULT_SUCCESS;
   UR_ASSERT(hMem->MemType == ur_mem_handle_t_::Type::Buffer,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(hMem->Mem.BufferMem.getMapPtr() != nullptr,
+  UR_ASSERT(std::get<BufferMem>(hMem->Mem).getMapPtr() != nullptr,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
-  UR_ASSERT(hMem->Mem.BufferMem.getMapPtr() == pMappedPtr,
+  UR_ASSERT(std::get<BufferMem>(hMem->Mem).getMapPtr() == pMappedPtr,
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-  const bool IsPinned =
-      hMem->Mem.BufferMem.MemAllocMode ==
-      ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr;
+  const bool IsPinned = std::get<BufferMem>(hMem->Mem).MemAllocMode ==
+                        BufferMem::AllocMode::AllocHostPtr;
 
-  if (!IsPinned && ((hMem->Mem.BufferMem.getMapFlags() & UR_MAP_FLAG_WRITE) ||
-                    (hMem->Mem.BufferMem.getMapFlags() &
-                     UR_MAP_FLAG_WRITE_INVALIDATE_REGION))) {
+  if (!IsPinned &&
+      ((std::get<BufferMem>(hMem->Mem).getMapFlags() & UR_MAP_FLAG_WRITE) ||
+       (std::get<BufferMem>(hMem->Mem).getMapFlags() &
+        UR_MAP_FLAG_WRITE_INVALIDATE_REGION))) {
     // Pinned host memory is only on host so it doesn't need to be written to.
     Result = urEnqueueMemBufferWrite(
-        hQueue, hMem, true, hMem->Mem.BufferMem.getMapOffset(),
-        hMem->Mem.BufferMem.getMapSize(), pMappedPtr, numEventsInWaitList,
-        phEventWaitList, phEvent);
+        hQueue, hMem, true, std::get<BufferMem>(hMem->Mem).getMapOffset(),
+        std::get<BufferMem>(hMem->Mem).getMapSize(), pMappedPtr,
+        numEventsInWaitList, phEventWaitList, phEvent);
   } else {
     ScopedContext Active(hQueue->getDevice());
 
@@ -1208,7 +1209,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
     }
   }
 
-  hMem->Mem.BufferMem.unmap(pMappedPtr);
+  std::get<BufferMem>(hMem->Mem).unmap(pMappedPtr);
   return Result;
 }
 

--- a/source/adapters/hip/kernel.cpp
+++ b/source/adapters/hip/kernel.cpp
@@ -272,7 +272,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgMemObj(
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {
     if (hArgValue->MemType == ur_mem_handle_t_::Type::Surface) {
-      auto array = hArgValue->Mem.SurfaceMem.getArray();
+      auto array = std::get<SurfaceMem>(hArgValue->Mem).getArray();
       hipArray_Format Format;
       size_t NumChannels;
       getArrayDesc(array, Format, NumChannels);
@@ -283,12 +283,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgMemObj(
             "UR HIP kernels only support images with channel types int32, "
             "uint32, float, and half.");
       }
-      hipSurfaceObject_t hipSurf = hArgValue->Mem.SurfaceMem.getSurface();
+      hipSurfaceObject_t hipSurf =
+          std::get<SurfaceMem>(hArgValue->Mem).getSurface();
       hKernel->setKernelArg(argIndex, sizeof(hipSurf), (void *)&hipSurf);
-    } else
-
-    {
-      void *HIPPtr = hArgValue->Mem.BufferMem.getVoid();
+    } else {
+      void *HIPPtr = std::get<BufferMem>(hArgValue->Mem).getVoid();
       hKernel->setKernelArg(argIndex, sizeof(void *), (void *)&HIPPtr);
     }
   } catch (ur_result_t Err) {

--- a/source/adapters/hip/memory.hpp
+++ b/source/adapters/hip/memory.hpp
@@ -11,6 +11,119 @@
 
 #include "common.hpp"
 #include <cassert>
+#include <variant>
+
+// Handler for plain, pointer-based HIP allocations
+struct BufferMem {
+  using native_type = hipDeviceptr_t;
+
+  // If this allocation is a sub-buffer (i.e., a view on an existing
+  // allocation), this is the pointer to the parent handler structure
+  ur_mem_handle_t Parent;
+  // HIP handler for the pointer
+  native_type Ptr;
+
+  /// Pointer associated with this device on the host
+  void *HostPtr;
+  /// Size of the allocation in bytes
+  size_t Size;
+  /// Size of the active mapped region.
+  size_t MapSize;
+  /// Offset of the active mapped region.
+  size_t MapOffset;
+  /// Pointer to the active mapped region, if any
+  void *MapPtr;
+  /// Original flags for the mapped region
+  ur_map_flags_t MapFlags;
+
+  /** AllocMode
+   * Classic: Just a normal buffer allocated on the device via hip malloc
+   * UseHostPtr: Use an address on the host for the device
+   * CopyIn: The data for the device comes from the host but the host
+   pointer is not available later for re-use
+   * AllocHostPtr: Uses pinned-memory allocation
+  */
+  enum class AllocMode {
+    Classic,
+    UseHostPtr,
+    CopyIn,
+    AllocHostPtr
+  } MemAllocMode;
+
+  BufferMem(ur_mem_handle_t Parent, AllocMode Mode, hipDeviceptr_t Ptr,
+            void *HostPtr, size_t Size)
+      : Parent{Parent}, Ptr{Ptr}, HostPtr{HostPtr}, Size{Size}, MapSize{0},
+        MapOffset{0}, MapPtr{nullptr}, MapFlags{UR_MAP_FLAG_WRITE},
+        MemAllocMode{Mode} {};
+
+  native_type get() const noexcept { return Ptr; }
+
+  native_type getWithOffset(size_t Offset) const noexcept {
+    return reinterpret_cast<native_type>(reinterpret_cast<uint8_t *>(Ptr) +
+                                         Offset);
+  }
+
+  void *getVoid() const noexcept { return reinterpret_cast<void *>(Ptr); }
+
+  size_t getSize() const noexcept { return Size; }
+
+  void *getMapPtr() const noexcept { return MapPtr; }
+
+  size_t getMapSize() const noexcept { return MapSize; }
+
+  size_t getMapOffset() const noexcept { return MapOffset; }
+
+  /// Returns a pointer to data visible on the host that contains
+  /// the data on the device associated with this allocation.
+  /// The offset is used to index into the HIP allocation.
+  ///
+  void *mapToPtr(size_t Size, size_t Offset, ur_map_flags_t Flags) noexcept {
+    assert(MapPtr == nullptr);
+    MapSize = Size;
+    MapOffset = Offset;
+    MapFlags = Flags;
+    if (HostPtr) {
+      MapPtr = static_cast<char *>(HostPtr) + Offset;
+    } else {
+      // TODO: Allocate only what is needed based on the offset
+      MapPtr = static_cast<void *>(malloc(this->getSize()));
+    }
+    return MapPtr;
+  }
+
+  /// Detach the allocation from the host memory.
+  void unmap(void *) noexcept {
+    assert(MapPtr != nullptr);
+
+    if (MapPtr != HostPtr) {
+      free(MapPtr);
+    }
+    MapPtr = nullptr;
+    MapSize = 0;
+    MapOffset = 0;
+  }
+
+  ur_map_flags_t getMapFlags() const noexcept {
+    assert(MapPtr != nullptr);
+    return MapFlags;
+  }
+};
+
+// Handler data for surface object (i.e. Images)
+struct SurfaceMem {
+  hipArray *Array;
+  hipSurfaceObject_t SurfObj;
+  ur_mem_type_t ImageType;
+
+  SurfaceMem(hipArray *Array, hipSurfaceObject_t Surf, ur_mem_type_t ImageType)
+      : Array{Array}, SurfObj{Surf}, ImageType{ImageType} {};
+
+  hipArray *getArray() const noexcept { return Array; }
+
+  hipSurfaceObject_t getSurface() const noexcept { return SurfObj; }
+
+  ur_mem_type_t getImageType() const noexcept { return ImageType; }
+};
 
 /// UR Mem mapping to HIP memory allocations, both data and texture/surface.
 /// \brief Represents non-SVM allocations on the HIP backend.
@@ -37,128 +150,16 @@ struct ur_mem_handle_t_ {
   /// In HIP their API handlers are different. Whereas "Buffers" are allocated
   /// as pointer-like structs, "Images" are stored in Textures or Surfaces.
   /// This union allows implementation to use either from the same handler.
-  union MemImpl {
-    // Handler for plain, pointer-based HIP allocations
-    struct BufferMem {
-      using native_type = hipDeviceptr_t;
-
-      // If this allocation is a sub-buffer (i.e., a view on an existing
-      // allocation), this is the pointer to the parent handler structure
-      ur_mem Parent;
-      // HIP handler for the pointer
-      native_type Ptr;
-
-      /// Pointer associated with this device on the host
-      void *HostPtr;
-      /// Size of the allocation in bytes
-      size_t Size;
-      /// Size of the active mapped region.
-      size_t MapSize;
-      /// Offset of the active mapped region.
-      size_t MapOffset;
-      /// Pointer to the active mapped region, if any
-      void *MapPtr;
-      /// Original flags for the mapped region
-      ur_map_flags_t MapFlags;
-
-      /** AllocMode
-       * Classic: Just a normal buffer allocated on the device via hip malloc
-       * UseHostPtr: Use an address on the host for the device
-       * CopyIn: The data for the device comes from the host but the host
-       pointer is not available later for re-use
-       * AllocHostPtr: Uses pinned-memory allocation
-      */
-      enum class AllocMode {
-        Classic,
-        UseHostPtr,
-        CopyIn,
-        AllocHostPtr
-      } MemAllocMode;
-
-      native_type get() const noexcept { return Ptr; }
-
-      native_type getWithOffset(size_t Offset) const noexcept {
-        return reinterpret_cast<native_type>(reinterpret_cast<uint8_t *>(Ptr) +
-                                             Offset);
-      }
-
-      void *getVoid() const noexcept { return reinterpret_cast<void *>(Ptr); }
-
-      size_t getSize() const noexcept { return Size; }
-
-      void *getMapPtr() const noexcept { return MapPtr; }
-
-      size_t getMapSize() const noexcept { return MapSize; }
-
-      size_t getMapOffset() const noexcept { return MapOffset; }
-
-      /// Returns a pointer to data visible on the host that contains
-      /// the data on the device associated with this allocation.
-      /// The offset is used to index into the HIP allocation.
-      ///
-      void *mapToPtr(size_t Size, size_t Offset,
-                     ur_map_flags_t Flags) noexcept {
-        assert(MapPtr == nullptr);
-        MapSize = Size;
-        MapOffset = Offset;
-        MapFlags = Flags;
-        if (HostPtr) {
-          MapPtr = static_cast<char *>(HostPtr) + Offset;
-        } else {
-          // TODO: Allocate only what is needed based on the offset
-          MapPtr = static_cast<void *>(malloc(this->getSize()));
-        }
-        return MapPtr;
-      }
-
-      /// Detach the allocation from the host memory.
-      void unmap(void *) noexcept {
-        assert(MapPtr != nullptr);
-
-        if (MapPtr != HostPtr) {
-          free(MapPtr);
-        }
-        MapPtr = nullptr;
-        MapSize = 0;
-        MapOffset = 0;
-      }
-
-      ur_map_flags_t getMapFlags() const noexcept {
-        assert(MapPtr != nullptr);
-        return MapFlags;
-      }
-    } BufferMem;
-
-    // Handler data for surface object (i.e. Images)
-    struct SurfaceMem {
-      hipArray *Array;
-      hipSurfaceObject_t SurfObj;
-      ur_mem_type_t ImageType;
-
-      hipArray *getArray() const noexcept { return Array; }
-
-      hipSurfaceObject_t getSurface() const noexcept { return SurfObj; }
-
-      ur_mem_type_t getImageType() const noexcept { return ImageType; }
-    } SurfaceMem;
-  } Mem;
+  std::variant<BufferMem, SurfaceMem> Mem;
 
   /// Constructs the UR MEM handler for a non-typed allocation ("buffer")
   ur_mem_handle_t_(ur_context Ctxt, ur_mem Parent, ur_mem_flags_t MemFlags,
-                   MemImpl::BufferMem::AllocMode Mode, hipDeviceptr_t Ptr,
-                   void *HostPtr, size_t Size)
-      : Context{Ctxt}, RefCount{1}, MemType{Type::Buffer}, MemFlags{MemFlags} {
-    Mem.BufferMem.Ptr = Ptr;
-    Mem.BufferMem.Parent = Parent;
-    Mem.BufferMem.HostPtr = HostPtr;
-    Mem.BufferMem.Size = Size;
-    Mem.BufferMem.MapSize = 0;
-    Mem.BufferMem.MapOffset = 0;
-    Mem.BufferMem.MapPtr = nullptr;
-    Mem.BufferMem.MapFlags = UR_MAP_FLAG_WRITE;
-    Mem.BufferMem.MemAllocMode = Mode;
+                   BufferMem::AllocMode Mode, hipDeviceptr_t Ptr, void *HostPtr,
+                   size_t Size)
+      : Context{Ctxt}, RefCount{1}, MemType{Type::Buffer}, MemFlags{MemFlags},
+        Mem{BufferMem{Parent, Mode, Ptr, HostPtr, Size}} {
     if (isSubBuffer()) {
-      urMemRetain(Mem.BufferMem.Parent);
+      urMemRetain(std::get<BufferMem>(Mem).Parent);
     } else {
       urContextRetain(Context);
     }
@@ -167,16 +168,14 @@ struct ur_mem_handle_t_ {
   /// Constructs the UR allocation for an Image object
   ur_mem_handle_t_(ur_context Ctxt, hipArray *Array, hipSurfaceObject_t Surf,
                    ur_mem_flags_t MemFlags, ur_mem_type_t ImageType, void *)
-      : Context{Ctxt}, RefCount{1}, MemType{Type::Surface}, MemFlags{MemFlags} {
-    Mem.SurfaceMem.Array = Array;
-    Mem.SurfaceMem.ImageType = ImageType;
-    Mem.SurfaceMem.SurfObj = Surf;
+      : Context{Ctxt}, RefCount{1}, MemType{Type::Surface}, MemFlags{MemFlags},
+        Mem{SurfaceMem{Array, Surf, ImageType}} {
     urContextRetain(Context);
   }
 
   ~ur_mem_handle_t_() {
     if (isBuffer() && isSubBuffer()) {
-      urMemRelease(Mem.BufferMem.Parent);
+      urMemRelease(std::get<BufferMem>(Mem).Parent);
       return;
     }
     urContextRelease(Context);
@@ -185,7 +184,7 @@ struct ur_mem_handle_t_ {
   bool isBuffer() const noexcept { return MemType == Type::Buffer; }
 
   bool isSubBuffer() const noexcept {
-    return (isBuffer() && (Mem.BufferMem.Parent != nullptr));
+    return (isBuffer() && (std::get<BufferMem>(Mem).Parent != nullptr));
   }
 
   bool isImage() const noexcept { return MemType == Type::Surface; }


### PR DESCRIPTION
Std::variant is safer than unions in the `ur_mem_handle_t_` class and it will make it easier to incrementally move to multi device ctx, which requires adding `std::vector`s to the MemImpl, which is not possible in a union.