### PR TITLE
Remove the spec requirement for adapters to bounds check USM operations.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -6619,7 +6619,6 @@ urEnqueueMemUnmap(
 ///         + `patternSize > size`
 ///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
-///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -6661,7 +6660,6 @@ urEnqueueUSMFill(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -6708,7 +6706,6 @@ urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -6754,7 +6751,6 @@ urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -6790,7 +6786,6 @@ urEnqueueUSMAdvise(
 ///         + `width == 0`
 ///         + `height == 0`
 ///         + `width * height % patternSize != 0`
-///         + If `pitch * height` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -6838,8 +6833,6 @@ urEnqueueUSMFill2D(
 ///         + `srcPitch < width`
 ///         + `dstPitch < width`
 ///         + `height == 0`
-///         + If `srcPitch * height` is higher than the allocation size of `pSrc`
-///         + If `dstPitch * height` is higher than the allocation size of `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -1027,7 +1027,6 @@ returns:
         - "`patternSize > size`"
         - "`(patternSize & (patternSize - 1)) != 0`"
         - "`size % patternSize != 0`"
-        - "If `size` is higher than the allocation size of `ptr`"
     - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
         - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
@@ -1074,7 +1073,6 @@ returns:
     - $X_RESULT_ERROR_INVALID_EVENT
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`size == 0`"
-        - "If `size` is higher than the allocation size of `pSrc` or `pDst`"
     - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
         - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
@@ -1121,7 +1119,6 @@ returns:
     - $X_RESULT_ERROR_INVALID_EVENT
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`size == 0`"
-        - "If `size` is higher than the allocation size of `pMem`"
     - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
         - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
         - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
@@ -1160,7 +1157,6 @@ returns:
     - $X_RESULT_ERROR_INVALID_EVENT
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`size == 0`"
-        - "If `size` is higher than the allocation size of `pMem`"
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
@@ -1214,7 +1210,6 @@ returns:
       - "`width == 0`"
       - "`height == 0`"
       - "`width * height % patternSize != 0`"
-      - "If `pitch * height` is higher than the allocation size of `pMem`"
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
       - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
       - "`phEventWaitList != NULL && numEventsInWaitList == 0`"
@@ -1273,8 +1268,6 @@ returns:
       - "`srcPitch < width`"
       - "`dstPitch < width`"
       - "`height == 0`"
-      - "If `srcPitch * height` is higher than the allocation size of `pSrc`"
-      - "If `dstPitch * height` is higher than the allocation size of `pDst`"
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
     - "`phEventWaitList != NULL && numEventsInWaitList == 0`"

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -5634,7 +5634,6 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
 ///         + `patternSize > size`
 ///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
-///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -5690,7 +5689,6 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -5748,7 +5746,6 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -5805,7 +5802,6 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -5850,7 +5846,6 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
 ///         + `width == 0`
 ///         + `height == 0`
 ///         + `width * height % patternSize != 0`
-///         + If `pitch * height` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -5913,8 +5908,6 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
 ///         + `srcPitch < width`
 ///         + `dstPitch < width`
 ///         + `height == 0`
-///         + If `srcPitch * height` is higher than the allocation size of `pSrc`
-///         + If `dstPitch * height` is higher than the allocation size of `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -4791,7 +4791,6 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
 ///         + `patternSize > size`
 ///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
-///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -4840,7 +4839,6 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pSrc` or `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -4891,7 +4889,6 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -4941,7 +4938,6 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `size == 0`
-///         + If `size` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -4980,7 +4976,6 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
 ///         + `width == 0`
 ///         + `height == 0`
 ///         + `width * height % patternSize != 0`
-///         + If `pitch * height` is higher than the allocation size of `pMem`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
@@ -5036,8 +5031,6 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
 ///         + `srcPitch < width`
 ///         + `dstPitch < width`
 ///         + `height == 0`
-///         + If `srcPitch * height` is higher than the allocation size of `pSrc`
-///         + If `dstPitch * height` is higher than the allocation size of `pDst`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 ///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
 ///         + `phEventWaitList != NULL && numEventsInWaitList == 0`

--- a/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
@@ -62,9 +62,3 @@ TEST_P(urEnqueueUSMAdviseTest, InvalidSizeZero) {
         UR_RESULT_ERROR_INVALID_SIZE,
         urEnqueueUSMAdvise(queue, ptr, 0, UR_USM_ADVICE_FLAG_DEFAULT, nullptr));
 }
-
-TEST_P(urEnqueueUSMAdviseTest, InvalidSizeTooLarge) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urEnqueueUSMAdvise(queue, ptr, allocation_size * 2,
-                                        UR_USM_ADVICE_FLAG_DEFAULT, nullptr));
-}

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -168,13 +168,6 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidSize) {
                      UR_RESULT_ERROR_INVALID_SIZE);
 }
 
-TEST_P(urEnqueueUSMFillNegativeTest, OutOfBounds) {
-    size_t out_of_bounds = size + 1;
-    ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
-                                      out_of_bounds, 0, nullptr, nullptr),
-                     UR_RESULT_ERROR_INVALID_SIZE);
-}
-
 TEST_P(urEnqueueUSMFillNegativeTest, invalidPatternSize) {
     /* pattern_size is 0 */
     ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, 0, pattern.data(), size, 0,

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -227,22 +227,6 @@ TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidSize) {
                      UR_RESULT_ERROR_INVALID_SIZE);
 }
 
-TEST_P(urEnqueueUSMFill2DNegativeTest, OutOfBounds) {
-    size_t out_of_bounds = pitch * height + 1;
-
-    /* Interpret memory as having just one row */
-    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, out_of_bounds, pattern_size,
-                                        pattern.data(), width, 1, 0, nullptr,
-                                        nullptr),
-                     UR_RESULT_ERROR_INVALID_SIZE);
-
-    /* Interpret memory as having just one column */
-    ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, out_of_bounds, pattern_size,
-                                        pattern.data(), 1, height, 0, nullptr,
-                                        nullptr),
-                     UR_RESULT_ERROR_INVALID_SIZE);
-}
-
 TEST_P(urEnqueueUSMFill2DNegativeTest, invalidPatternSize) {
     /* pattern size is 0 */
     ASSERT_EQ_RESULT(urEnqueueUSMFill2D(queue, ptr, pitch, 0, pattern.data(),

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -153,18 +153,6 @@ TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidSize) {
                      urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
                                           width + 1, height, 0, nullptr,
                                           nullptr));
-
-    // `dstPitch * height` is higher than the allocation size of `pDst`
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urEnqueueUSMMemcpy2D(queue, true, pDst, pitch + 1, pSrc,
-                                          pitch, width, height, 0, nullptr,
-                                          nullptr));
-
-    // `srcPitch * height` is higher than the allocation size of `pSrc`
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc,
-                                          pitch + 1, width, height, 0, nullptr,
-                                          nullptr));
 }
 
 TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidEventWaitList) {

--- a/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -102,13 +102,6 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidSizeZero) {
                                           nullptr, nullptr));
 }
 
-TEST_P(urEnqueueUSMPrefetchTest, InvalidSizeTooLarge) {
-    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                     urEnqueueUSMPrefetch(queue, ptr, allocation_size * 2,
-                                          UR_USM_MIGRATION_FLAG_DEFAULT, 0,
-                                          nullptr, nullptr));
-}
-
 TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
                      urEnqueueUSMPrefetch(queue, ptr, allocation_size,


### PR DESCRIPTION
None of the adapter APIs support this kind of bounds checking natively so mandating it in our spec means mandating an apparently unnecessary additional overhead in the adapters.

Addresses #926 