### PR TITLE
[CI][OPENCL] adapt e2e workflow to opencl target

### DIFF
--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         adapter: [
-          {name: CUDA}
+          {name: CUDA, str_name: cuda, prefix: "ext_oneapi_", config: "--cuda --hip", unit: "gpu"},
+          {name: OPENCL, str_name: opencl, prefix: "", config: "", unit: "cpu"}
         ]
         build_type: [Release]
         compiler: [{c: clang, cxx: clang++}]
@@ -59,12 +60,18 @@ jobs:
       run: LD_LIBRARY_PATH=${{github.workspace}}/dpcpp_compiler/lib
         cmake --build ${{github.workspace}}/ur-repo/build -j $(nproc)
 
-    - name: Set env vars & pre setup
+    - name: Set prefer UR
+      run: echo "SYCL_PREFER_UR=1" >> $GITHUB_ENV
+
+    - name: Set CUDA env vars
+      if: matrix.adapter.name == 'CUDA'
       run: |
-        echo "SYCL_PREFER_UR=1" >> $GITHUB_ENV
         echo "CUDA_LIB_PATH=/usr/local/cuda/lib64/stubs" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/usr/local/cuda/compat/:/usr/local/cuda/lib64:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        source /opt/intel/oneapi/setvars.sh
+
+    - name: Run pre setup
+      run: |
+        source /opt/intel/oneapi/setvars.sh --force
         sycl-ls
 
     - name: Configure SYCL
@@ -73,7 +80,7 @@ jobs:
         -t ${{matrix.build_type}}
         -o ${{github.workspace}}/sycl_build
         --cmake-gen "Unix Makefiles"
-        --ci-defaults --cuda --hip
+        --ci-defaults ${{matrix.adapter.config}}
         --cmake-opt="-DLLVM_INSTALL_UTILS=ON"
         --cmake-opt="-DSYCL_PI_TESTS=OFF"
         --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache
@@ -91,7 +98,7 @@ jobs:
     - name: Swap UR loader and adapters
       run: |
         cp ${{github.workspace}}/ur-repo/build/lib/libur_loader.so* ${{github.workspace}}/sycl_build/lib/
-        cp ${{github.workspace}}/ur-repo/build/lib/libur_adapter_cuda.so* ${{github.workspace}}/sycl_build/lib/
+        cp ${{github.workspace}}/ur-repo/build/lib/libur_adapter_${{matrix.adapter.str_name}}.so* ${{github.workspace}}/sycl_build/lib/
 
     - name: Set additional env. vars
       run: |
@@ -110,7 +117,7 @@ jobs:
         -GNinja
         -B ${{github.workspace}}/build-e2e/
         -S ${{github.workspace}}/sycl-repo/sycl/test-e2e/
-        -DSYCL_TEST_E2E_TARGETS="ext_oneapi_cuda:gpu"
+        -DSYCL_TEST_E2E_TARGETS="${{matrix.adapter.prefix}}${{matrix.adapter.str_name}}:${{matrix.adapter.unit}}"
         -DCMAKE_CXX_COMPILER="$(which clang++)"
         -DLLVM_LIT="${{github.workspace}}/sycl-repo/llvm/utils/lit/lit.py"
 


### PR DESCRIPTION
- [x] Waits for: https://github.com/oneapi-src/unified-runtime/pull/993 ([source/adapters/opencl/CMakeLists.txt](https://github.com/oneapi-src/unified-runtime/pull/993/files#diff-097e8a00604cf0f1635f4a7c6917bc25e00ad1375221c1a39b115934c91ccfb6))

- [x] build pass: -https://github.com/oneapi-src/unified-runtime/actions/runs/7221868465/job/19677743227 