### PR TITLE
[SPEC] Clarify the behaviour of UR warning messages

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -856,11 +856,11 @@ urAdapterRetain(
 /// returned by the failed driver entry-point.
 ///
 /// * If `pError` is ::UR_RESULT_SUCCESS, ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-/// represents a warning instead. This means that the entry-point call did not
-/// fail. However it might not have behaved as expected.
+///   represents a warning instead. This means that the entry-point call did not
+///   fail. However it might not have behaved as expected.
 ///
 /// * Using ::UR_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
-/// feature. Its usage is left at the discretion of adapter maintainers.
+///   feature. Its usage is left at the discretion of adapter maintainers.
 ///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -847,13 +847,17 @@ urAdapterRetain(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Get the last adapter specific error.
+/// @brief Get the last adapter specific warning or error.
 ///
 /// @details
 /// To be used after another entry-point has returned
 /// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
 /// the circumstances of the underlying driver error and the error code
 /// returned by the failed driver entry-point.
+///
+/// * If `pError` is ::UR_RESULT_SUCCESS, ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+/// represents a warning instead. This means that the entry-point call did not
+/// fail. However it might not have behaved as expected.
 ///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -859,6 +859,9 @@ urAdapterRetain(
 /// represents a warning instead. This means that the entry-point call did not
 /// fail. However it might not have behaved as expected.
 ///
+/// * Using ::UR_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
+/// feature. Its usage is left at the discretion of adapter maintainers.
+///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -83,6 +83,9 @@ details: |
     * If `pError` is $X_RESULT_SUCCESS, $X_RESULT_ERROR_ADAPTER_SPECIFIC
     represents a warning instead. This means that the entry-point call did not
     fail. However it might not have behaved as expected.
+  
+    * Using $X_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
+    feature. Its usage is left at the discretion of adapter maintainers.
 
     * Implementations *must* store the message and error code in thread-local
       storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -73,12 +73,16 @@ params:
           [in] Adapter handle to retain
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Get the last adapter specific error."
+desc: "Get the last adapter specific warning or error."
 details: |
     To be used after another entry-point has returned
     $X_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
     the circumstances of the underlying driver error and the error code
     returned by the failed driver entry-point.
+  
+    * If `pError` is $X_RESULT_SUCCESS, $X_RESULT_ERROR_ADAPTER_SPECIFIC
+    represents a warning instead. This means that the entry-point call did not
+    fail. However it might not have behaved as expected.
 
     * Implementations *must* store the message and error code in thread-local
       storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -81,11 +81,11 @@ details: |
     returned by the failed driver entry-point.
   
     * If `pError` is $X_RESULT_SUCCESS, $X_RESULT_ERROR_ADAPTER_SPECIFIC
-    represents a warning instead. This means that the entry-point call did not
-    fail. However it might not have behaved as expected.
+      represents a warning instead. This means that the entry-point call did not
+      fail. However it might not have behaved as expected.
   
     * Using $X_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
-    feature. Its usage is left at the discretion of adapter maintainers.
+      feature. Its usage is left at the discretion of adapter maintainers.
 
     * Implementations *must* store the message and error code in thread-local
       storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -353,13 +353,17 @@ ur_result_t UR_APICALL urAdapterRetain(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Get the last adapter specific error.
+/// @brief Get the last adapter specific warning or error.
 ///
 /// @details
 /// To be used after another entry-point has returned
 /// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
 /// the circumstances of the underlying driver error and the error code
 /// returned by the failed driver entry-point.
+///
+/// * If `pError` is ::UR_RESULT_SUCCESS, ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+/// represents a warning instead. This means that the entry-point call did not
+/// fail. However it might not have behaved as expected.
 ///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -362,11 +362,11 @@ ur_result_t UR_APICALL urAdapterRetain(
 /// returned by the failed driver entry-point.
 ///
 /// * If `pError` is ::UR_RESULT_SUCCESS, ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-/// represents a warning instead. This means that the entry-point call did not
-/// fail. However it might not have behaved as expected.
+///   represents a warning instead. This means that the entry-point call did not
+///   fail. However it might not have behaved as expected.
 ///
 /// * Using ::UR_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
-/// feature. Its usage is left at the discretion of adapter maintainers.
+///   feature. Its usage is left at the discretion of adapter maintainers.
 ///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -365,6 +365,9 @@ ur_result_t UR_APICALL urAdapterRetain(
 /// represents a warning instead. This means that the entry-point call did not
 /// fail. However it might not have behaved as expected.
 ///
+/// * Using ::UR_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
+/// feature. Its usage is left at the discretion of adapter maintainers.
+///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -320,11 +320,11 @@ ur_result_t UR_APICALL urAdapterRetain(
 /// returned by the failed driver entry-point.
 ///
 /// * If `pError` is ::UR_RESULT_SUCCESS, ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-/// represents a warning instead. This means that the entry-point call did not
-/// fail. However it might not have behaved as expected.
+///   represents a warning instead. This means that the entry-point call did not
+///   fail. However it might not have behaved as expected.
 ///
 /// * Using ::UR_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
-/// feature. Its usage is left at the discretion of adapter maintainers.
+///   feature. Its usage is left at the discretion of adapter maintainers.
 ///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -311,13 +311,17 @@ ur_result_t UR_APICALL urAdapterRetain(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Get the last adapter specific error.
+/// @brief Get the last adapter specific warning or error.
 ///
 /// @details
 /// To be used after another entry-point has returned
 /// ::UR_RESULT_ERROR_ADAPTER_SPECIFIC in order to retrieve a message describing
 /// the circumstances of the underlying driver error and the error code
 /// returned by the failed driver entry-point.
+///
+/// * If `pError` is ::UR_RESULT_SUCCESS, ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+/// represents a warning instead. This means that the entry-point call did not
+/// fail. However it might not have behaved as expected.
 ///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -323,6 +323,9 @@ ur_result_t UR_APICALL urAdapterRetain(
 /// represents a warning instead. This means that the entry-point call did not
 /// fail. However it might not have behaved as expected.
 ///
+/// * Using ::UR_RESULT_ERROR_ADAPTER_SPECIFIC to emit warnings is an optional
+/// feature. Its usage is left at the discretion of adapter maintainers.
+///
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///


### PR DESCRIPTION
* This commit updates the specification to clarify the behaviour
of UR_RESULT_ERROR_ADAPTER_SPECIFIC when returning warning messages.
* This is a temporary change until specific error codes for warnings
are added.