### PR TITLE
[CI] Clean up after conda init in cmake.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -265,6 +265,12 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: bin/codegen
 
+    # conda init adds content to user's profile making it failing (if conda is gone)
+    - name: Cleanup after conda init
+      run: |
+        cat ${HOME}/.profile || true
+        rm ${HOME}/.profile || true
+
   windows-build:
     name: Build - Windows
     strategy:


### PR DESCRIPTION
When initializing conda few extra commands are added to user's profile. These commands make it impossible to log in as the test user to the machine, since conda may be missing.

We can safely remove the whole '.profile' after the job.