### PR TITLE
Trim some jobs from PR workflows to reduce runner usage.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,10 +12,13 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-22.04']
-        build_type: [Debug, Release]
+        build_type: [Debug, ReleaseAssert]
         compiler: [{c: gcc, cxx: g++}]
         libbacktrace: ['-DVAL_USE_LIBBACKTRACE_BACKTRACE=OFF']
         pool_tracking: ['-DUMF_ENABLE_POOL_TRACKING=ON', '-DUMF_ENABLE_POOL_TRACKING=OFF']
+        exclude:
+          - build_type: Debug
+            pool_tracking: '-DUMF_ENABLE_POOL_TRACKING=ON'
         include:
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -116,7 +119,7 @@ jobs:
     name: Build and run quick fuzztest scenarios
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [ReleaseAssert]
         compiler: [{c: clang, cxx: clang++}]
 
     runs-on: 'ubuntu-22.04'
@@ -167,8 +170,12 @@ jobs:
           {name: HIP, triplet: spir64}, # should be amdgcn-amdhsa, but build scripts for device binaries are currently broken for this target.
           {name: L0, triplet: spir64}
         ]
-        build_type: [Debug, Release]
+        build_type: [Debug, ReleaseAssert]
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
+        exclude:
+          - build_type: Debug
+            compiler: {c: gcc, cxx: g++}
+
 
     runs-on: ${{matrix.adapter.name}}
 
@@ -223,7 +230,7 @@ jobs:
         adapter: [
           {name: L0}
         ]
-        build_type: [Debug, Release]
+        build_type: [ReleaseAssert]
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
 
     runs-on: ${{matrix.adapter.name}}
@@ -269,13 +276,16 @@ jobs:
         adapter: [
           {name: None, var: ''}, {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
         ]
-
-        # TODO: building level zero loader on windows-2019 is currently broken
-        exclude:
-         - os: 'windows-2019'
-           adapter: {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
         build_type: [Debug, Release]
         compiler: [{c: cl.exe, cxx: cl.exe}, {c: clang-cl.exe, cxx: clang-cl.exe}]
+        # TODO: building level zero loader on windows-2019 is currently broken
+        exclude:
+          - os: 'windows-2019'
+            adapter: {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
+          - os: 'windows-2022'
+            build_type: Debug
+            adapter: {name: None, var: ''}
+          
     runs-on: ${{matrix.os}}
 
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-22.04']
-        build_type: [Debug, ReleaseAssert]
+        build_type: [Debug, Release]
         compiler: [{c: gcc, cxx: g++}]
         libbacktrace: ['-DVAL_USE_LIBBACKTRACE_BACKTRACE=OFF']
         pool_tracking: ['-DUMF_ENABLE_POOL_TRACKING=ON', '-DUMF_ENABLE_POOL_TRACKING=OFF']
@@ -83,6 +83,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
         -DUR_BUILD_TESTS=ON
         -DUR_FORMAT_CPP_STYLE=ON
+        -DUR_ENABLE_ASSERTIONS=ON
         -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
         ${{matrix.libbacktrace}}
         ${{matrix.pool_tracking}}
@@ -98,6 +99,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
         -DUR_BUILD_TESTS=ON
         -DUR_FORMAT_CPP_STYLE=ON
+        -DUR_ENABLE_ASSERTIONS=ON
         ${{matrix.libbacktrace}}
         ${{matrix.pool_tracking}}
 
@@ -119,7 +121,7 @@ jobs:
     name: Build and run quick fuzztest scenarios
     strategy:
       matrix:
-        build_type: [ReleaseAssert]
+        build_type: [Release]
         compiler: [{c: clang, cxx: clang++}]
 
     runs-on: 'ubuntu-22.04'
@@ -151,6 +153,7 @@ jobs:
         -DUR_BUILD_TESTS=ON
         -DUR_USE_ASAN=ON
         -DUR_USE_UBSAN=ON
+        -DUR_ENABLE_ASSERTIONS=ON
         -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
 
     - name: Build
@@ -170,7 +173,7 @@ jobs:
           {name: HIP, triplet: spir64}, # should be amdgcn-amdhsa, but build scripts for device binaries are currently broken for this target.
           {name: L0, triplet: spir64}
         ]
-        build_type: [Debug, ReleaseAssert]
+        build_type: [Debug, Release]
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
         exclude:
           - build_type: Debug
@@ -201,6 +204,7 @@ jobs:
         -DUR_ENABLE_TRACING=ON
         -DUR_DEVELOPER_MODE=ON
         -DUR_BUILD_TESTS=ON
+        -DUR_ENABLE_ASSERTIONS=ON
         -DUR_BUILD_ADAPTER_${{matrix.adapter.name}}=ON
         -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
         -DUR_CONFORMANCE_TARGET_TRIPLES=${{matrix.adapter.triplet}}
@@ -230,7 +234,7 @@ jobs:
         adapter: [
           {name: L0}
         ]
-        build_type: [ReleaseAssert]
+        build_type: [Release]
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
 
     runs-on: ${{matrix.adapter.name}}
@@ -258,6 +262,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
         -DUR_BUILD_ADAPTER_${{matrix.adapter.name}}=ON
+        -DUR_ENABLE_ASSERTIONS=ON
         -DUR_BUILD_EXAMPLE_CODEGEN=ON
         -DUR_DEVELOPER_MODE=ON
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ option(UR_BUILD_EXAMPLE_CODEGEN "Build the codegen example." OFF)
 option(VAL_USE_LIBBACKTRACE_BACKTRACE "enable libbacktrace validation backtrace for linux" OFF)
 option(UR_ENABLE_ASSERTIONS "Enable assertions for all build types" OFF)
 
+include(Assertions)
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -76,32 +78,6 @@ if(NOT MSVC)
         # is available we still need to link this library.
         link_libraries(stdc++fs)
     endif()
-endif()
-
-# This is copied wholesale from the implementation of LLVM_ENABLE_ASSERTIONS
-if(UR_ENABLE_ASSERTIONS)
-  # MSVC doesn't like _DEBUG on release builds
-  if( NOT MSVC )
-    add_compile_definitions(_DEBUG)
-  endif()
-  # On non-Debug builds cmake automatically defines NDEBUG, so we
-  # explicitly undefine it:
-  if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
-    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
-    if (MSVC)
-      # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
-      foreach (flags_var_to_scrub
-          CMAKE_CXX_FLAGS_RELEASE
-          CMAKE_CXX_FLAGS_RELWITHDEBINFO
-          CMAKE_CXX_FLAGS_MINSIZEREL
-          CMAKE_C_FLAGS_RELEASE
-          CMAKE_C_FLAGS_RELWITHDEBINFO
-          CMAKE_C_FLAGS_MINSIZEREL)
-        string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
-          "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
-      endforeach()
-    endif()
-  endif()
 endif()
 
 if(UR_ENABLE_TRACING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(UR_BUILD_ADAPTER_CUDA "build cuda adapter from SYCL" OFF)
 option(UR_BUILD_ADAPTER_HIP "build hip adapter from SYCL" OFF)
 option(UR_BUILD_EXAMPLE_CODEGEN "Build the codegen example." OFF)
 option(VAL_USE_LIBBACKTRACE_BACKTRACE "enable libbacktrace validation backtrace for linux" OFF)
+option(UR_ENABLE_ASSERTIONS "Enable assertions for all build types" OFF)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -75,6 +76,32 @@ if(NOT MSVC)
         # is available we still need to link this library.
         link_libraries(stdc++fs)
     endif()
+endif()
+
+# This is copied wholesale from the implementation of LLVM_ENABLE_ASSERTIONS
+if(UR_ENABLE_ASSERTIONS)
+  # MSVC doesn't like _DEBUG on release builds
+  if( NOT MSVC )
+    add_compile_definitions(_DEBUG)
+  endif()
+  # On non-Debug builds cmake automatically defines NDEBUG, so we
+  # explicitly undefine it:
+  if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+    if (MSVC)
+      # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+      foreach (flags_var_to_scrub
+          CMAKE_CXX_FLAGS_RELEASE
+          CMAKE_CXX_FLAGS_RELWITHDEBINFO
+          CMAKE_CXX_FLAGS_MINSIZEREL
+          CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_RELWITHDEBINFO
+          CMAKE_C_FLAGS_MINSIZEREL)
+        string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+          "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+      endforeach()
+    endif()
+  endif()
 endif()
 
 if(UR_ENABLE_TRACING)

--- a/cmake/Assertions.cmake
+++ b/cmake/Assertions.cmake
@@ -1,0 +1,30 @@
+# From the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is lifted from llvm's LLVM_ENABLE_ASSERTIONS implementation
+# https://github.com/llvm/llvm-project/blob/6be0e979896f7dd610abf263f845c532f1be3762/llvm/cmake/modules/HandleLLVMOptions.cmake#L89
+if(UR_ENABLE_ASSERTIONS)
+  # MSVC doesn't like _DEBUG on release builds
+  if( NOT MSVC )
+    add_compile_definitions(_DEBUG)
+  endif()
+  # On non-Debug builds cmake automatically defines NDEBUG, so we
+  # explicitly undefine it:
+  if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+    if (MSVC)
+      # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+      foreach (flags_var_to_scrub
+          CMAKE_CXX_FLAGS_RELEASE
+          CMAKE_CXX_FLAGS_RELWITHDEBINFO
+          CMAKE_CXX_FLAGS_MINSIZEREL
+          CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_RELWITHDEBINFO
+          CMAKE_C_FLAGS_MINSIZEREL)
+        string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+          "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+      endforeach()
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
Moving the adapter code into this repo has brought a lot more PR traffic and as a result we are starving other projects in oneapi-src of github runners. This change reduces the number of jobs run per-pr from 47 to 37, which in turn reduces the number of runners used and should improve the runner situation for the other projects.