### PR TITLE
[NATIVECPU] Implement correct reference counting for Native CPU adapter

### DIFF
--- a/source/adapters/native_cpu/common.hpp
+++ b/source/adapters/native_cpu/common.hpp
@@ -61,16 +61,16 @@ struct _ur_object {
   ur_shared_mutex Mutex;
 };
 
+// Todo: replace this with a common helper once it is available
 struct RefCounted {
   std::atomic_uint32_t _refCount;
-  void incrementReferenceCount() { _refCount++; }
-  void decrementReferenceCount() { _refCount--; }
+  uint32_t incrementReferenceCount() { return ++_refCount; }
+  uint32_t decrementReferenceCount() { return --_refCount; }
   RefCounted() : _refCount{1} {}
   uint32_t getReferenceCount() const { return _refCount; }
 };
 
 template <typename T> inline void decrementOrDelete(T *refC) {
-  refC->decrementReferenceCount();
-  if (refC->getReferenceCount() == 0)
+  if (refC->decrementReferenceCount() == 0)
     delete refC;
 }

--- a/source/adapters/native_cpu/common.hpp
+++ b/source/adapters/native_cpu/common.hpp
@@ -69,8 +69,7 @@ struct RefCounted {
   uint32_t getReferenceCount() const { return _refCount; }
 };
 
-template <typename T>
-inline void decrementOrDelete(T* refC) {
+template <typename T> inline void decrementOrDelete(T *refC) {
   refC->decrementReferenceCount();
   if (refC->getReferenceCount() == 0)
     delete refC;

--- a/source/adapters/native_cpu/common.hpp
+++ b/source/adapters/native_cpu/common.hpp
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "ur/ur.hpp"
-#include <mutex>
 
 constexpr size_t MaxMessageSize = 256;
 
@@ -64,7 +63,6 @@ struct _ur_object {
 
 struct RefCounted {
   std::atomic_uint32_t _refCount;
-  std::mutex _mutex;
   void incrementReferenceCount() { _refCount++; }
   void decrementReferenceCount() { _refCount--; }
   RefCounted() : _refCount{1} {}
@@ -74,7 +72,6 @@ struct RefCounted {
 template <typename T>
 inline void decrementOrDelete(T* refC) {
   refC->decrementReferenceCount();
-  std::lock_guard<std::mutex> lock(refC->_mutex);
   if (refC->getReferenceCount() == 0)
     delete refC;
 }

--- a/source/adapters/native_cpu/context.cpp
+++ b/source/adapters/native_cpu/context.cpp
@@ -38,7 +38,9 @@ urContextRetain(ur_context_handle_t hContext) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  delete hContext;
+  hContext->decrementReferenceCount();
+  if(hContext->getReferenceCount() == 0)
+    delete hContext;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/native_cpu/context.cpp
+++ b/source/adapters/native_cpu/context.cpp
@@ -32,15 +32,13 @@ urContextCreate(uint32_t DeviceCount, const ur_device_handle_t *phDevices,
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRetain(ur_context_handle_t hContext) {
-  std::ignore = hContext;
-  DIE_NO_IMPLEMENTATION
+  hContext->incrementReferenceCount();
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  hContext->decrementReferenceCount();
-  if(hContext->getReferenceCount() == 0)
-    delete hContext;
+  decrementOrDelete(hContext);
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/native_cpu/context.hpp
+++ b/source/adapters/native_cpu/context.hpp
@@ -13,8 +13,9 @@
 #include <ur_api.h>
 
 #include "device.hpp"
+#include "common.hpp"
 
-struct ur_context_handle_t_ {
+struct ur_context_handle_t_ : RefCounted {
   ur_context_handle_t_(ur_device_handle_t_ *phDevices) : _device{phDevices} {}
 
   ur_device_handle_t _device;

--- a/source/adapters/native_cpu/context.hpp
+++ b/source/adapters/native_cpu/context.hpp
@@ -12,8 +12,8 @@
 
 #include <ur_api.h>
 
-#include "device.hpp"
 #include "common.hpp"
+#include "device.hpp"
 
 struct ur_context_handle_t_ : RefCounted {
   ur_context_handle_t_(ur_device_handle_t_ *phDevices) : _device{phDevices} {}

--- a/source/adapters/native_cpu/kernel.cpp
+++ b/source/adapters/native_cpu/kernel.cpp
@@ -182,9 +182,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
-  hKernel->decrementReferenceCount();
-  if(hKernel->getReferenceCount() == 0)
-    delete hKernel;
+  decrementOrDelete(hKernel);
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/kernel.cpp
+++ b/source/adapters/native_cpu/kernel.cpp
@@ -182,7 +182,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelRelease(ur_kernel_handle_t hKernel) {
-  delete hKernel;
+  hKernel->decrementReferenceCount();
+  if(hKernel->getReferenceCount() == 0)
+    delete hKernel;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -95,7 +95,9 @@ urProgramRetain(ur_program_handle_t hProgram) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
-  delete hProgram;
+  hProgram->decrementReferenceCount();
+  if(hProgram->getReferenceCount() == 0)
+    delete hProgram;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -95,10 +95,7 @@ urProgramRetain(ur_program_handle_t hProgram) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRelease(ur_program_handle_t hProgram) {
-  hProgram->decrementReferenceCount();
-  if(hProgram->getReferenceCount() == 0)
-    delete hProgram;
-
+  decrementOrDelete(hProgram);
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/native_cpu/queue.cpp
+++ b/source/adapters/native_cpu/queue.cpp
@@ -49,9 +49,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  hQueue->decrementReferenceCount();
-  if(hQueue->getReferenceCount() == 0)
-    delete hQueue;
+  decrementOrDelete(hQueue);
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/queue.cpp
+++ b/source/adapters/native_cpu/queue.cpp
@@ -43,12 +43,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
   std::ignore = hQueue;
+  hQueue->incrementReferenceCount();
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  delete hQueue;
+  hQueue->decrementReferenceCount();
+  if(hQueue->getReferenceCount() == 0)
+    delete hQueue;
+
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/native_cpu/queue.hpp
+++ b/source/adapters/native_cpu/queue.hpp
@@ -8,5 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 #pragma once
+#include "common.hpp"
 
-struct ur_queue_handle_t_ {};
+struct ur_queue_handle_t_ : RefCounted {};


### PR DESCRIPTION
Some types in the Native CPU adapter didn't have correct reference counting semantics. This PR should fix it by providing correct implementations for the `retain` and `release` functions.

intel/llvm pull request: https://github.com/intel/llvm/pull/11947