### PR TITLE
[CI] Fix Clang on Windows builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -98,7 +98,10 @@ jobs:
       matrix:
         os: ['windows-2019', 'windows-2022']
         build_type: [Debug, Release]
-        compiler: [{c: cl.exe, cxx: cl.exe}, {c: clang-cl.exe, cxx: clang-cl.exe}]
+        compiler: [{c: cl, cxx: cl}, {c: clang-cl, cxx: clang-cl}]
+        include:
+          - compiler: {c: clang-cl, cxx: clang-cl}
+            toolset: "-T ClangCL"
     runs-on: ${{matrix.os}}
 
     steps:
@@ -122,6 +125,7 @@ jobs:
       run: >
         cmake
         -B${{github.workspace}}/build
+        ${{matrix.toolset}}
         -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
         -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
@@ -135,7 +139,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{matrix.build_type}}
 
     - name: Build all
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j 2
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j $Env:NUMBER_OF_PROCESSORS
 
     - name: Test
       working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
Fixes issue #1111. Enable clang-cl test builds on Windows in the Github Actions workflow.

Also:
- Remove redundant '.exe' suffixes.
- Run Windows builds on the max available number of cpus.