### PR TITLE
[UR][L0] Add UR_L0_LEAKS_DEBUG key

### DIFF
--- a/source/adapters/level_zero/adapter.cpp
+++ b/source/adapters/level_zero/adapter.cpp
@@ -38,7 +38,7 @@ ur_result_t adapterStateTeardown() {
   // Print the balance of various create/destroy native calls.
   // The idea is to verify if the number of create(+) and destroy(-) calls are
   // matched.
-  if (ZeCallCount && (UrL0Debug & UR_L0_DEBUG_CALL_COUNT) != 0) {
+  if (ZeCallCount && (UrL0LeaksDebug) != 0) {
     // clang-format off
     //
     // The format of this table is such that each row accounts for a
@@ -79,8 +79,7 @@ ur_result_t adapterStateTeardown() {
     //
     // clang-format on
 
-    fprintf(stderr, "ZE_DEBUG=%d: check balance of create/destroy calls\n",
-            UR_L0_DEBUG_CALL_COUNT);
+    fprintf(stderr, "Check balance of create/destroy calls\n");
     fprintf(stderr,
             "----------------------------------------------------------\n");
     for (const auto &Row : CreateDestroySet) {

--- a/source/adapters/level_zero/common.cpp
+++ b/source/adapters/level_zero/common.cpp
@@ -149,7 +149,7 @@ ze_result_t ZeCall::doCall(ze_result_t ZeResult, const char *ZeName,
                            const char *ZeArgs, bool TraceError) {
   urPrint("ZE ---> %s%s\n", ZeName, ZeArgs);
 
-  if (UrL0Debug & UR_L0_DEBUG_CALL_COUNT) {
+  if (UrL0LeaksDebug) {
     ++(*ZeCallCount)[ZeName];
   }
 

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -187,7 +187,6 @@ enum UrDebugLevel {
   UR_L0_DEBUG_NONE = 0x0,
   UR_L0_DEBUG_BASIC = 0x1,
   UR_L0_DEBUG_VALIDATION = 0x2,
-  UR_L0_DEBUG_CALL_COUNT = 0x4,
   UR_L0_DEBUG_ALL = -1
 };
 
@@ -201,6 +200,13 @@ const int UrL0Debug = [] {
     DebugMode = std::atoi(ZeDebugMode);
   }
   return DebugMode;
+}();
+
+const int UrL0LeaksDebug = [] {
+  const char *UrRet = std::getenv("UR_L0_LEAKS_DEBUG");
+  if (!UrRet)
+    return 0;
+  return std::atoi(UrRet);
 }();
 
 // Controls Level Zero calls serialization to w/a Level Zero driver being not MT

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -30,7 +30,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
   static std::once_flag ZeCallCountInitialized;
   try {
     std::call_once(ZeCallCountInitialized, []() {
-      if (UrL0Debug & UR_L0_DEBUG_CALL_COUNT) {
+      if (UrL0LeaksDebug) {
         ZeCallCount = new std::map<std::string, int>;
       }
     });


### PR DESCRIPTION
Use a new environment variable, UR_L0_LEAKS_DEBUG, to check for leaks in the UR L0 adapter, instead of relying on a specific value being set in UR_L0_DEBUG.

LLVM testing: https://github.com/intel/llvm/pull/11820