### PR TITLE
[OpenCL] Fix memory leak and coverity issue with struct-to-array casts

### DIFF
--- a/source/adapters/opencl/enqueue.cpp
+++ b/source/adapters/opencl/enqueue.cpp
@@ -177,14 +177,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     size_t hostRowPitch, size_t hostSlicePitch, void *pDst,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
+  const size_t BufferOrigin[3] = {bufferOrigin.x, bufferOrigin.y,
+                                  bufferOrigin.z};
+  const size_t HostOrigin[3] = {hostOrigin.x, hostOrigin.y, hostOrigin.z};
+  const size_t Region[3] = {region.width, region.height, region.depth};
 
   auto ClErr = clEnqueueReadBufferRect(
       cl_adapter::cast<cl_command_queue>(hQueue),
-      cl_adapter::cast<cl_mem>(hBuffer), blockingRead,
-      cl_adapter::cast<const size_t *>(&bufferOrigin),
-      cl_adapter::cast<const size_t *>(&hostOrigin),
-      cl_adapter::cast<const size_t *>(&region), bufferRowPitch,
-      bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst, numEventsInWaitList,
+      cl_adapter::cast<cl_mem>(hBuffer), blockingRead, BufferOrigin, HostOrigin,
+      Region, bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch,
+      pDst, numEventsInWaitList,
       cl_adapter::cast<const cl_event *>(phEventWaitList),
       cl_adapter::cast<cl_event *>(phEvent));
 
@@ -201,14 +203,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     size_t hostRowPitch, size_t hostSlicePitch, void *pSrc,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
+  const size_t BufferOrigin[3] = {bufferOrigin.x, bufferOrigin.y,
+                                  bufferOrigin.z};
+  const size_t HostOrigin[3] = {hostOrigin.x, hostOrigin.y, hostOrigin.z};
+  const size_t Region[3] = {region.width, region.height, region.depth};
 
   auto ClErr = clEnqueueWriteBufferRect(
       cl_adapter::cast<cl_command_queue>(hQueue),
-      cl_adapter::cast<cl_mem>(hBuffer), blockingWrite,
-      cl_adapter::cast<const size_t *>(&bufferOrigin),
-      cl_adapter::cast<const size_t *>(&hostOrigin),
-      cl_adapter::cast<const size_t *>(&region), bufferRowPitch,
-      bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc, numEventsInWaitList,
+      cl_adapter::cast<cl_mem>(hBuffer), blockingWrite, BufferOrigin,
+      HostOrigin, Region, bufferRowPitch, bufferSlicePitch, hostRowPitch,
+      hostSlicePitch, pSrc, numEventsInWaitList,
       cl_adapter::cast<const cl_event *>(phEventWaitList),
       cl_adapter::cast<cl_event *>(phEvent));
 
@@ -245,16 +249,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     size_t srcSlicePitch, size_t dstRowPitch, size_t dstSlicePitch,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
+  const size_t SrcOrigin[3] = {srcOrigin.x, srcOrigin.y, srcOrigin.z};
+  const size_t DstOrigin[3] = {dstOrigin.x, dstOrigin.y, dstOrigin.z};
+  const size_t Region[3] = {region.width, region.height, region.depth};
 
   auto ClErr = clEnqueueCopyBufferRect(
       cl_adapter::cast<cl_command_queue>(hQueue),
       cl_adapter::cast<cl_mem>(hBufferSrc),
-      cl_adapter::cast<cl_mem>(hBufferDst),
-      cl_adapter::cast<const size_t *>(&srcOrigin),
-      cl_adapter::cast<const size_t *>(&dstOrigin),
-      cl_adapter::cast<const size_t *>(&region), srcRowPitch, srcSlicePitch,
-      dstRowPitch, dstSlicePitch, numEventsInWaitList,
-      cl_adapter::cast<const cl_event *>(phEventWaitList),
+      cl_adapter::cast<cl_mem>(hBufferDst), SrcOrigin, DstOrigin, Region,
+      srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
+      numEventsInWaitList, cl_adapter::cast<const cl_event *>(phEventWaitList),
       cl_adapter::cast<cl_event *>(phEvent));
 
   if (ClErr == CL_INVALID_VALUE) {
@@ -331,13 +335,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
     size_t slicePitch, void *pDst, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  const size_t Origin[3] = {origin.x, origin.y, origin.z};
+  const size_t Region[3] = {region.width, region.height, region.depth};
 
   auto ClErr = clEnqueueReadImage(
       cl_adapter::cast<cl_command_queue>(hQueue),
-      cl_adapter::cast<cl_mem>(hImage), blockingRead,
-      cl_adapter::cast<const size_t *>(&origin),
-      cl_adapter::cast<const size_t *>(&region), rowPitch, slicePitch, pDst,
-      numEventsInWaitList, cl_adapter::cast<const cl_event *>(phEventWaitList),
+      cl_adapter::cast<cl_mem>(hImage), blockingRead, Origin, Region, rowPitch,
+      slicePitch, pDst, numEventsInWaitList,
+      cl_adapter::cast<const cl_event *>(phEventWaitList),
       cl_adapter::cast<cl_event *>(phEvent));
 
   if (ClErr == CL_INVALID_VALUE) {
@@ -351,13 +356,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
     size_t slicePitch, void *pSrc, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  const size_t Origin[3] = {origin.x, origin.y, origin.z};
+  const size_t Region[3] = {region.width, region.height, region.depth};
 
   auto ClErr = clEnqueueWriteImage(
       cl_adapter::cast<cl_command_queue>(hQueue),
-      cl_adapter::cast<cl_mem>(hImage), blockingWrite,
-      cl_adapter::cast<const size_t *>(&origin),
-      cl_adapter::cast<const size_t *>(&region), rowPitch, slicePitch, pSrc,
-      numEventsInWaitList, cl_adapter::cast<const cl_event *>(phEventWaitList),
+      cl_adapter::cast<cl_mem>(hImage), blockingWrite, Origin, Region, rowPitch,
+      slicePitch, pSrc, numEventsInWaitList,
+      cl_adapter::cast<const cl_event *>(phEventWaitList),
       cl_adapter::cast<cl_event *>(phEvent));
 
   if (ClErr == CL_INVALID_VALUE) {
@@ -372,13 +378,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     ur_rect_offset_t dstOrigin, ur_rect_region_t region,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
+  const size_t SrcOrigin[3] = {srcOrigin.x, srcOrigin.y, srcOrigin.z};
+  const size_t DstOrigin[3] = {dstOrigin.x, dstOrigin.y, dstOrigin.z};
+  const size_t Region[3] = {region.width, region.height, region.depth};
 
   auto ClErr = clEnqueueCopyImage(
       cl_adapter::cast<cl_command_queue>(hQueue),
       cl_adapter::cast<cl_mem>(hImageSrc), cl_adapter::cast<cl_mem>(hImageDst),
-      cl_adapter::cast<const size_t *>(&srcOrigin),
-      cl_adapter::cast<const size_t *>(&dstOrigin),
-      cl_adapter::cast<const size_t *>(&region), numEventsInWaitList,
+      SrcOrigin, DstOrigin, Region, numEventsInWaitList,
       cl_adapter::cast<const cl_event *>(phEventWaitList),
       cl_adapter::cast<cl_event *>(phEvent));
 

--- a/source/adapters/opencl/memory.cpp
+++ b/source/adapters/opencl/memory.cpp
@@ -264,7 +264,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
       *phBuffer = reinterpret_cast<ur_mem_handle_t>(FuncPtr(
           CLContext, PropertiesIntel.data(), static_cast<cl_mem_flags>(flags),
           size, pProperties->pHost, cl_adapter::cast<cl_int *>(&RetErr)));
-      CL_RETURN_ON_FAILURE(RetErr);
+      return mapCLErrorToUR(RetErr);
     }
   }
 

--- a/source/adapters/opencl/program.cpp
+++ b/source/adapters/opencl/program.cpp
@@ -120,13 +120,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t *pBinary, const ur_program_properties_t *,
     ur_program_handle_t *phProgram) {
 
-  cl_int BinaryStatus;
+  const cl_device_id Devices[1] = {cl_adapter::cast<cl_device_id>(hDevice)};
+  const size_t Lengths[1] = {size};
+  cl_int BinaryStatus[1];
   cl_int CLResult;
   *phProgram = cl_adapter::cast<ur_program_handle_t>(clCreateProgramWithBinary(
       cl_adapter::cast<cl_context>(hContext), cl_adapter::cast<cl_uint>(1u),
-      cl_adapter::cast<const cl_device_id *>(&hDevice), &size, &pBinary,
-      &BinaryStatus, &CLResult));
-  CL_RETURN_ON_FAILURE(BinaryStatus);
+      Devices, Lengths, &pBinary, BinaryStatus, &CLResult));
+  CL_RETURN_ON_FAILURE(BinaryStatus[0]);
   CL_RETURN_ON_FAILURE(CLResult);
 
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
Fix memory leak reported in #1034 

This bug was introduced when porting the original OpenCL plugin to UR. If the `clCreateBufferWithProperties` extension function exists, we should return even if it succeeds rather than continuing to the fallback call to `clCreateBuffer`.

Also add fixes from #1054:

> Address coverity issue with dodgy struct-to-array casts
>
> Also fix a similar issue coverity had with CreateProgramWithBinary which was passing array pointers straight through to the cl entry point by putting these params in local const arrays.
> 