### PR TITLE
[docs] Printing C API html docs

### DIFF
--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  * See LICENSE.TXT
@@ -22,8 +22,6 @@ extern "C" {
 /// @brief Print ur_function_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintFunction(enum ur_function_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -32,8 +30,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintFunction(enum ur_function_t value, ch
 /// @brief Print ur_structure_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintStructureType(enum ur_structure_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -42,8 +38,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintStructureType(enum ur_structure_type_
 /// @brief Print ur_result_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintResult(enum ur_result_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -52,8 +46,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintResult(enum ur_result_t value, char *
 /// @brief Print ur_base_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBaseProperties(const struct ur_base_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -62,8 +54,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBaseProperties(const struct ur_base_p
 /// @brief Print ur_base_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBaseDesc(const struct ur_base_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -72,8 +62,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBaseDesc(const struct ur_base_desc_t 
 /// @brief Print ur_rect_offset_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintRectOffset(const struct ur_rect_offset_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -82,8 +70,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintRectOffset(const struct ur_rect_offse
 /// @brief Print ur_rect_region_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintRectRegion(const struct ur_rect_region_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -92,8 +78,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintRectRegion(const struct ur_rect_regio
 /// @brief Print ur_device_init_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceInitFlags(enum ur_device_init_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -102,8 +86,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceInitFlags(enum ur_device_init_f
 /// @brief Print ur_loader_config_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigInfo(enum ur_loader_config_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -112,8 +94,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigInfo(enum ur_loader_confi
 /// @brief Print ur_code_location_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCodeLocation(const struct ur_code_location_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -122,8 +102,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintCodeLocation(const struct ur_code_loc
 /// @brief Print ur_adapter_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterInfo(enum ur_adapter_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -132,8 +110,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterInfo(enum ur_adapter_info_t va
 /// @brief Print ur_adapter_backend_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterBackend(enum ur_adapter_backend_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -142,8 +118,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterBackend(enum ur_adapter_backen
 /// @brief Print ur_platform_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformInfo(enum ur_platform_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -152,8 +126,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformInfo(enum ur_platform_info_t 
 /// @brief Print ur_api_version_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintApiVersion(enum ur_api_version_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -162,8 +134,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintApiVersion(enum ur_api_version_t valu
 /// @brief Print ur_platform_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformNativeProperties(const struct ur_platform_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -172,8 +142,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformNativeProperties(const struct
 /// @brief Print ur_platform_backend_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformBackend(enum ur_platform_backend_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -182,8 +150,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformBackend(enum ur_platform_back
 /// @brief Print ur_device_binary_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceBinary(const struct ur_device_binary_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -192,8 +158,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceBinary(const struct ur_device_b
 /// @brief Print ur_device_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceType(enum ur_device_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -202,8 +166,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceType(enum ur_device_type_t valu
 /// @brief Print ur_device_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceInfo(enum ur_device_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -212,8 +174,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceInfo(enum ur_device_info_t valu
 /// @brief Print ur_device_affinity_domain_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceAffinityDomainFlags(enum ur_device_affinity_domain_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -222,8 +182,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceAffinityDomainFlags(enum ur_dev
 /// @brief Print ur_device_partition_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartition(enum ur_device_partition_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -232,8 +190,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartition(enum ur_device_partit
 /// @brief Print ur_device_partition_property_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartitionProperty(const struct ur_device_partition_property_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -242,8 +198,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartitionProperty(const struct 
 /// @brief Print ur_device_partition_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartitionProperties(const struct ur_device_partition_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -252,8 +206,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartitionProperties(const struc
 /// @brief Print ur_device_fp_capability_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceFpCapabilityFlags(enum ur_device_fp_capability_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -262,8 +214,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceFpCapabilityFlags(enum ur_devic
 /// @brief Print ur_device_mem_cache_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceMemCacheType(enum ur_device_mem_cache_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -272,8 +222,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceMemCacheType(enum ur_device_mem
 /// @brief Print ur_device_local_mem_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceLocalMemType(enum ur_device_local_mem_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -282,8 +230,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceLocalMemType(enum ur_device_loc
 /// @brief Print ur_device_exec_capability_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceExecCapabilityFlags(enum ur_device_exec_capability_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -292,8 +238,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceExecCapabilityFlags(enum ur_dev
 /// @brief Print ur_device_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceNativeProperties(const struct ur_device_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -302,8 +246,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceNativeProperties(const struct u
 /// @brief Print ur_memory_order_capability_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemoryOrderCapabilityFlags(enum ur_memory_order_capability_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -312,8 +254,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemoryOrderCapabilityFlags(enum ur_me
 /// @brief Print ur_memory_scope_capability_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemoryScopeCapabilityFlags(enum ur_memory_scope_capability_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -322,8 +262,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemoryScopeCapabilityFlags(enum ur_me
 /// @brief Print ur_device_usm_access_capability_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceUsmAccessCapabilityFlags(enum ur_device_usm_access_capability_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -332,8 +270,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceUsmAccessCapabilityFlags(enum u
 /// @brief Print ur_context_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextFlags(enum ur_context_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -342,8 +278,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintContextFlags(enum ur_context_flag_t v
 /// @brief Print ur_context_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextProperties(const struct ur_context_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -352,8 +286,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintContextProperties(const struct ur_con
 /// @brief Print ur_context_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextInfo(enum ur_context_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -362,8 +294,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintContextInfo(enum ur_context_info_t va
 /// @brief Print ur_context_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextNativeProperties(const struct ur_context_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -372,8 +302,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintContextNativeProperties(const struct 
 /// @brief Print ur_mem_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemFlags(enum ur_mem_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -382,8 +310,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemFlags(enum ur_mem_flag_t value, ch
 /// @brief Print ur_mem_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemType(enum ur_mem_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -392,8 +318,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemType(enum ur_mem_type_t value, cha
 /// @brief Print ur_mem_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemInfo(enum ur_mem_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -402,8 +326,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemInfo(enum ur_mem_info_t value, cha
 /// @brief Print ur_image_channel_order_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintImageChannelOrder(enum ur_image_channel_order_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -412,8 +334,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintImageChannelOrder(enum ur_image_chann
 /// @brief Print ur_image_channel_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintImageChannelType(enum ur_image_channel_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -422,8 +342,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintImageChannelType(enum ur_image_channe
 /// @brief Print ur_image_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintImageInfo(enum ur_image_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -432,8 +350,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintImageInfo(enum ur_image_info_t value,
 /// @brief Print ur_image_format_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintImageFormat(const struct ur_image_format_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -442,8 +358,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintImageFormat(const struct ur_image_for
 /// @brief Print ur_image_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintImageDesc(const struct ur_image_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -452,8 +366,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintImageDesc(const struct ur_image_desc_
 /// @brief Print ur_buffer_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferProperties(const struct ur_buffer_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -462,8 +374,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferProperties(const struct ur_buff
 /// @brief Print ur_buffer_channel_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferChannelProperties(const struct ur_buffer_channel_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -472,8 +382,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferChannelProperties(const struct 
 /// @brief Print ur_buffer_alloc_location_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferAllocLocationProperties(const struct ur_buffer_alloc_location_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -482,8 +390,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferAllocLocationProperties(const s
 /// @brief Print ur_buffer_region_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferRegion(const struct ur_buffer_region_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -492,8 +398,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferRegion(const struct ur_buffer_r
 /// @brief Print ur_buffer_create_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferCreateType(enum ur_buffer_create_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -502,8 +406,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBufferCreateType(enum ur_buffer_creat
 /// @brief Print ur_mem_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemNativeProperties(const struct ur_mem_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -512,8 +414,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemNativeProperties(const struct ur_m
 /// @brief Print ur_sampler_filter_mode_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerFilterMode(enum ur_sampler_filter_mode_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -522,8 +422,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerFilterMode(enum ur_sampler_fil
 /// @brief Print ur_sampler_addressing_mode_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerAddressingMode(enum ur_sampler_addressing_mode_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -532,8 +430,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerAddressingMode(enum ur_sampler
 /// @brief Print ur_sampler_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerInfo(enum ur_sampler_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -542,8 +438,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerInfo(enum ur_sampler_info_t va
 /// @brief Print ur_sampler_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerDesc(const struct ur_sampler_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -552,8 +446,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerDesc(const struct ur_sampler_d
 /// @brief Print ur_sampler_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerNativeProperties(const struct ur_sampler_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -562,8 +454,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerNativeProperties(const struct 
 /// @brief Print ur_usm_host_mem_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmHostMemFlags(enum ur_usm_host_mem_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -572,8 +462,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmHostMemFlags(enum ur_usm_host_mem_
 /// @brief Print ur_usm_device_mem_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDeviceMemFlags(enum ur_usm_device_mem_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -582,8 +470,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDeviceMemFlags(enum ur_usm_device_
 /// @brief Print ur_usm_pool_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolFlags(enum ur_usm_pool_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -592,8 +478,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolFlags(enum ur_usm_pool_flag_t 
 /// @brief Print ur_usm_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmType(enum ur_usm_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -602,8 +486,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmType(enum ur_usm_type_t value, cha
 /// @brief Print ur_usm_alloc_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmAllocInfo(enum ur_usm_alloc_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -612,8 +494,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmAllocInfo(enum ur_usm_alloc_info_t
 /// @brief Print ur_usm_advice_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmAdviceFlags(enum ur_usm_advice_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -622,8 +502,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmAdviceFlags(enum ur_usm_advice_fla
 /// @brief Print ur_usm_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDesc(const struct ur_usm_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -632,8 +510,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDesc(const struct ur_usm_desc_t pa
 /// @brief Print ur_usm_host_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmHostDesc(const struct ur_usm_host_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -642,8 +518,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmHostDesc(const struct ur_usm_host_
 /// @brief Print ur_usm_device_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDeviceDesc(const struct ur_usm_device_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -652,8 +526,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDeviceDesc(const struct ur_usm_dev
 /// @brief Print ur_usm_alloc_location_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmAllocLocationDesc(const struct ur_usm_alloc_location_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -662,8 +534,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmAllocLocationDesc(const struct ur_
 /// @brief Print ur_usm_pool_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolDesc(const struct ur_usm_pool_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -672,8 +542,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolDesc(const struct ur_usm_pool_
 /// @brief Print ur_usm_pool_limits_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolLimitsDesc(const struct ur_usm_pool_limits_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -682,8 +550,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolLimitsDesc(const struct ur_usm
 /// @brief Print ur_usm_pool_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolInfo(enum ur_usm_pool_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -692,8 +558,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolInfo(enum ur_usm_pool_info_t v
 /// @brief Print ur_virtual_mem_granularity_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemGranularityInfo(enum ur_virtual_mem_granularity_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -702,8 +566,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemGranularityInfo(enum ur_vir
 /// @brief Print ur_virtual_mem_access_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemAccessFlags(enum ur_virtual_mem_access_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -712,8 +574,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemAccessFlags(enum ur_virtual
 /// @brief Print ur_virtual_mem_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemInfo(enum ur_virtual_mem_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -722,8 +582,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemInfo(enum ur_virtual_mem_in
 /// @brief Print ur_physical_mem_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemFlags(enum ur_physical_mem_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -732,8 +590,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemFlags(enum ur_physical_mem
 /// @brief Print ur_physical_mem_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemProperties(const struct ur_physical_mem_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -742,8 +598,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemProperties(const struct ur
 /// @brief Print ur_program_metadata_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramMetadataType(enum ur_program_metadata_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -752,8 +606,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramMetadataType(enum ur_program_m
 /// @brief Print ur_program_metadata_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramMetadata(const struct ur_program_metadata_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -762,8 +614,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramMetadata(const struct ur_progr
 /// @brief Print ur_program_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramProperties(const struct ur_program_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -772,8 +622,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramProperties(const struct ur_pro
 /// @brief Print ur_program_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramInfo(enum ur_program_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -782,8 +630,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramInfo(enum ur_program_info_t va
 /// @brief Print ur_program_build_status_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBuildStatus(enum ur_program_build_status_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -792,8 +638,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBuildStatus(enum ur_program_bu
 /// @brief Print ur_program_binary_type_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBinaryType(enum ur_program_binary_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -802,8 +646,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBinaryType(enum ur_program_bin
 /// @brief Print ur_program_build_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBuildInfo(enum ur_program_build_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -812,8 +654,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBuildInfo(enum ur_program_buil
 /// @brief Print ur_specialization_constant_info_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSpecializationConstantInfo(const struct ur_specialization_constant_info_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -822,8 +662,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintSpecializationConstantInfo(const stru
 /// @brief Print ur_program_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramNativeProperties(const struct ur_program_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -832,8 +670,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramNativeProperties(const struct 
 /// @brief Print ur_kernel_arg_value_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgValueProperties(const struct ur_kernel_arg_value_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -842,8 +678,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgValueProperties(const struct
 /// @brief Print ur_kernel_arg_local_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgLocalProperties(const struct ur_kernel_arg_local_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -852,8 +686,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgLocalProperties(const struct
 /// @brief Print ur_kernel_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelInfo(enum ur_kernel_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -862,8 +694,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelInfo(enum ur_kernel_info_t valu
 /// @brief Print ur_kernel_group_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelGroupInfo(enum ur_kernel_group_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -872,8 +702,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelGroupInfo(enum ur_kernel_group_
 /// @brief Print ur_kernel_sub_group_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSubGroupInfo(enum ur_kernel_sub_group_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -882,8 +710,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSubGroupInfo(enum ur_kernel_sub
 /// @brief Print ur_kernel_cache_config_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelCacheConfig(enum ur_kernel_cache_config_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -892,8 +718,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelCacheConfig(enum ur_kernel_cach
 /// @brief Print ur_kernel_exec_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelExecInfo(enum ur_kernel_exec_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -902,8 +726,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelExecInfo(enum ur_kernel_exec_in
 /// @brief Print ur_kernel_arg_pointer_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgPointerProperties(const struct ur_kernel_arg_pointer_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -912,8 +734,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgPointerProperties(const stru
 /// @brief Print ur_kernel_exec_info_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelExecInfoProperties(const struct ur_kernel_exec_info_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -922,8 +742,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelExecInfoProperties(const struct
 /// @brief Print ur_kernel_arg_sampler_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgSamplerProperties(const struct ur_kernel_arg_sampler_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -932,8 +750,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgSamplerProperties(const stru
 /// @brief Print ur_kernel_arg_mem_obj_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgMemObjProperties(const struct ur_kernel_arg_mem_obj_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -942,8 +758,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelArgMemObjProperties(const struc
 /// @brief Print ur_kernel_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelNativeProperties(const struct ur_kernel_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -952,8 +766,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelNativeProperties(const struct u
 /// @brief Print ur_queue_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueInfo(enum ur_queue_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -962,8 +774,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueInfo(enum ur_queue_info_t value,
 /// @brief Print ur_queue_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFlags(enum ur_queue_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -972,8 +782,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFlags(enum ur_queue_flag_t value
 /// @brief Print ur_queue_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueProperties(const struct ur_queue_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -982,8 +790,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueProperties(const struct ur_queue
 /// @brief Print ur_queue_index_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueIndexProperties(const struct ur_queue_index_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -992,8 +798,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueIndexProperties(const struct ur_
 /// @brief Print ur_queue_native_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueNativeDesc(const struct ur_queue_native_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1002,8 +806,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueNativeDesc(const struct ur_queue
 /// @brief Print ur_queue_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueNativeProperties(const struct ur_queue_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1012,8 +814,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueNativeProperties(const struct ur
 /// @brief Print ur_command_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommand(enum ur_command_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1022,8 +822,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintCommand(enum ur_command_t value, char
 /// @brief Print ur_event_status_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventStatus(enum ur_event_status_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1032,8 +830,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintEventStatus(enum ur_event_status_t va
 /// @brief Print ur_event_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventInfo(enum ur_event_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1042,8 +838,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintEventInfo(enum ur_event_info_t value,
 /// @brief Print ur_profiling_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProfilingInfo(enum ur_profiling_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1052,8 +846,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProfilingInfo(enum ur_profiling_info_
 /// @brief Print ur_event_native_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventNativeProperties(const struct ur_event_native_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1062,8 +854,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintEventNativeProperties(const struct ur
 /// @brief Print ur_execution_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExecutionInfo(enum ur_execution_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1072,8 +862,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExecutionInfo(enum ur_execution_info_
 /// @brief Print ur_map_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMapFlags(enum ur_map_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1082,8 +870,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMapFlags(enum ur_map_flag_t value, ch
 /// @brief Print ur_usm_migration_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmMigrationFlags(enum ur_usm_migration_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1092,8 +878,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmMigrationFlags(enum ur_usm_migrati
 /// @brief Print ur_exp_image_copy_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpImageCopyFlags(enum ur_exp_image_copy_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1102,8 +886,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpImageCopyFlags(enum ur_exp_image_c
 /// @brief Print ur_exp_file_descriptor_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpFileDescriptor(const struct ur_exp_file_descriptor_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1112,8 +894,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpFileDescriptor(const struct ur_exp
 /// @brief Print ur_exp_win32_handle_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpWin32Handle(const struct ur_exp_win32_handle_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1122,8 +902,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpWin32Handle(const struct ur_exp_wi
 /// @brief Print ur_exp_sampler_mip_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerMipProperties(const struct ur_exp_sampler_mip_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1132,8 +910,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerMipProperties(const struct 
 /// @brief Print ur_exp_sampler_addr_modes_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerAddrModes(const struct ur_exp_sampler_addr_modes_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1142,8 +918,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerAddrModes(const struct ur_e
 /// @brief Print ur_exp_interop_mem_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropMemDesc(const struct ur_exp_interop_mem_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1152,8 +926,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropMemDesc(const struct ur_exp
 /// @brief Print ur_exp_interop_semaphore_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropSemaphoreDesc(const struct ur_exp_interop_semaphore_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1162,8 +934,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropSemaphoreDesc(const struct 
 /// @brief Print ur_exp_command_buffer_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpCommandBufferDesc(const struct ur_exp_command_buffer_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -1172,1848 +942,1478 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpCommandBufferDesc(const struct ur_
 /// @brief Print ur_exp_peer_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpPeerInfo(enum ur_exp_peer_info_t value, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_config_create_params_t params struct
+/// @brief Print ur_loader_config_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigCreateParams(const struct ur_loader_config_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_config_retain_params_t params struct
+/// @brief Print ur_loader_config_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigRetainParams(const struct ur_loader_config_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_config_release_params_t params struct
+/// @brief Print ur_loader_config_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigReleaseParams(const struct ur_loader_config_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_config_get_info_params_t params struct
+/// @brief Print ur_loader_config_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigGetInfoParams(const struct ur_loader_config_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_config_enable_layer_params_t params struct
+/// @brief Print ur_loader_config_enable_layer_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigEnableLayerParams(const struct ur_loader_config_enable_layer_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_config_set_code_location_callback_params_t params struct
+/// @brief Print ur_loader_config_set_code_location_callback_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigSetCodeLocationCallbackParams(const struct ur_loader_config_set_code_location_callback_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_platform_get_params_t params struct
+/// @brief Print ur_platform_get_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformGetParams(const struct ur_platform_get_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_platform_get_info_params_t params struct
+/// @brief Print ur_platform_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformGetInfoParams(const struct ur_platform_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_platform_get_native_handle_params_t params struct
+/// @brief Print ur_platform_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformGetNativeHandleParams(const struct ur_platform_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_platform_create_with_native_handle_params_t params struct
+/// @brief Print ur_platform_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformCreateWithNativeHandleParams(const struct ur_platform_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_platform_get_api_version_params_t params struct
+/// @brief Print ur_platform_get_api_version_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformGetApiVersionParams(const struct ur_platform_get_api_version_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_platform_get_backend_option_params_t params struct
+/// @brief Print ur_platform_get_backend_option_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPlatformGetBackendOptionParams(const struct ur_platform_get_backend_option_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_create_params_t params struct
+/// @brief Print ur_context_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextCreateParams(const struct ur_context_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_retain_params_t params struct
+/// @brief Print ur_context_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextRetainParams(const struct ur_context_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_release_params_t params struct
+/// @brief Print ur_context_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextReleaseParams(const struct ur_context_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_get_info_params_t params struct
+/// @brief Print ur_context_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextGetInfoParams(const struct ur_context_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_get_native_handle_params_t params struct
+/// @brief Print ur_context_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextGetNativeHandleParams(const struct ur_context_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_create_with_native_handle_params_t params struct
+/// @brief Print ur_context_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextCreateWithNativeHandleParams(const struct ur_context_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_context_set_extended_deleter_params_t params struct
+/// @brief Print ur_context_set_extended_deleter_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintContextSetExtendedDeleterParams(const struct ur_context_set_extended_deleter_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_get_info_params_t params struct
+/// @brief Print ur_event_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventGetInfoParams(const struct ur_event_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_get_profiling_info_params_t params struct
+/// @brief Print ur_event_get_profiling_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventGetProfilingInfoParams(const struct ur_event_get_profiling_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_wait_params_t params struct
+/// @brief Print ur_event_wait_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventWaitParams(const struct ur_event_wait_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_retain_params_t params struct
+/// @brief Print ur_event_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventRetainParams(const struct ur_event_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_release_params_t params struct
+/// @brief Print ur_event_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventReleaseParams(const struct ur_event_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_get_native_handle_params_t params struct
+/// @brief Print ur_event_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventGetNativeHandleParams(const struct ur_event_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_create_with_native_handle_params_t params struct
+/// @brief Print ur_event_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventCreateWithNativeHandleParams(const struct ur_event_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_event_set_callback_params_t params struct
+/// @brief Print ur_event_set_callback_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEventSetCallbackParams(const struct ur_event_set_callback_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_create_with_il_params_t params struct
+/// @brief Print ur_program_create_with_il_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramCreateWithIlParams(const struct ur_program_create_with_il_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_create_with_binary_params_t params struct
+/// @brief Print ur_program_create_with_binary_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramCreateWithBinaryParams(const struct ur_program_create_with_binary_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_build_params_t params struct
+/// @brief Print ur_program_build_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBuildParams(const struct ur_program_build_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_build_exp_params_t params struct
+/// @brief Print ur_program_build_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramBuildExpParams(const struct ur_program_build_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_compile_params_t params struct
+/// @brief Print ur_program_compile_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramCompileParams(const struct ur_program_compile_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_compile_exp_params_t params struct
+/// @brief Print ur_program_compile_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramCompileExpParams(const struct ur_program_compile_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_link_params_t params struct
+/// @brief Print ur_program_link_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramLinkParams(const struct ur_program_link_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_link_exp_params_t params struct
+/// @brief Print ur_program_link_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramLinkExpParams(const struct ur_program_link_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_retain_params_t params struct
+/// @brief Print ur_program_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramRetainParams(const struct ur_program_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_release_params_t params struct
+/// @brief Print ur_program_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramReleaseParams(const struct ur_program_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_get_function_pointer_params_t params struct
+/// @brief Print ur_program_get_function_pointer_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramGetFunctionPointerParams(const struct ur_program_get_function_pointer_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_get_info_params_t params struct
+/// @brief Print ur_program_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramGetInfoParams(const struct ur_program_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_get_build_info_params_t params struct
+/// @brief Print ur_program_get_build_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramGetBuildInfoParams(const struct ur_program_get_build_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_set_specialization_constants_params_t params struct
+/// @brief Print ur_program_set_specialization_constants_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramSetSpecializationConstantsParams(const struct ur_program_set_specialization_constants_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_get_native_handle_params_t params struct
+/// @brief Print ur_program_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramGetNativeHandleParams(const struct ur_program_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_program_create_with_native_handle_params_t params struct
+/// @brief Print ur_program_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramCreateWithNativeHandleParams(const struct ur_program_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_create_params_t params struct
+/// @brief Print ur_kernel_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelCreateParams(const struct ur_kernel_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_get_info_params_t params struct
+/// @brief Print ur_kernel_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelGetInfoParams(const struct ur_kernel_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_get_group_info_params_t params struct
+/// @brief Print ur_kernel_get_group_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelGetGroupInfoParams(const struct ur_kernel_get_group_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_get_sub_group_info_params_t params struct
+/// @brief Print ur_kernel_get_sub_group_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelGetSubGroupInfoParams(const struct ur_kernel_get_sub_group_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_retain_params_t params struct
+/// @brief Print ur_kernel_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelRetainParams(const struct ur_kernel_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_release_params_t params struct
+/// @brief Print ur_kernel_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelReleaseParams(const struct ur_kernel_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_get_native_handle_params_t params struct
+/// @brief Print ur_kernel_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelGetNativeHandleParams(const struct ur_kernel_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_create_with_native_handle_params_t params struct
+/// @brief Print ur_kernel_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelCreateWithNativeHandleParams(const struct ur_kernel_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_arg_value_params_t params struct
+/// @brief Print ur_kernel_set_arg_value_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetArgValueParams(const struct ur_kernel_set_arg_value_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_arg_local_params_t params struct
+/// @brief Print ur_kernel_set_arg_local_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetArgLocalParams(const struct ur_kernel_set_arg_local_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_arg_pointer_params_t params struct
+/// @brief Print ur_kernel_set_arg_pointer_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetArgPointerParams(const struct ur_kernel_set_arg_pointer_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_exec_info_params_t params struct
+/// @brief Print ur_kernel_set_exec_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetExecInfoParams(const struct ur_kernel_set_exec_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_arg_sampler_params_t params struct
+/// @brief Print ur_kernel_set_arg_sampler_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetArgSamplerParams(const struct ur_kernel_set_arg_sampler_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_arg_mem_obj_params_t params struct
+/// @brief Print ur_kernel_set_arg_mem_obj_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetArgMemObjParams(const struct ur_kernel_set_arg_mem_obj_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_set_specialization_constants_params_t params struct
+/// @brief Print ur_kernel_set_specialization_constants_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetSpecializationConstantsParams(const struct ur_kernel_set_specialization_constants_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_kernel_suggest_max_cooperative_group_count_exp_params_t params struct
+/// @brief Print ur_kernel_suggest_max_cooperative_group_count_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSuggestMaxCooperativeGroupCountExpParams(const struct ur_kernel_suggest_max_cooperative_group_count_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_sampler_create_params_t params struct
+/// @brief Print ur_sampler_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerCreateParams(const struct ur_sampler_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_sampler_retain_params_t params struct
+/// @brief Print ur_sampler_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerRetainParams(const struct ur_sampler_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_sampler_release_params_t params struct
+/// @brief Print ur_sampler_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerReleaseParams(const struct ur_sampler_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_sampler_get_info_params_t params struct
+/// @brief Print ur_sampler_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerGetInfoParams(const struct ur_sampler_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_sampler_get_native_handle_params_t params struct
+/// @brief Print ur_sampler_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerGetNativeHandleParams(const struct ur_sampler_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_sampler_create_with_native_handle_params_t params struct
+/// @brief Print ur_sampler_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintSamplerCreateWithNativeHandleParams(const struct ur_sampler_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_image_create_params_t params struct
+/// @brief Print ur_mem_image_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemImageCreateParams(const struct ur_mem_image_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_buffer_create_params_t params struct
+/// @brief Print ur_mem_buffer_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemBufferCreateParams(const struct ur_mem_buffer_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_retain_params_t params struct
+/// @brief Print ur_mem_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemRetainParams(const struct ur_mem_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_release_params_t params struct
+/// @brief Print ur_mem_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemReleaseParams(const struct ur_mem_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_buffer_partition_params_t params struct
+/// @brief Print ur_mem_buffer_partition_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemBufferPartitionParams(const struct ur_mem_buffer_partition_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_get_native_handle_params_t params struct
+/// @brief Print ur_mem_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemGetNativeHandleParams(const struct ur_mem_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_buffer_create_with_native_handle_params_t params struct
+/// @brief Print ur_mem_buffer_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemBufferCreateWithNativeHandleParams(const struct ur_mem_buffer_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_image_create_with_native_handle_params_t params struct
+/// @brief Print ur_mem_image_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemImageCreateWithNativeHandleParams(const struct ur_mem_image_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_get_info_params_t params struct
+/// @brief Print ur_mem_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemGetInfoParams(const struct ur_mem_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_mem_image_get_info_params_t params struct
+/// @brief Print ur_mem_image_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintMemImageGetInfoParams(const struct ur_mem_image_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_physical_mem_create_params_t params struct
+/// @brief Print ur_physical_mem_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemCreateParams(const struct ur_physical_mem_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_physical_mem_retain_params_t params struct
+/// @brief Print ur_physical_mem_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemRetainParams(const struct ur_physical_mem_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_physical_mem_release_params_t params struct
+/// @brief Print ur_physical_mem_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintPhysicalMemReleaseParams(const struct ur_physical_mem_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_get_params_t params struct
+/// @brief Print ur_adapter_get_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetParams(const struct ur_adapter_get_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_release_params_t params struct
+/// @brief Print ur_adapter_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterReleaseParams(const struct ur_adapter_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_retain_params_t params struct
+/// @brief Print ur_adapter_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterRetainParams(const struct ur_adapter_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_get_last_error_params_t params struct
+/// @brief Print ur_adapter_get_last_error_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetLastErrorParams(const struct ur_adapter_get_last_error_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_adapter_get_info_params_t params struct
+/// @brief Print ur_adapter_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetInfoParams(const struct ur_adapter_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_kernel_launch_params_t params struct
+/// @brief Print ur_enqueue_kernel_launch_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueKernelLaunchParams(const struct ur_enqueue_kernel_launch_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_events_wait_params_t params struct
+/// @brief Print ur_enqueue_events_wait_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueEventsWaitParams(const struct ur_enqueue_events_wait_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_events_wait_with_barrier_params_t params struct
+/// @brief Print ur_enqueue_events_wait_with_barrier_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueEventsWaitWithBarrierParams(const struct ur_enqueue_events_wait_with_barrier_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_read_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_read_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferReadParams(const struct ur_enqueue_mem_buffer_read_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_write_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_write_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferWriteParams(const struct ur_enqueue_mem_buffer_write_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_read_rect_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_read_rect_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferReadRectParams(const struct ur_enqueue_mem_buffer_read_rect_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_write_rect_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_write_rect_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferWriteRectParams(const struct ur_enqueue_mem_buffer_write_rect_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_copy_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_copy_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferCopyParams(const struct ur_enqueue_mem_buffer_copy_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_copy_rect_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_copy_rect_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferCopyRectParams(const struct ur_enqueue_mem_buffer_copy_rect_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_fill_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_fill_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferFillParams(const struct ur_enqueue_mem_buffer_fill_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_image_read_params_t params struct
+/// @brief Print ur_enqueue_mem_image_read_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemImageReadParams(const struct ur_enqueue_mem_image_read_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_image_write_params_t params struct
+/// @brief Print ur_enqueue_mem_image_write_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemImageWriteParams(const struct ur_enqueue_mem_image_write_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_image_copy_params_t params struct
+/// @brief Print ur_enqueue_mem_image_copy_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemImageCopyParams(const struct ur_enqueue_mem_image_copy_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_buffer_map_params_t params struct
+/// @brief Print ur_enqueue_mem_buffer_map_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemBufferMapParams(const struct ur_enqueue_mem_buffer_map_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_mem_unmap_params_t params struct
+/// @brief Print ur_enqueue_mem_unmap_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueMemUnmapParams(const struct ur_enqueue_mem_unmap_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_usm_fill_params_t params struct
+/// @brief Print ur_enqueue_usm_fill_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueUsmFillParams(const struct ur_enqueue_usm_fill_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_usm_memcpy_params_t params struct
+/// @brief Print ur_enqueue_usm_memcpy_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueUsmMemcpyParams(const struct ur_enqueue_usm_memcpy_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_usm_prefetch_params_t params struct
+/// @brief Print ur_enqueue_usm_prefetch_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueUsmPrefetchParams(const struct ur_enqueue_usm_prefetch_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_usm_advise_params_t params struct
+/// @brief Print ur_enqueue_usm_advise_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueUsmAdviseParams(const struct ur_enqueue_usm_advise_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_usm_fill_2d_params_t params struct
+/// @brief Print ur_enqueue_usm_fill_2d_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueUsmFill_2dParams(const struct ur_enqueue_usm_fill_2d_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_usm_memcpy_2d_params_t params struct
+/// @brief Print ur_enqueue_usm_memcpy_2d_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueUsmMemcpy_2dParams(const struct ur_enqueue_usm_memcpy_2d_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_device_global_variable_write_params_t params struct
+/// @brief Print ur_enqueue_device_global_variable_write_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueDeviceGlobalVariableWriteParams(const struct ur_enqueue_device_global_variable_write_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_device_global_variable_read_params_t params struct
+/// @brief Print ur_enqueue_device_global_variable_read_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueDeviceGlobalVariableReadParams(const struct ur_enqueue_device_global_variable_read_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_read_host_pipe_params_t params struct
+/// @brief Print ur_enqueue_read_host_pipe_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueReadHostPipeParams(const struct ur_enqueue_read_host_pipe_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_write_host_pipe_params_t params struct
+/// @brief Print ur_enqueue_write_host_pipe_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueWriteHostPipeParams(const struct ur_enqueue_write_host_pipe_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_enqueue_cooperative_kernel_launch_exp_params_t params struct
+/// @brief Print ur_enqueue_cooperative_kernel_launch_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueCooperativeKernelLaunchExpParams(const struct ur_enqueue_cooperative_kernel_launch_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_get_info_params_t params struct
+/// @brief Print ur_queue_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueGetInfoParams(const struct ur_queue_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_create_params_t params struct
+/// @brief Print ur_queue_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueCreateParams(const struct ur_queue_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_retain_params_t params struct
+/// @brief Print ur_queue_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueRetainParams(const struct ur_queue_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_release_params_t params struct
+/// @brief Print ur_queue_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueReleaseParams(const struct ur_queue_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_get_native_handle_params_t params struct
+/// @brief Print ur_queue_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueGetNativeHandleParams(const struct ur_queue_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_create_with_native_handle_params_t params struct
+/// @brief Print ur_queue_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueCreateWithNativeHandleParams(const struct ur_queue_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_finish_params_t params struct
+/// @brief Print ur_queue_finish_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFinishParams(const struct ur_queue_finish_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_flush_params_t params struct
+/// @brief Print ur_queue_flush_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFlushParams(const struct ur_queue_flush_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_unsampled_image_handle_destroy_exp_params_t params struct
+/// @brief Print ur_bindless_images_unsampled_image_handle_destroy_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesUnsampledImageHandleDestroyExpParams(const struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_sampled_image_handle_destroy_exp_params_t params struct
+/// @brief Print ur_bindless_images_sampled_image_handle_destroy_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesSampledImageHandleDestroyExpParams(const struct ur_bindless_images_sampled_image_handle_destroy_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_image_allocate_exp_params_t params struct
+/// @brief Print ur_bindless_images_image_allocate_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImageAllocateExpParams(const struct ur_bindless_images_image_allocate_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_image_free_exp_params_t params struct
+/// @brief Print ur_bindless_images_image_free_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImageFreeExpParams(const struct ur_bindless_images_image_free_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_unsampled_image_create_exp_params_t params struct
+/// @brief Print ur_bindless_images_unsampled_image_create_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesUnsampledImageCreateExpParams(const struct ur_bindless_images_unsampled_image_create_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_sampled_image_create_exp_params_t params struct
+/// @brief Print ur_bindless_images_sampled_image_create_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesSampledImageCreateExpParams(const struct ur_bindless_images_sampled_image_create_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_image_copy_exp_params_t params struct
+/// @brief Print ur_bindless_images_image_copy_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImageCopyExpParams(const struct ur_bindless_images_image_copy_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_image_get_info_exp_params_t params struct
+/// @brief Print ur_bindless_images_image_get_info_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImageGetInfoExpParams(const struct ur_bindless_images_image_get_info_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_mipmap_get_level_exp_params_t params struct
+/// @brief Print ur_bindless_images_mipmap_get_level_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMipmapGetLevelExpParams(const struct ur_bindless_images_mipmap_get_level_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_mipmap_free_exp_params_t params struct
+/// @brief Print ur_bindless_images_mipmap_free_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMipmapFreeExpParams(const struct ur_bindless_images_mipmap_free_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_import_opaque_fd_exp_params_t params struct
+/// @brief Print ur_bindless_images_import_opaque_fd_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportOpaqueFdExpParams(const struct ur_bindless_images_import_opaque_fd_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_map_external_array_exp_params_t params struct
+/// @brief Print ur_bindless_images_map_external_array_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMapExternalArrayExpParams(const struct ur_bindless_images_map_external_array_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_release_interop_exp_params_t params struct
+/// @brief Print ur_bindless_images_release_interop_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesReleaseInteropExpParams(const struct ur_bindless_images_release_interop_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t params struct
+/// @brief Print ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportExternalSemaphoreOpaqueFdExpParams(const struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_destroy_external_semaphore_exp_params_t params struct
+/// @brief Print ur_bindless_images_destroy_external_semaphore_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesDestroyExternalSemaphoreExpParams(const struct ur_bindless_images_destroy_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_wait_external_semaphore_exp_params_t params struct
+/// @brief Print ur_bindless_images_wait_external_semaphore_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesWaitExternalSemaphoreExpParams(const struct ur_bindless_images_wait_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_signal_external_semaphore_exp_params_t params struct
+/// @brief Print ur_bindless_images_signal_external_semaphore_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesSignalExternalSemaphoreExpParams(const struct ur_bindless_images_signal_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_host_alloc_params_t params struct
+/// @brief Print ur_usm_host_alloc_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmHostAllocParams(const struct ur_usm_host_alloc_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_device_alloc_params_t params struct
+/// @brief Print ur_usm_device_alloc_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmDeviceAllocParams(const struct ur_usm_device_alloc_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_shared_alloc_params_t params struct
+/// @brief Print ur_usm_shared_alloc_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmSharedAllocParams(const struct ur_usm_shared_alloc_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_free_params_t params struct
+/// @brief Print ur_usm_free_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmFreeParams(const struct ur_usm_free_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_get_mem_alloc_info_params_t params struct
+/// @brief Print ur_usm_get_mem_alloc_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmGetMemAllocInfoParams(const struct ur_usm_get_mem_alloc_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_pool_create_params_t params struct
+/// @brief Print ur_usm_pool_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolCreateParams(const struct ur_usm_pool_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_pool_retain_params_t params struct
+/// @brief Print ur_usm_pool_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolRetainParams(const struct ur_usm_pool_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_pool_release_params_t params struct
+/// @brief Print ur_usm_pool_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolReleaseParams(const struct ur_usm_pool_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_pool_get_info_params_t params struct
+/// @brief Print ur_usm_pool_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPoolGetInfoParams(const struct ur_usm_pool_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_pitched_alloc_exp_params_t params struct
+/// @brief Print ur_usm_pitched_alloc_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmPitchedAllocExpParams(const struct ur_usm_pitched_alloc_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_import_exp_params_t params struct
+/// @brief Print ur_usm_import_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmImportExpParams(const struct ur_usm_import_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_release_exp_params_t params struct
+/// @brief Print ur_usm_release_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmReleaseExpParams(const struct ur_usm_release_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_create_exp_params_t params struct
+/// @brief Print ur_command_buffer_create_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferCreateExpParams(const struct ur_command_buffer_create_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_retain_exp_params_t params struct
+/// @brief Print ur_command_buffer_retain_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferRetainExpParams(const struct ur_command_buffer_retain_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_release_exp_params_t params struct
+/// @brief Print ur_command_buffer_release_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferReleaseExpParams(const struct ur_command_buffer_release_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_finalize_exp_params_t params struct
+/// @brief Print ur_command_buffer_finalize_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferFinalizeExpParams(const struct ur_command_buffer_finalize_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_kernel_launch_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_kernel_launch_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendKernelLaunchExpParams(const struct ur_command_buffer_append_kernel_launch_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_usm_memcpy_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_usm_memcpy_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendUsmMemcpyExpParams(const struct ur_command_buffer_append_usm_memcpy_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_usm_fill_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_usm_fill_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendUsmFillExpParams(const struct ur_command_buffer_append_usm_fill_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_copy_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_copy_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferCopyExpParams(const struct ur_command_buffer_append_mem_buffer_copy_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_write_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_write_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferWriteExpParams(const struct ur_command_buffer_append_mem_buffer_write_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_read_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_read_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferReadExpParams(const struct ur_command_buffer_append_mem_buffer_read_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_copy_rect_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_copy_rect_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferCopyRectExpParams(const struct ur_command_buffer_append_mem_buffer_copy_rect_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_write_rect_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_write_rect_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferWriteRectExpParams(const struct ur_command_buffer_append_mem_buffer_write_rect_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_read_rect_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_read_rect_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferReadRectExpParams(const struct ur_command_buffer_append_mem_buffer_read_rect_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_mem_buffer_fill_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_mem_buffer_fill_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendMemBufferFillExpParams(const struct ur_command_buffer_append_mem_buffer_fill_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_usm_prefetch_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_usm_prefetch_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendUsmPrefetchExpParams(const struct ur_command_buffer_append_usm_prefetch_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_append_usm_advise_exp_params_t params struct
+/// @brief Print ur_command_buffer_append_usm_advise_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferAppendUsmAdviseExpParams(const struct ur_command_buffer_append_usm_advise_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_command_buffer_enqueue_exp_params_t params struct
+/// @brief Print ur_command_buffer_enqueue_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintCommandBufferEnqueueExpParams(const struct ur_command_buffer_enqueue_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_p2p_enable_peer_access_exp_params_t params struct
+/// @brief Print ur_usm_p2p_enable_peer_access_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmP2pEnablePeerAccessExpParams(const struct ur_usm_p2p_enable_peer_access_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_p2p_disable_peer_access_exp_params_t params struct
+/// @brief Print ur_usm_p2p_disable_peer_access_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmP2pDisablePeerAccessExpParams(const struct ur_usm_p2p_disable_peer_access_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_usm_p2p_peer_access_get_info_exp_params_t params struct
+/// @brief Print ur_usm_p2p_peer_access_get_info_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmP2pPeerAccessGetInfoExpParams(const struct ur_usm_p2p_peer_access_get_info_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_init_params_t params struct
+/// @brief Print ur_loader_init_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderInitParams(const struct ur_loader_init_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_loader_tear_down_params_t params struct
+/// @brief Print ur_loader_tear_down_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderTearDownParams(const struct ur_loader_tear_down_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_granularity_get_info_params_t params struct
+/// @brief Print ur_virtual_mem_granularity_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemGranularityGetInfoParams(const struct ur_virtual_mem_granularity_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_reserve_params_t params struct
+/// @brief Print ur_virtual_mem_reserve_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemReserveParams(const struct ur_virtual_mem_reserve_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_free_params_t params struct
+/// @brief Print ur_virtual_mem_free_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemFreeParams(const struct ur_virtual_mem_free_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_map_params_t params struct
+/// @brief Print ur_virtual_mem_map_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemMapParams(const struct ur_virtual_mem_map_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_unmap_params_t params struct
+/// @brief Print ur_virtual_mem_unmap_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemUnmapParams(const struct ur_virtual_mem_unmap_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_set_access_params_t params struct
+/// @brief Print ur_virtual_mem_set_access_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemSetAccessParams(const struct ur_virtual_mem_set_access_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_virtual_mem_get_info_params_t params struct
+/// @brief Print ur_virtual_mem_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintVirtualMemGetInfoParams(const struct ur_virtual_mem_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_get_params_t params struct
+/// @brief Print ur_device_get_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceGetParams(const struct ur_device_get_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_get_info_params_t params struct
+/// @brief Print ur_device_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceGetInfoParams(const struct ur_device_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_retain_params_t params struct
+/// @brief Print ur_device_retain_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceRetainParams(const struct ur_device_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_release_params_t params struct
+/// @brief Print ur_device_release_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceReleaseParams(const struct ur_device_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_partition_params_t params struct
+/// @brief Print ur_device_partition_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePartitionParams(const struct ur_device_partition_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_select_binary_params_t params struct
+/// @brief Print ur_device_select_binary_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceSelectBinaryParams(const struct ur_device_select_binary_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_get_native_handle_params_t params struct
+/// @brief Print ur_device_get_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceGetNativeHandleParams(const struct ur_device_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_create_with_native_handle_params_t params struct
+/// @brief Print ur_device_create_with_native_handle_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceCreateWithNativeHandleParams(const struct ur_device_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_device_get_global_timestamps_params_t params struct
+/// @brief Print ur_device_get_global_timestamps_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceGetGlobalTimestampsParams(const struct ur_device_get_global_timestamps_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
@@ -3025,7 +2425,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceGetGlobalTimestampsParams(const
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         - `NULL == params`
-///         - `NULL == buffer`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintFunctionParams(enum ur_function_t function, const void *params, char *buffer, const size_t buff_size, size_t *out_size);

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2022 Intel Corporation
+ Copyright (C) 2022-2024 Intel Corporation
 
  Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  See LICENSE.TXT
@@ -209,6 +209,7 @@ def generate_rst(docpath, section, namespace, tags, ver, rev, specs, meta):
         fout = os.path.join(dstpath, "api.rst")
         groupname = os.path.basename(dstpath).capitalize()
         util.makoWrite(fin, fout,
+            namespace=namespace,
             groupname=groupname,
             ver=ver,
             rev=rev,

--- a/scripts/templates/api_listing.mako
+++ b/scripts/templates/api_listing.mako
@@ -1,7 +1,7 @@
 <%!
 import re
 from templates import helper as th
-%><%
+from templates import print_helper as tph
 %>
 
 ==============================
@@ -264,3 +264,66 @@ ${th.make_type_name(n, tags, obj)}
 %endfor # obj in objects
 
 %endfor # s in specs
+
+#################################################################
+## Print API not part of the spec, needs to be generated separately
+#################################################################
+<%
+    x = tags['$x']
+    api_types_funcs = tph.get_api_types_funcs(specs, meta, namespace, tags)
+%>\
+## Generate Print API links table
+Print
+============================================================
+The Print API functions are helpful for printing Unified Runtime API objects'
+values as human-readable strings using C interface. Those functions are complimentary
+to the set of operators in the Print API C++ header (ur_print.hpp).
+
+Each function is named in the same style based on the Unified Runtime object name
+to be printed. See examples:
+
+To print the :any:`${x}_function_t` object's value, call:
+    :ref:`${x}PrintFunction`
+
+To print the :any:`${x}_kernel_arg_local_properties_t` object's value, call:
+    :ref:`${x}PrintKernelArgLocalProperties`
+
+There is also one 'extras' function in this API, which can be used for printing
+all values of given function's parameters - :any:`${x}PrintFunctionParams`.
+
+See :ref:`core/api:Print Functions` for the description of common parameters of Print API functions.
+
+* Functions
+%for func in api_types_funcs:
+    * :ref:`${func.c_name.replace("_", "-")}`
+%endfor
+
+## 'Extras' functions
+    * :ref:`${x}PrintFunctionParams`
+
+<%def name="generate_api_doc(func_name)">\
+.. _${func_name.replace("_", "-")}:
+
+${func_name}
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfunction:: ${func_name}
+    :project: UnifiedRuntime
+</%def>
+
+## Generate Print API documentation
+Print Functions
+------------------------------------------------------------------------------
+All functions output strings to print to the :any:`buffer` of a given
+size :any:`buff_size`. The outputted string's size is retrieved
+with the :any:`out_size` parameter.
+It is required for :any:`buff_size` to be less than :any:`out_size` in order
+to write the output string to the :any:`buffer`. Otherwise, :any:`buffer`
+will not be modified.
+
+%for func in api_types_funcs:
+${generate_api_doc(func.c_name)}
+%endfor
+
+## 'Extras' functions
+${generate_api_doc(f'{x}PrintFunctionParams')}

--- a/scripts/templates/print.h.mako
+++ b/scripts/templates/print.h.mako
@@ -1,6 +1,6 @@
 <%!
 import re
-from templates import helper as th
+from templates import print_helper as tph
 %><%
     n=namespace
     N=n.upper()
@@ -9,7 +9,7 @@ from templates import helper as th
     X=x.upper()
 %>/*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  * See LICENSE.TXT
@@ -27,50 +27,19 @@ from templates import helper as th
 extern "C" {
 #endif
 
-## Declarations ###############################################################
-%for spec in specs:
-%for obj in spec['objects']:
-%if re.match(r"enum", obj['type']):
-    ///////////////////////////////////////////////////////////////////////////////
-    /// @brief Print ${th.make_enum_name(n, tags, obj)} enum
-    /// @returns
-    ///     - ::${X}_RESULT_SUCCESS
-    ///     - ::${X}_RESULT_ERROR_INVALID_NULL_POINTER
-    ///         - `NULL == buffer`
-    ///     - ::${X}_RESULT_ERROR_INVALID_SIZE
-    ///         - `buff_size < out_size`
-    ${X}_APIEXPORT ${x}_result_t ${X}_APICALL ${th.make_func_name_with_prefix(f'{x}Print', obj['name'])}(enum ${th.make_enum_name(n, tags, obj)} value, char *buffer, const size_t buff_size, size_t *out_size);
-
-%elif re.match(r"struct", obj['type']):
-    ///////////////////////////////////////////////////////////////////////////////
-    /// @brief Print ${th.make_type_name(n, tags, obj)} struct
-    /// @returns
-    ///     - ::${X}_RESULT_SUCCESS
-    ///     - ::${X}_RESULT_ERROR_INVALID_NULL_POINTER
-    ///         - `NULL == buffer`
-    ///     - ::${X}_RESULT_ERROR_INVALID_SIZE
-    ///         - `buff_size < out_size`
-    ${X}_APIEXPORT ${x}_result_t ${X}_APICALL ${th.make_func_name_with_prefix(f'{x}Print', obj['name'])}(const ${obj['type']} ${th.make_type_name(n, tags, obj)} params, char *buffer, const size_t buff_size, size_t *out_size);
-
-%endif
-%endfor # obj in spec['objects']
-%endfor
-
-%for tbl in th.get_pfncbtables(specs, meta, n, tags):
-%for obj in tbl['functions']:
 <%
-    name = th.make_pfncb_param_type(n, tags, obj)
+    api_types_funcs = tph.get_api_types_funcs(specs, meta, n, tags)
 %>
+## Declarations ###############################################################
+%for func in api_types_funcs:
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ${th.make_pfncb_param_type(n, tags, obj)} params struct
+/// @brief Print ${func.print_arg.type_name} ${func.print_arg.base_type}
 /// @returns
 ///     - ::${X}_RESULT_SUCCESS
-///     - ::${X}_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
 ///     - ::${X}_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-${X}_APIEXPORT ${x}_result_t ${X}_APICALL ${th.make_func_name_with_prefix(f'{x}Print', name)}(const struct ${th.make_pfncb_param_type(n, tags, obj)} *params, char *buffer, const size_t buff_size, size_t *out_size);
-%endfor
+${X}_APIEXPORT ${x}_result_t ${X}_APICALL ${func.c_name}(${func.c_args});
+
 %endfor
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -80,7 +49,6 @@ ${X}_APIEXPORT ${x}_result_t ${X}_APICALL ${th.make_func_name_with_prefix(f'{x}P
 ///     - ::${X}_RESULT_ERROR_INVALID_ENUMERATION
 ///     - ::${X}_RESULT_ERROR_INVALID_NULL_POINTER
 ///         - `NULL == params`
-///         - `NULL == buffer`
 ///     - ::${X}_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 ${X}_APIEXPORT ${x}_result_t ${X}_APICALL ${x}PrintFunctionParams(enum ${x}_function_t function, const void *params, char *buffer, const size_t buff_size, size_t *out_size);

--- a/scripts/templates/print_helper.py
+++ b/scripts/templates/print_helper.py
@@ -1,0 +1,248 @@
+"""
+ Copyright (C) 2023-2024 Intel Corporation
+
+ Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ See LICENSE.TXT
+ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+A helper script for generating Printing API code and HTML documentation that aligns with the code.
+The script utilizes provided specifications to generate function objects and their associated details,
+such as function names, arguments, and types.
+The get_api_types() function generates all Printing API function objects, excluding "extras" functions.
+"""
+import re
+
+from templates import helper as th
+from typing import Dict, List, Union
+
+
+class Arg:
+    """
+    Represents a function argument by storing its type and name.
+
+    Args:
+    type (str): The type of the argument.
+    name (str): The name of the argument.
+    """
+
+    def __init__(self, type: str, name: str):
+        self.type = type
+        self.name = name
+
+    def __repr__(self):
+        return " ".join([self.type, self.name])
+
+
+class PrintArg(Arg):
+    """
+    Represents an argument that is printed by an API function's call.
+
+    Args:
+    type (str): The type of the argument.
+    type_name (str): The Unified Runtime type, such as 'ur_base_desc_t' for the argument's type 'const struct ur_base_desc_t'.
+    name (str): The name of the argument.
+
+    Attributes:
+    type_name (str): The Unified Runtime type name of the argument.
+
+    Properties:
+    base_type (str): Returns the base type of the argument, which can be either an enum or a struct.
+    """
+
+    def __init__(self, type: str, type_name: str, name: str):
+        super().__init__(type, name)
+        self.type_name = type_name
+
+    @property
+    def base_type(self) -> str:
+        match = re.search(r"enum|struct", self.type)
+        return match.group(0) if match else ""
+
+
+class Func:
+    """
+    A function object storing function's name and arguments
+    both in C and C++ versions
+
+    Args:
+    namespace (str): The namespace name
+    tags (Dict[str, str]): A dictionary of tags from the spec
+    obj (Dict[...]): A dictionary representing the function object, retrieved from the spec
+
+    Properties:
+    c_name (str): The generated C function name
+    c_args (str): The generated C arguments
+    cpp_name (str): The generated C++ function name
+    print_arg (PrintArg): The argument printed by a Printing API function call
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        tags: Dict[str, str],
+        obj: Dict[str, Union[str, List[Dict[str, str]]]],
+    ):
+        """
+        _x (str): The prefix for API functions
+        _c_common_args (List[Arg]): A list of common arguments for printing C API functions
+        _obj_type (str): The type of the function object, retrieved from the spec
+        _name (str): The name of the function object, retrieved from the spec
+        _type_name (str): The type name generated based on the spec
+        """
+        self._x = tags["$x"]
+        self._c_common_args = [
+            Arg("char *", "buffer"),
+            Arg("const size_t", "buff_size"),
+            Arg("size_t *", "out_size"),
+        ]
+        self._obj_type = obj["type"]
+        self._name = obj["name"]
+        self._type_name = self._make_type_name(namespace, tags, obj)
+
+    @property
+    def c_name(self) -> str:
+        return self._make_c_func_name()
+
+    @property
+    def c_args(self) -> str:
+        return self._make_c_args()
+
+    @property
+    def cpp_name(self) -> str:
+        return ""
+
+    @property
+    def print_arg(self) -> PrintArg:
+        return self._make_print_arg()
+
+    def _make_type_name(
+        self,
+        namespace: str,
+        tags: Dict[str, str],
+        obj: Dict[str, Union[str, List[Dict[str, str]]]],
+    ) -> str:
+        """
+        Generates a Unified Runtime API object type name based on the spec
+        """
+        if re.match("function", self._obj_type):
+            return th.make_pfncb_param_type(namespace, tags, obj)
+        elif re.match("enum", self._obj_type):
+            return th.make_enum_name(namespace, tags, obj)
+        elif re.match("struct", self._obj_type):
+            return th.make_type_name(namespace, tags, obj)
+        return ""
+
+    def _make_c_func_name(self) -> str:
+        """
+        Generates the C function name
+        """
+        if re.match("function", self._obj_type):
+            return th.make_func_name_with_prefix(f"{self._x}Print", self._type_name)
+        elif re.match(r"enum|struct", self._obj_type):
+            return th.make_func_name_with_prefix(f"{self._x}Print", self._name)
+        return ""
+
+    def _make_c_args(self) -> str:
+        """
+        Generates the C arguments
+        """
+        c_args = [self.print_arg]
+        c_args.extend(self._c_common_args)
+        return str(c_args).strip("[]")
+
+    def _make_print_arg(self) -> PrintArg:
+        """
+        Generates the argument object printed by a printing API function call
+        """
+        if re.match("enum", self._obj_type):
+            return PrintArg(
+                " ".join(["enum", self._type_name]),
+                self._type_name,
+                "value",
+            )
+        elif re.match("struct", self._obj_type):
+            return PrintArg(
+                " ".join(["const", "struct", self._type_name]),
+                self._type_name,
+                "params",
+            )
+        elif re.match("function", self._obj_type):
+            return PrintArg(
+                " ".join(["const", "struct", self._type_name, "*"]),
+                self._type_name,
+                "params",
+            )
+
+
+def _get_simple_types_funcs(
+    specs: List[
+        Dict[
+            str,
+            Union[
+                str,
+                Dict[str, Union[str, int]],
+                List[Dict[str, Union[str, List[Dict[str, str]]]]],
+            ],
+        ]
+    ],
+    namespace: str,
+    tags: Dict[str, str],
+) -> List[Func]:
+    """
+    Retrieves function objects for printing Unified Runtime API objects based on the provided specifications.
+    """
+    return [
+        Func(namespace, tags, obj)
+        for spec in specs
+        for obj in spec["objects"]
+        if re.match(r"enum|struct", obj["type"])
+    ]
+
+
+def _get_param_types_funcs(
+    specs: List[
+        Dict[
+            str,
+            Union[
+                str,
+                Dict[str, Union[str, int]],
+                List[Dict[str, Union[str, List[Dict[str, str]]]]],
+            ],
+        ]
+    ],
+    meta: Dict[str, Dict[str, Dict[str, Union[str, List[str]]]]],
+    namespace: str,
+    tags: Dict[str, str],
+) -> List[Func]:
+    """
+    Retrieves function objects for printing Unified Runtime *_params_t parameter types
+    based on the provided specifications.
+    """
+    return [
+        Func(namespace, tags, obj)
+        for tbl in th.get_pfncbtables(specs, meta, namespace, tags)
+        for obj in tbl["functions"]
+    ]
+
+
+def get_api_types_funcs(
+    specs: List[
+        Dict[
+            str,
+            Union[
+                str,
+                Dict[str, Union[str, int]],
+                List[Dict[str, Union[str, List[Dict[str, str]]]]],
+            ],
+        ]
+    ],
+    meta: Dict[str, Dict[str, Dict[str, Union[str, List[str]]]]],
+    namespace: str,
+    tags: Dict[str, str],
+) -> List[Func]:
+    """
+    Retrieve all printing API function objects, excluding "extras" functions.
+    """
+    api_types_funcs = _get_simple_types_funcs(specs, namespace, tags)
+    api_types_funcs.extend(_get_param_types_funcs(specs, meta, namespace, tags))
+    return api_types_funcs

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1,5 +1,5 @@
 """
- Copyright (C) 2022 Intel Corporation
+ Copyright (C) 2022-2024 Intel Corporation
 
  Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  See LICENSE.TXT
@@ -14,7 +14,7 @@ import glob
 import json
 import yaml
 from mako.template import Template
-from mako.exceptions import RichTraceback
+from mako import exceptions
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
@@ -161,13 +161,7 @@ def makoWrite(inpath, outpath, **args):
         makoFileList.append(outpath)
         return len(rendered.splitlines())
     except:
-        traceback = RichTraceback()
-        #for (filename, lineno, function, line) in traceback.traceback:
-        #    print("%s(%s) : error in %s" % (filename, lineno, function))
-        #    print(line, "\n")
-        line = "%s: %s" % (str(traceback.error.__class__.__name__), traceback.error)
-        makoErrorList.append(line)
-        print(line)
+        print(exceptions.text_error_template().render())
         raise
 
 def makoFileListWrite(outpath):

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  * See LICENSE.TXT
@@ -2498,10 +2498,6 @@ ur_result_t urPrintDeviceGetGlobalTimestampsParams(
 ur_result_t urPrintFunctionParams(enum ur_function_t function,
                                   const void *params, char *buffer,
                                   const size_t buff_size, size_t *out_size) {
-    if (!params) {
-        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-    }
-
     std::stringstream ss;
     ur_result_t result = ur::extras::printFunctionParams(ss, function, params);
     if (result != UR_RESULT_SUCCESS) {


### PR DESCRIPTION
Generate HTML documentation for printing C API.
[preview](https://patkamin.github.io/unified-runtime/core/api.html#print)