### PR TITLE
[common] add codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,78 @@
+name: Coverage
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+    name: Build - Ubuntu
+    strategy:
+      matrix:
+        os: ['ubuntu-22.04']
+        build_type: [Debug]
+        compiler: [{c: gcc, cxx: g++}]
+        libbacktrace: ['-DVAL_USE_LIBBACKTRACE_BACKTRACE=ON']
+        pool_tracking: ['-DUMF_ENABLE_POOL_TRACKING=ON']
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install apt packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen ${{matrix.compiler.c}}
+
+    - name: Install pip packages
+      run: pip install -r third_party/requirements.txt
+
+    - name: Install libbacktrace
+      if: matrix.libbacktrace == '-DVAL_USE_LIBBACKTRACE_BACKTRACE=ON'
+      run: |
+        git clone https://github.com/ianlancetaylor/libbacktrace.git
+        cd libbacktrace
+        ./configure
+        make
+        sudo make install
+        cd ..
+
+    - name: Download DPC++
+      run: |
+        sudo apt install libncurses5
+        wget -O ${{github.workspace}}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/sycl-nightly%2F20230626/dpcpp-compiler.tar.gz
+        tar -xvf ${{github.workspace}}/dpcpp_compiler.tar.gz
+
+    - name: Configure CMake
+      run: >
+        cmake
+        -B${{github.workspace}}/build
+        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+        -DUR_ENABLE_TRACING=ON
+        -DUR_DEVELOPER_MODE=ON
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DUR_BUILD_TESTS=ON
+        -DUR_FORMAT_CPP_STYLE=ON
+        -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
+        -DCMAKE_CXX_FLAGS="--coverage -fkeep-inline-functions -fkeep-static-functions"
+        -DCMAKE_EXE_LINKER_FLAGS="--coverage"
+        -DCMAKE_SHARED_LINKER_FLAGS="--coverage"
+        ${{matrix.libbacktrace}}
+        ${{matrix.pool_tracking}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build -j $(nproc)
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -L "python|umf|loader|validation|tracing|unit|urtrace"
+
+    - name: Quick Coverage Info
+      working-directory: ${{github.workspace}}/build
+      run: ctest -T Coverage
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        gcov: true
+        gcov_include: source


### PR DESCRIPTION
Preview: https://app.codecov.io/gh/pbalcer/unified-runtime

Codecov still needs to be enabled for the `oneapi-src` organization. Also, this workflow needs to run on the default branch on the repo, so until the adapter and main branches are merged, we won't see the adapter coverage.