### PR TITLE
[CUDA] Ifdef cuda 12 graph API

### DIFF
--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -140,8 +140,14 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
   try {
+#if CUDA_VERSION >= 12000
     UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
                                       hCommandBuffer->CudaGraph, 0));
+#else
+    UR_CHECK_ERROR(cuGraphInstantiate(&hCommandBuffer->CudaGraphExec,
+                                      hCommandBuffer->CudaGraph, nullptr,
+                                      nullptr, 0));
+#endif
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;
   }


### PR DESCRIPTION
The signature of this API changed in CUDA 12 from:

https://docs.nvidia.com/cuda/archive/11.8.0/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g433ae118a751c9f2087f53d7add7bc2c

to 

https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1gb53b435e178cccfa37ac87285d2c3fa1