### PR TITLE
[CUDA] Add support for binary type query

### DIFF
--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -180,8 +180,6 @@ ur_result_t createProgram(ur_context_handle_t hContext,
             UR_RESULT_ERROR_INVALID_CONTEXT);
   UR_ASSERT(size, UR_RESULT_ERROR_INVALID_SIZE);
 
-  ur_result_t Result = UR_RESULT_SUCCESS;
-
   std::unique_ptr<ur_program_handle_t_> RetProgram{
       new ur_program_handle_t_{hContext}};
 
@@ -191,19 +189,16 @@ ur_result_t createProgram(ur_context_handle_t hContext,
     } else if (pProperties->count == 0 && pProperties->pMetadatas != nullptr) {
       return UR_RESULT_ERROR_INVALID_SIZE;
     }
-    Result =
-        RetProgram->setMetadata(pProperties->pMetadatas, pProperties->count);
+    UR_CHECK_ERROR(
+        RetProgram->setMetadata(pProperties->pMetadatas, pProperties->count));
   }
-  UR_ASSERT(Result == UR_RESULT_SUCCESS, Result);
 
   auto pBinary_string = reinterpret_cast<const char *>(pBinary);
 
-  Result = RetProgram->setBinary(pBinary_string, size);
-  UR_ASSERT(Result == UR_RESULT_SUCCESS, Result);
-
+  UR_CHECK_ERROR(RetProgram->setBinary(pBinary_string, size));
   *phProgram = RetProgram.release();
 
-  return Result;
+  return UR_RESULT_SUCCESS;
 }
 
 /// CUDA will handle the PTX/CUBIN binaries internally through CUmodule object.

--- a/source/adapters/cuda/program.hpp
+++ b/source/adapters/cuda/program.hpp
@@ -24,6 +24,7 @@ struct ur_program_handle_t_ {
   size_t BinarySizeInBytes;
   std::atomic_uint32_t RefCount;
   ur_context_handle_t Context;
+  ur_program_binary_type_t BinaryType = UR_PROGRAM_BINARY_TYPE_NONE;
 
   // Metadata
   std::unordered_map<std::string, std::tuple<uint32_t, uint32_t, uint32_t>>

--- a/source/adapters/cuda/program.hpp
+++ b/source/adapters/cuda/program.hpp
@@ -24,6 +24,11 @@ struct ur_program_handle_t_ {
   size_t BinarySizeInBytes;
   std::atomic_uint32_t RefCount;
   ur_context_handle_t Context;
+
+  /* The ur_program_binary_type_t property is defined individually for every
+   * device in a program. However, since the CUDA adapter only has 1 device per
+   * context / program, there is no need to keep track of its value for each
+   * device. */
   ur_program_binary_type_t BinaryType = UR_PROGRAM_BINARY_TYPE_NONE;
 
   // Metadata


### PR DESCRIPTION
CUDA does not make a distinction between binaryTypes (it treats PTX and binaries using the same entrypoints). 

However, for UR, by definition:
-  `urProgramCompile` should set the binary type to `UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT` 
-  `urProgramBuild` / `urProgramLink` should set it to `UR_PROGRAM_BINARY_TYPE_EXECUTABLE`. 
- `urProgramCreateWithBinary` should set the binary type to `UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT`