### PR TITLE
[HIP] Fix host/device synchronization

### DIFF
--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -939,9 +939,6 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
   if (pDeviceTimestamp) {
     UR_CHECK_ERROR(hipEventCreateWithFlags(&Event, hipEventDefault));
     UR_CHECK_ERROR(hipEventRecord(Event));
-  }
-
-  if (pDeviceTimestamp) {
     UR_CHECK_ERROR(hipEventSynchronize(Event));
     float ElapsedTime = 0.0f;
     UR_CHECK_ERROR(hipEventElapsedTime(&ElapsedTime,

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -940,12 +940,6 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipEventCreateWithFlags(&Event, hipEventDefault));
     UR_CHECK_ERROR(hipEventRecord(Event));
   }
-  if (pHostTimestamp) {
-    using namespace std::chrono;
-    *pHostTimestamp =
-        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch())
-            .count();
-  }
 
   if (pDeviceTimestamp) {
     UR_CHECK_ERROR(hipEventSynchronize(Event));
@@ -955,5 +949,11 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
     *pDeviceTimestamp = (uint64_t)(ElapsedTime * (double)1e6);
   }
 
+  if (pHostTimestamp) {
+    using namespace std::chrono;
+    *pHostTimestamp =
+        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch())
+            .count();
+  }
   return UR_RESULT_SUCCESS;
 }

--- a/test/conformance/device/device_adapter_hip.match
+++ b/test/conformance/device/device_adapter_hip.match
@@ -1,5 +1,6 @@
 {{OPT}}urDeviceCreateWithNativeHandleTest.Success
 {{OPT}}urDeviceGetTest.InvalidValueNumEntries
+{{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_SINGLE_FP_CONFIG
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_DOUBLE_FP_CONFIG
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_QUEUE_PROPERTIES

--- a/test/conformance/device/device_adapter_hip.match
+++ b/test/conformance/device/device_adapter_hip.match
@@ -1,7 +1,5 @@
 {{OPT}}urDeviceCreateWithNativeHandleTest.Success
 {{OPT}}urDeviceGetTest.InvalidValueNumEntries
-{{OPT}}urDeviceGetGlobalTimestampTest.Success
-{{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_SINGLE_FP_CONFIG
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_DOUBLE_FP_CONFIG
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_QUEUE_PROPERTIES


### PR DESCRIPTION
This PR fixes the entry-point `urDeviceGetGlobalTimestamp`:
* Initialize the global `EvBase` event when getting platforms
* Re-order fetching host/device times
  * Fetching the device time takes longer so fetching this first results in a more synchronized time between host/device time.

llvm-testing: https://github.com/intel/llvm/pull/11669