### PR TITLE
[HIP] Add missing symbols hip

### DIFF
--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -310,13 +310,17 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
 // TODO: Implement
 UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     ur_api_version_t, ur_bindless_images_exp_dditable_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  // This needs to return UR_RESULT_SUCCESS or else the platform can't be
+  // initialized
+  return UR_RESULT_SUCCESS;
 }
 
 // TODO: Implement
 UR_DLLEXPORT ur_result_t UR_APICALL
 urGetUSMExpProcAddrTable(ur_api_version_t, ur_usm_exp_dditable_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  // This needs to return UR_RESULT_SUCCESS or else the platform can't be
+  // initialized
+  return UR_RESULT_SUCCESS;
 }
 
 UR_DLLEXPORT ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -307,6 +307,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
   return retVal;
 }
 
+// TODO: Implement
+UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
+    ur_api_version_t, ur_bindless_images_exp_dditable_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+// TODO: Implement
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMExpProcAddrTable(ur_api_version_t, ur_usm_exp_dditable_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_virtual_mem_dditable_t


### PR DESCRIPTION
The global exported symbols are here https://github.com/oneapi-src/unified-runtime/blob/adapters/source/adapters/adapter.map.in

This file https://github.com/oneapi-src/unified-runtime/blob/adapters/source/adapters/hip/ur_interface_loader.cpp is missing some symbols that are written in the lib map. This caused a linker error for LLD when linking in DPC++. This patch adds them, fixing the linker error.