### PR TITLE
[CUDA][HIP][OpenCL][NATIVECPU] Fix multi-device compile

### DIFF
--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -263,8 +263,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(ur_context_handle_t hContext,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(
-    ur_context_handle_t, uint32_t, const ur_program_handle_t *, uint32_t,
-    ur_device_handle_t *, const char *, ur_program_handle_t *) {
+    ur_context_handle_t, uint32_t, ur_device_handle_t *, uint32_t,
+    const ur_program_handle_t *, const char *, ur_program_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -399,9 +399,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   if (UR_RESULT_SUCCESS != retVal) {
     return retVal;
   }
-  pDdiTable->pfnBuildExp = nullptr;
-  pDdiTable->pfnCompileExp = nullptr;
-  pDdiTable->pfnLinkExp = nullptr;
+  pDdiTable->pfnBuildExp = urProgramBuildExp;
+  pDdiTable->pfnCompileExp = urProgramCompileExp;
+  pDdiTable->pfnLinkExp = urProgramLinkExp;
   return retVal;
 }
 

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -279,8 +279,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(ur_context_handle_t,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(
-    ur_context_handle_t, uint32_t, const ur_program_handle_t *, uint32_t,
-    ur_device_handle_t *, const char *, ur_program_handle_t *) {
+    ur_context_handle_t, uint32_t, ur_device_handle_t *, uint32_t,
+    const ur_program_handle_t *, const char *, ur_program_handle_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -354,9 +354,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   if (UR_RESULT_SUCCESS != retVal) {
     return retVal;
   }
-  pDdiTable->pfnBuildExp = nullptr;
-  pDdiTable->pfnCompileExp = nullptr;
-  pDdiTable->pfnLinkExp = nullptr;
+  pDdiTable->pfnBuildExp = urProgramBuildExp;
+  pDdiTable->pfnCompileExp = urProgramCompileExp;
+  pDdiTable->pfnLinkExp = urProgramLinkExp;
   return retVal;
 }
 

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -87,6 +87,26 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
   DIE_NO_IMPLEMENTATION
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urProgramCompileExp(ur_program_handle_t,
+                                                        uint32_t,
+                                                        ur_device_handle_t *,
+                                                        const char *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(ur_program_handle_t,
+                                                      uint32_t,
+                                                      ur_device_handle_t *,
+                                                      const char *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(
+    ur_context_handle_t, uint32_t, ur_device_handle_t *, uint32_t,
+    const ur_program_handle_t *, const char *, ur_program_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramRetain(ur_program_handle_t hProgram) {
   hProgram->incrementReferenceCount();

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -380,4 +380,19 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
   return retVal;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_program_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+  auto retVal = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != retVal) {
+    return retVal;
+  }
+  pDdiTable->pfnBuildExp = urProgramBuildExp;
+  pDdiTable->pfnCompileExp = urProgramCompileExp;
+  pDdiTable->pfnLinkExp = urProgramLinkExp;
+  return retVal;
+}
+
 } // extern "C"

--- a/source/adapters/opencl/program.cpp
+++ b/source/adapters/opencl/program.cpp
@@ -220,6 +220,26 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
   return UR_RESULT_SUCCESS;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urProgramCompileExp(ur_program_handle_t,
+                                                        uint32_t,
+                                                        ur_device_handle_t *,
+                                                        const char *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(ur_program_handle_t,
+                                                      uint32_t,
+                                                      ur_device_handle_t *,
+                                                      const char *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(
+    ur_context_handle_t, uint32_t, ur_device_handle_t *, uint32_t,
+    const ur_program_handle_t *, const char *, ur_program_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
 static cl_int mapURProgramBuildInfoToCL(ur_program_build_info_t URPropName) {
 
   switch (static_cast<uint32_t>(URPropName)) {

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -390,9 +390,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   if (UR_RESULT_SUCCESS != retVal) {
     return retVal;
   }
-  pDdiTable->pfnBuildExp = nullptr;
-  pDdiTable->pfnCompileExp = nullptr;
-  pDdiTable->pfnLinkExp = nullptr;
+  pDdiTable->pfnBuildExp = urProgramBuildExp;
+  pDdiTable->pfnCompileExp = urProgramCompileExp;
+  pDdiTable->pfnLinkExp = urProgramLinkExp;
   return retVal;
 }
 


### PR DESCRIPTION
Ensure that all adapters have the correct signatures for the multi-device compile experimental feature entry points and that they entry points exist even when returning `UR_RESULT_ERROR_UNSUPPORTED_FEATURE`.

Fixes the failing checks in https://github.com/intel/llvm/pull/11464.
