### PR TITLE
Use add_umf_library() instead of add_ur_library()

### DIFF
--- a/source/common/unified_malloc_framework/CMakeLists.txt
+++ b/source/common/unified_malloc_framework/CMakeLists.txt
@@ -3,6 +3,8 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+include(cmake/helpers.cmake)
+
 set(UMF_SOURCES
     src/memory_pool.c
     src/memory_provider.c
@@ -21,11 +23,11 @@ if(UMF_BUILD_SHARED_LIBRARY)
     message(WARNING "Unified Malloc Framework is still an early work in progress."
                      "There are no API/ABI backward compatibility guarantees. There will be breakages."
                      "Do not use the shared library in production software.")
-    add_ur_library(unified_malloc_framework SHARED
+    add_umf_library(unified_malloc_framework SHARED
         ${UMF_SOURCES})
     target_compile_definitions(unified_malloc_framework PUBLIC UMF_SHARED_LIBRARY)
 else()
-    add_ur_library(unified_malloc_framework STATIC
+    add_umf_library(unified_malloc_framework STATIC
         ${UMF_SOURCES})
 endif()
 

--- a/source/common/unified_malloc_framework/cmake/helpers.cmake
+++ b/source/common/unified_malloc_framework/cmake/helpers.cmake
@@ -1,0 +1,63 @@
+# Copyright (C) 2023 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#
+# helpers.cmake -- helper functions for the UMF's top-level CMakeLists.txt
+#
+
+function(add_umf_target_compile_options name)
+    if(NOT MSVC)
+        target_compile_options(${name} PRIVATE
+            -fPIC
+            -Wall
+            -Wpedantic
+            -Wempty-body
+            -Wunused-parameter
+            $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
+            $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
+        )
+        if (CMAKE_BUILD_TYPE STREQUAL "Release")
+            target_compile_definitions(${name} PRIVATE -D_FORTIFY_SOURCE=2)
+        endif()
+        if(UR_DEVELOPER_MODE)
+            target_compile_options(${name} PRIVATE
+                -Werror
+                -fno-omit-frame-pointer
+                -fstack-protector-strong
+            )
+        endif()
+    elseif(MSVC)
+        target_compile_options(${name} PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/MP>  # clang-cl.exe does not support /MP
+            /W3
+            /MD$<$<CONFIG:Debug>:d>
+            /GS
+        )
+
+        if(UR_DEVELOPER_MODE)
+            target_compile_options(${name} PRIVATE /WX /GS)
+        endif()
+    endif()
+endfunction()
+
+function(add_umf_target_link_options name)
+    if(NOT MSVC)
+        if (NOT APPLE)
+            target_link_options(${name} PRIVATE "LINKER:-z,relro,-z,now")
+        endif()
+    elseif(MSVC)
+        target_link_options(${name} PRIVATE
+            /DYNAMICBASE
+            /HIGHENTROPYVA
+            /NXCOMPAT
+        )
+    endif()
+endfunction()
+
+function(add_umf_library name)
+    add_library(${name} ${ARGN})
+    add_umf_target_compile_options(${name})
+    add_umf_target_link_options(${name})
+endfunction()


### PR DESCRIPTION
`add_ur_library()` is undefined in UMF now,
because it is defined only in the UR project.

Define and use `add_umf_library()` instead of `add_ur_library()`,
so that UMF can be used as a stand-alone project.

Fixes: #981