### PR TITLE
[SYCL][UR][L0] Distinguish min/max calls from macros

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -177,7 +177,7 @@ ur_result_t calculateKernelWorkDimensions(
             Device->ZeDeviceComputeProperties->maxGroupSizeX,
             Device->ZeDeviceComputeProperties->maxGroupSizeY,
             Device->ZeDeviceComputeProperties->maxGroupSizeZ};
-        GroupSize[I] = std::min(size_t(GroupSize[I]), GlobalWorkSize[I]);
+        GroupSize[I] = (std::min)(size_t(GroupSize[I]), GlobalWorkSize[I]);
         while (GlobalWorkSize[I] % GroupSize[I]) {
           --GroupSize[I];
         }

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -74,7 +74,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(
 
   uint32_t ZeDeviceCount = MatchedDevices.size();
 
-  auto N = std::min(ZeDeviceCount, NumEntries);
+  auto N = (std::min)(ZeDeviceCount, NumEntries);
   if (Devices)
     std::copy_n(MatchedDevices.begin(), N, Devices);
 
@@ -1240,7 +1240,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
   uint32_t *SelectedBinaryInd = SelectedBinary;
 
   // Find the appropriate device image, fallback to spirv if not found
-  constexpr uint32_t InvalidInd = std::numeric_limits<uint32_t>::max();
+  constexpr uint32_t InvalidInd = (std::numeric_limits<uint32_t>::max)();
   uint32_t Spirv = InvalidInd;
 
   for (uint32_t i = 0; i < NumBinaries; ++i) {

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -79,11 +79,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
             UR_RESULT_ERROR_INVALID_VALUE);
   if (LocalWorkSize) {
     // L0
-    UR_ASSERT(LocalWorkSize[0] < std::numeric_limits<uint32_t>::max(),
+    UR_ASSERT(LocalWorkSize[0] < (std::numeric_limits<uint32_t>::max)(),
               UR_RESULT_ERROR_INVALID_VALUE);
-    UR_ASSERT(LocalWorkSize[1] < std::numeric_limits<uint32_t>::max(),
+    UR_ASSERT(LocalWorkSize[1] < (std::numeric_limits<uint32_t>::max)(),
               UR_RESULT_ERROR_INVALID_VALUE);
-    UR_ASSERT(LocalWorkSize[2] < std::numeric_limits<uint32_t>::max(),
+    UR_ASSERT(LocalWorkSize[2] < (std::numeric_limits<uint32_t>::max)(),
               UR_RESULT_ERROR_INVALID_VALUE);
     WG[0] = static_cast<uint32_t>(LocalWorkSize[0]);
     WG[1] = static_cast<uint32_t>(LocalWorkSize[1]);
@@ -110,7 +110,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
             Queue->Device->ZeDeviceComputeProperties->maxGroupSizeX,
             Queue->Device->ZeDeviceComputeProperties->maxGroupSizeY,
             Queue->Device->ZeDeviceComputeProperties->maxGroupSizeZ};
-        GroupSize[I] = std::min(size_t(GroupSize[I]), GlobalWorkSize[I]);
+        GroupSize[I] = (std::min)(size_t(GroupSize[I]), GlobalWorkSize[I]);
         while (GlobalWorkSize[I] % GroupSize[I]) {
           --GroupSize[I];
         }

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -121,7 +121,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
     if (*NumPlatforms == 0)
       *NumPlatforms = URPlatformsCache->size();
     else
-      *NumPlatforms = std::min(URPlatformsCache->size(), (size_t)NumEntries);
+      *NumPlatforms = (std::min)(URPlatformsCache->size(), (size_t)NumEntries);
   }
 
   return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -930,8 +930,8 @@ ur_queue_handle_t_::ur_queue_handle_t_(
     // Set-up to round-robin across allowed range of engines.
     uint32_t FilterLowerIndex = getRangeOfAllowedComputeEngines().first;
     uint32_t FilterUpperIndex = getRangeOfAllowedComputeEngines().second;
-    FilterUpperIndex = std::min((size_t)FilterUpperIndex,
-                                FilterLowerIndex + ComputeQueues.size() - 1);
+    FilterUpperIndex = (std::min)((size_t)FilterUpperIndex,
+                                  FilterLowerIndex + ComputeQueues.size() - 1);
     if (FilterLowerIndex <= FilterUpperIndex) {
       ComputeQueueGroup.LowerIndex = FilterLowerIndex;
       ComputeQueueGroup.UpperIndex = FilterUpperIndex;
@@ -959,8 +959,8 @@ ur_queue_handle_t_::ur_queue_handle_t_(
   } else {
     uint32_t FilterLowerIndex = Range.first;
     uint32_t FilterUpperIndex = Range.second;
-    FilterUpperIndex = std::min((size_t)FilterUpperIndex,
-                                FilterLowerIndex + CopyQueues.size() - 1);
+    FilterUpperIndex = (std::min)((size_t)FilterUpperIndex,
+                                  FilterLowerIndex + CopyQueues.size() - 1);
     if (FilterLowerIndex <= FilterUpperIndex) {
       CopyQueueGroup.ZeQueues = CopyQueues;
       CopyQueueGroup.LowerIndex = FilterLowerIndex;


### PR DESCRIPTION
This fixes collision between min/max functions and macros on Windows.