### PR TITLE
[Command-buffer][L0] Reset sync-point events

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -38,6 +38,8 @@
 
   There is also a WaitEvent used by the `ur_exp_command_buffer_handle_t` class
   in the prefix to wait on any dependencies passed in the enqueue wait-list.
+  This WaitEvent is reset at the end of the suffix, along with reset commands
+  to reset the L0 events used to implement the UR sync-points.
 
   ┌──────────┬────────────────────────────────────────────────┬─────────┐
   │  Prefix  │ Commands added to UR command-buffer by UR user │ Suffix  │
@@ -47,10 +49,10 @@
   Prefix    │Reset signal event │ Barrier waiting on wait event│
             └───────────────────┴──────────────────────────────┘
 
-            ┌─────────────────────────────────────────┐
-  Suffix    │Signal the UR command-buffer signal event│
-            └─────────────────────────────────────────┘
-
+            ┌─────────────────────────────────────────────┐──────────────┐
+  Suffix    │Barrier waiting on sync-point event,         │ Reset events │
+            │signalling the UR command-buffer signal event│              │
+            └─────────────────────────────────────────────┘──────────────┘
 
   For a call to `urCommandBufferEnqueueExp` with an event_list `EL`,
   command-buffer `CB`, and return event `RE` our implementation has to create
@@ -437,26 +439,31 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t CommandBuffer) {
-  // Reset the L0 events we use for command-buffer internal sync-points to the
-  // non-signalled state
-  ZE2UR_CALL(zeCommandListAppendBarrier,
-             (CommandBuffer->ZeCommandList, nullptr, 0, nullptr));
-  for (auto SyncPoint : CommandBuffer->SyncPoints) {
-    ur_event_handle_t Event = SyncPoint.second;
-    ZE2UR_CALL(zeCommandListAppendEventReset,
-               (CommandBuffer->ZeCommandList, Event->ZeEvent));
+  // Create a list of events for our signal event to wait on
+  const size_t NumEvents = CommandBuffer->SyncPoints.size();
+  std::vector<ze_event_handle_t> WaitEventList{NumEvents};
+  for (size_t i = 0; i < NumEvents; i++) {
+    WaitEventList[i] = CommandBuffer->SyncPoints[i]->ZeEvent;
   }
+
+  // Wait for all the user added commands to complete, and signal the
+  // command-buffer signal-event when they are done.
+  ZE2UR_CALL(zeCommandListAppendBarrier,
+             (CommandBuffer->ZeCommandList, CommandBuffer->SignalEvent->ZeEvent,
+              NumEvents, WaitEventList.data()));
 
   // Reset the wait-event for the UR command-buffer that is signalled when its
   // submission dependencies have been satisfied.
   ZE2UR_CALL(zeCommandListAppendEventReset,
              (CommandBuffer->ZeCommandList, CommandBuffer->WaitEvent->ZeEvent));
 
-  // We need to append signal that will indicate that command-buffer has
-  // finished executing.
-  ZE2UR_CALL(
-      zeCommandListAppendSignalEvent,
-      (CommandBuffer->ZeCommandList, CommandBuffer->SignalEvent->ZeEvent));
+  // Reset the L0 events we use for command-buffer internal sync-points to the
+  // non-signalled state
+  for (auto Event : WaitEventList) {
+    ZE2UR_CALL(zeCommandListAppendEventReset,
+               (CommandBuffer->ZeCommandList, Event));
+  }
+
   // Close the command list and have it ready for dispatch.
   ZE2UR_CALL(zeCommandListClose, (CommandBuffer->ZeCommandList));
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
The L0 events used to implement [UR sync-points](https://oneapi-src.github.io/unified-runtime/core/EXP-COMMAND-BUFFER.html#sync-points) in a command-buffer aren't reset after the first execution. Leaving them in a signaled state before subsequent submissions of the UR command-buffer.

This patch resets the L0 events used as UR command-buffer sync-points to the non-signaled state, by appending event reset commands to the end of the user defined command-list. There is also a reset added for the UR command-buffer wait event that is signaled when the wait list dependencies of `urCommandBufferEnqueueExp` are met.

Additionally this patch removes the host scope flag from being set on L0 events created by the UR command-buffer, as we never signal/reset them from host, only device.

Companion DPC++ PR - https://github.com/intel/llvm/pull/11553