### PR TITLE
[HIP] Fix get mem size segfault

### DIFF
--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -29,7 +29,7 @@ size_t GetHipFormatPixelSize(hipArray_Format Format) {
   case HIP_AD_FORMAT_FLOAT:
     return 4;
   default:
-    assert(0 && "Invalid hipFormat specifier.");
+    detail::ur::die("Invalid HIP format specifier");
   }
 }
 
@@ -257,7 +257,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
 
   UR_ASSERT(MemInfoType <= UR_MEM_INFO_CONTEXT,
             UR_RESULT_ERROR_INVALID_ENUMERATION);
-  UR_ASSERT(hMemory->isBuffer(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   UrReturnHelper ReturnValue(propSize, pMemInfo, pPropSizeRet);
 
@@ -279,9 +278,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
           const auto PixelSizeBytes =
               GetHipFormatPixelSize(ArrayDescriptor.Format) *
               ArrayDescriptor.NumChannels;
-          const auto ImageSizeBytes = PixelSizeBytes * ArrayDescriptor.Width *
-                                      ArrayDescriptor.Height *
-                                      ArrayDescriptor.Depth;
+          const auto ImageSizeBytes =
+              PixelSizeBytes *
+              (ArrayDescriptor.Width ? ArrayDescriptor.Width : 1) *
+              (ArrayDescriptor.Height ? ArrayDescriptor.Height : 1) *
+              (ArrayDescriptor.Depth ? ArrayDescriptor.Depth : 1);
           return ImageSizeBytes;
         } else {
           static_assert(ur_always_false_t<T>, "Not exhaustive visitor!");

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -293,4 +293,6 @@ inline ur_result_t exceptionToResult(std::exception_ptr eptr) {
     }
 }
 
+template <class> inline constexpr bool ur_always_false_t = false;
+
 #endif /* UR_UTIL_H */

--- a/test/conformance/memory/memory_adapter_cuda.match
+++ b/test/conformance/memory/memory_adapter_cuda.match
@@ -3,6 +3,8 @@ urMemGetInfoTest.InvalidNullPointerParamValue/NVIDIA_CUDA_BACKEND___{{.*}}___UR_
 urMemGetInfoTest.InvalidNullPointerParamValue/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_INFO_CONTEXT
 urMemGetInfoTest.InvalidNullPointerPropSizeRet/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_INFO_SIZE
 urMemGetInfoTest.InvalidNullPointerPropSizeRet/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_INFO_CONTEXT
+urMemGetInfoImageTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_INFO_SIZE
+urMemGetInfoImageTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_INFO_CONTEXT
 {{OPT}}urMemImageGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_IMAGE_INFO_FORMAT
 {{OPT}}urMemImageGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_IMAGE_INFO_ELEMENT_SIZE
 {{OPT}}urMemImageGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_IMAGE_INFO_ROW_PITCH

--- a/test/conformance/memory/memory_adapter_hip.match
+++ b/test/conformance/memory/memory_adapter_hip.match
@@ -1,2 +1,20 @@
 urMemBufferCreateWithNativeHandleTest.Success/AMD_HIP_BACKEND___{{.*}}_
-Segmentation fault
+urMemGetInfoTest.InvalidNullPointerParamValue/AMD_HIP_BACKEND___{{.*}}___UR_MEM_INFO_SIZE
+urMemGetInfoTest.InvalidNullPointerParamValue/AMD_HIP_BACKEND___{{.*}}___UR_MEM_INFO_CONTEXT
+urMemGetInfoTest.InvalidNullPointerPropSizeRet/AMD_HIP_BACKEND___{{.*}}___UR_MEM_INFO_SIZE
+urMemGetInfoTest.InvalidNullPointerPropSizeRet/AMD_HIP_BACKEND___{{.*}}___UR_MEM_INFO_CONTEXT
+urMemImageCreateTest.InvalidSize/AMD_HIP_BACKEND___{{.*}}_
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_FORMAT
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_ELEMENT_SIZE
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_ROW_PITCH
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_SLICE_PITCH
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_WIDTH
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_HEIGHT
+urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_DEPTH
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_FORMAT
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_ELEMENT_SIZE
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_ROW_PITCH
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_SLICE_PITCH
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_WIDTH
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_HEIGHT
+urMemImageGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_IMAGE_INFO_DEPTH

--- a/test/conformance/memory/memory_adapter_level_zero.match
+++ b/test/conformance/memory/memory_adapter_level_zero.match
@@ -7,5 +7,4 @@ urMemGetInfoTest.InvalidNullPointerParamValue/Intel_R__oneAPI_Unified_Runtime_ov
 urMemGetInfoTest.InvalidNullPointerPropSizeRet/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_SIZE
 urMemGetInfoTest.InvalidNullPointerPropSizeRet/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_CONTEXT
 urMemGetInfoImageTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_SIZE
-urMemGetInfoImageTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_CONTEXT
 {{Segmentation fault|Aborted}}

--- a/test/conformance/memory/memory_adapter_level_zero.match
+++ b/test/conformance/memory/memory_adapter_level_zero.match
@@ -6,4 +6,6 @@ urMemGetInfoTest.InvalidNullPointerParamValue/Intel_R__oneAPI_Unified_Runtime_ov
 urMemGetInfoTest.InvalidNullPointerParamValue/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_CONTEXT
 urMemGetInfoTest.InvalidNullPointerPropSizeRet/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_SIZE
 urMemGetInfoTest.InvalidNullPointerPropSizeRet/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_CONTEXT
+urMemGetInfoImageTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_SIZE
+urMemGetInfoImageTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_CONTEXT
 {{Segmentation fault|Aborted}}

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -7,13 +7,14 @@
 
 using urMemGetInfoTest = uur::urMemBufferTestWithParam<ur_mem_info_t>;
 
+static constexpr std::array mem_info_values = {UR_MEM_INFO_SIZE,
+                                               UR_MEM_INFO_CONTEXT};
 static std::unordered_map<ur_mem_info_t, size_t> mem_info_size_map = {
     {UR_MEM_INFO_SIZE, sizeof(size_t)},
     {UR_MEM_INFO_CONTEXT, sizeof(ur_context_handle_t)},
 };
 
-UUR_TEST_SUITE_P(urMemGetInfoTest,
-                 ::testing::Values(UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT),
+UUR_TEST_SUITE_P(urMemGetInfoTest, ::testing::ValuesIn(mem_info_values),
                  uur::deviceTestWithParamPrinter<ur_mem_info_t>);
 
 TEST_P(urMemGetInfoTest, Success) {
@@ -70,4 +71,36 @@ TEST_P(urMemGetInfoTest, InvalidNullPointerPropSizeRet) {
     ASSERT_EQ_RESULT(
         urMemGetInfo(buffer, UR_MEM_INFO_SIZE, 0, nullptr, nullptr),
         UR_RESULT_ERROR_INVALID_SIZE);
+}
+
+using urMemGetInfoImageTest = uur::urMemImageTestWithParam<ur_mem_info_t>;
+UUR_TEST_SUITE_P(urMemGetInfoImageTest, ::testing::ValuesIn(mem_info_values),
+                 uur::deviceTestWithParamPrinter<ur_mem_info_t>);
+
+TEST_P(urMemGetInfoImageTest, Success) {
+    ur_mem_info_t info = getParam();
+    size_t size;
+    ASSERT_SUCCESS(urMemGetInfo(image, info, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+
+    if (const auto expected_size = mem_info_size_map.find(info);
+        expected_size != mem_info_size_map.end()) {
+        ASSERT_EQ(expected_size->second, size);
+    }
+
+    std::vector<uint8_t> info_data(size);
+    ASSERT_SUCCESS(urMemGetInfo(image, info, size, info_data.data(), nullptr));
+
+    if (info == UR_MEM_INFO_SIZE) {
+        const size_t ExpectedPixelSize = sizeof(float) * 4 /*NumChannels*/;
+        const size_t ExpectedImageSize = ExpectedPixelSize * desc.arraySize *
+                                         desc.width * desc.height * desc.depth;
+        const size_t ImageSizeBytes =
+            *reinterpret_cast<const size_t *>(info_data.data());
+        ASSERT_EQ(ImageSizeBytes, ExpectedImageSize);
+    } else if (info == UR_MEM_INFO_CONTEXT) {
+        ur_context_handle_t InfoContext =
+            *reinterpret_cast<ur_context_handle_t *>(info_data.data());
+        ASSERT_EQ(InfoContext, context);
+    }
 }

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -2,13 +2,14 @@
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#include <array>
 #include <map>
 #include <uur/fixtures.h>
 
 using urMemGetInfoTest = uur::urMemBufferTestWithParam<ur_mem_info_t>;
 
-static constexpr std::array mem_info_values = {UR_MEM_INFO_SIZE,
-                                               UR_MEM_INFO_CONTEXT};
+static constexpr std::array<ur_mem_info_t, 2> mem_info_values{
+    UR_MEM_INFO_SIZE, UR_MEM_INFO_CONTEXT};
 static std::unordered_map<ur_mem_info_t, size_t> mem_info_size_map = {
     {UR_MEM_INFO_SIZE, sizeof(size_t)},
     {UR_MEM_INFO_CONTEXT, sizeof(ur_context_handle_t)},


### PR DESCRIPTION
This PR:
* Fixes segfault when querying memory for it's size as the BasePtr was not defined
* Supports getting the memory size for surface types
* Adds CTS for `urMemGetInfo` with an Image

intel-llvm testing [here](https://github.com/intel/llvm/pull/11709)