### PR TITLE
[OpenCL] Return INVALID_SIZE from GetInfo entry points.

### DIFF
--- a/source/adapters/opencl/context.cpp
+++ b/source/adapters/opencl/context.cpp
@@ -89,10 +89,17 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_NUM_DEVICES:
   case UR_CONTEXT_INFO_DEVICES:
   case UR_CONTEXT_INFO_REFERENCE_COUNT: {
-
-    CL_RETURN_ON_FAILURE(
+    size_t CheckPropSize = 0;
+    auto ClResult =
         clGetContextInfo(cl_adapter::cast<cl_context>(hContext), CLPropName,
-                         propSize, pPropValue, pPropSizeRet));
+                         propSize, pPropValue, &CheckPropSize);
+    if (pPropValue && CheckPropSize != propSize) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    CL_RETURN_ON_FAILURE(ClResult);
+    if (pPropSizeRet) {
+      *pPropSizeRet = CheckPropSize;
+    }
     return UR_RESULT_SUCCESS;
   }
   default:

--- a/source/adapters/opencl/enqueue.cpp
+++ b/source/adapters/opencl/enqueue.cpp
@@ -350,9 +350,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
     return mapCLErrorToUR(CLErr);
   }
 
-  clEnqueueReadHostPipeINTEL_fn FuncPtr = nullptr;
+  cl_ext::clEnqueueReadHostPipeINTEL_fn FuncPtr = nullptr;
   ur_result_t RetVal =
-      cl_ext::getExtFuncFromContext<clEnqueueReadHostPipeINTEL_fn>(
+      cl_ext::getExtFuncFromContext<cl_ext::clEnqueueReadHostPipeINTEL_fn>(
           CLContext, cl_ext::ExtFuncPtrCache->clEnqueueReadHostPipeINTELCache,
           cl_ext::EnqueueReadHostPipeName, &FuncPtr);
 
@@ -382,9 +382,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     return mapCLErrorToUR(CLErr);
   }
 
-  clEnqueueWriteHostPipeINTEL_fn FuncPtr = nullptr;
+  cl_ext::clEnqueueWriteHostPipeINTEL_fn FuncPtr = nullptr;
   ur_result_t RetVal =
-      cl_ext::getExtFuncFromContext<clEnqueueWriteHostPipeINTEL_fn>(
+      cl_ext::getExtFuncFromContext<cl_ext::clEnqueueWriteHostPipeINTEL_fn>(
           CLContext, cl_ext::ExtFuncPtrCache->clEnqueueWriteHostPipeINTELCache,
           cl_ext::EnqueueWriteHostPipeName, &FuncPtr);
 

--- a/source/adapters/opencl/event.cpp
+++ b/source/adapters/opencl/event.cpp
@@ -50,6 +50,62 @@ convertURProfilingInfoToCL(const ur_profiling_info_t PropName) {
   }
 }
 
+const ur_command_t
+convertCLCommandTypeToUR(const cl_command_type &CommandType) {
+  /* Note: the following enums don't have a CL equivalent:
+    UR_COMMAND_USM_FILL_2D
+    UR_COMMAND_USM_MEMCPY_2D
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ
+    UR_COMMAND_READ_HOST_PIPE
+    UR_COMMAND_WRITE_HOST_PIPE
+    UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP
+    UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP
+    UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP */
+  switch (CommandType) {
+  case CL_COMMAND_NDRANGE_KERNEL:
+    return UR_COMMAND_KERNEL_LAUNCH;
+  case CL_COMMAND_MARKER:
+    // CL can't distinguish between UR_COMMAND_EVENTS_WAIT_WITH_BARRIER and
+    // UR_COMMAND_EVENTS_WAIT.
+    return UR_COMMAND_EVENTS_WAIT;
+  case CL_COMMAND_READ_BUFFER:
+    return UR_COMMAND_MEM_BUFFER_READ;
+  case CL_COMMAND_WRITE_BUFFER:
+    return UR_COMMAND_MEM_BUFFER_WRITE;
+  case CL_COMMAND_READ_BUFFER_RECT:
+    return UR_COMMAND_MEM_BUFFER_READ_RECT;
+  case CL_COMMAND_WRITE_BUFFER_RECT:
+    return UR_COMMAND_MEM_BUFFER_WRITE_RECT;
+  case CL_COMMAND_COPY_BUFFER:
+    return UR_COMMAND_MEM_BUFFER_COPY;
+  case CL_COMMAND_COPY_BUFFER_RECT:
+    return UR_COMMAND_MEM_BUFFER_COPY_RECT;
+  case CL_COMMAND_FILL_BUFFER:
+    return UR_COMMAND_MEM_BUFFER_FILL;
+  case CL_COMMAND_READ_IMAGE:
+    return UR_COMMAND_MEM_IMAGE_READ;
+  case CL_COMMAND_WRITE_IMAGE:
+    return UR_COMMAND_MEM_IMAGE_WRITE;
+  case CL_COMMAND_COPY_IMAGE:
+    return UR_COMMAND_MEM_IMAGE_COPY;
+  case CL_COMMAND_MAP_BUFFER:
+    return UR_COMMAND_MEM_BUFFER_MAP;
+  case CL_COMMAND_UNMAP_MEM_OBJECT:
+    return UR_COMMAND_MEM_UNMAP;
+  case CL_COMMAND_MEMFILL_INTEL:
+    return UR_COMMAND_USM_FILL;
+  case CL_COMMAND_MEMCPY_INTEL:
+    return UR_COMMAND_USM_MEMCPY;
+  case CL_COMMAND_MIGRATEMEM_INTEL:
+    return UR_COMMAND_USM_PREFETCH;
+  case CL_COMMAND_MEMADVISE_INTEL:
+    return UR_COMMAND_USM_ADVISE;
+  default:
+    return UR_COMMAND_FORCE_UINT32;
+  }
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t hNativeEvent,
     [[maybe_unused]] ur_context_handle_t hContext,
@@ -90,24 +146,36 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
                                                    void *pPropValue,
                                                    size_t *pPropSizeRet) {
   cl_event_info CLEventInfo = convertUREventInfoToCL(propName);
+
+  size_t CheckPropSize = 0;
   cl_int RetErr =
       clGetEventInfo(cl_adapter::cast<cl_event>(hEvent), CLEventInfo, propSize,
-                     pPropValue, pPropSizeRet);
+                     pPropValue, &CheckPropSize);
+  if (pPropValue && CheckPropSize != propSize) {
+    return UR_RESULT_ERROR_INVALID_SIZE;
+  }
   CL_RETURN_ON_FAILURE(RetErr);
+  if (pPropSizeRet) {
+    *pPropSizeRet = CheckPropSize;
+  }
 
-  if (RetErr == CL_SUCCESS &&
-      propName == UR_EVENT_INFO_COMMAND_EXECUTION_STATUS) {
-    /* If the CL_EVENT_COMMAND_EXECUTION_STATUS info value is CL_QUEUED, change
-     * it to CL_SUBMITTED. sycl::info::event::event_command_status has no
-     * equivalent to CL_QUEUED.
-     *
-     * FIXME UR Port: This should not be part of the UR adapter. Since PI_QUEUED
-     * exists, SYCL RT should be changed to handle this situation. In addition,
-     * SYCL RT is relying on PI_QUEUED status to make sure that the queues are
-     * flushed. */
-    const auto param_value_int = static_cast<ur_event_status_t *>(pPropValue);
-    if (*param_value_int == UR_EVENT_STATUS_QUEUED) {
-      *param_value_int = UR_EVENT_STATUS_SUBMITTED;
+  if (pPropValue) {
+    if (propName == UR_EVENT_INFO_COMMAND_TYPE) {
+      *reinterpret_cast<ur_command_t *>(pPropValue) = convertCLCommandTypeToUR(
+          *reinterpret_cast<cl_command_type *>(pPropValue));
+    } else if (propName == UR_EVENT_INFO_COMMAND_EXECUTION_STATUS) {
+      /* If the CL_EVENT_COMMAND_EXECUTION_STATUS info value is CL_QUEUED,
+       * change it to CL_SUBMITTED. sycl::info::event::event_command_status has
+       * no equivalent to CL_QUEUED.
+       *
+       * FIXME UR Port: This should not be part of the UR adapter. Since
+       * PI_QUEUED exists, SYCL RT should be changed to handle this situation.
+       * In addition, SYCL RT is relying on PI_QUEUED status to make sure that
+       * the queues are flushed. */
+      const auto param_value_int = static_cast<ur_event_status_t *>(pPropValue);
+      if (*param_value_int == UR_EVENT_STATUS_QUEUED) {
+        *param_value_int = UR_EVENT_STATUS_SUBMITTED;
+      }
     }
   }
 

--- a/source/adapters/opencl/kernel.cpp
+++ b/source/adapters/opencl/kernel.cpp
@@ -69,10 +69,34 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
                                                     size_t propSize,
                                                     void *pPropValue,
                                                     size_t *pPropSizeRet) {
-
-  CL_RETURN_ON_FAILURE(clGetKernelInfo(cl_adapter::cast<cl_kernel>(hKernel),
-                                       mapURKernelInfoToCL(propName), propSize,
-                                       pPropValue, pPropSizeRet));
+  // We need this little bit of ugliness because the UR NUM_ARGS property is
+  // size_t whereas the CL one is cl_uint. We should consider changing that see
+  // #1038
+  if (propName == UR_KERNEL_INFO_NUM_ARGS) {
+    if (pPropSizeRet)
+      *pPropSizeRet = sizeof(size_t);
+    cl_uint NumArgs = 0;
+    CL_RETURN_ON_FAILURE(clGetKernelInfo(cl_adapter::cast<cl_kernel>(hKernel),
+                                         mapURKernelInfoToCL(propName),
+                                         sizeof(NumArgs), &NumArgs, nullptr));
+    if (pPropValue) {
+      if (propSize != sizeof(size_t))
+        return UR_RESULT_ERROR_INVALID_SIZE;
+      *static_cast<size_t *>(pPropValue) = static_cast<size_t>(NumArgs);
+    }
+  } else {
+    size_t CheckPropSize = 0;
+    cl_int ClResult = clGetKernelInfo(cl_adapter::cast<cl_kernel>(hKernel),
+                                      mapURKernelInfoToCL(propName), propSize,
+                                      pPropValue, &CheckPropSize);
+    if (pPropValue && CheckPropSize != propSize) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    CL_RETURN_ON_FAILURE(ClResult);
+    if (pPropSizeRet) {
+      *pPropSizeRet = CheckPropSize;
+    }
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -101,7 +125,20 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
                      ur_kernel_group_info_t propName, size_t propSize,
                      void *pPropValue, size_t *pPropSizeRet) {
-
+  // From the CL spec for GROUP_INFO_GLOBAL: "If device is not a custom device
+  // and kernel is not a built-in kernel, clGetKernelWorkGroupInfo returns the
+  // error CL_INVALID_VALUE.". Unfortunately there doesn't seem to be a nice
+  // way to query whether a kernel is a builtin kernel but this should suffice
+  // to deter naive use of the query.
+  if (propName == UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE) {
+    cl_device_type ClDeviceType;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_TYPE,
+                        sizeof(ClDeviceType), &ClDeviceType, nullptr));
+    if (ClDeviceType != CL_DEVICE_TYPE_CUSTOM) {
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    }
+  }
   CL_RETURN_ON_FAILURE(clGetKernelWorkGroupInfo(
       cl_adapter::cast<cl_kernel>(hKernel),
       cl_adapter::cast<cl_device_id>(hDevice),
@@ -199,7 +236,8 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
     }
   }
 
-  *(static_cast<uint32_t *>(pPropValue)) = static_cast<uint32_t>(RetVal);
+  if (pPropValue)
+    *(static_cast<uint32_t *>(pPropValue)) = static_cast<uint32_t>(RetVal);
   if (pPropSizeRet)
     *pPropSizeRet = sizeof(uint32_t);
 

--- a/source/adapters/opencl/program.cpp
+++ b/source/adapters/opencl/program.cpp
@@ -176,11 +176,17 @@ static cl_int mapURProgramInfoToCL(ur_program_info_t URPropName) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
                  size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
-
-  CL_RETURN_ON_FAILURE(clGetProgramInfo(cl_adapter::cast<cl_program>(hProgram),
-                                        mapURProgramInfoToCL(propName),
-                                        propSize, pPropValue, pPropSizeRet));
-
+  size_t CheckPropSize = 0;
+  auto ClResult = clGetProgramInfo(cl_adapter::cast<cl_program>(hProgram),
+                                   mapURProgramInfoToCL(propName), propSize,
+                                   pPropValue, &CheckPropSize);
+  if (pPropValue && CheckPropSize != propSize) {
+    return UR_RESULT_ERROR_INVALID_SIZE;
+  }
+  CL_RETURN_ON_FAILURE(ClResult);
+  if (pPropSizeRet) {
+    *pPropSizeRet = CheckPropSize;
+  }
   return UR_RESULT_SUCCESS;
 }
 
@@ -249,30 +255,30 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
                       ur_program_build_info_t propName, size_t propSize,
                       void *pPropValue, size_t *pPropSizeRet) {
-
-  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
-
-  switch (propName) {
-  case UR_PROGRAM_BUILD_INFO_BINARY_TYPE:
-    cl_program_binary_type cl_value;
+  if (propName == UR_PROGRAM_BUILD_INFO_BINARY_TYPE) {
+    UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+    cl_program_binary_type BinaryType;
     CL_RETURN_ON_FAILURE(clGetProgramBuildInfo(
         cl_adapter::cast<cl_program>(hProgram),
         cl_adapter::cast<cl_device_id>(hDevice),
         mapURProgramBuildInfoToCL(propName), sizeof(cl_program_binary_type),
-        &cl_value, nullptr));
-    return ReturnValue(mapCLBinaryTypeToUR(cl_value));
-  case UR_PROGRAM_BUILD_INFO_LOG:
-  case UR_PROGRAM_BUILD_INFO_OPTIONS:
-  case UR_PROGRAM_BUILD_INFO_STATUS:
-    CL_RETURN_ON_FAILURE(
-        clGetProgramBuildInfo(cl_adapter::cast<cl_program>(hProgram),
-                              cl_adapter::cast<cl_device_id>(hDevice),
-                              mapURProgramBuildInfoToCL(propName), propSize,
-                              pPropValue, pPropSizeRet));
-    return UR_RESULT_SUCCESS;
-  default:
-    return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        &BinaryType, nullptr));
+    return ReturnValue(mapCLBinaryTypeToUR(BinaryType));
   }
+  size_t CheckPropSize = 0;
+  cl_int ClErr = clGetProgramBuildInfo(cl_adapter::cast<cl_program>(hProgram),
+                                       cl_adapter::cast<cl_device_id>(hDevice),
+                                       mapURProgramBuildInfoToCL(propName),
+                                       propSize, pPropValue, &CheckPropSize);
+  if (pPropValue && CheckPropSize != propSize) {
+    return UR_RESULT_ERROR_INVALID_SIZE;
+  }
+  CL_RETURN_ON_FAILURE(ClErr);
+  if (pPropSizeRet) {
+    *pPropSizeRet = CheckPropSize;
+  }
+
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL

--- a/source/adapters/opencl/queue.cpp
+++ b/source/adapters/opencl/queue.cpp
@@ -19,7 +19,7 @@ cl_command_queue_info mapURQueueInfoToCL(const ur_queue_info_t PropName) {
   case UR_QUEUE_INFO_DEVICE_DEFAULT:
     return CL_QUEUE_DEVICE_DEFAULT;
   case UR_QUEUE_INFO_FLAGS:
-    return CL_QUEUE_PROPERTIES_ARRAY;
+    return CL_QUEUE_PROPERTIES;
   case UR_QUEUE_INFO_REFERENCE_COUNT:
     return CL_QUEUE_REFERENCE_COUNT;
   case UR_QUEUE_INFO_SIZE:
@@ -47,6 +47,24 @@ convertURQueuePropertiesToCL(const ur_queue_properties_t *URQueueProperties) {
   }
 
   return CLCommandQueueProperties;
+}
+
+const ur_queue_flags_t
+mapCLQueuePropsToUR(const cl_command_queue_properties &Properties) {
+  ur_queue_flags_t Flags = 0;
+  if (Properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
+    Flags |= UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+  }
+  if (Properties & CL_QUEUE_PROFILING_ENABLE) {
+    Flags |= UR_QUEUE_FLAG_PROFILING_ENABLE;
+  }
+  if (Properties & CL_QUEUE_ON_DEVICE) {
+    Flags |= UR_QUEUE_FLAG_ON_DEVICE;
+  }
+  if (Properties & CL_QUEUE_ON_DEVICE_DEFAULT) {
+    Flags |= UR_QUEUE_FLAG_ON_DEVICE_DEFAULT;
+  }
+  return Flags;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
@@ -102,15 +120,35 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
                                                    size_t *pPropSizeRet) {
   if (propName == UR_QUEUE_INFO_EMPTY) {
     // OpenCL doesn't provide API to check the status of the queue.
-    return UR_RESULT_ERROR_INVALID_VALUE;
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
-
   cl_command_queue_info CLCommandQueueInfo = mapURQueueInfoToCL(propName);
 
-  cl_int RetErr = clGetCommandQueueInfo(
-      cl_adapter::cast<cl_command_queue>(hQueue), CLCommandQueueInfo, propSize,
-      pPropValue, pPropSizeRet);
-  CL_RETURN_ON_FAILURE(RetErr);
+  // Unfortunately the size of cl_bitfield (unsigned long) doesn't line up with
+  // our enums (forced to be sizeof(uint32_t)) so this needs special handling.
+  if (propName == UR_QUEUE_INFO_FLAGS) {
+    UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+    cl_command_queue_properties QueueProperties = 0;
+    CL_RETURN_ON_FAILURE(clGetCommandQueueInfo(
+        cl_adapter::cast<cl_command_queue>(hQueue), CLCommandQueueInfo,
+        sizeof(QueueProperties), &QueueProperties, nullptr));
+
+    return ReturnValue(mapCLQueuePropsToUR(QueueProperties));
+  } else {
+    size_t CheckPropSize = 0;
+    cl_int RetErr = clGetCommandQueueInfo(
+        cl_adapter::cast<cl_command_queue>(hQueue), CLCommandQueueInfo,
+        propSize, pPropValue, &CheckPropSize);
+    if (pPropValue && CheckPropSize != propSize) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    CL_RETURN_ON_FAILURE(RetErr);
+    if (pPropSizeRet) {
+      *pPropSizeRet = CheckPropSize;
+    }
+  }
+
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -190,6 +190,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
   pDdiTable->pfnUSMMemcpy2D = urEnqueueUSMMemcpy2D;
   pDdiTable->pfnUSMMemcpy = urEnqueueUSMMemcpy;
   pDdiTable->pfnUSMPrefetch = urEnqueueUSMPrefetch;
+  pDdiTable->pfnReadHostPipe = urEnqueueReadHostPipe;
+  pDdiTable->pfnWriteHostPipe = urEnqueueWriteHostPipe;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/opencl/usm.cpp
+++ b/source/adapters/opencl/usm.cpp
@@ -357,16 +357,31 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
   return UR_RESULT_ERROR_INVALID_OPERATION;
 }
 
+const ur_usm_type_t
+mapCLUSMTypeToUR(const cl_unified_shared_memory_type_intel &Type) {
+  switch (Type) {
+  case CL_MEM_TYPE_HOST_INTEL:
+    return UR_USM_TYPE_HOST;
+  case CL_MEM_TYPE_DEVICE_INTEL:
+    return UR_USM_TYPE_DEVICE;
+  case CL_MEM_TYPE_SHARED_INTEL:
+    return UR_USM_TYPE_SHARED;
+  case CL_MEM_TYPE_UNKNOWN_INTEL:
+  default:
+    return UR_USM_TYPE_UNKNOWN;
+  }
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
                      ur_usm_alloc_info_t propName, size_t propSize,
                      void *pPropValue, size_t *pPropSizeRet) {
 
-  clGetMemAllocInfoINTEL_fn FuncPtr = nullptr;
+  clGetMemAllocInfoINTEL_fn GetMemAllocInfo = nullptr;
   cl_context CLContext = cl_adapter::cast<cl_context>(hContext);
-  ur_result_t RetVal = cl_ext::getExtFuncFromContext<clGetMemAllocInfoINTEL_fn>(
+  UR_RETURN_ON_FAILURE(cl_ext::getExtFuncFromContext<clGetMemAllocInfoINTEL_fn>(
       CLContext, cl_ext::ExtFuncPtrCache->clGetMemAllocInfoINTELCache,
-      cl_ext::GetMemAllocInfoName, &FuncPtr);
+      cl_ext::GetMemAllocInfoName, &GetMemAllocInfo));
 
   cl_mem_info_intel PropNameCL;
   switch (propName) {
@@ -386,36 +401,24 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
-  if (FuncPtr) {
-    RetVal =
-        mapCLErrorToUR(FuncPtr(cl_adapter::cast<cl_context>(hContext), pMem,
-                               PropNameCL, propSize, pPropValue, pPropSizeRet));
-    if (RetVal == UR_RESULT_SUCCESS && pPropValue &&
-        propName == UR_USM_ALLOC_INFO_TYPE) {
-      auto *AllocTypeCL =
-          static_cast<cl_unified_shared_memory_type_intel *>(pPropValue);
-      ur_usm_type_t AllocTypeUR;
-      switch (*AllocTypeCL) {
-      case CL_MEM_TYPE_HOST_INTEL:
-        AllocTypeUR = UR_USM_TYPE_HOST;
-        break;
-      case CL_MEM_TYPE_DEVICE_INTEL:
-        AllocTypeUR = UR_USM_TYPE_DEVICE;
-        break;
-      case CL_MEM_TYPE_SHARED_INTEL:
-        AllocTypeUR = UR_USM_TYPE_SHARED;
-        break;
-      case CL_MEM_TYPE_UNKNOWN_INTEL:
-      default:
-        AllocTypeUR = UR_USM_TYPE_UNKNOWN;
-        break;
-      }
-      auto *AllocTypeOut = static_cast<ur_usm_type_t *>(pPropValue);
-      *AllocTypeOut = AllocTypeUR;
-    }
+  size_t CheckPropSize = 0;
+  cl_int ClErr =
+      GetMemAllocInfo(cl_adapter::cast<cl_context>(hContext), pMem, PropNameCL,
+                      propSize, pPropValue, &CheckPropSize);
+  if (pPropValue && CheckPropSize != propSize) {
+    return UR_RESULT_ERROR_INVALID_SIZE;
+  }
+  CL_RETURN_ON_FAILURE(ClErr);
+  if (pPropSizeRet) {
+    *pPropSizeRet = CheckPropSize;
   }
 
-  return RetVal;
+  if (pPropValue && propName == UR_USM_ALLOC_INFO_TYPE) {
+    *static_cast<ur_usm_type_t *>(pPropValue) = mapCLUSMTypeToUR(
+        *static_cast<cl_unified_shared_memory_type_intel *>(pPropValue));
+  }
+
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL

--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -22,12 +22,16 @@ TEST_P(urKernelGetGroupInfoTest, Success) {
     auto property_name = getParam();
     size_t property_size = 0;
     std::vector<char> property_value;
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name, 0,
-                                        nullptr, &property_size));
-    property_value.resize(property_size);
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
+    auto result = urKernelGetGroupInfo(kernel, device, property_name, 0,
+                                       nullptr, &property_size);
+    if (result == UR_RESULT_SUCCESS) {
+        property_value.resize(property_size);
+        ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                            property_size,
+                                            property_value.data(), nullptr));
+    } else {
+        ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
+    }
 }
 
 TEST_P(urKernelGetGroupInfoTest, InvalidNullHandleKernel) {


### PR DESCRIPTION
Also includes a few other GetInfo related fixes:
* Add missing device info queries
* Add mapping of CL command type to UR command type
* Correct mapping of UR_QUEUE_INFO_FLAGS
* Add mapping of cl_command_queue_properties to ur_queue_flags_t
* Add mapping of cl_unified_shared_memory_type_intel to ur_usm_type_t