### PR TITLE
Add validation for a few image_desc_t members.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2466,8 +2466,8 @@ typedef struct ur_image_desc_t {
     size_t arraySize;          ///< [in] image array size
     size_t rowPitch;           ///< [in] image row pitch
     size_t slicePitch;         ///< [in] image slice pitch
-    uint32_t numMipLevel;      ///< [in] number of MIP levels
-    uint32_t numSamples;       ///< [in] number of samples
+    uint32_t numMipLevel;      ///< [in] number of MIP levels, must be `0`
+    uint32_t numSamples;       ///< [in] number of samples, must be `0`
 
 } ur_image_desc_t;
 
@@ -2495,6 +2495,10 @@ typedef struct ur_image_desc_t {
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
 ///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///         + `pImageDesc && pImageDesc->numMipLevel != 0`
+///         + `pImageDesc && pImageDesc->numSamples != 0`
+///         + `pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`
+///         + `pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -201,10 +201,10 @@ members:
       desc: "[in] image slice pitch"
     - type: uint32_t
       name: numMipLevel
-      desc: "[in] number of MIP levels"
+      desc: "[in] number of MIP levels, must be `0`"
     - type: uint32_t
       name: numSamples
-      desc: "[in] number of samples"
+      desc: "[in] number of samples, must be `0`"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Create an image object"
@@ -237,6 +237,10 @@ returns:
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
       - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`"
+      - "`pImageDesc && pImageDesc->numMipLevel != 0`"
+      - "`pImageDesc && pImageDesc->numSamples != 0`"
+      - "`pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`"
+      - "`pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
     - $X_RESULT_ERROR_INVALID_HOST_PTR:

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -231,16 +231,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
             UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
   UR_ASSERT(pImageDesc->type <= UR_MEM_TYPE_IMAGE1D_BUFFER,
             UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  UR_ASSERT(pImageDesc->numMipLevel == 0,
-            UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  UR_ASSERT(pImageDesc->numSamples == 0,
-            UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  if (!pHost) {
-    UR_ASSERT(pImageDesc->rowPitch == 0,
-              UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-    UR_ASSERT(pImageDesc->slicePitch == 0,
-              UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  }
 
   ur_result_t Result = UR_RESULT_SUCCESS;
 

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -328,16 +328,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
             UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
   UR_ASSERT(pImageDesc->type <= UR_MEM_TYPE_IMAGE1D_BUFFER,
             UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  UR_ASSERT(pImageDesc->numMipLevel == 0,
-            UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  UR_ASSERT(pImageDesc->numSamples == 0,
-            UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  if (!pHost) {
-    UR_ASSERT(pImageDesc->rowPitch == 0,
-              UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-    UR_ASSERT(pImageDesc->slicePitch == 0,
-              UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
-  }
 
   // We only support RBGA channel order
   // TODO: check SYCL CTS and spec. May also have to support BGRA

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1012,6 +1012,22 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
 
+        if (pImageDesc && pImageDesc->numMipLevel != 0) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+
+        if (pImageDesc && pImageDesc->numSamples != 0) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+
+        if (pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+
+        if (pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+
         if (pHost == NULL &&
             (flags & (UR_MEM_FLAG_USE_HOST_POINTER |
                       UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) != 0) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1445,6 +1445,10 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
 ///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///         + `pImageDesc && pImageDesc->numMipLevel != 0`
+///         + `pImageDesc && pImageDesc->numSamples != 0`
+///         + `pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`
+///         + `pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1242,6 +1242,10 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
 ///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_BUFFER < pImageDesc->type`
+///         + `pImageDesc && pImageDesc->numMipLevel != 0`
+///         + `pImageDesc && pImageDesc->numSamples != 0`
+///         + `pImageDesc && pImageDesc->rowPitch != 0 && pHost == nullptr`
+///         + `pImageDesc && pImageDesc->slicePitch != 0 && pHost == nullptr`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_INVALID_HOST_PTR


### PR DESCRIPTION
Also removes these checks from the cuda and hip adapters since they should be caught by the validation layer now.

The new validation rules bring image_desc_t in line with the CL struct it was derived from. We already had CTS coverage for them.

LLVM testing https://github.com/intel/llvm/pull/12267