### PR TITLE
[UR][CUDA] Fix compatibility with CUDA 11.x

### DIFF
--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -140,12 +140,13 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   try {
-#if CUDART_VERSION >= 12000
+#if CUDA_VERSION >= 12000
     UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
                                       hCommandBuffer->CudaGraph, 0));
 #else
     UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
-                                      hCommandBuffer->CudaGraph, nullptr, nullptr, 0));
+                                      hCommandBuffer->CudaGraph, nullptr,
+                                      nullptr, 0));
 #endif
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;

--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -140,8 +140,13 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   try {
+#if CUDART_VERSION >= 12000
     UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
                                       hCommandBuffer->CudaGraph, 0));
+#else
+    UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
+                                      hCommandBuffer->CudaGraph, nullptr, nullptr, 0));
+#endif
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;
   }

--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -140,10 +140,15 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   try {
+    const unsigned long long flags = 0;
 #if CUDA_VERSION >= 12000
     UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
-                                      hCommandBuffer->CudaGraph, 0));
+                                      hCommandBuffer->CudaGraph, flags));
+#elif CUDA_VERSION >= 11040
+    UR_CHECK_ERROR(cuGraphInstantiateWithFlags(
+        &hCommandBuffer->CudaGraphExec, hCommandBuffer->CudaGraph, flags));
 #else
+    // Cannot use flags
     UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
                                       hCommandBuffer->CudaGraph, nullptr,
                                       nullptr, 0));


### PR DESCRIPTION
The code introduced in 74f42f8fdd3b92b355c5769bd13d4d982e839c78 uses the signature of `cuGraphInstantiate` from CUDA 12.x. In CUDA 11.4-11.8, the same function is called `cuGraphInstantiateWithFlags`, so we use it. In older CUDA, there is only the old version of `cuGraphInstantiate` which does not accept flags.

- https://docs.nvidia.com/cuda/archive/11.8.0/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g433ae118a751c9f2087f53d7add7bc2c
- https://docs.nvidia.com/cuda/archive/12.0.0/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g433ae118a751c9f2087f53d7add7bc2c