### PR TITLE
[CI][L0] adapt e2e workflow to l0 target

### DIFF
--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -1,0 +1,29 @@
+name: E2E Level Zero
+
+on:
+  schedule:
+    # Run every day at 23:00 UTC
+    - cron: '0 23 * * *'
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  e2e-build-hw:
+    # trigger only if PR comment contains "e2e-l0"
+    if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/e2e-l0')) || (github.event_name == 'schedule') }}
+    name: Start e2e job
+    # use core flow, run it with level zero specific parameters
+    uses: ./.github/workflows/e2e_core.yml
+    # parameters that we pass to the core flow
+    with:
+      name: "L0"
+      runner_tag: "LEVEL_ZERO"
+      str_name: "level_zero"
+      prefix: "ext_oneapi_"
+      config: ""
+      unit: "gpu"
+      trigger: "${{github.event_name}}"


### PR DESCRIPTION
This change adds support for l0 to e2e tests.
PR will not pass until we have a stable runner configuration with Intel GPU and level zero:
https://jira.devtools.intel.com/browse/GSD-7337