### PR TITLE
[Bindless] Structs & enums for image types and cubemap enablement

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -245,6 +245,8 @@ class ur_structure_type_v(IntEnum):
     EXP_INTEROP_SEMAPHORE_DESC = 0x2002             ## ::ur_exp_interop_semaphore_desc_t
     EXP_FILE_DESCRIPTOR = 0x2003                    ## ::ur_exp_file_descriptor_t
     EXP_WIN32_HANDLE = 0x2004                       ## ::ur_exp_win32_handle_t
+    EXP_IMAGE_TYPE_DESC = 0x2005                    ## ::ur_exp_image_type_desc_t
+    EXP_SAMPLER_CUBEMAP_PROPERTIES = 0x2006         ## ::ur_exp_sampler_cubemap_properties_t
 
 class ur_structure_type_t(c_int):
     def __str__(self):
@@ -2171,6 +2173,34 @@ class ur_exp_image_copy_flags_t(c_int):
 
 
 ###############################################################################
+## @brief Dictates the image type to distinguish between image types that can be
+##        represented equivalently in memory.
+class ur_exp_image_type_v(IntEnum):
+    _1D = 0                                         ## 1D image type
+    _2D = 1                                         ## 2D image type
+    _3D = 2                                         ## 3D image type
+    CUBEMAP = 3                                     ## Cubemap image type
+    _1D_ARRAY = 4                                   ## 1D image array type
+    _2D_ARRAY = 5                                   ## 2D image array type
+    CUBEMAP_ARRAY = 6                               ## Cubemap array image type
+
+class ur_exp_image_type_t(c_int):
+    def __str__(self):
+        return str(ur_exp_image_type_v(self.value))
+
+
+###############################################################################
+## @brief Sampler cubemap seamless filtering mode.
+class ur_exp_sampler_cubemap_filter_mode_v(IntEnum):
+    SEAMLESS = 0                                    ## Seamless filtering
+    DISJOINTED = 1                                  ## Disable seamless filtering
+
+class ur_exp_sampler_cubemap_filter_mode_t(c_int):
+    def __str__(self):
+        return str(ur_exp_sampler_cubemap_filter_mode_v(self.value))
+
+
+###############################################################################
 ## @brief File descriptor
 class ur_exp_file_descriptor_t(Structure):
     _fields_ = [
@@ -2211,6 +2241,21 @@ class ur_exp_sampler_mip_properties_t(Structure):
     ]
 
 ###############################################################################
+## @brief Describes cubemap sampler properties
+## 
+## @details
+##     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
+##       as part of a `pNext` chain.
+class ur_exp_sampler_cubemap_properties_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES
+        ("pNext", c_void_p),                                            ## [in,out][optional] pointer to extension-specific structure
+        ("cubemapFilterMode", ur_exp_sampler_cubemap_filter_mode_t)     ## [in] enables or disables seamless cubemap filtering between cubemap
+                                                                        ## faces
+    ]
+
+###############################################################################
 ## @brief Describes an interop memory resource descriptor
 class ur_exp_interop_mem_desc_t(Structure):
     _fields_ = [
@@ -2226,6 +2271,20 @@ class ur_exp_interop_semaphore_desc_t(Structure):
         ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
                                                                         ## ::UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
         ("pNext", c_void_p)                                             ## [in][optional] pointer to extension-specific structure
+    ]
+
+###############################################################################
+## @brief Describes image type properties
+## 
+## @details
+##     - Specify these properties in ::urBindlessImagesImageAllocateExp via
+##       ::ur_image_desc_t as part of a `pNext` chain.
+class ur_exp_image_type_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("type", ur_exp_image_type_t)                                   ## [in] indicates image type
     ]
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -214,46 +214,48 @@ typedef enum ur_function_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines structure types
 typedef enum ur_structure_type_t {
-    UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES = 0,               ///< ::ur_context_properties_t
-    UR_STRUCTURE_TYPE_IMAGE_DESC = 1,                       ///< ::ur_image_desc_t
-    UR_STRUCTURE_TYPE_BUFFER_PROPERTIES = 2,                ///< ::ur_buffer_properties_t
-    UR_STRUCTURE_TYPE_BUFFER_REGION = 3,                    ///< ::ur_buffer_region_t
-    UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES = 4,        ///< ::ur_buffer_channel_properties_t
-    UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES = 5, ///< ::ur_buffer_alloc_location_properties_t
-    UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES = 6,               ///< ::ur_program_properties_t
-    UR_STRUCTURE_TYPE_USM_DESC = 7,                         ///< ::ur_usm_desc_t
-    UR_STRUCTURE_TYPE_USM_HOST_DESC = 8,                    ///< ::ur_usm_host_desc_t
-    UR_STRUCTURE_TYPE_USM_DEVICE_DESC = 9,                  ///< ::ur_usm_device_desc_t
-    UR_STRUCTURE_TYPE_USM_POOL_DESC = 10,                   ///< ::ur_usm_pool_desc_t
-    UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 11,            ///< ::ur_usm_pool_limits_desc_t
-    UR_STRUCTURE_TYPE_DEVICE_BINARY = 12,                   ///< ::ur_device_binary_t
-    UR_STRUCTURE_TYPE_SAMPLER_DESC = 13,                    ///< ::ur_sampler_desc_t
-    UR_STRUCTURE_TYPE_QUEUE_PROPERTIES = 14,                ///< ::ur_queue_properties_t
-    UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES = 15,          ///< ::ur_queue_index_properties_t
-    UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES = 16,       ///< ::ur_context_native_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES = 17,        ///< ::ur_kernel_native_properties_t
-    UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES = 18,         ///< ::ur_queue_native_properties_t
-    UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES = 19,           ///< ::ur_mem_native_properties_t
-    UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES = 20,         ///< ::ur_event_native_properties_t
-    UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES = 21,      ///< ::ur_platform_native_properties_t
-    UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES = 22,        ///< ::ur_device_native_properties_t
-    UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES = 23,       ///< ::ur_program_native_properties_t
-    UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES = 24,       ///< ::ur_sampler_native_properties_t
-    UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC = 25,               ///< ::ur_queue_native_desc_t
-    UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES = 26,     ///< ::ur_device_partition_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_ARG_MEM_OBJ_PROPERTIES = 27,   ///< ::ur_kernel_arg_mem_obj_properties_t
-    UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES = 28,         ///< ::ur_physical_mem_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_ARG_POINTER_PROPERTIES = 29,   ///< ::ur_kernel_arg_pointer_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_ARG_SAMPLER_PROPERTIES = 30,   ///< ::ur_kernel_arg_sampler_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_EXEC_INFO_PROPERTIES = 31,     ///< ::ur_kernel_exec_info_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_ARG_VALUE_PROPERTIES = 32,     ///< ::ur_kernel_arg_value_properties_t
-    UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES = 33,     ///< ::ur_kernel_arg_local_properties_t
-    UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC = 0x1000,     ///< ::ur_exp_command_buffer_desc_t
-    UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES = 0x2000,  ///< ::ur_exp_sampler_mip_properties_t
-    UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC = 0x2001,        ///< ::ur_exp_interop_mem_desc_t
-    UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC = 0x2002,  ///< ::ur_exp_interop_semaphore_desc_t
-    UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR = 0x2003,         ///< ::ur_exp_file_descriptor_t
-    UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE = 0x2004,            ///< ::ur_exp_win32_handle_t
+    UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES = 0,                  ///< ::ur_context_properties_t
+    UR_STRUCTURE_TYPE_IMAGE_DESC = 1,                          ///< ::ur_image_desc_t
+    UR_STRUCTURE_TYPE_BUFFER_PROPERTIES = 2,                   ///< ::ur_buffer_properties_t
+    UR_STRUCTURE_TYPE_BUFFER_REGION = 3,                       ///< ::ur_buffer_region_t
+    UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES = 4,           ///< ::ur_buffer_channel_properties_t
+    UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES = 5,    ///< ::ur_buffer_alloc_location_properties_t
+    UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES = 6,                  ///< ::ur_program_properties_t
+    UR_STRUCTURE_TYPE_USM_DESC = 7,                            ///< ::ur_usm_desc_t
+    UR_STRUCTURE_TYPE_USM_HOST_DESC = 8,                       ///< ::ur_usm_host_desc_t
+    UR_STRUCTURE_TYPE_USM_DEVICE_DESC = 9,                     ///< ::ur_usm_device_desc_t
+    UR_STRUCTURE_TYPE_USM_POOL_DESC = 10,                      ///< ::ur_usm_pool_desc_t
+    UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC = 11,               ///< ::ur_usm_pool_limits_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_BINARY = 12,                      ///< ::ur_device_binary_t
+    UR_STRUCTURE_TYPE_SAMPLER_DESC = 13,                       ///< ::ur_sampler_desc_t
+    UR_STRUCTURE_TYPE_QUEUE_PROPERTIES = 14,                   ///< ::ur_queue_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES = 15,             ///< ::ur_queue_index_properties_t
+    UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES = 16,          ///< ::ur_context_native_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES = 17,           ///< ::ur_kernel_native_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES = 18,            ///< ::ur_queue_native_properties_t
+    UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES = 19,              ///< ::ur_mem_native_properties_t
+    UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES = 20,            ///< ::ur_event_native_properties_t
+    UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES = 21,         ///< ::ur_platform_native_properties_t
+    UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES = 22,           ///< ::ur_device_native_properties_t
+    UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES = 23,          ///< ::ur_program_native_properties_t
+    UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES = 24,          ///< ::ur_sampler_native_properties_t
+    UR_STRUCTURE_TYPE_QUEUE_NATIVE_DESC = 25,                  ///< ::ur_queue_native_desc_t
+    UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES = 26,        ///< ::ur_device_partition_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_ARG_MEM_OBJ_PROPERTIES = 27,      ///< ::ur_kernel_arg_mem_obj_properties_t
+    UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES = 28,            ///< ::ur_physical_mem_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_ARG_POINTER_PROPERTIES = 29,      ///< ::ur_kernel_arg_pointer_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_ARG_SAMPLER_PROPERTIES = 30,      ///< ::ur_kernel_arg_sampler_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_EXEC_INFO_PROPERTIES = 31,        ///< ::ur_kernel_exec_info_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_ARG_VALUE_PROPERTIES = 32,        ///< ::ur_kernel_arg_value_properties_t
+    UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES = 33,        ///< ::ur_kernel_arg_local_properties_t
+    UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC = 0x1000,        ///< ::ur_exp_command_buffer_desc_t
+    UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES = 0x2000,     ///< ::ur_exp_sampler_mip_properties_t
+    UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC = 0x2001,           ///< ::ur_exp_interop_mem_desc_t
+    UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC = 0x2002,     ///< ::ur_exp_interop_semaphore_desc_t
+    UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR = 0x2003,            ///< ::ur_exp_file_descriptor_t
+    UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE = 0x2004,               ///< ::ur_exp_win32_handle_t
+    UR_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC = 0x2005,            ///< ::ur_exp_image_type_desc_t
+    UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES = 0x2006, ///< ::ur_exp_sampler_cubemap_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -6947,6 +6949,34 @@ typedef enum ur_exp_image_copy_flag_t {
 #define UR_EXP_IMAGE_COPY_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Dictates the image type to distinguish between image types that can be
+///        represented equivalently in memory.
+typedef enum ur_exp_image_type_t {
+    UR_EXP_IMAGE_TYPE_1D = 0,            ///< 1D image type
+    UR_EXP_IMAGE_TYPE_2D = 1,            ///< 2D image type
+    UR_EXP_IMAGE_TYPE_3D = 2,            ///< 3D image type
+    UR_EXP_IMAGE_TYPE_CUBEMAP = 3,       ///< Cubemap image type
+    UR_EXP_IMAGE_TYPE_1D_ARRAY = 4,      ///< 1D image array type
+    UR_EXP_IMAGE_TYPE_2D_ARRAY = 5,      ///< 2D image array type
+    UR_EXP_IMAGE_TYPE_CUBEMAP_ARRAY = 6, ///< Cubemap array image type
+    /// @cond
+    UR_EXP_IMAGE_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_image_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler cubemap seamless filtering mode.
+typedef enum ur_exp_sampler_cubemap_filter_mode_t {
+    UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS = 0,   ///< Seamless filtering
+    UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED = 1, ///< Disable seamless filtering
+    /// @cond
+    UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_sampler_cubemap_filter_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief File descriptor
 typedef struct ur_exp_file_descriptor_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
@@ -6987,6 +7017,21 @@ typedef struct ur_exp_sampler_mip_properties_t {
 } ur_exp_sampler_mip_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Describes cubemap sampler properties
+///
+/// @details
+///     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
+///       as part of a `pNext` chain.
+typedef struct ur_exp_sampler_cubemap_properties_t {
+    ur_structure_type_t stype;                              ///< [in] type of this structure, must be
+                                                            ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES
+    void *pNext;                                            ///< [in,out][optional] pointer to extension-specific structure
+    ur_exp_sampler_cubemap_filter_mode_t cubemapFilterMode; ///< [in] enables or disables seamless cubemap filtering between cubemap
+                                                            ///< faces
+
+} ur_exp_sampler_cubemap_properties_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Describes an interop memory resource descriptor
 typedef struct ur_exp_interop_mem_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
@@ -7003,6 +7048,20 @@ typedef struct ur_exp_interop_semaphore_desc_t {
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_exp_interop_semaphore_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Describes image type properties
+///
+/// @details
+///     - Specify these properties in ::urBindlessImagesImageAllocateExp via
+///       ::ur_image_desc_t as part of a `pNext` chain.
+typedef struct ur_exp_image_type_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    ur_exp_image_type_t type;  ///< [in] indicates image type
+
+} ur_exp_image_type_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM allocate pitched memory

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -50,6 +50,7 @@ Runtime:
   * Sampled images
   * Unsampled images
   * Mipmaps
+  * Cubemaps
   * USM backed images
 
 * Interoperability support
@@ -68,6 +69,8 @@ Enums
     ${X}_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
     ${X}_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
     ${X}_STRUCTURE_TYPE_EXP_WIN32_HANDLE
+    ${X}_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC
+    ${X}_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES
 
 * ${x}_device_info_t
     * ${X}_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP
@@ -95,6 +98,19 @@ Enums
     * ${X}_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE
     * ${X}_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST
     * ${X}_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE
+
+* ${x}_exp_image_type_t
+    * ${X}_EXP_IMAGE_TYPE_1D
+    * ${X}_EXP_IMAGE_TYPE_2D
+    * ${X}_EXP_IMAGE_TYPE_3D
+    * ${X}_EXP_IMAGE_TYPE_CUBEMAP
+    * ${X}_EXP_IMAGE_TYPE_1D_ARRAY
+    * ${X}_EXP_IMAGE_TYPE_2D_ARRAY
+    * ${X}_EXP_IMAGE_TYPE_CUBEMAP_ARRAY
+
+* ${x}_exp_sampler_cubemap_filter_mode_t
+    * ${X}_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS
+    * ${X}_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED
 
 * ${x}_function_t
     * ${X}_FUNCTION_USM_PITCHED_ALLOC_EXP
@@ -127,6 +143,8 @@ Types
 * ${x}_exp_interop_semaphore_desc_t
 * ${x}_exp_file_descriptor_t
 * ${x}_exp_win32_handle_t
+* ${x}_exp_image_type_desc_t
+* ${x}_exp_sampler_cubemap_properties_t
 
 Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -175,6 +193,9 @@ Changelog
 | 5.0      | Update interop struct and func param names to adhere to convention. |
 +----------+-------------------------------------------------------------+
 | 6.0      | Fix semaphore import function parameter name.               |
++----------+-------------------------------------------------------------+
+| 7.0      | Add image type descriptor, image type enum, and cubemap     |
+|          | sampling properties.                                        |
 +----------+-------------------------------------------------------------+
 
 Contributors

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -107,6 +107,12 @@ etors:
     - name: EXP_WIN32_HANDLE
       desc: $x_exp_win32_handle_t
       value: "0x2004"
+    - name: EXP_IMAGE_TYPE_DESC
+      desc: $x_exp_image_type_desc_t
+      value: "0x2005"
+    - name: EXP_SAMPLER_CUBEMAP_PROPERTIES
+      desc: $x_exp_sampler_cubemap_properties_t
+      value: "0x2006"
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true
@@ -131,6 +137,36 @@ etors:
     desc: "Device to host"
   - name: DEVICE_TO_DEVICE
     desc: "Device to device"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Dictates the image type to distinguish between image types that can be represented equivalently in memory."
+class: $xBindlessImages
+name: $x_exp_image_type_t
+etors:
+  - name: 1D
+    desc: "1D image type"
+  - name: 2D
+    desc: "2D image type"
+  - name: 3D
+    desc: "3D image type"
+  - name: CUBEMAP
+    desc: "Cubemap image type"
+  - name: 1D_ARRAY
+    desc: "1D image array type"
+  - name: 2D_ARRAY
+    desc: "2D image array type"
+  - name: CUBEMAP_ARRAY
+    desc: "Cubemap array image type"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Sampler cubemap seamless filtering mode."
+class: $xBindlessImages
+name: $x_exp_sampler_cubemap_filter_mode_t
+etors:
+  - name: SEAMLESS
+    desc: "Seamless filtering"
+  - name: DISJOINTED
+    desc: "Disable seamless filtering"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "File descriptor"
@@ -173,6 +209,19 @@ members:
       desc: "[in] mipmap filter mode used for filtering between mipmap levels"
 --- #--------------------------------------------------------------------------
 type: struct
+desc: "Describes cubemap sampler properties"
+details:
+    - Specify these properties in $xSamplerCreate via $x_sampler_desc_t as part
+      of a `pNext` chain.
+class: $xBindlessImages
+name: $x_exp_sampler_cubemap_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_exp_sampler_cubemap_filter_mode_t
+      name: cubemapFilterMode
+      desc: "[in] enables or disables seamless cubemap filtering between cubemap faces"
+--- #--------------------------------------------------------------------------
+type: struct
 desc: "Describes an interop memory resource descriptor"
 class: $xBindlessImages
 name: $x_exp_interop_mem_desc_t
@@ -185,6 +234,19 @@ class: $xBindlessImages
 name: $x_exp_interop_semaphore_desc_t
 base: $x_base_desc_t
 members: []
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Describes image type properties"
+details:
+    - Specify these properties in $xBindlessImagesImageAllocateExp via 
+      $x_image_desc_t as part of a `pNext` chain.
+class: $xBindlessImages
+name: $x_exp_image_type_desc_t
+base: $x_base_desc_t
+members:
+    - type: ur_exp_image_type_t
+      name: type
+      desc: "[in] indicates image type"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "USM allocate pitched memory"

--- a/source/common/ur_params.hpp
+++ b/source/common/ur_params.hpp
@@ -426,17 +426,26 @@ inline std::ostream &operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_exp_image_copy_flag_t value);
 inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_exp_image_type_t value);
+inline std::ostream &
+operator<<(std::ostream &os, enum ur_exp_sampler_cubemap_filter_mode_t value);
+inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_exp_file_descriptor_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_exp_win32_handle_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_exp_sampler_mip_properties_t params);
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_exp_sampler_cubemap_properties_t params);
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_exp_interop_mem_desc_t params);
 inline std::ostream &
 operator<<(std::ostream &os,
            const struct ur_exp_interop_semaphore_desc_t params);
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_exp_image_type_desc_t params);
 inline std::ostream &
 operator<<(std::ostream &os, const struct ur_exp_command_buffer_desc_t params);
 inline std::ostream &operator<<(std::ostream &os,
@@ -1310,6 +1319,14 @@ inline std::ostream &operator<<(std::ostream &os,
     case UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE:
         os << "UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE";
         break;
+
+    case UR_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC:
+        os << "UR_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC";
+        break;
+
+    case UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -1555,6 +1572,18 @@ inline void serializeStruct(std::ostream &os, const void *ptr) {
     case UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE: {
         const ur_exp_win32_handle_t *pstruct =
             (const ur_exp_win32_handle_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_IMAGE_TYPE_DESC: {
+        const ur_exp_image_type_desc_t *pstruct =
+            (const ur_exp_image_type_desc_t *)ptr;
+        ur_params::serializePtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES: {
+        const ur_exp_sampler_cubemap_properties_t *pstruct =
+            (const ur_exp_sampler_cubemap_properties_t *)ptr;
         ur_params::serializePtr(os, pstruct);
     } break;
     default:
@@ -9771,6 +9800,60 @@ inline void serializeFlag<ur_exp_image_copy_flag_t>(std::ostream &os,
 }
 } // namespace ur_params
 inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_exp_image_type_t value) {
+    switch (value) {
+
+    case UR_EXP_IMAGE_TYPE_1D:
+        os << "UR_EXP_IMAGE_TYPE_1D";
+        break;
+
+    case UR_EXP_IMAGE_TYPE_2D:
+        os << "UR_EXP_IMAGE_TYPE_2D";
+        break;
+
+    case UR_EXP_IMAGE_TYPE_3D:
+        os << "UR_EXP_IMAGE_TYPE_3D";
+        break;
+
+    case UR_EXP_IMAGE_TYPE_CUBEMAP:
+        os << "UR_EXP_IMAGE_TYPE_CUBEMAP";
+        break;
+
+    case UR_EXP_IMAGE_TYPE_1D_ARRAY:
+        os << "UR_EXP_IMAGE_TYPE_1D_ARRAY";
+        break;
+
+    case UR_EXP_IMAGE_TYPE_2D_ARRAY:
+        os << "UR_EXP_IMAGE_TYPE_2D_ARRAY";
+        break;
+
+    case UR_EXP_IMAGE_TYPE_CUBEMAP_ARRAY:
+        os << "UR_EXP_IMAGE_TYPE_CUBEMAP_ARRAY";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+inline std::ostream &
+operator<<(std::ostream &os, enum ur_exp_sampler_cubemap_filter_mode_t value) {
+    switch (value) {
+
+    case UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS:
+        os << "UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS";
+        break;
+
+    case UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED:
+        os << "UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_exp_file_descriptor_t params) {
     os << "(struct ur_exp_file_descriptor_t){";
 
@@ -9849,6 +9932,28 @@ operator<<(std::ostream &os,
     os << "}";
     return os;
 }
+inline std::ostream &
+operator<<(std::ostream &os,
+           const struct ur_exp_sampler_cubemap_properties_t params) {
+    os << "(struct ur_exp_sampler_cubemap_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".cubemapFilterMode = ";
+
+    os << (params.cubemapFilterMode);
+
+    os << "}";
+    return os;
+}
 inline std::ostream &operator<<(std::ostream &os,
                                 const struct ur_exp_interop_mem_desc_t params) {
     os << "(struct ur_exp_interop_mem_desc_t){";
@@ -9878,6 +9983,27 @@ operator<<(std::ostream &os,
     os << ".pNext = ";
 
     ur_params::serializeStruct(os, (params.pNext));
+
+    os << "}";
+    return os;
+}
+inline std::ostream &operator<<(std::ostream &os,
+                                const struct ur_exp_image_type_desc_t params) {
+    os << "(struct ur_exp_image_type_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur_params::serializeStruct(os, (params.pNext));
+
+    os << ", ";
+    os << ".type = ";
+
+    os << (params.type);
 
     os << "}";
     return os;


### PR DESCRIPTION
Add structs/enums to distinguish between image types that can be represented equivalently in memory:

 - `ur_exp_image_type_desc_t` struct to hold the type of an image
 - `ur_exp_image_type_t` enum to enable distinguishing between image types that have the same underlying memory ordering/type

Add structs/enums for cubemap sampling:

 - `ur_exp_sampler_cubemap_properties_t` struct to enable seamless filtering between cubemap faces
 - `ur_exp_sampler_cubemap_filter_mode_t` enum to enable distinguishing between cubemap seamless filtering options
 
 This should enable image arrays, cubemaps, and combined image types. 